### PR TITLE
Fix false positives for `Lint/InterpolationCheck`

### DIFF
--- a/changelog/fix_false_positive_for_lint_interpolation_check.md
+++ b/changelog/fix_false_positive_for_lint_interpolation_check.md
@@ -1,0 +1,1 @@
+* [#13461](https://github.com/rubocop/rubocop/pull/13461): Fix false positives for `Lint/InterpolationCheck` when using invalid syntax in interpolation. ([@koic][])

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -24,14 +24,17 @@ module RuboCop
         MSG = 'Interpolation in single quoted string detected. ' \
               'Use double quoted strings if you need interpolation.'
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def on_str(node)
           return if node.parent&.regexp_type?
           return unless /(?<!\\)#\{.*\}/.match?(node.source)
           return if heredoc?(node)
           return unless node.loc.begin && node.loc.end
+          return unless valid_syntax?(node)
 
           add_offense(node) { |corrector| autocorrect(corrector, node) }
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
 
@@ -48,6 +51,12 @@ module RuboCop
 
         def heredoc?(node)
           node.loc.is_a?(Parser::Source::Map::Heredoc) || (node.parent && heredoc?(node.parent))
+        end
+
+        def valid_syntax?(node)
+          double_quoted_string = node.source.gsub(/\A'|'\z/, '"')
+
+          parse(double_quoted_string).valid_syntax?
         end
       end
     end

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -19,8 +19,7 @@ module RuboCop
         include Interpolation
         extend AutoCorrector
 
-        MSG = 'Replace interpolated variable `%<variable>s` ' \
-              'with expression `#{%<variable>s}`.' # rubocop:disable Lint/InterpolationCheck
+        MSG = 'Replace interpolated variable `%<variable>s` with expression `#{%<variable>s}`.'
 
         def on_node_with_interpolations(node)
           var_nodes(node.children).each do |var_node|

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -80,4 +80,10 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck, :config do
       %w("#{a}-foo")
     RUBY
   end
+
+  it 'does not register an offense when using invalid syntax in interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      '#{%<expression>s}'
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes false positives for `Lint/InterpolationCheck` when using invalid syntax in interpolation.

```console
$ cat example.rb
'#{%<expression>s}'

$ bundle exec rubocop -A /tmp/a/a.rb --only Lint/InterpolationCheck
Inspecting 1 file
F

Offenses:

/tmp/a/a.rb:1:1: W: [Corrected] Lint/InterpolationCheck: Interpolation in single quoted string detected. Use double quoted strings if you need interpolation.
'#{%<expression>s}'
^^^^^^^^^^^^^^^^^^^
/tmp/a/a.rb:1:17: F: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
"#{%<expression>s}"
                ^

1 file inspected, 2 offenses detected, 1 offense corrected
````

A string interpolation should not be expected in a state where a syntax error occurs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
