### PR TITLE
Add `RESTRICT_ON_SEND` to more cops

### DIFF
--- a/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
+++ b/lib/rubocop/cop/internal_affairs/location_line_equality_comparison.rb
@@ -19,6 +19,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `%<preferred>s`.'
+        RESTRICT_ON_SEND = [:==].freeze
 
         # @!method line_send(node)
         def_node_matcher :line_send, <<~PATTERN

--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -46,6 +46,7 @@ module RuboCop
       class BinaryOperatorWithIdenticalOperands < Base
         MSG = 'Binary operator `%<op>s` has identical operands.'
         MATH_OPERATORS = %i[- + * / ** << >>].to_set.freeze
+        RESTRICT_ON_SEND = %i[== != === <=> =~ && || > >= < <= | ^].freeze
 
         def on_send(node)
           return unless node.binary_operation?

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -33,6 +33,7 @@ module RuboCop
 
         MSG = 'Use `%<constant>s.%<method>s(%<replacement_args>s)` instead of `%<original>s`.'
 
+        RESTRICT_ON_SEND = %i[new digest].freeze
         NO_ARG_ALGORITHM = %w[BF DES IDEA RC4].freeze
 
         # @!method algorithm_const(node)

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -36,6 +36,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Literal `%<literal>s` appeared as a condition.'
+        RESTRICT_ON_SEND = [:!].freeze
 
         def on_if(node)
           check_for_literal(node)

--- a/lib/rubocop/cop/security/compound_hash.rb
+++ b/lib/rubocop/cop/security/compound_hash.rb
@@ -32,6 +32,7 @@ module RuboCop
         MONUPLE_HASH_MSG =
           'Delegate hash directly without wrapping in an array when only using a single value.'
         REDUNDANT_HASH_MSG = 'Calling .hash on elements of a hashed array is redundant.'
+        RESTRICT_ON_SEND = %i[hash ^ + * |].freeze
 
         # @!method hash_method_definition?(node)
         def_node_matcher :hash_method_definition?, <<~PATTERN

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -26,6 +26,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `ENV.fetch(%<key>s)` or `ENV.fetch(%<key>s, nil)` instead of `ENV[%<key>s]`.'
+        RESTRICT_ON_SEND = [:[]].freeze
 
         # @!method env_with_bracket?(node)
         def_node_matcher :env_with_bracket?, <<~PATTERN

--- a/lib/rubocop/cop/style/object_then.rb
+++ b/lib/rubocop/cop/style/object_then.rb
@@ -30,6 +30,7 @@ module RuboCop
         minimum_target_ruby_version 2.6
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
+        RESTRICT_ON_SEND = %i[then yield_self].freeze
 
         def on_block(node)
           check_method_node(node.send_node)


### PR DESCRIPTION
Adds `RESTRICT_ON_SEND` configuration to `Lint/BinaryOperatorWithIdenticalOperands`, `Lint/DeprecatedOpenSSLConstant`, `Lint/LiteralAsCondition`, `Security/CompoundHash`, `Style/FetchEnvVar`, `Style/ObjectThen`, and `InternalAffairs/LocationLineEqualityComparison`.
