### PR TITLE
Fix an incorrect autocorrect for `Style/NestedTernaryOperator`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_nested_ternary_operator.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_nested_ternary_operator.md
@@ -1,0 +1,1 @@
+* [#13442](https://github.com/rubocop/rubocop/pull/13442): Fix an incorrect autocorrect for `Style/NestedTernaryOperator` when ternary operators are nested and the inner condition is parenthesized. ([@koic][])

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -45,9 +45,11 @@ module RuboCop
         end
 
         def remove_parentheses(source)
-          return source unless source.start_with?('(')
-
-          source.delete_prefix('(').delete_suffix(')')
+          if source.start_with?('(') && source.end_with?(')')
+            source.delete_prefix('(').delete_suffix(')')
+          else
+            source
+          end
         end
 
         def replace_loc_and_whitespace(corrector, range, replacement)

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -99,4 +99,19 @@ RSpec.describe RuboCop::Cop::Style::NestedTernaryOperator, :config do
       end
     RUBY
   end
+
+  it 'registers an offense and corrects when ternary operators are nested and the inner condition is parenthesized' do
+    expect_offense(<<~RUBY)
+      foo ? (bar && baz) ? qux : quux : corge
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo
+      (bar && baz) ? qux : quux
+      else
+      corge
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/NestedTernaryOperator` when ternary operators are nested and the inner condition is parenthesized.

Before:

Autocorrect makes invalid syntax:

```console
$ echo 'foo ? (bar && baz) ? qux : quux : corge' | bundle exec rubocop --stdin dummy.rb -a --only Style/NestedTernaryOperator
Inspecting 1 file
F

Offenses:

dummy.rb:1:7: C: [Corrected] Style/NestedTernaryOperator: Ternary operators must not be nested. Prefer if or else constructs instead.
foo ? (bar && baz) ? qux : quux : corge
      ^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:2:11: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
bar && baz) ? qux : quux
          ^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
if foo
bar && baz) ? qux : quux
else
corge
end
```

After:

Autocorrect makes valid syntax:

```console
$ echo 'foo ? (bar && baz) ? qux : quux : corge' | bundle exec rubocop --stdin dummy.rb -a --only Style/NestedTernaryOperator
Inspecting 1 file
C

Offenses:

dummy.rb:1:7: C: [Corrected] Style/NestedTernaryOperator: Ternary operators must not be nested. Prefer if or else constructs instead.
foo ? (bar && baz) ? qux : quux : corge
      ^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
if foo
(bar && baz) ? qux : quux
else
corge
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
