### PR TITLE
[Fix #7958] Properly tag unsafe autocorrections with `rubocop:todo` when using `--autocorrect --disable-uncorrectable`

### DIFF
--- a/changelog/fix_handle_correctable_but_unsafe_cops_when_using.md
+++ b/changelog/fix_handle_correctable_but_unsafe_cops_when_using.md
@@ -1,0 +1,1 @@
+* [#7958](https://github.com/rubocop/rubocop/issues/7958): Properly tag unsafe autocorrections with `rubocop:todo` when using `--autocorrect --disable-uncorrectable`. ([@dvandersluis][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -432,6 +432,8 @@ module RuboCop
       def use_corrector(range, corrector)
         if autocorrect?
           attempt_correction(range, corrector)
+        elsif disable_uncorrectable?
+          attempt_correction(range, nil)
         elsif corrector && (always_autocorrect? || (contextual_autocorrect? && !LSP.enabled?))
           :uncorrected
         else


### PR DESCRIPTION
Previously, if a cop was correctable but not corrected due to being unsafe, `--autocorrect --disable-uncorrectable` would report the offense but not tag it with `rubocop:todo`. This is now updated, so that unsafe offenses are tagged as well.

In order to do so, we have to treat all cops as "autocorrect_cops" in `Team#investigate`, since adding the directive is also a correction; otherwise, the offense report will mark the offense as `[Todo]` but not actually apply the correction.

Fixes #7958.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
