### PR TITLE
Fix false positive for `Lint/FloatComparison` against nil

### DIFF
--- a/changelog/fix_false_positive_for_lint_float_comparison_against_nil.md
+++ b/changelog/fix_false_positive_for_lint_float_comparison_against_nil.md
@@ -1,0 +1,1 @@
+* [#13432](https://github.com/rubocop/rubocop/pull/13432): Fix false positive for `Lint/FloatComparison` against nil. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -29,6 +29,9 @@ module RuboCop
       #   tolerance = 0.0001
       #   (x - 0.1).abs < tolerance
       #
+      #   # good - comparing against nil
+      #   Float(x, exception: false) == nil
+      #
       #   # Or some other epsilon based type of comparison:
       #   # https://www.embeddeduse.com/2019/08/26/qt-compare-two-floats/
       #
@@ -43,7 +46,7 @@ module RuboCop
 
         def on_send(node)
           lhs, _method, rhs = *node
-          return if literal_zero?(lhs) || literal_zero?(rhs)
+          return if literal_safe?(lhs) || literal_safe?(rhs)
 
           add_offense(node) if float?(lhs) || float?(rhs)
         end
@@ -65,8 +68,10 @@ module RuboCop
           end
         end
 
-        def literal_zero?(node)
-          node&.numeric_type? && node.value.zero?
+        def literal_safe?(node)
+          return false unless node
+
+          (node.numeric_type? && node.value.zero?) || node.nil_type?
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -85,4 +85,11 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
       x.to_f.nonzero?
     RUBY
   end
+
+  it 'does not register an offense when comparing against nil' do
+    expect_no_offenses(<<~RUBY)
+      Float('not_a_float', exception: false) == nil
+      nil != Float('not_a_float', exception: false)
+    RUBY
+  end
 end


### PR DESCRIPTION
Hi! This PR fixes a false positive for Lint/FloatComparison against nil.

Here is an example when a false positive can occur:
```ruby
Float(user_submitted_value, exception: false) == nil
```

If `user_submitted_value` is a value that cannot be made a Float, `nil` is returned because of the `exception: false` param. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
