### PR TITLE
[Fix #13434] False positive for `Naming/MemoizedInstanceVariableName` with assignment methods

### DIFF
--- a/changelog/fix_false_positive_for_memoised_instance_variable_with_assignment.md
+++ b/changelog/fix_false_positive_for_memoised_instance_variable_with_assignment.md
@@ -1,0 +1,1 @@
+* [#13434](https://github.com/rubocop/rubocop/issues/13434): Fix a false positive for `Naming/MemoizedInstanceVariableName` for assignment methods`. ([@earlopain][])

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -254,7 +254,7 @@ module RuboCop
         def matches?(method_name, ivar_assign)
           return true if ivar_assign.nil? || INITIALIZE_METHODS.include?(method_name)
 
-          method_name = method_name.to_s.delete('!?')
+          method_name = method_name.to_s.delete('!?=')
           variable = ivar_assign.children.first
           variable_name = variable.to_s.sub('@', '')
 
@@ -270,7 +270,7 @@ module RuboCop
         end
 
         def suggested_var(method_name)
-          suggestion = method_name.to_s.delete('!?')
+          suggestion = method_name.to_s.delete('!?=')
 
           style == :required ? "_#{suggestion}" : suggestion
         end

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -134,6 +134,23 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
             end
           RUBY
         end
+
+        it 'registers an offense for a assignment method' do
+          expect_offense(<<~RUBY)
+            def foo=(bar)
+              helper_variable = something_we_need_to_calculate(foo)
+              @bar ||= calculate_expensive_thing(helper_variable)
+              ^^^^ Memoized variable `@bar` does not match method name `foo=`. Use `@foo` instead.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo=(bar)
+              helper_variable = something_we_need_to_calculate(foo)
+              @foo ||= calculate_expensive_thing(helper_variable)
+            end
+          RUBY
+        end
       end
 
       context 'memoized variable matches method name' do


### PR DESCRIPTION
Fixes #13434

Maybe this cop should not register offenses for methods that take arguments but let's fix wrong autocorrect first.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
