### PR TITLE
[Doc] Improve documentation for `Naming/AccessorMethodName`

### DIFF
--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -3,13 +3,13 @@
 module RuboCop
   module Cop
     module Naming
-      # Makes sure that accessor methods are named properly. Applies
-      # to both instance and class methods.
+      # Avoid prefixing accessor method names with `get_` or `set_`.
+      # Applies to both instance and class methods.
       #
-      # NOTE: Offenses are only registered for methods with the expected
-      # arity. Getters (`get_attribute`) must have no arguments to be
-      # registered, and setters (`set_attribute(value)`) must have exactly
-      # one.
+      # NOTE: Method names starting with `get_` or `set_` only register an offense
+      # when the methods match the expected arity for getters and setters respectively.
+      # Getters (`get_attribute`) must have no arguments to be registered,
+      # and setters (`set_attribute(value)`) must have exactly one.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Update documentation of `Naming/AccessorMethodName` to be more specific about how to properly name an accessor method.