### PR TITLE
Fix `Style/RedundantArgument` cop failure while inspecting string literal with invalid encoding

### DIFF
--- a/changelog/fix_style_redundant_argument_cop_failure_on_invalid_string_literal.md
+++ b/changelog/fix_style_redundant_argument_cop_failure_on_invalid_string_literal.md
@@ -1,0 +1,1 @@
+* [#13524](https://github.com/rubocop/rubocop/pull/13524): Fix `Style/RedundantArgument` cop failure while inspecting string literal with invalid encoding. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -118,7 +118,9 @@ module RuboCop
         end
 
         def exclude_cntrl_character?(target_argument, redundant_argument)
-          !target_argument.to_s.sub(/\A'/, '"').sub(/'\z/, '"').match?(/[[:cntrl:]]/) ||
+          return true unless (target_argument_string = target_argument.to_s).valid_encoding?
+
+          !target_argument_string.sub(/\A'/, '"').sub(/'\z/, '"').match?(/[[:cntrl:]]/) ||
             !redundant_argument.match?(/[[:cntrl:]]/)
         end
       end

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -122,6 +122,29 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     RUBY
   end
 
+  it 'does not fail on invalid encoding of string literal' do
+    expect_no_offenses(<<~'RUBY')
+      foo.chomp("\x82")
+    RUBY
+  end
+
+  context 'with invalid encoding of string literal configured as default argument' do
+    let(:cop_config) do
+      {
+        'Methods' => {
+          'chomp' => "\x82"
+        }
+      }
+    end
+
+    it 'registers an offense' do
+      expect_offense(<<~'RUBY')
+        foo.chomp("\x82")
+                 ^^^^^^^^ Argument "\x82" is redundant because it is implied by default.
+      RUBY
+    end
+  end
+
   it 'does not register an offense when method called with no arguments' do
     expect_no_offenses(<<~RUBY)
       foo.join


### PR DESCRIPTION
We have (roughly) this code in our test sutie:

```ruby
s.chomp("\x82")
```

it fails with this backtrace:

```
An error occurred while Style/RedundantArgument cop was inspecting test.rb:1:0.
invalid byte sequence in UTF-8
lib/rubocop/cop/style/redundant_argument.rb:121:in `sub'
lib/rubocop/cop/style/redundant_argument.rb:121:in `exclude_cntrl_character?'
lib/rubocop/cop/style/redundant_argument.rb:111:in `argument_matched?'
lib/rubocop/cop/style/redundant_argument.rb:90:in `redundant_argument?'
lib/rubocop/cop/style/redundant_argument.rb:67:in `on_send'
```

Seems like we have to check if provided value's encoding is valid before performing string operations.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
