### PR TITLE
Fix `Style/RedundantCondition` cop failure in case of empty arguments node

### DIFF
--- a/changelog/fix_style_redundant_condition_cop_failure_with_empty_arguments.md
+++ b/changelog/fix_style_redundant_condition_cop_failure_with_empty_arguments.md
@@ -1,0 +1,1 @@
+* [#13542](https://github.com/rubocop/rubocop/pull/13542): Fix `Style/RedundantCondition` cop failure in case of empty arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -16,6 +16,8 @@ module RuboCop
       end
 
       def comments_in_range(node)
+        return [] unless node.source_range
+
         start_line = node.source_range.line
         end_line = find_end_line(node)
 
@@ -74,7 +76,8 @@ module RuboCop
           end
         elsif node.block_type? || node.numblock_type?
           node.loc.end.line
-        elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node)
+        elsif (next_sibling = node.right_sibling) && next_sibling.is_a?(AST::Node) &&
+              next_sibling.source_range
           next_sibling.loc.line
         elsif (parent = node.parent)
           if parent.loc.respond_to?(:end) && parent.loc.end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -558,6 +558,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects with empty arguments' do
+        expect_offense(<<~RUBY)
+          test ? test : Proc.new {}
+               ^^^^^^^^ Use double pipes `||` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          test || Proc.new {}
+        RUBY
+      end
+
       it 'registers an offense and corrects nested vars' do
         expect_offense(<<~RUBY)
           b.x ? b.x : c


### PR DESCRIPTION
I’ve encountered an error with this Ruby code:

```
rubocop --stdin bug.rb -d <<EOF
  test ? test : Proc.new {}
EOF
```

Backtrace:

```
An error occurred while Style/RedundantCondition cop was inspecting bug.rb:1:0.
undefined method `line' for nil
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/map.rb:100:in `line'
lib/rubocop/cop/mixin/comments_help.rb:81:in `find_end_line'
lib/rubocop/cop/mixin/comments_help.rb:22:in `comments_in_range'
lib/rubocop/cop/mixin/comments_help.rb:15:in `contains_comments?'
lib/rubocop/cop/style/redundant_condition.rb:77:in `block in autocorrect'
```

It seems the issue is not with the cop itself but with `lib/rubocop/cop/mixin/comments_help.rb`:

1. The public API method `contains_comments?(node)` does not verify whether the provided node has a source. Nodes such as `s(:args)` (empty arguments) have their `source_range` set to `nil`. There are many cops using this API but `Style/RedundantCondition` is the only one that uses some kind of wildcard search pattern with `each_descendant.any? { |node| contains_comments?(node) }`

2. In the `find_end_line` routine, the `next_sibling` may also be an `s(:args)` node and fail for the same reason.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
