### PR TITLE
Improve syntax error output for `rake documentation_syntax_check`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,12 @@ task documentation_syntax_check: :yard_for_generate_documentation do
       parser.parse(buffer)
     rescue Parser::SyntaxError => e
       path = example.object.file
-      puts "#{path}: Syntax Error in an example. #{e}"
+      line, column = buffer.decompose_position(e.diagnostic.location.begin_pos)
+
+      puts "#{path}:#{line}:#{column} Syntax Error in an example: #{e}"
+      puts buffer.source_lines[line - 1]
+      puts (' ' * column) + ('^' * Unicode::DisplayWidth.of(e.diagnostic.location.source))
+
       ok = false
     end
   end


### PR DESCRIPTION
Added context to the warning that there's a syntax error in `rake documentation_syntax_check`.

<img width="682" alt="image" src="https://github.com/user-attachments/assets/724be54e-2f70-4a29-b35a-e256281b5195">
