### PR TITLE
Improve warning when an invalid foldable type is given to `CodeLengthCalculator`

### DIFF
--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -9,7 +9,7 @@ module RuboCop
           extend NodePattern::Macros
           include Util
 
-          FOLDABLE_TYPES = %i[array hash heredoc send csend].freeze
+          FOLDABLE_TYPES = %i[array hash heredoc method_call].freeze
           CLASSLIKE_TYPES = %i[class module].freeze
           private_constant :FOLDABLE_TYPES, :CLASSLIKE_TYPES
 

--- a/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
+++ b/spec/rubocop/cop/metrics/utils/code_length_calculator_spec.rb
@@ -467,9 +467,12 @@ RSpec.describe RuboCop::Cop::Metrics::Utils::CodeLengthCalculator do
         end
       RUBY
 
+      warning = 'Unknown foldable type: :send. ' \
+                'Valid foldable types are: array, hash, heredoc, method_call.'
+
       expect do
-        described_class.new(source.ast, source, foldable_types: %i[unknown]).calculate
-      end.to raise_error(RuboCop::Warning, /Unknown foldable type/)
+        described_class.new(source.ast, source, foldable_types: %i[send]).calculate
+      end.to raise_error(RuboCop::Warning, warning)
     end
   end
 end


### PR DESCRIPTION
The warning message previously offered `send` and `csend` as possible options, but they are not in fact valid, and will raise a warning if used. `method_call` should be offered instead.