### PR TITLE
Make `Style/ArrayIntersect` aware of `none?`

### DIFF
--- a/changelog/change_array_intersect_none.md
+++ b/changelog/change_array_intersect_none.md
@@ -1,0 +1,1 @@
+* [#13470](https://github.com/rubocop/rubocop/pull/13470): Make `Style/ArrayIntersect` aware of `none?`. ([@earlopain][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -28,6 +28,7 @@ module RuboCop
       #   # bad
       #   (array1 & array2).any?
       #   (array1 & array2).empty?
+      #   (array1 & array2).none?
       #
       #   # good
       #   array1.intersect?(array2)
@@ -57,7 +58,7 @@ module RuboCop
           (send
             (begin
               (send $(...) :& $(...))
-            ) ${:any? :empty?}
+            ) ${:any? :empty? :none?}
           )
         PATTERN
 
@@ -66,14 +67,14 @@ module RuboCop
           (send
             (begin
               (send $(...) :& $(...))
-            ) ${:present? :any? :blank? :empty?}
+            ) ${:present? :any? :blank? :empty? :none?}
           )
         PATTERN
 
         MSG = 'Use `%<negated>s%<receiver>s.intersect?(%<argument>s)` ' \
               'instead of `(%<receiver>s & %<argument>s).%<method_name>s`.'
         STRAIGHT_METHODS = %i[present? any?].freeze
-        NEGATED_METHODS = %i[blank? empty?].freeze
+        NEGATED_METHODS = %i[blank? empty? none?].freeze
         RESTRICT_ON_SEND = (STRAIGHT_METHODS + NEGATED_METHODS).freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
       RUBY
     end
 
+    it 'registers an offense when using `none?`' do
+      expect_offense(<<~RUBY)
+        (a & b).none?
+        ^^^^^^^^^^^^^ Use `!a.intersect?(b)` instead of `(a & b).none?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !a.intersect?(b)
+      RUBY
+    end
+
     it 'does not register an offense when using `(array1 & array2).any?` with block' do
       expect_no_offenses(<<~RUBY)
         (array1 & array2).any? { |x| false }


### PR DESCRIPTION
It's the inverse of `any?`.
There's further improvements to be made for `count == 0` and similar but it requires a more complex change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
