### PR TITLE
Remove `MATH_OPERATORS` check from `Lint/BinaryOperatorWithIdenticalOperands`

### DIFF
--- a/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
+++ b/lib/rubocop/cop/lint/binary_operator_with_identical_operands.rb
@@ -45,12 +45,10 @@ module RuboCop
       #
       class BinaryOperatorWithIdenticalOperands < Base
         MSG = 'Binary operator `%<op>s` has identical operands.'
-        MATH_OPERATORS = %i[- + * / ** << >>].to_set.freeze
         RESTRICT_ON_SEND = %i[== != === <=> =~ && || > >= < <= | ^].freeze
 
         def on_send(node)
           return unless node.binary_operation?
-          return if MATH_OPERATORS.include?(node.method_name)
           return unless node.receiver == node.first_argument
 
           add_offense(node, message: format(MSG, op: node.method_name))


### PR DESCRIPTION
Noticed this while looking at #13519, since the relevant operators are covered by the new `RESTRICT_ON_SEND`, we don't have to check for these anymore.

No changelog entry added as behavior is identical.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
