### PR TITLE
Add `Config#for_enabled_cop` and `Config#cop_enabled?`

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,6 +16,7 @@ module RuboCop
 
     CopConfig = Struct.new(:name, :metadata)
 
+    EMPTY_CONFIG = {}.freeze
     DEFAULT_RAILS_VERSION = 5.0
     attr_reader :loaded_path
 
@@ -123,6 +124,13 @@ module RuboCop
       @for_cop[cop]
     end
 
+    # @return [Config, Hash] for the given cop / cop name.
+    # If the given cop is enabled, returns its configuration hash.
+    # Otherwise, returns an empty hash.
+    def for_enabled_cop(cop)
+      cop_enabled?(cop) ? for_cop(cop) : EMPTY_CONFIG
+    end
+
     # @return [Config] for the given cop merged with that of its department (if any)
     # Note: the 'Enabled' attribute is same as that returned by `for_cop`
     def for_badge(badge)
@@ -157,6 +165,10 @@ module RuboCop
 
     def for_all_cops
       @for_all_cops ||= self['AllCops'] || {}
+    end
+
+    def cop_enabled?(name)
+      !!for_cop(name)['Enabled']
     end
 
     def disabled_new_cops?

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'internal_affairs/cop_description'
+require_relative 'internal_affairs/cop_enabled'
 require_relative 'internal_affairs/create_empty_file'
 require_relative 'internal_affairs/empty_line_between_expect_offense_and_correction'
 require_relative 'internal_affairs/example_description'

--- a/lib/rubocop/cop/internal_affairs/cop_enabled.rb
+++ b/lib/rubocop/cop/internal_affairs/cop_enabled.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Use `config.cop_enabled?('Department/CopName')` instead of
+      # traversing the config hash.
+      #
+      # @example
+      #   # `for_cop(...)['Enabled']
+      #
+      #   # bad
+      #   config.for_cop('Department/CopName')['Enabled']
+      #
+      #   # good
+      #   config.cop_enabled?('Department/CopName')
+      #
+      # @example
+      #   # when keeping a cop's config in a local and then checking the `Enabled` key
+      #
+      #   # bad
+      #   cop_config = config.for_cop('Department/CopName')
+      #   cop_config['Enabled'] && cop_config['Foo']
+      #
+      #   # good
+      #   config.for_enabled_cop('Department/CopName')['Foo']
+      #
+      class CopEnabled < Base
+        extend AutoCorrector
+
+        MSG = 'Use `%<replacement>s` instead of `%<source>s`.'
+        MSG_HASH = 'Consider replacing uses of `%<hash_name>s` with `config.for_enabled_cop`.'
+
+        RESTRICT_ON_SEND = [:[]].freeze
+
+        # @!method for_cop_enabled?(node)
+        def_node_matcher :for_cop_enabled?, <<~PATTERN
+          (send
+            (send
+              ${(send nil? :config) (ivar :@config)} :for_cop
+              $(str _)) :[]
+            (str "Enabled"))
+        PATTERN
+
+        # @!method config_enabled_lookup?(node)
+        def_node_matcher :config_enabled_lookup?, <<~PATTERN
+          (send
+            {(lvar $_) (ivar $_) (send nil? $_)} :[]
+            (str "Enabled"))
+        PATTERN
+
+        def on_send(node)
+          if (config_var, cop_name = for_cop_enabled?(node))
+            handle_for_cop(node, config_var, cop_name)
+          elsif (config_var = config_enabled_lookup?(node))
+            return unless config_var.end_with?('_config')
+
+            handle_hash(node, config_var)
+          end
+        end
+
+        private
+
+        def handle_for_cop(node, config_var, cop_name)
+          source = node.source
+          quote = cop_name.loc.begin.source
+          cop_name = cop_name.value
+
+          replacement = "#{config_var.source}.cop_enabled?(#{quote}#{cop_name}#{quote})"
+          message = format(MSG, source: source, replacement: replacement)
+
+          add_offense(node, message: message) do |corrector|
+            corrector.replace(node, replacement)
+          end
+        end
+
+        def handle_hash(node, config_var)
+          message = format(MSG_HASH, hash_name: config_var)
+
+          add_offense(node, message: message)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -141,15 +141,9 @@ module RuboCop
         end
 
         def enforce_hash_argument_with_separator?
-          return false unless hash_argument_config['Enabled']
-
           RuboCop::Cop::Layout::HashAlignment::SEPARATOR_ALIGNMENT_STYLES.any? do |style|
-            hash_argument_config[style]&.include?('separator')
+            config.for_enabled_cop('Layout/HashAlignment')[style]&.include?('separator')
           end
-        end
-
-        def hash_argument_config
-          config.for_cop('Layout/HashAlignment')
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -269,17 +269,12 @@ module RuboCop
         end
 
         def enforce_first_argument_with_fixed_indentation?
-          return false unless argument_alignment_config['Enabled']
-
+          argument_alignment_config = config.for_enabled_cop('Layout/ArgumentAlignment')
           argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
         end
 
         def enable_layout_first_method_argument_line_break?
-          config.for_cop('Layout/FirstMethodArgumentLineBreak')['Enabled']
-        end
-
-        def argument_alignment_config
-          config.for_cop('Layout/ArgumentAlignment')
+          config.cop_enabled?('Layout/FirstMethodArgumentLineBreak')
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -180,13 +180,8 @@ module RuboCop
         end
 
         def enforce_first_argument_with_fixed_indentation?
-          return false unless array_alignment_config['Enabled']
-
-          array_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
-        end
-
-        def array_alignment_config
-          config.for_cop('Layout/ArrayAlignment')
+          argument_alignment_config = config.for_enabled_cop('Layout/ArrayAlignment')
+          argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
         end
       end
     end

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -225,13 +225,8 @@ module RuboCop
         end
 
         def enforce_first_argument_with_fixed_indentation?
-          return false unless argument_alignment_config['Enabled']
-
+          argument_alignment_config = config.for_enabled_cop('Layout/ArgumentAlignment')
           argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
-        end
-
-        def argument_alignment_config
-          config.for_cop('Layout/ArgumentAlignment')
         end
       end
     end

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -382,13 +382,8 @@ module RuboCop
         end
 
         def enforce_first_argument_with_fixed_indentation?
-          return false unless argument_alignment_config['Enabled']
-
+          argument_alignment_config = config.for_enabled_cop('Layout/ArgumentAlignment')
           argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
-        end
-
-        def argument_alignment_config
-          config.for_cop('Layout/ArgumentAlignment')
         end
       end
     end

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         def single_line_block_chain_enabled?
-          @config.for_cop('Layout/SingleLineBlockChain')['Enabled']
+          @config.cop_enabled?('Layout/SingleLineBlockChain')
         end
 
         def convertible_block?(node)

--- a/lib/rubocop/cop/mixin/dig_help.rb
+++ b/lib/rubocop/cop/mixin/dig_help.rb
@@ -20,7 +20,7 @@ module RuboCop
       private
 
       def dig_chain_enabled?
-        @config.for_cop('Style/DigChain')['Enabled']
+        @config.cop_enabled?('Style/DigChain')
       end
     end
   end

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -96,7 +96,7 @@ module RuboCop
       end
 
       def max_line_length
-        return unless config.for_cop('Layout/LineLength')['Enabled']
+        return unless config.cop_enabled?('Layout/LineLength')
 
         config.for_cop('Layout/LineLength')['Max']
       end

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -26,7 +26,7 @@ module RuboCop
       end
 
       def string_literals_config
-        config.for_cop('Style/StringLiterals')
+        config.for_enabled_cop('Style/StringLiterals')
       end
     end
   end

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -540,10 +540,7 @@ module RuboCop
         end
 
         def explicit_block_name?
-          block_forwarding_config = config.for_cop('Naming/BlockForwarding')
-          return false unless block_forwarding_config['Enabled']
-
-          block_forwarding_config['EnforcedStyle'] == 'explicit'
+          config.for_enabled_cop('Naming/BlockForwarding')['EnforcedStyle'] == 'explicit'
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -136,7 +136,7 @@ module RuboCop
         def frozen_strings?
           return true if frozen_string_literals_enabled?
 
-          frozen_string_cop_enabled = config.for_cop('Style/FrozenStringLiteralComment')['Enabled']
+          frozen_string_cop_enabled = config.cop_enabled?('Style/FrozenStringLiteralComment')
           frozen_string_cop_enabled &&
             !frozen_string_literals_disabled? &&
             string_literals_frozen_by_default?.nil?

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -109,7 +109,7 @@ module RuboCop
         end
 
         def max_line_length
-          return unless config.for_cop('Layout/LineLength')['Enabled']
+          return unless config.cop_enabled?('Layout/LineLength')
 
           config.for_cop('Layout/LineLength')['Max']
         end

--- a/lib/rubocop/cop/style/quoted_symbols.rb
+++ b/lib/rubocop/cop/style/quoted_symbols.rb
@@ -98,7 +98,7 @@ module RuboCop
 
         def style
           return super unless super == :same_as_string_literals
-          return :single_quotes unless string_literals_config['Enabled']
+          return :single_quotes unless config.cop_enabled?('Style/StringLiterals')
 
           string_literals_config['EnforcedStyle'].to_sym
         end

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -166,10 +166,7 @@ module RuboCop
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
         def allow_in_multiline_conditions?
-          parentheses_around_condition_config = config.for_cop('Style/ParenthesesAroundCondition')
-          return false unless parentheses_around_condition_config['Enabled']
-
-          !!parentheses_around_condition_config['AllowInMultilineConditions']
+          !!config.for_enabled_cop('Style/ParenthesesAroundCondition')['AllowInMultilineConditions']
         end
 
         def check_send(begin_node, node)

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -323,7 +323,7 @@ module RuboCop
           return true if unsafe_method?(method)
 
           method.each_ancestor(:send).any? do |ancestor|
-            break true unless config.for_cop('Lint/SafeNavigationChain')['Enabled']
+            break true unless config.cop_enabled?('Lint/SafeNavigationChain')
 
             break true if unsafe_method?(ancestor)
             break true if nil_methods.include?(ancestor.method_name)

--- a/lib/rubocop/cop/style/single_line_do_end_block.rb
+++ b/lib/rubocop/cop/style/single_line_do_end_block.rb
@@ -68,8 +68,7 @@ module RuboCop
         end
 
         def single_line_blocks_preferred?
-          redundant_line_break_config = @config.for_cop('Layout/RedundantLineBreak')
-          redundant_line_break_config['Enabled'] && redundant_line_break_config['InspectBlocks']
+          @config.for_enabled_cop('Layout/RedundantLineBreak')['InspectBlocks']
         end
       end
     end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -134,10 +134,9 @@ module RuboCop
         end
 
         def disallow_endless_method_style?
-          endless_method_config = config.for_cop('Style/EndlessMethod')
-          return true unless endless_method_config['Enabled']
+          return true unless config.cop_enabled?('Style/EndlessMethod')
 
-          endless_method_config['EnforcedStyle'] == 'disallow'
+          config.for_cop('Style/EndlessMethod')['EnforcedStyle'] == 'disallow'
         end
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -723,6 +723,42 @@ RSpec.describe RuboCop::Config do
     end
   end
 
+  describe '#for_enabled_cop' do
+    let(:hash) do
+      {
+        'Layout/TrailingWhitespace' => { 'Enabled' => true },
+        'Layout/LineLength' => { 'Enabled' => false },
+        'Metrics/MethodLength' => { 'Enabled' => 'pending' }
+      }
+    end
+
+    it 'returns config for an enabled cop' do
+      expect(configuration.for_enabled_cop('Layout/TrailingWhitespace')).to eq('Enabled' => true)
+    end
+
+    it 'returns an empty hash for a disabled cop' do
+      expect(configuration.for_enabled_cop('Layout/LineLength')).to be_empty
+    end
+
+    it 'returns config for an pending cop' do
+      expect(configuration.for_enabled_cop('Metrics/MethodLength')).to eq('Enabled' => 'pending')
+    end
+  end
+
+  describe '#cop_enabled?' do
+    let(:hash) do
+      {
+        'Layout/TrailingWhitespace' => { 'Enabled' => true },
+        'Layout/LineLength' => { 'Enabled' => false },
+        'Metrics/MethodLength' => { 'Enabled' => 'pending' }
+      }
+    end
+
+    it { is_expected.to be_cop_enabled('Layout/TrailingWhitespace') }
+    it { is_expected.not_to be_cop_enabled('Layout/LineLength') }
+    it { is_expected.to be_cop_enabled('Metrics/MethodLength') }
+  end
+
   context 'whether the cop is enabled' do
     def cop_enabled(cop_class)
       configuration.for_cop(cop_class).fetch('Enabled')

--- a/spec/rubocop/cop/internal_affairs/cop_enabled_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_enabled_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::CopEnabled, :config do
+  context 'with .for_cop' do
+    it "registers an offense when using `config.for_cop(...)['Enabled']" do
+      expect_offense(<<~RUBY)
+        config.for_cop('Foo/Bar')['Enabled']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `config.cop_enabled?('Foo/Bar')` instead [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        config.cop_enabled?('Foo/Bar')
+      RUBY
+    end
+
+    it "registers an offense when using `@config.for_cop(...)['Enabled']" do
+      expect_offense(<<~RUBY)
+        @config.for_cop('Foo/Bar')['Enabled']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@config.cop_enabled?('Foo/Bar')` instead [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        @config.cop_enabled?('Foo/Bar')
+      RUBY
+    end
+
+    it 'maintains existing quote style when correcting' do
+      expect_offense(<<~RUBY)
+        @config.for_cop("Foo/Bar")["Enabled"]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@config.cop_enabled?("Foo/Bar")` instead [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        @config.cop_enabled?("Foo/Bar")
+      RUBY
+    end
+
+    it 'does not register an offense when :Enabled is a symbol' do
+      expect_no_offenses(<<~RUBY)
+        @config.for_cop('Foo/Bar')[:Enabled]
+      RUBY
+    end
+  end
+
+  context "when checking `*_config['Enabled']`" do
+    it 'registers an offense and does not correct with a method call' do
+      expect_offense(<<~RUBY)
+        return false unless argument_alignment_config['Enabled']
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider replacing uses of `argument_alignment_config` with `config.for_enabled_cop`.
+
+        argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+      RUBY
+    end
+
+    it 'registers an offense and does not correct with a local variable' do
+      expect_offense(<<~RUBY)
+        argument_alignment_config = config.for_cop('Layout/ArgumentAlignment')
+        return false unless argument_alignment_config['Enabled']
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider replacing uses of `argument_alignment_config` with `config.for_enabled_cop`.
+
+        argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+      RUBY
+    end
+
+    it 'registers an offense and does not correct with an instance variable' do
+      expect_offense(<<~RUBY)
+        @argument_alignment_config = config.for_cop('Layout/ArgumentAlignment')
+        return false unless @argument_alignment_config['Enabled']
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider replacing uses of `@argument_alignment_config` with `config.for_enabled_cop`.
+
+        @argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+      RUBY
+    end
+
+    it 'does not register an offense when the hash name does not end with `_config`' do
+      expect_no_offenses(<<~RUBY)
+        foo['Enabled']
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Update `RuboCop::Cop::Config` to introduce a fluent interface for checking if a cop is enabled. Two methods have been added: `Config#cop_enabled?` to replace `config.for_cop(...)['Enabled']` and `Config#for_enabled_cop` (only returns configuration if the cop is enabled).

To help use the new methods, a new `InternalAffairs/CopEnabled` cop has been added as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
