### PR TITLE
Support unicode-display_width v3

### DIFF
--- a/changelog/change_support_unicodedisplay_width_v3.md
+++ b/changelog/change_support_unicodedisplay_width_v3.md
@@ -1,0 +1,1 @@
+* [#13481](https://github.com/rubocop/rubocop/pull/13481): Support unicode-display_width v3. ([@gemmaro][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |s|
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
   s.add_dependency('rubocop-ast', '>= 1.36.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
-  s.add_dependency('unicode-display_width', '>= 2.4.0', '< 3.0')
+  s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end


### PR DESCRIPTION
This updates `unicode-display_width` gem's version limit to 3.0 to 4.0.

Reference: [`unicode-display_width` change log at version 3.0.0](https://github.com/janlelis/unicode-display_width/blob/main/CHANGELOG.md#300)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
