### PR TITLE
Replace `EnsureNode.body` with `EnsureNode.branch`

### DIFF
--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -62,12 +62,14 @@ module RuboCop
           check_indentation(node.loc.else, else_node)
         end
 
-        def on_ensure(node)
+        def on_resbody(node)
           check_indentation(node.loc.keyword, node.body)
         end
+        alias on_for on_resbody
 
-        alias on_resbody on_ensure
-        alias on_for     on_ensure
+        def on_ensure(node)
+          check_indentation(node.loc.keyword, node.branch)
+        end
 
         def on_kwbegin(node)
           # Check indentation against end keyword but only if it's first on its

--- a/lib/rubocop/cop/lint/empty_ensure.rb
+++ b/lib/rubocop/cop/lint/empty_ensure.rb
@@ -38,7 +38,7 @@ module RuboCop
         MSG = 'Empty `ensure` block detected.'
 
         def on_ensure(node)
-          return if node.body
+          return if node.branch
 
           add_offense(node.loc.keyword) { |corrector| corrector.remove(node.loc.keyword) }
         end

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -43,7 +43,7 @@ module RuboCop
         MSG = 'Do not return from an `ensure` block.'
 
         def on_ensure(node)
-          node.body&.each_node(:return) { |return_node| add_offense(return_node) }
+          node.branch&.each_node(:return) { |return_node| add_offense(return_node) }
         end
       end
     end

--- a/lib/rubocop/cop/lint/useless_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_rescue.rb
@@ -75,7 +75,7 @@ module RuboCop
         def use_exception_variable_in_ensure?(resbody_node)
           return false unless (exception_variable = resbody_node.exception_variable)
           return false unless (ensure_node = resbody_node.each_ancestor(:ensure).first)
-          return false unless (ensure_body = ensure_node.body)
+          return false unless (ensure_body = ensure_node.branch)
 
           ensure_body.each_descendant(:lvar).map(&:source).include?(exception_variable.source)
         end

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -196,7 +196,7 @@ module RuboCop
         end
 
         def check_ensure(node)
-          return unless (body = node.body)
+          return unless (body = node.branch)
           # NOTE: the `begin` node case is already handled via `on_begin`
           return if body.begin_type?
 

--- a/lib/rubocop/cop/style/redundant_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_assignment.rb
@@ -93,7 +93,7 @@ module RuboCop
         end
 
         def check_ensure_node(node)
-          check_branch(node.body)
+          check_branch(node.branch)
         end
 
         def check_begin_node(node)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.34.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.36.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
 end


### PR DESCRIPTION
`EnsureNode.body` has been deprecated in rubocop/rubocop-ast#337, and will be reimplemented in the next major version of rubocop-ast. In order to prepare for that, existing `EnsureNode.body` calls, which retreive the `ensure` branch of exception handling, have been replaced with `EnsureNode.branch`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-minitest/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

