### PR TITLE
[Fix #13532] Fix `Lint/NumericOperationWithConstantResult` cop not to complain about `% 1` operation

### DIFF
--- a/changelog/fix_lint_numeric_operation_with_constant_result_with_modulo_one.md
+++ b/changelog/fix_lint_numeric_operation_with_constant_result_with_modulo_one.md
@@ -1,0 +1,1 @@
+* [#13532](https://github.com/rubocop/rubocop/issues/13532): Fix `Lint/NumericOperationWithConstantResult` cop not to complain about `% 1` operation. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
+++ b/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # Certain numeric operations have a constant result, usually 0 or 1.
       # Subtracting a number from itself or multiplying it by 0 will always return 0.
-      # Additionally, a variable modulo 0 or itself will always return 0.
+      # Additionally, a variable modulo itself will always return 0.
       # Dividing a number by itself or raising it to the power of 0 will always return 1.
       # As such, they can be replaced with that result.
       # These are probably leftover from debugging, or are mistakes.
@@ -17,7 +17,6 @@ module RuboCop
       #   # bad
       #   x - x
       #   x * 0
-      #   x % 1
       #   x % x
       #
       #   # good
@@ -26,7 +25,6 @@ module RuboCop
       #   # bad
       #   x -= x
       #   x *= 0
-      #   x %= 1
       #   x %= x
       #
       #   # good
@@ -85,13 +83,10 @@ module RuboCop
 
         private
 
-        # rubocop :disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def constant_result?(variable, operation, number)
           if number.to_s == '0'
             return 0 if operation == :*
             return 1 if operation == :**
-          elsif number.to_s == '1'
-            return 0 if operation == :%
           elsif number == variable
             return 0 if %i[- %].include?(operation)
             return 1 if operation == :/
@@ -99,7 +94,6 @@ module RuboCop
           # If we weren't able to find any matches, return false so we can bail out.
           false
         end
-        # rubocop :enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
+++ b/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
@@ -23,14 +23,9 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     RUBY
   end
 
-  it 'registers an offense when the modulo of variable and 1 is taken' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when the modulo of variable and 1 is taken' do
+    expect_no_offenses(<<~RUBY)
       x % 1
-      ^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      0
     RUBY
   end
 
@@ -89,14 +84,9 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     RUBY
   end
 
-  it 'registers an offense when the modulo of variable and 1 is taken via abbreviated assignment' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when the modulo of variable and 1 is taken via abbreviated assignment' do
+    expect_no_offenses(<<~RUBY)
       x %= 1
-      ^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x = 0
     RUBY
   end
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/13532

That's clearly not true that `%numeric == 0 (mod 1)` in general:

```
docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.2.0 ./all-ruby -e 'p(1.42 % 1)'
ruby-2.2.0          0.41999999999999993
...
ruby-3.4.0-preview2 0.41999999999999993
```

Thus it makes sense not to complain about `% 1` or `%= 1` at all.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
