### PR TITLE
[Fix #13284] Add new `target_gem_version` API

### DIFF
--- a/changelog/new_target_gem_version.md
+++ b/changelog/new_target_gem_version.md
@@ -1,0 +1,1 @@
+* [#13284](https://github.com/rubocop/rubocop/issues/13284): Add new `target_gem_version` API to change behavior of a cop at runtime depending on which gem version is present. ([@earlopain][])

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -426,6 +426,22 @@ end
 
 You can specify any gem requirement using https://guides.rubygems.org/patterns/#declaring-dependencies[the same syntax as your `Gemfile`].
 
+You can also handle multiple versions of a gem with `target_gem_version`. It behaves similar to `target_ruby_version`, allowing you to inspect a gem version at runtime:
+
+```Ruby
+class MyCop < Base
+  requires_gem "my-gem"
+
+  def on_send(node)
+    if target_gem_version("my-gem) < "1.0"
+      # ...
+    else
+      # ...
+    end
+  end
+end
+```
+
 ==== Special case: Rails
 
 Historically, many cops in `rubocop-rails` aren't actually specific to Rails itself, but some of its components (e.g. `ActiveSupport`). These dependencies are declared with https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/TargetRailsVersion#minimum_target_rails_version-instance_method[`TargetRailsVersion.minimum_target_rails_version`].

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -261,6 +261,12 @@ module RuboCop
         @config.target_ruby_version
       end
 
+      # Returns a gems locked versions (i.e. from Gemfile.lock or gems.locked)
+      # @returns [Gem::Version | nil] The locked gem version, or nil if the gem is not present.
+      def target_gem_version(gem_name)
+        @config.gem_versions_in_target && @config.gem_versions_in_target[gem_name]
+      end
+
       def parser_engine
         @config.parser_engine
       end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -136,11 +136,13 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
       rails_version || RuboCop::Config::DEFAULT_RAILS_VERSION
     )
 
-    allow(config).to receive(:gem_versions_in_target).and_return(
-      {
-        'railties' => rails_version_in_gemfile
-      }
-    )
+    allow(config).to receive(:gem_versions_in_target).and_wrap_original do |method|
+      result = method.call
+      next unless result
+
+      result['railties'] = rails_version_in_gemfile
+      result
+    end
 
     config
   end


### PR DESCRIPTION
This allows cops that require a gem to handle multiple different versions of a gem at the same time.
Previously the only piece of information you had was that the gem was present.

For example in rack 3.1, new status code aliases were added that should not be handled on earlier versions.

Since this only looks at the lockfile, default gems are not considered.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
