### PR TITLE
Update references to `children` on assignment nodes to node methods

### DIFF
--- a/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
@@ -40,7 +40,7 @@ module RuboCop
           traverse_node(node.condition) do |asgn_node|
             next unless asgn_node.loc.operator
 
-            rhs = asgn_node.to_a.last
+            rhs = asgn_node.rhs
             next if !all_literals?(rhs) || parallel_assignment_with_splat_operator?(rhs)
 
             range = offense_range(asgn_node, rhs)

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -54,9 +54,9 @@ module RuboCop
           parent = node.parent
 
           if parent&.assignment?
-            block_node = parent.children[1]
+            block_node = parent.expression
           elsif parent&.parent&.masgn_type?
-            block_node = parent.parent.children[1]
+            block_node = parent.parent.expression
           else
             _scope, _name, block_node = *node
           end

--- a/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/abc_size_calculator.rb
@@ -95,7 +95,7 @@ module RuboCop
           def compound_assignment(node)
             # Methods setter cannot be detected for multiple assignments
             # and shorthand assigns, so we'll count them here instead
-            children = node.masgn_type? ? node.children[0].children : node.children
+            children = node.masgn_type? ? node.assignments : node.children
 
             will_be_miscounted = children.count do |child|
               child.respond_to?(:setter_method?) && !child.setter_method?

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -109,7 +109,7 @@ module RuboCop
               variable_name_matches?(lvasgn_node, name)
             end
           else
-            node.children.first == name
+            node.name == name
           end
         end
 
@@ -141,12 +141,7 @@ module RuboCop
         # Further `lvar` nodes will not be corrected though since they now refer to a
         # different variable.
         def correct_reassignment(corrector, node, offending_name, preferred_name)
-          if node.lvasgn_type?
-            correct_node(corrector, node.child_nodes.first, offending_name, preferred_name)
-          elsif node.masgn_type?
-            # With multiple assign, the assignments are in an array as the last child
-            correct_node(corrector, node.children.last, offending_name, preferred_name)
-          end
+          correct_node(corrector, node.rhs, offending_name, preferred_name)
         end
 
         def preferred_name(variable_name)
@@ -159,10 +154,7 @@ module RuboCop
         end
 
         def variable_name(node)
-          asgn_node = node.exception_variable
-          return unless asgn_node
-
-          asgn_node.children.last
+          node.exception_variable&.name
         end
 
         def message(node)

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -98,20 +98,14 @@ module RuboCop
             # `obj.method ||= value` parses as (or-asgn (send ...) ...)
             # which IS an `asgn_node`. Similarly, `obj.method += value` parses
             # as (op-asgn (send ...) ...), which is also an `asgn_node`.
-            if asgn_node.shorthand_asgn?
-              asgn_node, _value = *asgn_node
-              next if asgn_node.send_type?
-            end
+            next if asgn_node.shorthand_asgn? && asgn_node.lhs.send_type?
 
             yield asgn_node
           end
         end
 
         def variable_in_mass_assignment?(variable_name, node)
-          mlhs_node, _mrhs_node = *node
-          var_nodes = *mlhs_node
-
-          var_nodes.any? { |n| n.to_a.first == variable_name }
+          node.assignments.any? { |n| n.name == variable_name }
         end
 
         def offense_range(node)

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -194,15 +194,10 @@ module RuboCop
       end
 
       def process_variable_operator_assignment(node)
-        if LOGICAL_OPERATOR_ASSIGNMENT_TYPES.include?(node.type)
-          asgn_node, rhs_node = *node
-        else
-          asgn_node, _operator, rhs_node = *node
-        end
-
+        asgn_node = node.lhs
         return unless asgn_node.lvasgn_type?
 
-        name = asgn_node.children.first
+        name = asgn_node.name
 
         variable_table.declare_variable(name, asgn_node) unless variable_table.variable_exist?(name)
 
@@ -222,7 +217,7 @@ module RuboCop
         # before processing rhs nodes.
 
         variable_table.reference_variable(name, node)
-        process_node(rhs_node)
+        process_node(node.rhs)
         variable_table.assign_to_variable(name, asgn_node)
 
         skip_children!
@@ -355,8 +350,7 @@ module RuboCop
         when :lvasgn
           AssignmentReference.new(node)
         when *OPERATOR_ASSIGNMENT_TYPES
-          asgn_node = node.children.first
-          VariableReference.new(asgn_node.children.first) if asgn_node.lvasgn_type?
+          VariableReference.new(node.lhs.name) if node.lhs.lvasgn_type?
         end
       end
 

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::VariableForce::Assignment do
 
   let(:lvasgn_node) { ast.each_node.find(&:lvasgn_type?) }
 
-  let(:name) { lvasgn_node.children.first }
+  let(:name) { lvasgn_node.name }
   let(:scope) { RuboCop::Cop::VariableForce::Scope.new(def_node) }
   let(:variable) { RuboCop::Cop::VariableForce::Variable.new(name, lvasgn_node, scope) }
   let(:assignment) { described_class.new(lvasgn_node, variable) }


### PR DESCRIPTION
Following #13413, this updates some code that uses `children` or `to_a` on assignment nodes with the methods now available in rubocop-ast.