### PR TITLE
Update `Lint/ItWithoutArgumentsInBlock` to not register an offense in Ruby 3.4

### DIFF
--- a/changelog/change_update_it_without_arguments_in_block_to_not.md
+++ b/changelog/change_update_it_without_arguments_in_block_to_not.md
@@ -1,0 +1,1 @@
+* [#13473](https://github.com/rubocop/rubocop/pull/13473): Update `Lint/ItWithoutArgumentsInBlock` to not register offenses in Ruby 3.4. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/it_without_arguments_in_block.rb
+++ b/lib/rubocop/cop/lint/it_without_arguments_in_block.rb
@@ -26,6 +26,9 @@ module RuboCop
       #
       class ItWithoutArgumentsInBlock < Base
         include NodePattern::Macros
+        extend TargetRubyVersion
+
+        maximum_target_ruby_version 3.3
 
         MSG = '`it` calls without arguments will refer to the first block param in Ruby 3.4; ' \
               'use `it()` or `self.it`.'

--- a/lib/rubocop/cop/mixin/target_ruby_version.rb
+++ b/lib/rubocop/cop/mixin/target_ruby_version.rb
@@ -8,12 +8,28 @@ module RuboCop
         @minimum_target_ruby_version
       end
 
+      def required_maximum_ruby_version
+        @maximum_target_ruby_version
+      end
+
       def minimum_target_ruby_version(version)
         @minimum_target_ruby_version = version
       end
 
+      def maximum_target_ruby_version(version)
+        @maximum_target_ruby_version = version
+      end
+
       def support_target_ruby_version?(version)
-        required_minimum_ruby_version <= version
+        # By default, no minimum or maximum versions of ruby are required
+        # to run any cop. In order to do a simple numerical comparison of
+        # the requested version against any requirements, we use 0 and
+        # Infinity as the default values to indicate no minimum (0) and no
+        # maximum (Infinity).
+        min = required_minimum_ruby_version || 0
+        max = required_maximum_ruby_version || Float::INFINITY
+
+        min <= version && max >= version
       end
     end
   end

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -114,7 +114,15 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   def required_ruby_version(cop)
     return '' unless cop.respond_to?(:required_minimum_ruby_version)
 
-    "NOTE: Required Ruby version: #{cop.required_minimum_ruby_version}\n\n"
+    if cop.required_minimum_ruby_version
+      requirement = cop.required_minimum_ruby_version
+    elsif cop.required_maximum_ruby_version
+      requirement = "<= #{cop.required_maximum_ruby_version}"
+    else
+      return ''
+    end
+
+    "NOTE: Requires Ruby version #{requirement}\n\n"
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/spec/rubocop/cop/lint/it_without_arguments_in_block_spec.rb
+++ b/spec/rubocop/cop/lint/it_without_arguments_in_block_spec.rb
@@ -1,14 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
-  it 'registers an offense when using `it` without arguments in the single line block' do
+  context '>= Ruby 3.4', :ruby34 do
+    it 'does not register an offense when using `it` without arguments in a single line block' do
+      expect_no_offenses(<<~RUBY)
+        0.times { it }
+      RUBY
+    end
+
+    it 'does not register an offense when using `it` without arguments in a multiline block' do
+      expect_no_offenses(<<~RUBY)
+        0.times do
+          it
+          it = 1
+          it
+        end
+      RUBY
+    end
+  end
+
+  it 'registers an offense when using `it` without arguments in a single line block' do
     expect_offense(<<~RUBY)
       0.times { it }
                 ^^ `it` calls without arguments will refer to the first block param in Ruby 3.4; use `it()` or `self.it`.
     RUBY
   end
 
-  it 'registers an offense when using `it` without arguments in the multiline block' do
+  it 'registers an offense when using `it` without arguments in a multiline block' do
     expect_offense(<<~RUBY)
       0.times do
         it
@@ -19,31 +37,31 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `it` with arguments in the single line block' do
+  it 'does not register an offense when using `it` with arguments in a single line block' do
     expect_no_offenses(<<~RUBY)
       0.times { it(42) }
     RUBY
   end
 
-  it 'does not register an offense when using `it` with block argument in the single line block' do
+  it 'does not register an offense when using `it` with block argument in a single line block' do
     expect_no_offenses(<<~RUBY)
       0.times { it { do_something } }
     RUBY
   end
 
-  it 'does not register an offense when using `it()` in the single line block' do
+  it 'does not register an offense when using `it()` in a single line block' do
     expect_no_offenses(<<~RUBY)
       0.times { it() }
     RUBY
   end
 
-  it 'does not register an offense when using `self.it` in the single line block' do
+  it 'does not register an offense when using `self.it` in a single line block' do
     expect_no_offenses(<<~RUBY)
       0.times { self.it }
     RUBY
   end
 
-  it 'does not register an offense when using `it` with arguments in the multiline block' do
+  it 'does not register an offense when using `it` with arguments in a multiline block' do
     expect_no_offenses(<<~RUBY)
       0.times do
         it(42)
@@ -53,7 +71,7 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `it` with block argument in the multiline block' do
+  it 'does not register an offense when using `it` with block argument in a multiline block' do
     expect_no_offenses(<<~RUBY)
       0.times do
         it { do_something }
@@ -63,7 +81,7 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `it()` in the multiline block' do
+  it 'does not register an offense when using `it()` in a multiline block' do
     expect_no_offenses(<<~RUBY)
       0.times do
         it()
@@ -73,7 +91,7 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `self.it` without arguments in the multiline block' do
+  it 'does not register an offense when using `self.it` without arguments in a multiline block' do
     expect_no_offenses(<<~RUBY)
       0.times do
         self.it
@@ -99,7 +117,7 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `it` without arguments in the block with empty block parameter' do
+  it 'does not register an offense when using `it` without arguments in a block with empty block parameter' do
     expect_no_offenses(<<~RUBY)
       0.times { ||
         it
@@ -107,7 +125,7 @@ RSpec.describe RuboCop::Cop::Lint::ItWithoutArgumentsInBlock, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `it` without arguments in the block with useless block parameter' do
+  it 'does not register an offense when using `it` without arguments in a block with useless block parameter' do
     expect_no_offenses(<<~RUBY)
       0.times { |_n|
         it


### PR DESCRIPTION
`it` as a block parameter should not register an offense in Ruby 3.4. Currently if using 3.4-dev and setting `TargetRubyVersion: 3.4` in `.rubocop.yml`, rubocop will give offenses when using `it`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
