### PR TITLE
Update `rake new_cop` to handle `InternalAffairs` cops

### DIFF
--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -9,12 +9,19 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
+  badge = RuboCop::Cop::Badge.parse(cop_name)
   generator = RuboCop::Cop::Generator.new(cop_name)
 
   generator.write_source
   generator.write_spec
-  generator.inject_require
-  generator.inject_config
+
+  if badge.department == :InternalAffairs
+    # InternalAffairs cops are required separately, and not added to config/default.yml
+    generator.inject_require(root_file_path: 'lib/rubocop/cop/internal_affairs.rb')
+  else
+    generator.inject_require
+    generator.inject_config
+  end
 
   puts generator.todo
 end


### PR DESCRIPTION
`InternalAffairs` cops are not added to `lib/rubocop.rb` or `config.default.yml`. Instead, they are required via `lib/rubocop/cop/internal_affairs.rb`, so if generating an `InternalAffairs` cop, automatically update the correct file.

I added these changes to the rake task, not to `RuboCop::Cop::Generator`, so that they would not affect other rubocop extensions. As far as I can tell, the other extensions tend to define their own `new_cop` rake task so they should not be affected.