### PR TITLE
Fix typo: Layout//ParameterAlignment -> Layout/ParameterAlignment

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -4843,7 +4843,7 @@ are recommended to further format the broken lines.
 * `Layout/MultilineHashKeyLineBreaks`
 * `Layout/MultilineMethodArgumentLineBreaks`
 * `Layout/MultilineMethodParameterLineBreaks`
-* `Layout//ParameterAlignment`
+* `Layout/ParameterAlignment`
 * `Style/BlockDelimiters`
 
 Together, these cops will pretty print hashes, arrays,

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -38,7 +38,7 @@ module RuboCop
       # * `Layout/MultilineHashKeyLineBreaks`
       # * `Layout/MultilineMethodArgumentLineBreaks`
       # * `Layout/MultilineMethodParameterLineBreaks`
-      # * `Layout//ParameterAlignment`
+      # * `Layout/ParameterAlignment`
       # * `Style/BlockDelimiters`
       #
       # Together, these cops will pretty print hashes, arrays,


### PR DESCRIPTION
Remove the extra slash in the cop name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
