### PR TITLE
Make strict warnings opt-in, in CI as well as locally

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
           CC_TEST_REPORTER_ID: dummy # Value doesn't matter, enables json formatter
+          STRICT_WARNINGS: 1
         run: COVERAGE=true bundle exec rake spec
       - name: Upload Coverage Artifact
         uses: actions/upload-artifact@v4

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -35,7 +35,7 @@ module StrictWarnings
     return if RUBY_PATCHLEVEL == -1
     # Don't raise for warnings during development. It's expected that
     # some code will warn like "unused variable" while iterating.
-    return unless ENV['CI']
+    return unless ENV['STRICT_WARNINGS'] == '1'
 
     raise WarningError, message
   end


### PR DESCRIPTION
In `rubocop-ast`, main gem tests should not fail when a warning is introduced. Sort of a followup to https://github.com/rubocop/rubocop/pull/13273

Ref https://github.com/rubocop/rubocop-ast/pull/337#discussion_r1838552501 cc @dvandersluis 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
