### PR TITLE
Remove unnecessary `include IgnoredNode`

### DIFF
--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -74,7 +74,6 @@ module RuboCop
         extend AutoCorrector
         include AllowedMethods
         include AllowedPattern
-        include IgnoredNode
 
         CONVERSION_METHOD_CLASS_MAPPING = {
           to_i: "#{Integer.name}(%<number_object>s, 10)",

--- a/lib/rubocop/cop/lint/regexp_as_condition.rb
+++ b/lib/rubocop/cop/lint/regexp_as_condition.rb
@@ -17,7 +17,6 @@ module RuboCop
       #     do_something
       #   end
       class RegexpAsCondition < Base
-        include IgnoredNode
         extend AutoCorrector
 
         MSG = 'Do not use regexp literal as a condition. ' \

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -207,7 +207,6 @@ module RuboCop
       class ConditionalAssignment < Base
         include ConditionalAssignmentHelper
         include ConfigurableEnforcedStyle
-        include IgnoredNode
         extend AutoCorrector
 
         MSG = 'Use the return of the conditional for variable assignment and comparison.'

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -59,7 +59,6 @@ module RuboCop
       #   end
       #
       class IfInsideElse < Base
-        include IgnoredNode
         include RangeHelp
         extend AutoCorrector
 

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -41,7 +41,6 @@ module RuboCop
       #     f != 1
       #   end
       class InverseMethods < Base
-        include IgnoredNode
         include RangeHelp
         extend AutoCorrector
 

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -20,7 +20,6 @@ module RuboCop
       #  lambda.(x, y)
       class LambdaCall < Base
         include ConfigurableEnforcedStyle
-        include IgnoredNode
         extend AutoCorrector
 
         MSG = 'Prefer the use of `%<prefer>s` over `%<current>s`.'

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -18,7 +18,6 @@ module RuboCop
       class NestedTernaryOperator < Base
         extend AutoCorrector
         include RangeHelp
-        include IgnoredNode
 
         MSG = 'Ternary operators must not be nested. Prefer `if` or `else` constructs instead.'
 


### PR DESCRIPTION
`IgnoredNode` is already included in `RuboCop::Cop::Base`, so including it again inside a cop is redundant.