### PR TITLE
Fix an incorrect autocorrect for `Style/OneLineConditional`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_one_line_conditional.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_one_line_conditional.md
@@ -1,0 +1,1 @@
+* [#13444](https://github.com/rubocop/rubocop/pull/13444): Fix an incorrect autocorrect for `Style/OneLineConditional` when the else branch of a ternary operator has multiple expressions. ([@koic][])

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -83,7 +83,9 @@ module RuboCop
         end
 
         def cannot_replace_to_ternary?(node)
-          node.elsif_conditional?
+          return true if node.elsif_conditional?
+
+          node.else_branch.begin_type? && node.else_branch.children.compact.count >= 2
         end
 
         def ternary_replacement(node)

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe RuboCop::Cop::Style::OneLineConditional, :config do
       RUBY
     end
 
+    it 'registers and corrects an offense when the else branch of a ternary operator has multiple expressions' do
+      expect_offense(<<~RUBY)
+        if cond; foo; else bar; baz; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+          foo
+        else
+          bar; baz
+        end
+      RUBY
+    end
+
     it 'does not register an offense for unless/then/else/end with empty else' do
       expect_no_offenses('unless cond then run else end')
     end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/OneLineConditional` when the else branch of a ternary operator has multiple expressions.

Before:

The autocorrect makes incorrect code that is not compatible.

```console
$ echo 'if cond; foo; else bar; baz; end' | bundle exec rubocop --stdin dummy.rb -a --only Style/OneLineConditional
Inspecting 1 file
C

Offenses:

dummy.rb:1:1: C: [Corrected] Style/OneLineConditional: Favor the ternary operator (?:) or multi-line constructs over single-line if/then/else/end constructs.
if cond; foo; else bar; baz; end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
cond ? foo : bar; baz
```

`cond ? foo : bar; baz` is equivalent to `(cond ? foo : bar); baz`, not `cond ? foo : (bar; baz)`.

```console
$ ruby-parse -e '(cond ? foo : bar); baz'
(begin
  (begin
    (if
      (send nil :cond)
      (send nil :foo)
      (send nil :bar)))
  (send nil :baz))
```

After:

The autocorrect makes compatible code.

```console
$ echo 'if cond; foo; else bar; baz; end' | bundle exec rubocop --stdin dummy.rb -a --only Style/OneLineConditional
Inspecting 1 file
C

Offenses:

dummy.rb:1:1: C: [Corrected] Style/OneLineConditional: Favor the ternary operator (?:) or multi-line constructs over single-line if/then/else/end constructs.
if cond; foo; else bar; baz; end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
if cond
  foo
else
  bar; baz
end
```

Multiple expressions in the else branch using semicolons are resolved by the `Style/Semicolon` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
