### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_cop.md
@@ -1,0 +1,1 @@
+* [#13448](https://github.com/rubocop/rubocop/pull/13448): Fix an incorrect autocorrect for `Style/IfWithSemicolon` when the then body contains an arithmetic operator method call with an argument. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def require_argument_parentheses?(node)
-          return false unless node.call_type?
+          return false if !node.call_type? || node.arithmetic_operation?
 
           !node.parenthesized? && node.arguments.any? && !node.method?(:[]) && !node.method?(:[]=)
         end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -100,6 +100,17 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects a single-line `if/;/end` when the then body contains an arithmetic operator method call' do
+    expect_offense(<<~RUBY)
+      if cond;do_something - arg end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      cond ? do_something - arg : nil
+    RUBY
+  end
+
   it 'registers an offense and corrects a single-line `if/;/end` when the then body contains a method call with `[]`' do
     expect_offense(<<~RUBY)
       if cond; foo[key] else bar end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/IfWithSemicolon` when the then body contains an arithmetic operator method call.

## Before

Autocorrect makes invalid syntax:

```console
$ echo 'if cond;do_something - arg end' | bundle exec rubocop --stdin dummy.rb -a --only Style/IfWithSemicolon
Inspecting 1 file
F

Offenses:

dummy.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if cond; - use a ternary operator instead.
if cond;do_something - arg end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:1:21: F: Lint/Syntax: -' interpreted as argument prefix
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops`)
cond ? do_something -(arg) : nil
                    ^
dummy.rb:1:28: F: Lint/Syntax: unexpected token tCOLON
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
cond ? do_something -(arg) : nil
                           ^

1 file inspected, 3 offenses detected, 1 offense corrected
====================
cond ? do_something -(arg) : nil
```

## After

Autocorrect makes valid syntax:

```console
$ echo 'if cond;do_something - arg end' | bundle exec rubocop --stdin dummy.rb -a --only Style/IfWithSemicolon
Inspecting 1 file
C

Offenses:

dummy.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if cond; - use a ternary operator instead.
if cond;do_something - arg end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
cond ? do_something - arg : nil
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
