### PR TITLE
Fix spacing in Lint/NoReturnInBeginEndBlocks

### DIFF
--- a/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
+++ b/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
@@ -45,8 +45,8 @@ module RuboCop
             end
           end
         end
-        alias on_or_asgn    on_lvasgn
-        alias on_op_asgn    on_lvasgn
+        alias on_or_asgn on_lvasgn
+        alias on_op_asgn on_lvasgn
       end
     end
   end


### PR DESCRIPTION
This doesn't get caught by `Layout/ExtraSpacing` because `AllowForAlignment` is enabled, but I presume this is still something that can be manually fixed. I assume this is not the correct layout because `lint/self_assignment.rb` has three `alias` calls with the regular spacing from lines 53-55:
```ruby
          add_offense(node) if rhs.type == rhs_type && rhs.source == lhs.to_s
        end
        alias on_ivasgn on_lvasgn
        alias on_cvasgn on_lvasgn
        alias on_gvasgn on_lvasgn

        def on_casgn(node)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
