### PR TITLE
Improve `Layout/EmptyLinesAroundBeginBody` example

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
@@ -8,19 +8,18 @@ module RuboCop
       #
       # @example
       #
-      #   # good
-      #
-      #   begin
-      #     # ...
-      #   end
-      #
       #   # bad
-      #
       #   begin
       #
       #     # ...
       #
       #   end
+      #
+      #   # good
+      #   begin
+      #     # ...
+      #   end
+      #
       class EmptyLinesAroundBeginBody < Base
         include EmptyLinesAroundBody
         extend AutoCorrector


### PR DESCRIPTION
How about listing them in the order of bad → good, just like the examples of other cops?

(In addition, I removed unnecessary blank lines directly below `# bad` and `# good`.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
