### PR TITLE
Fix a false positive for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_empty_line_after_guard_clause.md
+++ b/changelog/fix_a_false_positive_for_layout_empty_line_after_guard_clause.md
@@ -1,0 +1,1 @@
+* [#13455](https://github.com/rubocop/rubocop/pull/13455): Fix a false positive for `Layout/EmptyLineAfterGuardClause` when using a guard clause outside oneliner block. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -200,7 +200,7 @@ module RuboCop
           parent = node.parent
           return false unless parent
 
-          parent.begin_type? && parent.single_line?
+          parent.begin_type? && same_line?(node, node.right_sibling)
         end
 
         # SimpleCov excludes code from the coverage report by wrapping it in `# :nocov:`:

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -349,6 +349,44 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'registers a guard clause outside difference line block' do
+    expect_offense(<<~RUBY)
+      return if condition
+      ^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+      foo do
+        bar
+      end
+      baz
+    RUBY
+
+    expect_correction(<<~RUBY)
+      return if condition
+
+      foo do
+        bar
+      end
+      baz
+    RUBY
+  end
+
+  it 'accepts a guard clause outside oneliner block' do
+    expect_no_offenses(<<~RUBY)
+      return if condition; foo do
+        bar
+      end
+      baz
+    RUBY
+  end
+
+  it 'accepts a guard clause outside oneliner numbered block' do
+    expect_no_offenses(<<~RUBY)
+      return if condition; foo do
+        bar(_1)
+      end
+      baz
+    RUBY
+  end
+
   it 'accepts multiple guard clauses' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes a false positive for `Layout/EmptyLineAfterGuardClause` when using a guard clause outside oneliner block.

It avoids the following infinit loop error:

```console
$ cat example.rb
return if condition; foo do
  bar
end

$ bundle exec rubocop --only Layout/EmptyLineAfterGuardClause,Layout/EmptyLinesAroundBlockBody -a
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
return if condition; foo do
^^^^^^^^^^^^^^^^^^^
example.rb:2:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body beginning.

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in /Users/koic/src/github.com/koic/rubocop-issues/block/example.rb and
caused by Layout/EmptyLineAfterGuardClause -> Layout/EmptyLinesAroundBlockBody
Hint: Please update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
Please check the latest version at https://rubygems.org/gems/rubocop.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
