### PR TITLE
[Fix #13509] Update `Layout/ExtraSpacing` and `Layout/SpaceAroundOperators` to handle preceding operators inside strings

### DIFF
--- a/changelog/fix_update_layout_extra_spacing_and.md
+++ b/changelog/fix_update_layout_extra_spacing_and.md
@@ -1,0 +1,1 @@
+* [#13509](https://github.com/rubocop/rubocop/issues/13509): Update `Layout/ExtraSpacing` and `Layout/SpaceAroundOperators` to handle preceding operators inside strings. ([@dvandersluis][])

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -602,6 +602,32 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         end
       RUBY
     end
+
+    it 'registers an offense and corrects when there is = in a string after assignment' do
+      expect_offense(<<~RUBY)
+        e, f = val.split('=')
+        opt.ssh_config[e] = f
+                          ^ `=` is not aligned with the preceding assignment.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        e, f              = val.split('=')
+        opt.ssh_config[e] = f
+      RUBY
+    end
+
+    it 'registers an offense and corrects with op-asgn when there is = in a string after assignment' do
+      expect_offense(<<~RUBY)
+        xy &&= val.split('=')
+        opt.ssh_config[e] = f
+                          ^ `=` is not aligned with the preceding assignment.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        xy              &&= val.split('=')
+        opt.ssh_config[e] = f
+      RUBY
+    end
   end
 
   context 'when exactly two comments have extra spaces' do

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -958,6 +958,32 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
 
+    it 'registers an offense when operator is followed by aligned << inside a string' do
+      expect_offense(<<~RUBY)
+        x   += foo
+            ^^ Operator `+=` should be surrounded by a single space.
+        'yz << bar'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x += foo
+        'yz << bar'
+      RUBY
+    end
+
+    it 'registers an offense when operator is preceded by aligned << inside a string' do
+      expect_offense(<<~RUBY)
+        'yz << bar'
+        x   += foo
+            ^^ Operator `+=` should be surrounded by a single space.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        'yz << bar'
+        x += foo
+      RUBY
+    end
+
     it 'registers an offense and corrects various assignments with too many spaces' do
       expect_offense(<<~RUBY)
         x ||=  0


### PR DESCRIPTION
The `PrecedingFollowingAlignment` mixin is used to determine if lines are aligned properly based on certain criteria. For alignment involving assignment or `<<`, it was previously just matching the text content at a given column, but this could cause a false result if a string containing the operator was perfectly aligned with the column.

This update fixes that by ensuring that the position is within the correct token type.

Fixes #13509.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
