### PR TITLE
Fix infinite loop error for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_infinite_loop_error_for_style_if_with_semicolon].md
+++ b/changelog/fix_infinite_loop_error_for_style_if_with_semicolon].md
@@ -1,0 +1,1 @@
+* [#13497](https://github.com/rubocop/rubocop/pull/13497): Fix infinite loop error for `Style/IfWithSemicolon` when using nested if/;/end in if body. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -23,6 +23,7 @@ module RuboCop
 
         def on_normal_if_unless(node)
           return if node.parent&.if_type?
+          return if part_of_ignored_node?(node)
 
           beginning = node.loc.begin
           return unless beginning&.is?(';')
@@ -32,6 +33,8 @@ module RuboCop
           add_offense(node, message: message) do |corrector|
             autocorrect(corrector, node)
           end
+
+          ignore_node(node)
         end
 
         private

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -224,7 +224,6 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
         if cond; run
         ^^^^^^^^^^^^ Do not use `if cond;` - use a newline instead.
           if cond; run
-          ^^^^^^^^^^^^ Do not use `if cond;` - use a ternary operator instead.
           end
         end
       RUBY
@@ -232,7 +231,8 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
       expect_correction(<<~RUBY)
         if cond
          run
-          cond ? run : nil
+          if cond; run
+          end
         end
       RUBY
     end
@@ -240,52 +240,48 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     it 'registers an offense and corrects when using nested single-line if/;/end in block of if body' do
       expect_offense(<<~RUBY)
         if foo?; bar { if qux?; quux else end } end
-                       ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if qux?;` - use a ternary operator instead.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
       RUBY
 
       expect_correction(<<~RUBY)
         if foo?
-         bar { qux? ? quux : nil } end
+         bar { if qux?; quux else end } end
       RUBY
     end
 
     it 'registers an offense and corrects when using nested single-line if/;/end in the block of else body' do
       expect_offense(<<~RUBY)
         if foo?; bar else baz { if qux?; quux else end } end
-                                ^^^^^^^^^^^^^^^^^^^^^^ Do not use `if qux?;` - use a ternary operator instead.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
       RUBY
 
       expect_correction(<<~RUBY)
         if foo?
-         bar else baz { qux? ? quux : nil } end
+         bar else baz { if qux?; quux else end } end
       RUBY
     end
 
     it 'registers an offense and corrects when using nested single-line if/;/end in numblock of if body' do
       expect_offense(<<~RUBY)
         if foo?; bar { if _1; quux else end } end
-                       ^^^^^^^^^^^^^^^^^^^^ Do not use `if _1;` - use a ternary operator instead.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
       RUBY
 
       expect_correction(<<~RUBY)
         if foo?
-         bar { _1 ? quux : nil } end
+         bar { if _1; quux else end } end
       RUBY
     end
 
     it 'registers an offense and corrects when using nested single-line if/;/end in the numblock of else body' do
       expect_offense(<<~RUBY)
         if foo?; bar else baz { if _1; quux else end } end
-                                ^^^^^^^^^^^^^^^^^^^^ Do not use `if _1;` - use a ternary operator instead.
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo?;` - use `if/else` instead.
       RUBY
 
       expect_correction(<<~RUBY)
         if foo?
-         bar else baz { _1 ? quux : nil } end
+         bar else baz { if _1; quux else end } end
       RUBY
     end
 
@@ -309,6 +305,22 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
 
       expect_correction(<<~RUBY)
         cond ? return : nil
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using nested if/;/end in if body' do
+      expect_offense(<<~RUBY)
+        if cond1; foo + if cond2; bar
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond1;` - use a ternary operator instead.
+          else
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond1 ? foo + if cond2; bar
+          else
+          end : nil
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes infinite loop error for `Style/IfWithSemicolon` when using nested if/;/end in if body.

```console
$ cat example.rb
if cond1; foo + if cond2; bar
  else
  end
end
$ bundle exec rubocop -a -d
(snip)
Parser::Source::TreeRewriter detected clobbering
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:427:
in 'Parser::Source::TreeRewriter#trigger_policy'
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:414:
in 'Parser::Source::TreeRewriter#enforce_policy'
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter/action.rb:234:
in 'Method#call'
```

The autocorrection for the nested conventional case is handled as a repeated autocorrection, so there is no impact on the user experience.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
