### PR TITLE
Remove unnecessary `include Util`

### DIFF
--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -51,7 +51,6 @@ module RuboCop
       #   Pathname.new('/') + 'test'
       #
       class StringConcatenation < Base
-        include Util
         include RangeHelp
         extend AutoCorrector
 


### PR DESCRIPTION
`Util` is already included in `RuboCop::Cop::Base`, so including it again inside a cop is redundant.