### PR TITLE
Fix `Style/RedundantParentheses` cop failure in case of splatted `case` node  without condition

### DIFF
--- a/changelog/fix_style_redundant_parenthese_cop_failure_with_case_splat.md
+++ b/changelog/fix_style_redundant_parenthese_cop_failure_with_case_splat.md
@@ -1,0 +1,1 @@
+* [#13528](https://github.com/rubocop/rubocop/pull/13528): Fix `Style/RedundantParentheses` cop failure in case of splatted `case` node without condition. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -244,7 +244,7 @@ module RuboCop
         end
 
         def only_begin_arg?(args)
-          args.one? && args.first.begin_type?
+          args.one? && args.first&.begin_type?
         end
 
         def first_argument?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -723,6 +723,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('x = *(y || z)')
   end
 
+  it 'accepts parentheses around `case` expression in splat' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('x = *(case true when true then false end)')
+  end
+
+  it 'accepts parentheses around `case` expression without condition in splat' do
+    # Parentheses are redundant, but respect user's intentions for readability.
+    expect_no_offenses('x = *(case when rand > 0.5 then 1 end)')
+  end
+
   it 'accepts parentheses around logical operator in double splat' do
     # Parentheses are redundant, but respect user's intentions for readability.
     expect_no_offenses('x(**(y || z))')


### PR DESCRIPTION
The following ruby code leads to an error:

```shell
rubocop --stdin bug.rb --only Style/RedundantParentheses -d <<EOF
_ = *(case when rand > 0.5 then 1 end)
EOF
```

Backtrace:

```
An error occurred while Style/RedundantParentheses cop was inspecting /bug.rb:1:5.
undefined method `begin_type?' for nil
lib/rubocop/cop/style/redundant_parentheses.rb:247:in `only_begin_arg?'
lib/rubocop/cop/style/redundant_parentheses.rb:230:in `keyword_with_redundant_parentheses?'
lib/rubocop/cop/style/redundant_parentheses.rb:139:in `find_offense_message'
lib/rubocop/cop/style/redundant_parentheses.rb:130:in `check'
lib/rubocop/cop/style/redundant_parentheses.rb:37:in `on_begin'
```

```shell
ruby-parse --legacy -e 'case when rand > 0.5 then 1 end'
(case nil
  (when
    (send
      (send nil :rand) :>
      (float 0.5))
    (int 1)) nil)
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
