### PR TITLE
Automatic pre-commit repository revision update in docs

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -125,7 +125,7 @@ following to your `.pre-commit-config.yaml` file:
 [source,yaml]
 ----
 - repo: https://github.com/rubocop/rubocop
-  rev: v1.9.0
+  rev: v1.69.1
   hooks:
     - id: rubocop
 ----
@@ -136,13 +136,15 @@ entries in `additional_dependencies`:
 [source,yaml]
 ----
 - repo: https://github.com/rubocop/rubocop
-  rev: v1.9.0
+  rev: v1.69.1
   hooks:
     - id: rubocop
       additional_dependencies:
         - rubocop-rails
         - rubocop-rspec
 ----
+
+RuboCop supports pre-commit hook integration since version 1.9.
 
 == Guard integration
 

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -47,6 +47,10 @@ namespace :cut_release do
         "gem 'rubocop', '~> #{version_sans_patch(new_version)}', require: false"
       )
     end
+
+    update_file('docs/modules/ROOT/pages/integration_with_other_tools.adoc') do |integration|
+      integration.gsub("rev: v#{old_version}", "rev: v#{new_version}")
+    end
   end
 
   def update_issue_template(old_version, new_version)


### PR DESCRIPTION
It makes sense to both motivate users to use the latest RuboCop repo version when configuring `pre-commit` integration and specify the oldest supported version (v1.9) in docs.

See https://github.com/rubocop/rubocop/pull/13536#discussion_r1867451231

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
