### PR TITLE
Fix `Style/RedundantSelf` cop failure with `kwnilarg` argument node

### DIFF
--- a/changelog/fix_style_redundant_self_failure_with_kwnilarg_node.md
+++ b/changelog/fix_style_redundant_self_failure_with_kwnilarg_node.md
@@ -1,0 +1,1 @@
+* [#13521](https://github.com/rubocop/rubocop/pull/13521): Fix `Style/RedundantSelf` cop failure with `kwnilarg` argument node. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -175,7 +175,7 @@ module RuboCop
         def on_argument(node)
           if node.mlhs_type?
             on_args(node)
-          else
+          elsif node.respond_to?(:name)
             @local_variables_scopes[node] << node.name
           end
         end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -238,6 +238,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
         end
       RUBY
     end
+
+    it 'accepts `kwnilarg` argument node type' do
+      expect_no_offenses(<<~RUBY)
+        def requested_specs(groups, **nil)
+          some_method(self.groups)
+        end
+      RUBY
+    end
   end
 
   describe 'class methods' do


### PR DESCRIPTION
The following ruby code leads to an error:

```ruby
def foo(a, **nil)
  self.a
end
```

```
An error occurred while Style/RedundantSelf cop was inspecting rubocop/test.rb:1:5. undefined method `name' for an instance of RuboCop::AST::Node
rubocop/lib/rubocop/cop/style/redundant_self.rb:179:in `on_argument' 
rubocop/lib/rubocop/cop/style/redundant_self.rb:85:in `block in on_args' 
rubocop/lib/rubocop/cop/style/redundant_self.rb:85:in `each' rubocop/lib/rubocop/cop/style/redundant_self.rb:85:in `on_args'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
