### PR TITLE
Fix `Style::AccessModifierDeclarations` cop failure in case of `if` without `else`

### DIFF
--- a/changelog/fix_style_access_modifier_declarations_failure_on_if_without_else.md
+++ b/changelog/fix_style_access_modifier_declarations_failure_on_if_without_else.md
@@ -1,0 +1,1 @@
+* [#13523](https://github.com/rubocop/rubocop/pull/13523): Fix `Style::AccessModifierDeclarations` cop failure in case of `if` node without `else`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -196,7 +196,7 @@ module RuboCop
 
         def offense?(node)
           (group_style? && access_modifier_is_inlined?(node) &&
-            !right_siblings_same_inline_method?(node)) ||
+            !node.parent&.if_type? && !right_siblings_same_inline_method?(node)) ||
             (inline_style? && access_modifier_is_not_inlined?(node))
         end
 

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -505,6 +505,56 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
 
+      context "with #{access_modifier} within `if` node" do
+        it "does not offend when #{access_modifier} does not have right sibling node" do
+          expect_no_offenses(<<~RUBY)
+            class Test
+              #{access_modifier} :inspect if METHODS.include?(:inspect)
+            end
+          RUBY
+        end
+
+        it 'registers and autocorrects offense if conditional modifier is followed by a normal one' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              #{access_modifier} get_method_name if get_method_name =~ /a/
+              #{access_modifier} def bar; end
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              #{access_modifier} get_method_name if get_method_name =~ /a/
+            #{access_modifier}
+
+            def bar; end
+            end
+          RUBY
+        end
+
+        it 'registers and autocorrects offense if conditional modifiers wrap a normal one' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              #{access_modifier} get_method_name_1 if get_method_name_1 =~ /a/
+              #{access_modifier} def bar; end
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+              #{access_modifier} get_method_name_2 if get_method_name_2 =~ /b/
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              #{access_modifier} get_method_name_1 if get_method_name_1 =~ /a/
+              #{access_modifier} get_method_name_2 if get_method_name_2 =~ /b/
+            #{access_modifier}
+
+            def bar; end
+            end
+          RUBY
+        end
+      end
+
       include_examples 'always accepted', access_modifier
     end
 


### PR DESCRIPTION
The following ruby code leads to an error:

```ruby
class A
  METHOD_ID = :_

  private METHOD_ID if ::REGISTRY.include? METHOD_ID
end
```

when `Style/AccessModifierDeclarations` is configured with `group` style.

Backtrace:

```
An error occurred while Style/AccessModifierDeclarations cop was inspecting rubocop/test.rb:4:2.
undefined method `send_type?' for nil
rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:228:in `block in right_siblings_same_inline_method?'
rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:227:in `any?'
rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:227:in `right_siblings_same_inline_method?'
rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:199:in `offense?'
rubocop/lib/rubocop/cop/style/access_modifier_declarations.rb:151:in `on_send'
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
