### PR TITLE
Update `Lint/RedundantSafeNavigation` to register an offense when the receiver is `self`

### DIFF
--- a/changelog/change_update_lint_redundant_safe_navigation_to_register.md
+++ b/changelog/change_update_lint_redundant_safe_navigation_to_register.md
@@ -1,0 +1,1 @@
+* [#13420](https://github.com/rubocop/rubocop/pull/13420): Update `Lint/RedundantSafeNavigation` to register an offense when the receiver is `self`. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for redundant safe navigation calls.
       # Use cases where a constant, named in camel case for classes and modules is `nil` are rare,
       # and an offense is not detected when the receiver is a constant. The detection also applies
-      # to literal receivers, except for `nil`.
+      # to `self`, and to literal receivers, except for `nil`.
       #
       # For all receivers, the `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`,
       # and `equal?` methods are checked by default.
@@ -29,6 +29,9 @@ module RuboCop
       #   # bad
       #   CamelCaseConst&.do_something
       #
+      #   # good
+      #   CamelCaseConst.do_something
+      #
       #   # bad
       #   do_something if attrs&.respond_to?(:[])
       #
@@ -39,9 +42,6 @@ module RuboCop
       #   while node&.is_a?(BeginNode)
       #     node = node.parent
       #   end
-      #
-      #   # good
-      #   CamelCaseConst.do_something
       #
       #   # good
       #   while node.is_a?(BeginNode)
@@ -66,6 +66,12 @@ module RuboCop
       #   foo.to_i
       #   foo.to_f
       #   foo.to_s
+      #
+      #   # bad
+      #   self&.foo
+      #
+      #   # good
+      #   self.foo
       #
       # @example AllowedMethods: [nil_safe_method]
       #   # bad
@@ -133,7 +139,7 @@ module RuboCop
         def assume_receiver_instance_exists?(receiver)
           return true if receiver.const_type? && !receiver.short_name.match?(SNAKE_CASE)
 
-          receiver.literal? && !receiver.nil_type?
+          receiver.self_type? || (receiver.literal? && !receiver.nil_type?)
         end
 
         def check?(node)

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -132,6 +132,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
+  it 'registers an offense and correct when `&.` is used with `self`' do
+    expect_offense(<<~RUBY)
+      self&.foo
+          ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      self.foo
+    RUBY
+  end
+
   %i[while until].each do |loop_type|
     it 'registers an offense and corrects when `&.` is used inside `#{loop_type}` condition' do
       expect_offense(<<~RUBY, loop_type: loop_type)


### PR DESCRIPTION
It is redundant to use safe-navigation on `self` because `self` always is the current object, and therefore not nil (other than if reopening `NilClass`).

```ruby
# bad
self&.foo

# good
self.foo
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
