### PR TITLE
Fix `Lint/UnescapedBracketInRegexp` failure in case of invalid regexp

### DIFF
--- a/changelog/fix_lint_unescaped_bracket_in_regexp_cop_for_invalid_regexp.md
+++ b/changelog/fix_lint_unescaped_bracket_in_regexp_cop_for_invalid_regexp.md
@@ -1,0 +1,1 @@
+* [#13522](https://github.com/rubocop/rubocop/pull/13522): Fix `Lint/UnescapedBracketInRegexp` cop failure with invalid regular expression. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -58,6 +58,9 @@ module RuboCop
             Regexp::Parser.parse(text.value)&.each_expression do |expr|
               detect_offenses(text, expr)
             end
+          rescue Regexp::Parser::ParserError
+            # Upon encountering an invalid regular expression,
+            # we aim to proceed and identify any remaining potential offenses.
           end
         end
 

--- a/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
@@ -229,6 +229,23 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
           RUBY
         end
       end
+
+      context 'invalid regular expressions' do
+        %w[+ * {42}].each do |invalid_regexp|
+          it "does not register an offense for single invalid `/#{invalid_regexp}/` regexp`" do
+            expect_no_offenses(<<~RUBY)
+              Regexp.#{method}("#{invalid_regexp}")
+            RUBY
+          end
+
+          it "registers an offense for regexp following invalid `/#{invalid_regexp}/` regexp" do
+            expect_offense(<<~RUBY, method: method, invalid_regexp: invalid_regexp)
+              [Regexp.#{method}('#{invalid_regexp}'), Regexp.#{method}('abc]123')]
+                      _{method}  _{invalid_regexp}           _{method}     ^ Regular expression has `]` without escape.
+            RUBY
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `Lint/UnescapedBracketInRegexp` cop does not handle exceptions raised by the `regexp_parser` gem. While raising exceptions (or issuing dedicated warnings) might be useful for runtime-parsed regular expressions (e.g., `Regexp.parse(<string-literal>)`), this behavior appears to fall outside the scope of this cop.

Proposed fix: ignore regular expressions that the gem cannot parse. Alternatively, we could emit a warning, either here or in a different cop.

I could not find any discussion on this topic in [the PR](https://github.com/rubocop/rubocop/pull/13385) where this cop was implemented.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
