### PR TITLE
[Fix #13511] Update `regexp_parser` dependency

### DIFF
--- a/changelog/fix_update_regexp_parser_dependency.md
+++ b/changelog/fix_update_regexp_parser_dependency.md
@@ -1,0 +1,1 @@
+* [#13511](https://github.com/rubocop/rubocop/issues/13511): Fix false positive in `Lint/UnescapedBracketInRegexp` when using regexp_parser 2.9.2 and earlier. ([@dvandersluis][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parallel', '~> 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
-  s.add_dependency('regexp_parser', '>= 2.4', '< 3.0')
+  s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
   s.add_dependency('rubocop-ast', '>= 1.36.2', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')

--- a/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
         RUBY
       end
     end
+
+    context 'character class in lookbehind' do
+      # See https://github.com/ammar/regexp_parser/issues/93
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          /(?<=[<>=:])/
+        RUBY
+      end
+    end
   end
 
   context '%r{} Regexp' do
@@ -132,6 +141,15 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           %r{[abc]}
+        RUBY
+      end
+    end
+
+    context 'character class in lookbehind' do
+      # See https://github.com/ammar/regexp_parser/issues/93
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          %r{(?<=[<>=:])}
         RUBY
       end
     end


### PR DESCRIPTION
`Lint/UnescapedBracketInRegexp` had a false positive due to ammar/regexp_parser#93. The dependency is now updated, and a test has been added for this situation.

Fixes #13511.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
