### PR TITLE
Fix a test failure on 3.4-dev with webmock

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'rubocop'
 require 'rubocop/cop/internal_affairs'
 require 'rubocop/server'
 
+# FIXME: Remove when https://github.com/bblimke/webmock/pull/1081 is merged and released
+Net::HTTPSession = Net::HTTP unless defined?(Net::HTTPSession)
 require 'webmock/rspec'
 
 require_relative 'core_ext/string'


### PR DESCRIPTION
`net/http` removed old constants that webmock relies on. This can be reverted when https://github.com/bblimke/webmock/pull/1081 is released