### PR TITLE
Update the new cop generator to suggest supporting `on_csend` along with `on_send`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -71,11 +71,17 @@ module RuboCop
                   (send nil? :bad_method ...)
                 PATTERN
 
+                # Called on every `send` node (method call) while walking the AST.
+                # TODO: remove this method if inspecting `send` nodes is unneeded for your cop.
+                # By default, this is aliased to `on_csend` as well to handle method calls
+                # with safe navigation, remove the alias if this is unnecessary.
+                # If kept, ensure your tests cover safe navigation as well!
                 def on_send(node)
                   return unless bad_method?(node)
 
                   add_offense(node)
                 end
+                alias on_csend on_send
               end
             end
           end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -78,11 +78,17 @@ RSpec.describe RuboCop::Cop::Generator do
                   (send nil? :bad_method ...)
                 PATTERN
 
+                # Called on every `send` node (method call) while walking the AST.
+                # TODO: remove this method if inspecting `send` nodes is unneeded for your cop.
+                # By default, this is aliased to `on_csend` as well to handle method calls
+                # with safe navigation, remove the alias if this is unnecessary.
+                # If kept, ensure your tests cover safe navigation as well!
                 def on_send(node)
                   return unless bad_method?(node)
 
                   add_offense(node)
                 end
+                alias on_csend on_send
               end
             end
           end


### PR DESCRIPTION
Follows #13510. 

In order to try to encourage supporting `csend` nodes along with `send` nodes, I updated the generator to add an alias for the provided `def on_send` to `on_csend`. Of course, the user can remove it if its unnecessary, but it might prompt new cop developers to be thinking about safe navigation when they're working on method calls.