### PR TITLE
[Fix #13502] Fix incorrect `Style/DigChain` correction when the receiver to the chain uses safe navigation

### DIFF
--- a/changelog/fix_fix_incorrect_style_dig_chain_correction_when_the.md
+++ b/changelog/fix_fix_incorrect_style_dig_chain_correction_when_the.md
@@ -1,0 +1,1 @@
+* [#13502](https://github.com/rubocop/rubocop/issues/13502): Fix incorrect `Style/DigChain` correction when the receiver to the chain uses safe navigation. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/dig_chain.rb
+++ b/lib/rubocop/cop/style/dig_chain.rb
@@ -52,7 +52,7 @@ module RuboCop
           end_pos = node.source_range.end_pos
 
           while dig?((node = node.receiver))
-            begin_pos = node.loc.dot ? node.loc.dot.begin_pos + 1 : 0
+            begin_pos = node.loc.dot ? node.loc.dot.end_pos : 0
             arguments.unshift(*node.arguments)
             ignore_node(node)
           end

--- a/spec/rubocop/cop/style/dig_chain_spec.rb
+++ b/spec/rubocop/cop/style/dig_chain_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe RuboCop::Cop::Style::DigChain, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects with safe navigation on the receiver' do
+      expect_offense(<<~RUBY)
+        x&.dig(:foo)&.dig(:bar)&.dig(:baz, :quux)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `dig(:foo, :bar, :baz, :quux)` instead of chaining.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.dig(:foo, :bar, :baz, :quux)
+      RUBY
+    end
+
     it 'registers an offense and corrects without a receiver' do
       expect_offense(<<~RUBY)
         dig(:foo, :bar).dig(:baz, :quux)


### PR DESCRIPTION
Fixes incorrect correction for `Style/DigChain` when the receiver itself uses safe navigation, ie.:

```ruby
x&.dig(:foo)&.dig(:bar)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
