### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#13441](https://github.com/rubocop/rubocop/pull/13441): Fix an incorrect autocorrect for `Style/IfWithSemicolon` when using `return` with value in `if` with a semicolon is used. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -58,11 +58,15 @@ module RuboCop
         end
 
         def require_newline?(node)
-          node.branches.compact.any?(&:begin_type?)
+          node.branches.compact.any?(&:begin_type?) || use_return_with_argument?(node)
         end
 
         def use_block_in_branches?(node)
           node.branches.compact.any? { |branch| branch.block_type? || branch.numblock_type? }
+        end
+
+        def use_return_with_argument?(node)
+          node.if_branch&.return_type? && node.if_branch&.arguments&.any?
         end
 
         def replacement(node)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -277,5 +277,28 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
          bar else baz { _1 ? quux : nil } end
       RUBY
     end
+
+    it 'registers an offense when using `return` with value in `if` with a semicolon is used' do
+      expect_offense(<<~RUBY)
+        if cond; return value end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a newline instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+         return value end
+      RUBY
+    end
+
+    it 'registers an offense when using `return` without value in `if` with a semicolon is used' do
+      expect_offense(<<~RUBY)
+        if cond; return end
+        ^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? return : nil
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/IfWithSemicolon` when using `return` with value in `if` with a semicolon is used.

```console
$ echo 'if cond; return value end' | bundle exec rubocop --stdin dummy.rb -a --only Style/IfWithSemicolon
Inspecting 1 file
F

Offenses:

dummy.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if cond; - use a ternary operator instead.
if cond; return value end
^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:1:15: F: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
cond ? return value : nil
              ^^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
cond ? return value : nil
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
