### PR TITLE
[Fix #13477] Update `Layout/LeadingCommentSpace` to accept multiline shebangs at the top of the file

### DIFF
--- a/changelog/fix_update_layout_leading_comment_space_to_accept.md
+++ b/changelog/fix_update_layout_leading_comment_space_to_accept.md
@@ -1,0 +1,1 @@
+* [#13477](https://github.com/rubocop/rubocop/issues/13477): Update `Layout/LeadingCommentSpace` to accept multiline shebangs at the top of the file. ([@dvandersluis][])

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
     RUBY
   end
 
+  it 'does not register an offense for a multiline shebang starting on the first line' do
+    expect_no_offenses(<<~RUBY)
+      #!/usr/bin/env nix-shell
+      #! nix-shell -i ruby --pure
+      #! nix-shell -p ruby gh git
+      test
+    RUBY
+  end
+
   it 'registers an offense and corrects #! after the first line' do
     expect_offense(<<~RUBY)
       test
@@ -45,6 +54,25 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
     expect_correction(<<~RUBY)
       test
       # !/usr/bin/ruby
+    RUBY
+  end
+
+  it 'registers an offense and corrects for a multiline shebang starting after the first line' do
+    expect_offense(<<~RUBY)
+      test
+      #!/usr/bin/env nix-shell
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Missing space after `#`.
+      #! nix-shell -i ruby --pure
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing space after `#`.
+      #! nix-shell -p ruby gh git
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing space after `#`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      test
+      # !/usr/bin/env nix-shell
+      # ! nix-shell -i ruby --pure
+      # ! nix-shell -p ruby gh git
     RUBY
   end
 


### PR DESCRIPTION
Accept a multiline shebang at the top of a file, eg.

```ruby
#!/usr/bin/env nix-shell
#! nix-shell -i ruby --pure
#! nix-shell -p ruby gh git
#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/aebe249544837ce42588aa4b2e7972222ba12e8f.tar.gz

puts "Hello world"
puts RUBY_VERSION
puts `gh --version`
```

FIxes #13477.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
