### PR TITLE
Fix `Style/HashExcept` to recognize safe navigation with Active Support methods

### DIFF
--- a/changelog/fix_style_hash_except_when_using_safe_navigation_with_active_support.md
+++ b/changelog/fix_style_hash_except_when_using_safe_navigation_with_active_support.md
@@ -1,0 +1,1 @@
+* [#13517](https://github.com/rubocop/rubocop/pull/13517): Fixes `Style/HashExcept` to recognize safe navigation when `ActiveSupportExtensionsEnabled` config is enabled. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/hash_except.rb
+++ b/lib/rubocop/cop/style/hash_except.rb
@@ -10,8 +10,10 @@ module RuboCop
       # (`Hash#except` was added in Ruby 3.0.)
       #
       # For safe detection, it is limited to commonly used string and symbol comparisons
-      # when used `==`.
-      # And do not check `Hash#delete_if` and `Hash#keep_if` to change receiver object.
+      # when using `==` or `!=`.
+      #
+      # This cop doesn't check for `Hash#delete_if` and `Hash#keep_if` because they
+      # modify the receiver.
       #
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver
@@ -51,44 +53,31 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead.'
         RESTRICT_ON_SEND = %i[reject select filter].freeze
 
-        # @!method bad_method_with_poro?(node)
-        def_node_matcher :bad_method_with_poro?, <<~PATTERN
+        SUBSET_METHODS = %i[== != eql? include?].freeze
+        ACTIVE_SUPPORT_SUBSET_METHODS = (SUBSET_METHODS + %i[in? exclude?]).freeze
+
+        # @!method block_with_first_arg_check?(node)
+        def_node_matcher :block_with_first_arg_check?, <<~PATTERN
           (block
             (call _ _)
             (args
-              $(arg _)
+              $(arg _key)
               (arg _))
             {
               $(send
-                _ {:== :!= :eql? :include?} _)
+                {(lvar _key) $_ _ | _ $_ (lvar _key)})
               (send
                 $(send
-                  _ {:== :!= :eql? :include?} _) :!)
-              })
-        PATTERN
-
-        # @!method bad_method_with_active_support?(node)
-        def_node_matcher :bad_method_with_active_support?, <<~PATTERN
-          (block
-            (send _ _)
-            (args
-              $(arg _)
-              (arg _))
-            {
-              $(send
-                _ {:== :!= :eql? :in? :include? :exclude?} _)
-              (send
-                $(send
-                  _ {:== :!= :eql? :in? :include? :exclude?} _) :!)
+                  {(lvar _key) $_ _ | _ $_ (lvar _key)}) :!)
               })
         PATTERN
 
         def on_send(node)
           block = node.parent
-          return unless bad_method?(block) && semantically_except_method?(node, block)
+          return unless extracts_hash_subset?(block) && semantically_except_method?(node, block)
 
           except_key = except_key(block)
-          return if except_key.nil? || !safe_to_register_offense?(block, except_key)
+          return unless safe_to_register_offense?(block, except_key)
 
           range = offense_range(node)
           preferred_method = "except(#{except_key_source(except_key)})"
@@ -101,42 +90,40 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        def bad_method?(block)
+        def extracts_hash_subset?(block)
+          block_with_first_arg_check?(block) do |key_arg, send_node, method|
+            return false unless supported_subset_method?(method)
+
+            case method
+            when :include?, :exclude?
+              send_node.first_argument.source == key_arg.source
+            when :in?
+              send_node.receiver.source == key_arg.source
+            else
+              true
+            end
+          end
+        end
+
+        def supported_subset_method?(method)
           if active_support_extensions_enabled?
-            bad_method_with_active_support?(block) do |key_arg, send_node|
-              if send_node.method?(:in?) && send_node.receiver&.source != key_arg.source
-                return false
-              end
-              return true if !send_node.method?(:include?) && !send_node.method?(:exclude?)
-
-              send_node.first_argument&.source == key_arg.source
-            end
+            ACTIVE_SUPPORT_SUBSET_METHODS.include?(method)
           else
-            bad_method_with_poro?(block) do |key_arg, send_node|
-              !send_node.method?(:include?) || send_node.first_argument&.source == key_arg.source
-            end
-          end
-        end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
-        def semantically_except_method?(send, block)
-          body = block.body
-
-          negated = body.method?('!')
-          body = body.receiver if negated
-
-          case send.method_name
-          when :reject
-            body.method?('==') || body.method?('eql?') || included?(negated, body)
-          when :select, :filter
-            body.method?('!=') || not_included?(negated, body)
-          else
-            false
+            SUBSET_METHODS.include?(method)
           end
         end
 
-        def included?(negated, body)
+        def semantically_except_method?(node, block)
+          body, negated = extract_body_if_negated(block.body)
+
+          if node.method?('reject')
+            body.method?('==') || body.method?('eql?') || included?(body, negated)
+          else
+            body.method?('!=') || not_included?(body, negated)
+          end
+        end
+
+        def included?(body, negated)
           if negated
             body.method?('exclude?')
           else
@@ -144,25 +131,26 @@ module RuboCop
           end
         end
 
-        def not_included?(negated, body)
-          included?(!negated, body)
+        def not_included?(body, negated)
+          included?(body, !negated)
         end
 
         def safe_to_register_offense?(block, except_key)
-          extracted = extract_body_if_negated(block.body)
-          if extracted.method?('in?') || extracted.method?('include?') ||
-             extracted.method?('exclude?')
-            return true
-          end
-          return true if block.body.method?('eql?')
+          body = block.body
 
-          except_key.sym_type? || except_key.str_type?
+          if body.method?('==') || body.method?('!=')
+            except_key.sym_type? || except_key.str_type?
+          else
+            true
+          end
         end
 
         def extract_body_if_negated(body)
-          return body unless body.method?('!')
-
-          body.receiver
+          if body.method?('!')
+            [body.receiver, true]
+          else
+            [body, false]
+          end
         end
 
         def except_key_source(key)
@@ -187,12 +175,11 @@ module RuboCop
         end
 
         def except_key(node)
-          key_argument = node.argument_list.first.source
-          body = extract_body_if_negated(node.body)
+          key_arg = node.argument_list.first.source
+          body, = extract_body_if_negated(node.body)
           lhs, _method_name, rhs = *body
-          return if [lhs, rhs].map(&:source).none?(key_argument)
 
-          [lhs, rhs].find { |operand| operand.source != key_argument }
+          lhs.source == key_arg ? rhs : lhs
         end
 
         def offense_range(node)


### PR DESCRIPTION
Fixes `Style/HashExcept` to recognize offenses when safe navigation is used and `ActiveSupportExtensionsEnabled` config option is enabled.

Previously, this code:
```ruby
{foo: 1, bar: 2, baz: 3}&.reject { |k, v| k.in?(%i[foo bar]) }
```
wouldn't register as offense (but without safe nav it would). Now it registers and autocorrects to:
```ruby
{foo: 1, bar: 2, baz: 3}&.except(:foo, :bar)
```

Additional context for the refactoring done in this PR: https://github.com/rubocop/rubocop/pull/13507#discussion_r1861491315

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
