### PR TITLE
Update `Style/LambdaCall` to be aware of safe navigation

### DIFF
--- a/changelog/fix_update_style_lambda_call_to_be_aware_of_safe.md
+++ b/changelog/fix_update_style_lambda_call_to_be_aware_of_safe.md
@@ -1,0 +1,1 @@
+* [#13512](https://github.com/rubocop/rubocop/pull/13512): Update `Style/LambdaCall` to be aware of safe navigation. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -44,6 +44,7 @@ module RuboCop
             correct_style_detected
           end
         end
+        alias on_csend on_send
 
         private
 
@@ -54,9 +55,10 @@ module RuboCop
         def prefer(node)
           receiver = node.receiver.source
           arguments = node.arguments.map(&:source).join(', ')
+          dot = node.loc.dot.source
           method = explicit_style? ? "call(#{arguments})" : "(#{arguments})"
 
-          "#{receiver}.#{method}"
+          "#{receiver}#{dot}#{method}"
         end
 
         def implicit_style?

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
+    it 'registers an offense for x&.()' do
+      expect_offense(<<~RUBY)
+        x&.(a, b)
+        ^^^^^^^^^ Prefer the use of `x&.call(a, b)` over `x&.(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.call(a, b)
+      RUBY
+    end
+
     it 'registers an offense for x.().()' do
       expect_offense(<<~RUBY)
         x.(a, b).(c)
@@ -24,6 +35,18 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
 
       expect_correction(<<~RUBY)
         x.(a, b).call(c)
+      RUBY
+    end
+
+    it 'registers an offense for x&.()&.()' do
+      expect_offense(<<~RUBY)
+        x&.(a, b)&.(c)
+        ^^^^^^^^^^^^^^ Prefer the use of `x&.(a, b)&.call(c)` over `x&.(a, b)&.(c)`.
+        ^^^^^^^^^ Prefer the use of `x&.call(a, b)` over `x&.(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.(a, b)&.call(c)
       RUBY
     end
 
@@ -40,6 +63,19 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
+    it 'registers an offense for correct + opposite with safe navigation' do
+      expect_offense(<<~RUBY)
+        x&.call(a, b)
+        x&.(a, b)
+        ^^^^^^^^^ Prefer the use of `x&.call(a, b)` over `x&.(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.call(a, b)
+        x&.call(a, b)
+      RUBY
+    end
+
     it 'registers an offense for correct + multiple opposite styles' do
       expect_offense(<<~RUBY)
         x.call(a, b)
@@ -53,6 +89,22 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.call(a, b)
         x.call(a, b)
         x.call(a, b)
+      RUBY
+    end
+
+    it 'registers an offense for correct + multiple opposite styles with safe navigation' do
+      expect_offense(<<~RUBY)
+        x&.call(a, b)
+        x&.(a, b)
+        ^^^^^^^^^ Prefer the use of `x&.call(a, b)` over `x&.(a, b)`.
+        x&.(a, b)
+        ^^^^^^^^^ Prefer the use of `x&.call(a, b)` over `x&.(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.call(a, b)
+        x&.call(a, b)
+        x&.call(a, b)
       RUBY
     end
   end
@@ -71,6 +123,17 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
+    it 'registers an offense for x&.call()' do
+      expect_offense(<<~RUBY)
+        x&.call(a, b)
+        ^^^^^^^^^^^^^ Prefer the use of `x&.(a, b)` over `x&.call(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.(a, b)
+      RUBY
+    end
+
     it 'registers an offense for opposite + correct' do
       expect_offense(<<~RUBY)
         x.call(a, b)
@@ -81,6 +144,19 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       expect_correction(<<~RUBY)
         x.(a, b)
         x.(a, b)
+      RUBY
+    end
+
+    it 'registers an offense for opposite + correct with safe navigation' do
+      expect_offense(<<~RUBY)
+        x&.call(a, b)
+        ^^^^^^^^^^^^^ Prefer the use of `x&.(a, b)` over `x&.call(a, b)`.
+        x&.(a, b)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.(a, b)
+        x&.(a, b)
       RUBY
     end
 
@@ -97,6 +173,22 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
         x.(a, b)
         x.(a, b)
         x.(a, b)
+      RUBY
+    end
+
+    it 'registers an offense for correct + multiple opposite styles with safe navigation' do
+      expect_offense(<<~RUBY)
+        x&.call(a, b)
+        ^^^^^^^^^^^^^ Prefer the use of `x&.(a, b)` over `x&.call(a, b)`.
+        x&.(a, b)
+        x&.call(a, b)
+        ^^^^^^^^^^^^^ Prefer the use of `x&.(a, b)` over `x&.call(a, b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.(a, b)
+        x&.(a, b)
+        x&.(a, b)
       RUBY
     end
 
@@ -123,6 +215,17 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
 
       expect_correction(<<~RUBY)
         a.(asdf, x123)
+      RUBY
+    end
+
+    it 'autocorrects x&.call asdf, x123 to x&.(asdf, x123)' do
+      expect_offense(<<~RUBY)
+        a&.call asdf, x123
+        ^^^^^^^^^^^^^^^^^^ Prefer the use of `a&.(asdf, x123)` over `a&.call asdf, x123`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a&.(asdf, x123)
       RUBY
     end
   end


### PR DESCRIPTION
Follows #13510.

Adds support for safe navigation in `Style/LambdaCall`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
