### PR TITLE
Fix EmptyLinesAroundMethodBody for methods with arguments spanning multiple lines

### DIFF
--- a/changelog/fix_fix_empty_lines_around_method_body_for_methods.md
+++ b/changelog/fix_fix_empty_lines_around_method_body_for_methods.md
@@ -1,0 +1,1 @@
+* [#13430](https://github.com/rubocop/rubocop/issues/13430): Fix EmptyLinesAroundMethodBody for methods with arguments spanning multiple lines. ([@aduth][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -127,7 +127,6 @@ module RuboCop
                              start_loc,
                              end_loc,
                              do_source_line_column)
-
           error_source_line_column = if style == :start_of_block
                                        do_source_line_column
                                      else

--- a/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
@@ -27,7 +27,9 @@ module RuboCop
         KIND = 'method'
 
         def on_def(node)
-          check(node, node.body)
+          first_line = node.arguments.source_range&.last_line
+
+          check(node, node.body, adjusted_first_line: first_line)
         end
         alias on_defs on_def
 

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -56,7 +56,6 @@ module RuboCop
                                        range: NOT_GIVEN, side: :both, newlines: true,
                                        whitespace: false, continuations: false,
                                        buffer: @processed_source.buffer)
-
         range = range_positional unless range_positional == NOT_GIVEN
 
         src = buffer.source

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -71,4 +71,44 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody, :config do
       something_else
     RUBY
   end
+
+  it 'registers an offense for methods with empty lines and arguments spanning multiple lines' do
+    expect_offense(<<~RUBY)
+      def some_method(
+        arg
+      )
+
+      #{beginning_offense_annotation}
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method(
+        arg
+      )
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense for methods with empty lines, empty arguments spanning multiple lines' do
+    expect_offense(<<~RUBY)
+      def some_method(
+
+      )
+
+      #{beginning_offense_annotation}
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method(
+
+      )
+        do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #13430

Fixes `Layout/EmptyLinesAroundMethodBody` to identify empty lines for methods which have arguments spanning multiple lines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
