### PR TITLE
Recognize percent literal array arg in safe navigation for `Lint/RedundantSplatExpansion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_redundant_splat_expansion.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_redundant_splat_expansion.md
@@ -1,0 +1,1 @@
+* [#13436](https://github.com/rubocop/rubocop/pull/13436): Fix incorrect offense and autocorrect for `Lint/RedundantSplatExpansion` when percent literal array is used in a safe navigation method call. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -157,7 +157,7 @@ module RuboCop
         end
 
         def method_argument?(node)
-          node.parent.send_type?
+          node.parent.call_type?
         end
 
         def part_of_an_array?(node)
@@ -171,7 +171,7 @@ module RuboCop
           parent = node.parent
           grandparent = node.parent.parent
 
-          parent.when_type? || parent.send_type? || part_of_an_array?(node) ||
+          parent.when_type? || method_argument?(node) || part_of_an_array?(node) ||
             grandparent&.resbody_type?
         end
 
@@ -196,7 +196,7 @@ module RuboCop
         def use_percent_literal_array_argument?(node)
           argument = node.children.first
 
-          node.parent.send_type? &&
+          method_argument?(node) &&
             (argument.percent_literal?(:string) || argument.percent_literal?(:symbol))
         end
 

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -376,6 +376,12 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
       RUBY
     end
 
+    it 'does not register an offense when using percent string literal array in safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        maybe_nil&.do_something(*%w[foo bar baz])
+      RUBY
+    end
+
     it 'does not register an offense when using percent symbol literal array' do
       expect_no_offenses(<<~RUBY)
         do_something(*%i[foo bar baz])
@@ -393,6 +399,21 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
       expect_offense(<<~RUBY)
         do_something(*%w[foo bar baz])
                      ^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something('foo', 'bar', 'baz')
+      RUBY
+    end
+
+    it 'registers an offense when using percent literal array in safe navigation' do
+      expect_offense(<<~RUBY)
+        maybe_nil&.do_something(*%w[foo bar baz])
+                                ^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        maybe_nil&.do_something('foo', 'bar', 'baz')
       RUBY
     end
 


### PR DESCRIPTION
Fixes incorrect offense and auto-correction for `Lint/RedundantSplatExpansion` cop when percent literal array is used as an argument in a **safe navigation** method call.

Here's a (renamed) production example from a Rails controller:
```ruby
params[:param_which_may_not_exist]&.exclude(*%w[foo bar])
```

When `AllowPercentLiteralArrayArgument` option is `true` (by default), the cop shouldn't register an offense, but it does:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/a581b733-a2ca-44f4-ab54-eae011409e28">
and auto-corrects it to (removes the `*`):
```ruby
params[:param_which_may_not_exist]&.exclude(%w[foo bar])
```
which is not correct (nor desired in this case).

When `AllowPercentLiteralArrayArgument` is `false`, the cop prints an offense as expected, but the message is wrong (I believe):
<img width="690" alt="image" src="https://github.com/user-attachments/assets/712f24f0-18b3-4b1b-aee9-e14b9687d449">

The correct auto-correction (only in the latter case), should be:
```ruby
params[:param_which_may_not_exist]&.exclude('foo', 'bar')
```

Note also that when safe navigation is not used, e.g.:
```ruby
params[:param_which_may_not_exist].exclude(*%w[foo bar])
```
the cop works as expected (no offense for the default cop option, and the expected auto-correct for the other option).

This patch contains tests which fail on master and a fix for the issue. I've done my best with my limited knowledge of rubocop-ast, let me know if there's a better way to fix this 🙏 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
