### PR TITLE
docs: fix cop name difference in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### New features
 
 * [#13439](https://github.com/rubocop/rubocop/pull/13439): Add new `Lint/HashNewWithKeywordArgumentsAsDefault` cop. ([@koic][])
-* [#11191](https://github.com/rubocop/rubocop/issues/11191): Add new `Lint/BinaryOperatorWithIdenticalOperands` cop. ([@zopolis4][])
+* [#11191](https://github.com/rubocop/rubocop/issues/11191): Add new `Lint/NumericOperationWithConstantResult` cop. ([@zopolis4][])
 * [#13486](https://github.com/rubocop/rubocop/issues/13486): Add new `Style/DigChain` cop. ([@dvandersluis][])
 * [#13490](https://github.com/rubocop/rubocop/issues/13490): Add new `Style/FileNull` cop. ([@dvandersluis][])
 * [#13484](https://github.com/rubocop/rubocop/pull/13484): Add new `Style/FileTouch` cop. ([@lovro-bikic][])

--- a/relnotes/v1.69.0.md
+++ b/relnotes/v1.69.0.md
@@ -1,7 +1,7 @@
 ### New features
 
 * [#13439](https://github.com/rubocop/rubocop/pull/13439): Add new `Lint/HashNewWithKeywordArgumentsAsDefault` cop. ([@koic][])
-* [#11191](https://github.com/rubocop/rubocop/issues/11191): Add new `Lint/BinaryOperatorWithIdenticalOperands` cop. ([@zopolis4][])
+* [#11191](https://github.com/rubocop/rubocop/issues/11191): Add new `Lint/NumericOperationWithConstantResult` cop. ([@zopolis4][])
 * [#13486](https://github.com/rubocop/rubocop/issues/13486): Add new `Style/DigChain` cop. ([@dvandersluis][])
 * [#13490](https://github.com/rubocop/rubocop/issues/13490): Add new `Style/FileNull` cop. ([@dvandersluis][])
 * [#13484](https://github.com/rubocop/rubocop/pull/13484): Add new `Style/FileTouch` cop. ([@lovro-bikic][])


### PR DESCRIPTION
Change the name of the cop from
`Lint/BinaryOperatorWithIdenticalOperands` to
`Lint/NumericOperationWithConstantResult`
in the changelog as to prevent confusion
to what cop it is in reference to

-----

I was looking over the release for [`1.69.0`](https://github.com/rubocop/rubocop/releases/tag/v1.69.0) and noticed that the cop name listed in the changelog doesn't match what the actual cop name is. I didn't see anything on the PR (#13186) that showed this name (I could've missed it), so I figured it would be less confusing to have the names match.

I didn't add anything to the change log because I didn't think it really needed to be added as it is just updating the name within the change log.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
