### PR TITLE
Fix `Layout/LineLength` cop failure in case of tabbed YARD-comment-like string

### DIFF
--- a/changelog/fix_layout_line_length_cop_failure_with_yard_like_string.md
+++ b/changelog/fix_layout_line_length_cop_failure_with_yard_like_string.md
@@ -1,0 +1,1 @@
+* [#13534](https://github.com/rubocop/rubocop/pull/13534): Fix `Layout/LineLength` cop failure in case of YARD-comment-like string. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -37,11 +37,12 @@ module RuboCop
         last_uri_match = match_uris(line).last
         return nil unless last_uri_match
 
-        begin_position, end_position = last_uri_match.offset(0).map do |pos|
-          pos + indentation_difference(line)
-        end
-
+        begin_position, end_position = last_uri_match.offset(0)
         end_position = extend_uri_end_position(line, end_position)
+
+        line_indentation_difference = indentation_difference(line)
+        begin_position += line_indentation_difference
+        end_position += line_indentation_difference
 
         return nil if begin_position < max_line_length && end_position < max_line_length
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -167,6 +167,17 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'with URI starting before or after limit depending on tabs count' do
+      let(:cop_config) { { 'Max' => 30, 'AllowURI' => true } }
+
+      it 'registers an offense for the line' do
+        expect_offense(<<~RUBY)
+          \t\t\t\t# There is some content http://test.com
+                                    ^^^^^^^^^^^^^^^^^ Line is too long. [47/30]
+        RUBY
+      end
+    end
+
     context 'and an error other than URI::InvalidURIError is raised ' \
             'while validating a URI-ish string' do
       let(:cop_config) { { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[LDAP] } }
@@ -463,6 +474,13 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
 
       it "accepts a line that's including URI in quotes with text" do
         expect_no_offenses("\t\t# See 'https://github.com/rubocop/rubocop'")
+      end
+
+      it 'registers the line which looks like YARD comment' do
+        expect_offense(<<-RUBY)
+	        \texpect(some_exception_variable) {|e| e.url.should == 'http://host/path'}
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [83/30]
+        RUBY
       end
     end
   end


### PR DESCRIPTION
The following ruby code leads to an error:

```
rubocop -c <(echo "Layout/LineLength:\n AllowURI: true\n Max: 1") --stdin bug.rb --only Layout/LineLength -d <<EOF
  expect(some_exception_variable) {|e| e.url.should == 'http://host/path'}
EOF
```

(there's a `\t` in the beginning)

Backtrace:

```
An error occurred while Layout/LineLength cop was inspecting bug.rb.
undefined method `offset' for nil
lib/rubocop/cop/mixin/line_length_help.rb:76:in `extend_uri_end_position'
lib/rubocop/cop/mixin/line_length_help.rb:44:in `find_excessive_uri_range'
lib/rubocop/cop/layout/line_length.rb:359:in `check_uri_line'
lib/rubocop/cop/layout/line_length.rb:258:in `check_line'
lib/rubocop/cop/layout/line_length.rb:103:in `block in on_investigation_end'
lib/rubocop/cop/layout/line_length.rb:102:in `each'
lib/rubocop/cop/layout/line_length.rb:102:in `each_with_index'
lib/rubocop/cop/layout/line_length.rb:102:in `on_investigation_end'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
