### PR TITLE
Fix false positives for `Style/HashExcept` cop

### DIFF
--- a/changelog/fix_incorrect_offenses_for_style_hash_except.md
+++ b/changelog/fix_incorrect_offenses_for_style_hash_except.md
@@ -1,0 +1,1 @@
+* [#13494](https://github.com/rubocop/rubocop/pull/13494): Fix false positives for `Style/HashExcept` cop when using `reject/!include?`, `reject/!in?` or `select/!exclude?` combinations. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -390,6 +390,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
           RUBY
         end
 
+        it 'does not register an offense when using `reject` and calling `!key.in?` method with symbol array' do
+          expect_no_offenses(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !k.in?(%i[foo bar]) }
+          RUBY
+        end
+
         it 'does not register an offense when using `reject` and calling `in?` method with symbol array and second block value' do
           expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.reject { |k, v| v.in?([1, 2]) }
@@ -398,14 +404,9 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
       end
 
       context 'using `include?`' do
-        it 'registers and corrects an offense when using `reject` and calling `include?` method with symbol array' do
-          expect_offense(<<~RUBY)
+        it 'does not register an offense when using `reject` and calling `!include?` method with symbol array' do
+          expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(:foo, :bar)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.except(:foo, :bar)
           RUBY
         end
 
@@ -453,27 +454,16 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
           RUBY
         end
 
-        it 'registers and corrects an offense when using `reject` and calling `include?` method with variable' do
-          expect_offense(<<~RUBY)
+        it 'does not register an offense when using `reject` and calling `!include?` method with variable' do
+          expect_no_offenses(<<~RUBY)
             array = %i[foo bar]
             {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            array = %i[foo bar]
-            {foo: 1, bar: 2, baz: 3}.except(*array)
           RUBY
         end
 
-        it 'registers and corrects an offense when using `reject` and calling `include?` method with method call' do
-          expect_offense(<<~RUBY)
+        it 'does not register an offense when using `reject` and calling `!include?` method with method call' do
+          expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.reject { |k, v| !array.include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `except(*array)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.except(*array)
           RUBY
         end
 
@@ -521,6 +511,12 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
 
           expect_correction(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.except(:foo, :bar)
+          RUBY
+        end
+
+        it 'does not register an offense when using `select` and calling `!exclude?` method with symbol array' do
+          expect_no_offenses(<<~RUBY)
+            {foo: 1, bar: 2, baz: 3}.select { |k, v| !%i[foo bar].exclude?(k) }
           RUBY
         end
 


### PR DESCRIPTION
Fixes false positive for `Style/HashExcept` cop when using `reject`/`!include?`, `reject`/`!in?` or `select/!exclude?` combinations. Adds new test cases which fail on master.

The tests that have been changed in this patch weren't correct and actually produced the inverse result; for example, the first updated test in this patch expected that
```ruby
{foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
# => {:foo=>1, :bar=>2}
```
is auto-corrected to
```ruby
{foo: 1, bar: 2, baz: 3}.except(:foo, :bar)
# => {:baz=>3}
```
when this shouldn't have been an offense for this cop since the code is equivalent to:
```ruby
{foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
```
<br />

This PR fixes these combinations:
```ruby
h.reject { |k, v| !k.in?(X) }
h.reject { |k, v| !X.include?(k) }
h.select { |k, v| !X.exclude?(k) }
```
Previously they would register as offenses, now they don't since they're functionally equivalent to `h.slice(*X)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
