### PR TITLE
[Fix #13433] Fix autocorrection for `Style/AccessModifierDeclarations` for multiple inline symbols

### DIFF
--- a/changelog/fix_fix_autocorrection_for.md
+++ b/changelog/fix_fix_autocorrection_for.md
@@ -1,0 +1,1 @@
+* [#13433](https://github.com/rubocop/rubocop/issues/13433): Fix autocorrection for `Style/AccessModifierDeclarations` for multiple inline symbols. ([@dvandersluis][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3463,6 +3463,51 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       RUBY
     end
 
+    it 'corrects a symbol list with defined methods and `AllowModifiersOnSymbols` is false' do
+      source_file = Pathname('example.rb')
+      create_file('.rubocop.yml', <<~YAML)
+        Style/AccessModifierDeclarations:
+          AllowModifiersOnSymbols: false
+      YAML
+      create_file(source_file, <<~RUBY)
+        class Test
+          private def foo; end
+          private :bar, :baz
+          def bar; end
+          def baz; end
+          def quux; end
+        end
+      RUBY
+      status = cli.run(%w[--autocorrect-all --only Style/AccessModifierDeclarations])
+      expect($stdout.string).to eq(<<~RESULT)
+        Inspecting 1 file
+        C
+
+        Offenses:
+
+        example.rb:2:3: C: [Corrected] Style/AccessModifierDeclarations: private should not be inlined in method definitions.
+          private def foo; end
+          ^^^^^^^
+        example.rb:3:3: C: [Corrected] Style/AccessModifierDeclarations: private should not be inlined in method definitions.
+          private :bar, :baz
+          ^^^^^^^
+
+        1 file inspected, 2 offenses detected, 2 offenses corrected
+      RESULT
+      expect(status).to eq(0)
+      expect(source_file.read).to eq(<<~RUBY)
+        class Test
+          def quux; end
+        private
+
+        def foo; end
+
+        def bar; end
+        def baz; end
+        end
+      RUBY
+    end
+
     it 'corrects when the first is an attr list and `AllowModifiersOnAttrs` is false' do
       source_file = Pathname('example.rb')
       create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
   shared_examples 'always accepted' do |access_modifier|
-    it 'accepts when #{access_modifier} is a hash literal value' do
+    it "accepts when #{access_modifier} is a hash literal value" do
       expect_no_offenses(<<~RUBY)
         class Foo
           foo
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
     context 'allow access modifiers on symbols' do
       let(:cop_config) { { 'AllowModifiersOnSymbols' => true } }
 
-      it 'accepts when argument to #{access_modifier} is a symbol' do
+      it "accepts when argument to #{access_modifier} is a symbol" do
         expect_no_offenses(<<~RUBY)
           class Foo
             foo
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'accepts when argument to #{access_modifier} is multiple symbols' do
+      it "accepts when argument to #{access_modifier} is multiple symbols" do
         expect_no_offenses(<<~RUBY)
           class Foo
             foo
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'accepts when argument to #{access_modifier} is splat with a `%i` array literal' do
+      it "accepts when argument to #{access_modifier} is splat with a `%i` array literal" do
         expect_no_offenses(<<~RUBY)
           class Foo
             foo
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'accepts when argument to #{access_modifier} is splat with a constant' do
+      it "accepts when argument to #{access_modifier} is splat with a constant" do
         expect_no_offenses(<<~RUBY)
           class Foo
             foo
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'accepts when argument to #{access_modifier} is a splat with a method call' do
+      it "accepts when argument to #{access_modifier} is a splat with a method call" do
         expect_no_offenses(<<~RUBY)
           class Foo
             foo
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
     context 'do not allow access modifiers on symbols' do
       let(:cop_config) { { 'AllowModifiersOnSymbols' => false } }
 
-      it 'registers an offense when argument to #{access_modifier} is a symbol' do
+      it "registers an offense when argument to #{access_modifier} is a symbol" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Foo
             foo
@@ -75,19 +75,107 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         expect_no_corrections
       end
 
-      it 'registers an offense when argument to #{access_modifier} is multiple symbols' do
-        expect_offense(<<~RUBY, access_modifier: access_modifier)
-          class Foo
-            foo
-            %{access_modifier} :bar, :baz
-            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
-          end
-        RUBY
+      context "when argument to #{access_modifier} is multiple symbols" do
+        it 'registers an offense and does not autocorrect when methods are not defined' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Foo
+              foo
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
 
-        expect_no_corrections
+          expect_no_corrections
+        end
+
+        it 'registers an offense and autocorrects when methods are all defined in class' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            module Foo
+              def bar; end
+              def baz; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+
+            #{access_modifier}
+
+            def bar; end
+            def baz; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when methods are all defined in class and there is a comment' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            module Foo
+              def bar; end
+              def baz; end
+
+              # comment
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+
+            #{access_modifier}
+
+            # comment
+            def bar; end
+            def baz; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when methods are all defined in class and there is already a bare access modifier' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            module Foo
+              def bar; end
+              def baz; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+
+              %{access_modifier}
+              def quux; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Foo
+
+
+              #{access_modifier}
+
+            def bar; end
+            def baz; end
+              def quux; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when not all methods are defined in class' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            module Foo
+              def bar; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
       end
 
-      it 'registers an offense when argument to #{access_modifier} is splat with a `%i` array literal' do
+      it "registers an offense when argument to #{access_modifier} is splat with a `%i` array literal" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Foo
             foo
@@ -99,7 +187,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         expect_no_corrections
       end
 
-      it 'registers an offense when argument to #{access_modifier} is splat with a constant' do
+      it "registers an offense when argument to #{access_modifier} is splat with a constant" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Foo
             foo
@@ -115,7 +203,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
     context 'allow access modifiers on attrs' do
       let(:cop_config) { { 'AllowModifiersOnAttrs' => true } }
 
-      it 'accepts when argument to #{access_modifier} is an attr_*' do
+      it "accepts when argument to #{access_modifier} is an attr_*" do
         expect_no_offenses(<<~RUBY)
           class Foo
             #{access_modifier} attr_reader :foo
@@ -227,7 +315,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'accepts when using only #{access_modifier}' do
+      it "accepts when using only #{access_modifier}" do
         expect_no_offenses(<<~RUBY)
           #{access_modifier}
         RUBY
@@ -241,7 +329,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'registers an offense for correct + multiple opposite styles of #{access_modifier} usage' do
+      it "registers an offense for correct + multiple opposite styles of #{access_modifier} usage" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class TestOne
             #{access_modifier}
@@ -296,7 +384,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
 
-      it 'does not register an offense when using #{access_modifier} in a block' do
+      it "does not register an offense when using #{access_modifier} in a block" do
         expect_no_offenses(<<~RUBY)
           module MyModule
             singleton_methods.each { |method| #{access_modifier}(method) }
@@ -495,7 +583,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
-      it 'registers an offense for correct + multiple opposite styles of #{access_modifier} usage' do
+      it "registers an offense for correct + multiple opposite styles of #{access_modifier} usage" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class TestOne
             #{access_modifier} def foo; end


### PR DESCRIPTION
When correcting `Style/AccessModifierDeclarations` to remove an inline group of symbols, we need to move all methods below the bare access modifier.

This is handled in two ways:
1. If every method in the symbol list is defined in scope, they will all be moved below the access modifier (either a newly inserted one or an existed one)
2. If none of the methods are defined in scope, an offense will be registered but no correction will take place (like how it worked previously for a single symbol).

Fixes #13433.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
