### PR TITLE
Remove "here we check" from cop descriptions

### DIFF
--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -3,8 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Here we check if the arguments on a multi-line method
-      # definition are aligned.
+      # Check that the arguments on a multi-line method definition are aligned.
       #
       # @example EnforcedStyle: with_first_argument (default)
       #   # good

--- a/lib/rubocop/cop/layout/array_alignment.rb
+++ b/lib/rubocop/cop/layout/array_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Here we check if the elements of a multi-line array literal are
+      # Check that the elements of a multi-line array literal are
       # aligned.
       #
       # @example EnforcedStyle: with_first_element (default)

--- a/lib/rubocop/cop/layout/parameter_alignment.rb
+++ b/lib/rubocop/cop/layout/parameter_alignment.rb
@@ -3,11 +3,10 @@
 module RuboCop
   module Cop
     module Layout
-      # Here we check if the parameters on a multi-line method call or
-      # definition are aligned.
+      # Check that the parameters on a multi-line method call or definition are aligned.
       #
-      # To set the alignment of the first argument, use the cop
-      # FirstParameterIndentation.
+      # To set the alignment of the first argument, use the
+      # `Layout/FirstParameterIndentation` cop.
       #
       # @example EnforcedStyle: with_first_parameter (default)
       #   # good


### PR DESCRIPTION
Similar to #10628, change the description of these cops to use a consistent voice.