### PR TITLE
Specify `maximum_target_ruby_version` for a handful of cops, document it

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -378,12 +378,12 @@ Some cops apply changes that only apply in particular contexts, such as if the u
 
 ==== Requiring a minimum Ruby version
 
-If your cop uses new Ruby syntax or standard library APIs, it should only autocorrect if the user has the target Ruby version, which you set with https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/TargetRubyVersion#minimum_target_ruby_version-instance_metho[`TargetRubyVersion#minimum_target_ruby_version`].
+If your cop uses new Ruby syntax or standard library APIs, it should only register offenses if the user has the proper target Ruby version, which you can require with https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/TargetRubyVersion#minimum_target_ruby_version-instance_method[`TargetRubyVersion#minimum_target_ruby_version`].
 
 For example, the `Performance/SelectMap` cop requires Ruby 2.7, which introduced `Enumerable#filter_map`:
 
 ```ruby
-module RuboCop::Cop::Performance::SelectMap < Base
+class RuboCop::Cop::Performance::SelectMap < Base
   extend TargetRubyVersion
 
   minimum_target_ruby_version 2.7
@@ -392,7 +392,23 @@ module RuboCop::Cop::Performance::SelectMap < Base
 end
 ```
 
-This cop won't autocorrect on Ruby 2.6 or older, and it won't even report an offense (since there's no better alternative to recommend instead).
+This cop won't register offenses on Ruby 2.6 or older.
+
+==== Requiring a maximum Ruby version
+
+Mirroring `minimum_target_ruby_version`, you can also specify a maximum Ruby version your cop should analyze.
+
+For example, the `Lint/CircularArgumentReference` cop only runs when analyzing code for Ruby before 2.7. The code it is looking for can never be written in more recent Rubies, it would be a syntax error:
+
+```ruby
+class RuboCop::Cop::Lint::CircularArgumentReference < Base
+  extend TargetRubyVersion
+
+  maximum_target_ruby_version 2.6
+
+  # ...
+end
+```
 
 ==== Requiring a gem
 

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -37,7 +37,11 @@ module RuboCop
       #     dry_ingredients.combine
       #   end
       class CircularArgumentReference < Base
+        extend TargetRubyVersion
+
         MSG = 'Circular argument reference - `%<arg_name>s`.'
+
+        maximum_target_ruby_version 2.6
 
         def on_kwoptarg(node)
           check_for_circular_argument_references(*node)

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -59,11 +59,13 @@ module RuboCop
       #
       class NonDeterministicRequireOrder < Base
         extend AutoCorrector
+        extend TargetRubyVersion
 
         MSG = 'Sort files before requiring them.'
 
+        maximum_target_ruby_version 2.7
+
         def on_block(node)
-          return if target_ruby_version >= 3.0
           return unless node.body
           return unless unsorted_dir_loop?(node.send_node)
 
@@ -75,7 +77,6 @@ module RuboCop
         end
 
         def on_numblock(node)
-          return if target_ruby_version >= 3.0
           return unless node.body
           return unless unsorted_dir_loop?(node.send_node)
 
@@ -87,7 +88,6 @@ module RuboCop
         end
 
         def on_block_pass(node)
-          return if target_ruby_version >= 3.0
           return unless method_require?(node)
           return unless unsorted_dir_pass?(node.parent)
 

--- a/lib/rubocop/cop/lint/refinement_import_methods.rb
+++ b/lib/rubocop/cop/lint/refinement_import_methods.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks if `include` or `prepend` is called in `refine` block.
       # These methods are deprecated and should be replaced with `Refinement#import_methods`.
       #
-      # It emulates deprecation warnings in Ruby 3.1.
+      # It emulates deprecation warnings in Ruby 3.1. Functionality has been removed in Ruby 3.2.
       #
       # @safety
       #   This cop's autocorrection is unsafe because `include M` will affect the included class

--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -25,7 +25,11 @@ module RuboCop
       #     do_something_else
       #   end
       class UselessElseWithoutRescue < Base
+        extend TargetRubyVersion
+
         MSG = '`else` without `rescue` is useless.'
+
+        maximum_target_ruby_version 2.5
 
         def on_new_investigation
           processed_source.diagnostics.each do |diagnostic|

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -25,9 +25,12 @@ module RuboCop
       #
       class YAMLLoad < Base
         extend AutoCorrector
+        extend TargetRubyVersion
 
         MSG = 'Prefer using `YAML.safe_load` over `YAML.load`.'
         RESTRICT_ON_SEND = %i[load].freeze
+
+        maximum_target_ruby_version 3.0
 
         # @!method yaml_load(node)
         def_node_matcher :yaml_load, <<~PATTERN
@@ -35,8 +38,6 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if target_ruby_version >= 3.1
-
           yaml_load(node) do
             add_offense(node.loc.selector) do |corrector|
               corrector.replace(node.loc.selector, 'safe_load')


### PR DESCRIPTION
Followup to https://github.com/rubocop/rubocop/pull/13473

* `Lint/CircularArgumentReference`: Invalid syntax on modern rubies
* `Lint/NonDeterministicRequireOrder`: Skipped in node handlers
* `Lint/UselessElseWithoutRescue`: Invalid syntax on modern rubies
* `Security/YAMLLoad`: Skipped in node handler

I left `Lint/RefinementImportMethods` alone and just added the removal timeframe in the docs.
Probably it could get an upper bound but docs currently don't handle both min/max at the same time.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
