### PR TITLE
Fix `Style/StringConcatenation` cop failure when there are mixed implicit and explicit concatenation

### DIFF
--- a/changelog/fix_style_string_concatenation_cop_failure_for_mixed_concats.md
+++ b/changelog/fix_style_string_concatenation_cop_failure_for_mixed_concats.md
@@ -1,0 +1,1 @@
+* [#13526](https://github.com/rubocop/rubocop/pull/13526): Fix `Style/StringConcatenation` cop failure when there are mixed implicit and explicit concatenations. ([@viralpraxis][])

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -52,6 +52,41 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
     RUBY
   end
 
+  context 'implicit concatenation' do
+    it 'registers an offense and corrects with implicit concatenation at the end' do
+      expect_offense(<<~RUBY)
+        "a" + "b" "c"
+        ^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "abc"
+      RUBY
+    end
+
+    it 'registers an offense and corrects with implicit concatenation at the start' do
+      expect_offense(<<~RUBY)
+        "a" "b" + "c"
+        ^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "abc"
+      RUBY
+    end
+
+    it 'registers an offense and corrects with implicit concatenation at the middle' do
+      expect_offense(<<~RUBY)
+        "a" + "b" "c" + "d"
+        ^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        "abcd"
+      RUBY
+    end
+  end
+
   context 'multiline' do
     context 'string continuation' do
       it 'does not register an offense' do


### PR DESCRIPTION
After years of using ruby daily I was enlightened about the 'implicit concatenation' syntax, which results in an error in the following code:

```ruby
"a" + b" "c"
# => "abc"
```

Backtrace:

```
An error occurred while Style/StringConcatenation cop was inspecting test.rb:1:0.
undefined method `end_pos' for nil
lib/rubocop/cop/mixin/range_help.rb:33:in `contents_range'
lib/rubocop/cop/style/string_concatenation.rb:152:in `block in replacement'
lib/rubocop/cop/style/string_concatenation.rb:146:in `map'
lib/rubocop/cop/style/string_concatenation.rb:146:in `replacement'
lib/rubocop/cop/style/string_concatenation.rb:89:in `block in register_offense'
```

I'm not sure if proposed patch is the optimal one, but it should fix the issue.

NB: This cop uses `RESTRICT_ON_SEND = %i[+].freeze` so things like `"a" "b" "c"` are not detected.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
