### PR TITLE
[Fix #13299] Fix `Style/BlockDelimiters` to always accept braces when an operator method argument is chained

### DIFF
--- a/changelog/fix_fix_style_block_delimiters_when_an_operator_method.md
+++ b/changelog/fix_fix_style_block_delimiters_when_an_operator_method.md
@@ -1,0 +1,1 @@
+* [#13299](https://github.com/rubocop/rubocop/issues/13299): Fix `Style/BlockDelimiters` to always accept braces when an operator method argument is chained. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -183,7 +183,8 @@ module RuboCop
         def on_send(node)
           return unless node.arguments?
           return if node.parenthesized?
-          return if node.operator_method? || node.assignment_method?
+          return if node.assignment_method?
+          return if single_argument_operator_method?(node)
 
           node.arguments.each do |arg|
             get_blocks(arg) do |block|
@@ -500,6 +501,12 @@ module RuboCop
           # If the block contains `rescue` or `ensure`, it needs to be wrapped in
           # `begin`...`end` when changing `do-end` to `{}`.
           block_node.each_child_node(:rescue, :ensure).any? && !block_node.single_line?
+        end
+
+        def single_argument_operator_method?(node)
+          return false unless node.operator_method?
+
+          node.arguments.one? && node.first_argument.block_type?
         end
       end
     end


### PR DESCRIPTION
Update `Style/BlockDelimiters` to not register an offense when braces are necessary to avoid changing precedence. Previously when an operator method was encountered, it was automatically evaluated (ie. not marked as ignored), but this can result in block delimiters being changed that affects block binding.

Now operator methods are evaluated for nodes to ignore, other than if it only has a single argument which is of block type.

As well, I added the missing `expect_corrections` tests for offenses without it.

Fixes #13299.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
