### PR TITLE
[Fix #13453] Update `Style/AccessModifierDeclarations` to handle `attr_*` methods with multiple parameters

### DIFF
--- a/changelog/fix_update_style_access_modifier_declarations_to.md
+++ b/changelog/fix_update_style_access_modifier_declarations_to.md
@@ -1,0 +1,1 @@
+* [#13453](https://github.com/rubocop/rubocop/issues/13453): Update `Style/AccessModifierDeclarations` to handle `attr_*` methods with multiple parameters. ([@dvandersluis][])


### PR DESCRIPTION
Similarly to #13404, update `Style/AccessModifierDeclarations` to handle attr methods with multiple parameters.

The autocorrect fix in #13443 does not affect attrs, so this PR handles autocorrect as well.  

Fixes #13453.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
