### PR TITLE
[Fix #13320] Fix incorrect autocorrect when `Layout/LineContinuationLeadingSpace` and `Style/StringLiterals` autocorrects in the same pass

### DIFF
--- a/changelog/fix_fix_incorrect_autocorrect_when.md
+++ b/changelog/fix_fix_incorrect_autocorrect_when.md
@@ -1,0 +1,1 @@
+* [#13320](https://github.com/rubocop/rubocop/issues/13320): Fix incorrect autocorrect when `Layout/LineContinuationLeadingSpace` and `Style/StringLiterals` autocorrects in the same pass. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/line_continuation_leading_space.rb
+++ b/lib/rubocop/cop/layout/line_continuation_leading_space.rb
@@ -51,6 +51,15 @@ module RuboCop
         private_constant :LINE_1_ENDING, :LINE_2_BEGINNING,
                          :LEADING_STYLE_OFFENSE, :TRAILING_STYLE_OFFENSE
 
+        # When both cops are activated and run in the same iteration of the correction loop,
+        # `Style/StringLiterals` undoes the moving of spaces that
+        # `Layout/LineContinuationLeadingSpace` performs. This is because `Style/StringLiterals`
+        # takes the original string content and transforms it, rather than just modifying the
+        # delimiters, in order to handle escaping for quotes within the string.
+        def self.autocorrect_incompatible_with
+          [Style::StringLiterals]
+        end
+
         def on_dstr(node)
           # Quick check if we possibly have line continuations.
           return unless node.source.include?('\\')

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3756,7 +3756,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
   it 'does not change the number of spaces when autocorrecting a combination of `Layout/LineEndStringConcatenationIndentation`' \
      'and `Style/StringLiterals` with newlines' do
     source_file = Pathname('example.rb')
-    create_file(source_file, <<~'RUBY')
+    create_file(source_file, <<~'RUBY', retain_line_terminators: RuboCop::Platform.windows?)
       "    0:  4\n" \
       "    8: 12\n" \
       "   16: 20"

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -3,15 +3,21 @@
 require 'fileutils'
 
 module FileHelper
-  def create_file(file_path, content)
+  def create_file(file_path, content, retain_line_terminators: false)
     file_path = File.expand_path(file_path)
+
+    # On Windows, when a file is opened in 'w' mode, LF line terminators (`\n`)
+    # are automatically converted to CRLF (`\r\n`).
+    # If this is not desired, `force_lf: true` will cause the file to be opened
+    # in 'wb' mode instead, which keeps existing line terminators.
+    file_mode = retain_line_terminators ? 'wb' : 'w'
 
     ensure_descendant(file_path)
 
     dir_path = File.dirname(file_path)
     FileUtils.mkdir_p dir_path
 
-    File.open(file_path, 'w') do |file|
+    File.open(file_path, file_mode) do |file|
       case content
       when String
         file.puts content


### PR DESCRIPTION
When both cops are activated and run in the same iteration of the correction loop, `Style/StringLiterals` undoes the moving of spaces that `Layout/LineContinuationLeadingSpace` performs. This is because `StringLiterals` takes the original string content and transforms it, rather than just modifying the delimiters, in order to handle escaping for quotes within the string.

By marking `Style/StringLiterals` as incompatible with `Layout/LineContinuationLeadingSpace`, it allows the correction to be deferred to the next inspection loop, thereby avoiding the problem.

Fixes #13320.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
