### PR TITLE
[Fix #13483] Fix an incorrect autocorrect for `Style/RedundantRegexpArgument`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_argument.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_argument.md
@@ -1,0 +1,1 @@
+* [#13483](https://github.com/rubocop/rubocop/issues/13483): Fix an incorrect autocorrect for `Style/RedundantRegexpArgument` when using escaped double quote character. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -71,6 +71,7 @@ module RuboCop
 
           if new_argument.include?('"')
             new_argument.gsub!("'", "\\\\'")
+            new_argument.gsub!('\"', '"')
             quote = "'"
           elsif new_argument.include?('\\')
             quote = '"'

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -49,12 +49,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
 
   it 'registers an offense and corrects when using escaped double quote character' do
     expect_offense(<<~'RUBY')
+      str.gsub(/\"/)
+               ^^^^ Use string `'"'` as argument instead of regexp `/\"/`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str.gsub('"')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using escape character with double quote character' do
+    expect_offense(<<~'RUBY')
       str.gsub(/\\"/)
-               ^^^^^ Use string `'\\"'` as argument instead of regexp `/\\"/`.
+               ^^^^^ Use string `'\"'` as argument instead of regexp `/\\"/`.
     RUBY
 
     expect_correction(<<~'RUBY')
-      str.gsub('\\"')
+      str.gsub('\"')
     RUBY
   end
 


### PR DESCRIPTION
Fixes #13483.

This PR fixes an incorrect autocorrect for `Style/RedundantRegexpArgument` when using escaped double quote character.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
