### PR TITLE
Allow to write generics type of rbs-inline annotation after subclass definition in `Style/CommentedKeyword`

### DIFF
--- a/changelog/fix_allow_to_write_generics_type_of_rbs__inline.md
+++ b/changelog/fix_allow_to_write_generics_type_of_rbs__inline.md
@@ -1,0 +1,1 @@
+* [#13476](https://github.com/rubocop/rubocop/pull/13476): Allow to write generics type of RBS::Inline annotation after subclass definition in `Style/CommentedKeyword`. ([@dak2][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -57,6 +57,9 @@ module RuboCop
 
         REGEXP = /(?<keyword>\S+).*#/.freeze
 
+        SUBCLASS_DEFINITION = /\A\s*class\s+\w+\s*<\s*\w+/.freeze
+        METHOD_DEFINITION = /\A\s*def\s/.freeze
+
         def on_new_investigation
           processed_source.comments.each do |comment|
             next unless offensive?(comment) && (match = source_line(comment).match(REGEXP))
@@ -93,7 +96,14 @@ module RuboCop
         end
 
         def rbs_inline_annotation?(line, comment)
-          comment.text.start_with?('#:') && line.start_with?(/\A\s*def\s/)
+          case line
+          when SUBCLASS_DEFINITION
+            comment.text.start_with?(/#\[.+\]/)
+          when METHOD_DEFINITION
+            comment.text.start_with?('#:')
+          else
+            false
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -237,6 +237,51 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
     RUBY
   end
 
+  it 'does not register an offense for RBS::Inline generics annotation' do
+    expect_no_offenses(<<~RUBY)
+      class X < Y #[String]
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for RBS::Inline non generics annotation' do
+    expect_offense(<<~RUBY)
+      class X #[String]
+              ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class X < Y #[String
+                  ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class X < Y #String]
+                  ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class X < Y # String]
+                  ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class X < Y #String ]
+                  ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      #[String]
+      class X
+      end
+      #[String
+      class X < Y
+      end
+      #String]
+      class X < Y
+      end
+      # String]
+      class X < Y
+      end
+      #String ]
+      class X < Y
+      end
+    RUBY
+  end
+
   it 'does not register an offense for RBS::Inline annotation for method definition' do
     expect_no_offenses(<<~RUBY)
       def x #: String


### PR DESCRIPTION
[rbs-inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.

This allows to write generics type rbs-inline annotation comment just after subclass definition in `Style/CommentedKeyword`.

refs: https://github.com/soutaro/rbs-inline/wiki/Syntax-guide#defining-classes

Follow https://github.com/rubocop/rubocop/pull/13222

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
