### PR TITLE
Fix grammar in `Layout/LineContinuationLeadingSpace` offense messages

### DIFF
--- a/lib/rubocop/cop/layout/line_continuation_leading_space.rb
+++ b/lib/rubocop/cop/layout/line_continuation_leading_space.rb
@@ -129,9 +129,9 @@ module RuboCop
 
         def message(_range)
           if enforced_style_leading?
-            'Move trailing spaces to the start of next line.'
+            'Move trailing spaces to the start of the next line.'
           else
-            'Move leading spaces to the end of previous line.'
+            'Move leading spaces to the end of the previous line.'
           end
         end
 

--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         'this text is too' \
         ' long'
-         ^ Move leading spaces to the end of previous line.
+         ^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         'this text is too' \
           ' long'
-           ^ Move leading spaces to the end of previous line.
+           ^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         'this text contains a lot of' \
         '               spaces'
-         ^^^^^^^^^^^^^^^ Move leading spaces to the end of previous line.
+         ^^^^^^^^^^^^^^^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -47,9 +47,9 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         'this text is too' \
         ' long' \
-         ^ Move leading spaces to the end of previous line.
+         ^ Move leading spaces to the end of the previous line.
         '  long long'
-         ^^ Move leading spaces to the end of previous line.
+         ^^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         something_unrelated_to_the_line_continuation_below
         'this text is too' \
         ' long'
-         ^ Move leading spaces to the end of previous line.
+         ^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         long_method_name 'this text is too' \
           ' long' do
-           ^ Move leading spaces to the end of previous line.
+           ^ Move leading spaces to the end of the previous line.
         end
       RUBY
 
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         long_method_name(
           'this text is too' \
           ' long'
-           ^ Move leading spaces to the end of previous line.
+           ^ Move leading spaces to the end of the previous line.
         )
       RUBY
 
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         "foo
         bar" \
         " baz"
-         ^ Move leading spaces to the end of previous line.
+         ^ Move leading spaces to the end of the previous line.
       RUBY
 
       expect_correction(<<~'RUBY')
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         expect_offense(<<~'RUBY')
           "foo #{bar}" \
           ' long'
-           ^ Move leading spaces to the end of previous line.
+           ^ Move leading spaces to the end of the previous line.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         expect_offense(<<~'RUBY')
           'this line is' \
           " #{foo}"
-           ^ Move leading spaces to the end of previous line.
+           ^ Move leading spaces to the end of the previous line.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
         expect_offense(<<~'RUBY')
           "foo #{'bar' \
             ' baz'}"
-             ^ Move leading spaces to the end of previous line.
+             ^ Move leading spaces to the end of the previous line.
         RUBY
 
         expect_correction(<<~'RUBY')
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
     it 'registers an offense when 1st line has one trailing space' do
       expect_offense(<<~'RUBY')
         'this text is too ' \
-                         ^ Move trailing spaces to the start of next line.
+                         ^ Move trailing spaces to the start of the next line.
         'long'
       RUBY
 
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         'this text is too' \
           ' very ' \
-                ^ Move trailing spaces to the start of next line.
+                ^ Move trailing spaces to the start of the next line.
           'long'
       RUBY
 
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
     it 'registers an offense when 1st line has multiple trailing spaces' do
       expect_offense(<<~'RUBY')
         'this text contains a lot of               ' \
-                                    ^^^^^^^^^^^^^^^ Move trailing spaces to the start of next line.
+                                    ^^^^^^^^^^^^^^^ Move trailing spaces to the start of the next line.
         'spaces'
       RUBY
 
@@ -251,9 +251,9 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
     it 'registers offenses when 1st and 2nd line has trailing spaces' do
       expect_offense(<<~'RUBY')
         'this text is too ' \
-                         ^ Move trailing spaces to the start of next line.
+                         ^ Move trailing spaces to the start of the next line.
         'long  ' \
-             ^^ Move trailing spaces to the start of next line.
+             ^^ Move trailing spaces to the start of the next line.
         'long long'
       RUBY
 
@@ -268,7 +268,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         something_unrelated_to_the_line_continuation_below
         'this text is too ' \
-                         ^ Move trailing spaces to the start of next line.
+                         ^ Move trailing spaces to the start of the next line.
         'long'
       RUBY
 
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         long_method_name 'this text is too' \
           ' very ' \
-                ^ Move trailing spaces to the start of next line.
+                ^ Move trailing spaces to the start of the next line.
           'long' do
         end
       RUBY
@@ -300,7 +300,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       expect_offense(<<~'RUBY')
         long_method_name(
           'this text is too ' \
-                           ^ Move trailing spaces to the start of next line.
+                           ^ Move trailing spaces to the start of the next line.
           'long'
         )
       RUBY
@@ -336,7 +336,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       it 'registers offenses when 1st line has trailing spaces and 2nd line is interpolated' do
         expect_offense(<<~'RUBY')
           'foo ' \
-              ^ Move trailing spaces to the start of next line.
+              ^ Move trailing spaces to the start of the next line.
           "#{bar} long"
         RUBY
 
@@ -349,7 +349,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       it 'registers offenses when 1st line has leading spaces and 1st line is interpolated' do
         expect_offense(<<~'RUBY')
           "this #{foo} is " \
-                         ^ Move trailing spaces to the start of next line.
+                         ^ Move trailing spaces to the start of the next line.
           'long'
         RUBY
 
@@ -376,7 +376,7 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       it 'registers an offense for incorrectly formatted multiline interpolated string' do
         expect_offense(<<~'RUBY')
           "foo #{'bar ' \
-                     ^ Move trailing spaces to the start of next line.
+                     ^ Move trailing spaces to the start of the next line.
             'baz'}"
         RUBY
 


### PR DESCRIPTION
Use "of **the** next/previous line" instead of "of next/previous line".