### PR TITLE
Document that `CircularArgumentReference` is useless on modern rubies

### DIFF
--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -8,6 +8,8 @@ module RuboCop
       #
       # This cop mirrors a warning produced by MRI since 2.2.
       #
+      # NOTE: This syntax is no longer valid on Ruby 2.7 or higher.
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
```sh
$ ruby-parse --27 -e 'def foo(bar: bar); end'
(fragment:0):1:14: error: circular argument reference bar
(fragment:0):1: def foo(bar: bar); end
(fragment:0):1:              ^~~
```