### PR TITLE
Specify newer repository revision for precommit integration in docs

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -125,7 +125,7 @@ following to your `.pre-commit-config.yaml` file:
 [source,yaml]
 ----
 - repo: https://github.com/rubocop/rubocop
-  rev: v1.8.1
+  rev: v1.9.0
   hooks:
     - id: rubocop
 ----
@@ -136,7 +136,7 @@ entries in `additional_dependencies`:
 [source,yaml]
 ----
 - repo: https://github.com/rubocop/rubocop
-  rev: v1.8.1
+  rev: v1.9.0
   hooks:
     - id: rubocop
       additional_dependencies:


### PR DESCRIPTION
I've tried to add rubocop to my `.pre-commit-config.yaml` using snippet from [docs](https://docs.rubocop.org/rubocop/integration_with_other_tools.html#git-pre-commit-hook-integration-with-pre-commit), but it seems there's no `.pre-commit-hooks.yaml` at 1.8.1:

> An error has occurred: InvalidManifestError: 
> =====> ~/.cache/pre-commit/repopxc490ng/.pre-commit-hooks.yaml is not a file

It worked fine after changing `rev` to 1.69.0

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
