### PR TITLE
Fix incorrect correction in `Lint/Void` if an operator is called in a void context using a dot

### DIFF
--- a/changelog/fix_fix_incorrect_correction_in_lint_void_if_an.md
+++ b/changelog/fix_fix_incorrect_correction_in_lint_void_if_an.md
@@ -1,0 +1,1 @@
+* [#13438](https://github.com/rubocop/rubocop/pull/13438): Fix incorrect correction in `Lint/Void` if an operator is called in a void context using a dot. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -126,7 +126,7 @@ module RuboCop
 
         def check_void_op(node, &block)
           node = node.children.first while node.begin_type?
-          return unless node.send_type? && OPERATORS.include?(node.method_name)
+          return unless node.call_type? && OPERATORS.include?(node.method_name)
           return if block && yield(node)
 
           add_offense(node.loc.selector,
@@ -219,6 +219,7 @@ module RuboCop
           if node.arguments.empty?
             corrector.replace(node, node.receiver.source)
           else
+            corrector.remove(node.loc.dot) if node.loc.dot
             corrector.replace(
               range_with_surrounding_space(range: node.loc.selector, side: :both,
                                            newlines: false),

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -60,6 +60,34 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     it "accepts parenthesized void op #{op} by itself without a begin block" do
       expect_no_offenses("(a #{op} b)")
     end
+
+    it 'handles methods called by dot' do
+      expect_offense(<<~RUBY, op: op)
+        a.%{op}(b)
+          ^{op} Operator `#{op}` used in void context.
+        nil
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a
+        (b)
+        nil
+      RUBY
+    end
+
+    it 'handles methods called by dot with safe navigation' do
+      expect_offense(<<~RUBY, op: op)
+        a&.%{op}(b)
+           ^{op} Operator `#{op}` used in void context.
+        nil
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a
+        (b)
+        nil
+      RUBY
+    end
   end
 
   sign_unary_operators = %i[+ -]
@@ -98,6 +126,32 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         b
         b
         #{op}b
+      RUBY
+    end
+
+    it "registers an offense for void unary op #{op} with dot" do
+      expect_offense(<<~RUBY, op: op)
+        b.%{op}
+          ^{op} Operator `#{op}` used in void context.
+        b.%{op}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        b
+        b.#{op}
+      RUBY
+    end
+
+    it "registers an offense for void unary op #{op} with dot with safe navigation" do
+      expect_offense(<<~RUBY, op: op)
+        b&.%{op}
+           ^{op} Operator `#{op}` used in void context.
+        b&.%{op}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        b
+        b&.#{op}
       RUBY
     end
   end


### PR DESCRIPTION
With an operator called using a dot or safe navigation in a void context (eg. `a.==(b)`).

Previously it would correct to:
```ruby
a.
(b)
```

This change fixes the correction to:
```ruby
a
(b)
```

NOTE: The extra parentheses would be cleaned up by `Style/RedundantParentheses`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
