### PR TITLE
Add anon splat tests to `Style/ParallelAssignment`

### DIFF
--- a/changelog/fix_error_parallel_assignment_anon_splat.md
+++ b/changelog/fix_error_parallel_assignment_anon_splat.md
@@ -1,0 +1,1 @@
+* [#13505](https://github.com/rubocop/rubocop/issues/13505): Fix an error for `Style/ParallelAssignment` when using the anonymous splat operator. ([@earlopain][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.36.1', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.36.2', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -208,6 +208,8 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
   it_behaves_like('allowed', 'a, = *foo')
   it_behaves_like('allowed', 'a, *b = [1, 2, 3]')
   it_behaves_like('allowed', '*a, b = [1, 2, 3]')
+  it_behaves_like('allowed', '*, b = [1, 2, 3]')
+  it_behaves_like('allowed', 'a, *, b = [1, 2, 3]')
   it_behaves_like('allowed', 'a, b = b, a')
   it_behaves_like('allowed', 'a, b, c = b, c, a')
   it_behaves_like('allowed', 'a, b = (a + b), (a - b)')


### PR DESCRIPTION
Related to https://github.com/rubocop/rubocop/issues/13505
The fix was applied in https://github.com/rubocop/rubocop-ast/pull/340 but it still makes sense to test here as well

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
