### PR TITLE
Fix `Style/IdenticalConditionalBranches` cop failure in case of `if` node with implicit `then`

### DIFF
--- a/changelog/fix_style_identical_conditional_branches_failure_with_implicit_if_then.md
+++ b/changelog/fix_style_identical_conditional_branches_failure_with_implicit_if_then.md
@@ -1,0 +1,1 @@
+* [#13547](https://github.com/rubocop/rubocop/pull/13547): Fix `Style/IdenticalConditionalBranches` cop failure in case of `if` node with implicit `then`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -189,7 +189,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def check_expressions(node, expressions, insert_position)
           return if expressions.any?(&:nil?)
 
@@ -197,7 +197,9 @@ module RuboCop
 
           expressions.each do |expression|
             add_offense(expression) do |corrector|
-              next if node.if_type? && node.ternary?
+              if (node.if_type? && node.ternary?) || node.loc.begin&.source&.start_with?('then')
+                next
+              end
 
               range = range_by_whole_lines(expression.source_range, include_final_newline: true)
               corrector.remove(range)
@@ -213,7 +215,7 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def correct_assignment(corrector, node, expression, insert_position)
           if insert_position == :after_condition

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -930,5 +930,55 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
         end
       end
     end
+
+    context 'with `if` in non-modifier form with `then`' do
+      context 'when expression is on the same line as `then`' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            def fixed_point(value)
+              if value then value
+                            ^^^^^ Move `value` out of the conditional.
+              else value
+                   ^^^^^ Move `value` out of the conditional.
+              end
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+
+        it 'registers an offense when `else` branch is not inlined' do
+          expect_offense(<<~RUBY)
+            def fixed_point(value)
+              if value then value
+                            ^^^^^ Move `value` out of the conditional.
+              else
+                value
+                ^^^^^ Move `value` out of the conditional.
+              end
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'when expression is on the next line' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            def fixed_point(value)
+              if value then
+                value
+                ^^^^^ Move `value` out of the conditional.
+              else value
+                   ^^^^^ Move `value` out of the conditional.
+              end
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I observe an issue with the following ruby code:

```ruby
rubocop --only Style/IdenticalConditionalBranches -d --stdin bug.rb <<EOF
  def fixed_point(value)
    if value then value
    else value
    end
  end
EOF
```

Backtrace:

```
An error occurred while Style/IdenticalConditionalBranches cop was inspecting bug.rb:2:2.
Parser::Source::TreeRewriter detected clobbering
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter.rb:414:in `enforce_policy'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:210:in `call'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:210:in `block in check_fusible'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:208:in `each'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:208:in `check_fusible'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:188:in `analyse_hierarchy'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:112:in `place_in_hierarchy'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:107:in `do_combine'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter/action.rb:31:in `combine'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter.rb:400:in `combine'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter.rb:207:in `wrap'
~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/parser-3.3.5.0/lib/parser/source/tree_rewriter.rb:243:in `insert_after'
lib/rubocop/cop/style/identical_conditional_branches.rb:210:in `block (2 levels) in check_expressions'
```

Since these implicit `then`s are not represented in the AST, I adopted `Style/MultilineIfThen`'s approach and extracted it to dedicated mixin.

This patch disable autocorrection in this case and preserves offense messages.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
