### PR TITLE
[Fix #13421] Fix false positives for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_for_style_safe_navigation.md
+++ b/changelog/fix_false_positives_for_style_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#13421](https://github.com/rubocop/rubocop/issues/13421): Fix false positives for `Style/SafeNavigation` when using a method chain that exceeds the `MaxChainLength` value and includes safe navigation operator. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -312,7 +312,7 @@ module RuboCop
         end
 
         def chain_length(method_chain, method)
-          method.each_ancestor(:send).inject(0) do |total, ancestor|
+          method.each_ancestor(:send, :csend).inject(0) do |total, ancestor|
             break total + 1 if ancestor == method_chain
 
             total + 1

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1089,7 +1089,13 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
             it 'allows an object check followed by 4 chained method calls' do
               expect_no_offenses(<<~RUBY)
-                #{variable} && #{variable}.one.two.three.fore
+                #{variable} && #{variable}.one.two.three.four
+              RUBY
+            end
+
+            it 'allows an object check followed by 4 chained method calls with safe navigation' do
+              expect_no_offenses(<<~RUBY)
+                #{variable} && #{variable}.one.two.three&.four
               RUBY
             end
           end


### PR DESCRIPTION
Fixes #13421 and #13423.

This PR fixes false positives for `Style/SafeNavigation` when using a method chain that exceeds the `MaxChainLength` value and includes safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
