### PR TITLE
Enhance `Lint/DuplicateSetElement` to detect offences within `SortedSet`

### DIFF
--- a/changelog/change_lint_duplicate_set_element_cop_to_detect_sorted_set_duplicates.md
+++ b/changelog/change_lint_duplicate_set_element_cop_to_detect_sorted_set_duplicates.md
@@ -1,0 +1,1 @@
+* [#13548](https://github.com/rubocop/rubocop/pull/13548): Enhance `Lint/DuplicateSetElement` to detect offences within `SortedSet`. ([@viralpraxis][])

--- a/spec/rubocop/cop/lint/duplicate_set_element_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_set_element_spec.rb
@@ -1,140 +1,154 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::DuplicateSetElement, :config do
-  it 'registers an offense when using duplicate symbol element in `Set[...]`' do
-    expect_offense(<<~RUBY)
-      Set[:foo, :bar, :foo]
-                      ^^^^ Remove the duplicate element in Set.
-    RUBY
+  %w[Set SortedSet].each do |class_name|
+    it "registers an offense when using duplicate symbol element in `#{class_name}[...]`" do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}[:foo, :bar, :foo]
+        _{class_name}             ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set[:foo, :bar]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}[:foo, :bar]
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate symbol element in `::Set[...]`' do
-    expect_offense(<<~RUBY)
-      ::Set[:foo, :bar, :foo]
-                        ^^^^ Remove the duplicate element in Set.
-    RUBY
+    it "registers an offense when using duplicate symbol element in `::#{class_name}[...]`" do
+      expect_offense(<<~RUBY, class_name: class_name)
+        ::#{class_name}[:foo, :bar, :foo]
+          _{class_name}             ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      ::Set[:foo, :bar]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ::#{class_name}[:foo, :bar]
+      RUBY
+    end
 
-  it 'registers an offense when using multiple duplicate symbol element' do
-    expect_offense(<<~RUBY)
-      Set[:foo, :bar, :foo, :baz, :baz]
-                      ^^^^ Remove the duplicate element in Set.
-                                  ^^^^ Remove the duplicate element in Set.
-    RUBY
+    it 'registers an offense when using multiple duplicate symbol element' do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}[:foo, :bar, :foo, :baz, :baz]
+        _{class_name}             ^^^^ Remove the duplicate element in #{class_name}.
+        _{class_name}                         ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set[:foo, :bar, :baz]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}[:foo, :bar, :baz]
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate lvar element' do
-    expect_offense(<<~RUBY)
-      foo = do_foo
-      bar = do_bar
+    it 'registers an offense when using duplicate lvar element' do
+      expect_offense(<<~RUBY, class_name: class_name)
+        foo = do_foo
+        bar = do_bar
 
-      Set[foo, bar, foo]
-                    ^^^ Remove the duplicate element in Set.
-    RUBY
+        #{class_name}[foo, bar, foo]
+        _{class_name}           ^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      foo = do_foo
-      bar = do_bar
+      expect_correction(<<~RUBY)
+        foo = do_foo
+        bar = do_bar
 
-      Set[foo, bar]
-    RUBY
-  end
+        #{class_name}[foo, bar]
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate ivar element' do
-    expect_offense(<<~RUBY)
-      Set[@foo, @bar, @foo]
-                      ^^^^ Remove the duplicate element in Set.
-    RUBY
+    it 'registers an offense when using duplicate ivar element' do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}[@foo, @bar, @foo]
+        _{class_name}             ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set[@foo, @bar]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}[@foo, @bar]
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate constant element' do
-    expect_offense(<<~RUBY)
-      Set[Foo, Bar, Foo]
-                    ^^^ Remove the duplicate element in Set.
-    RUBY
+    it 'registers an offense when using duplicate constant element' do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}[Foo, Bar, Foo]
+        _{class_name}           ^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set[Foo, Bar]
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}[Foo, Bar]
+      RUBY
+    end
 
-  it 'does not register an offense when using duplicate method call element' do
-    expect_no_offenses(<<~RUBY)
-      Set[foo, bar, foo]
-    RUBY
-  end
+    it 'does not register an offense when using duplicate method call element' do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[foo, bar, foo]
+      RUBY
+    end
 
-  it 'does not register an offense when using duplicate safe navigation method call element' do
-    expect_no_offenses(<<~RUBY)
-      Set[obj&.foo, obj&.bar, obj&.foo]
-    RUBY
-  end
+    it 'does not register an offense when using duplicate safe navigation method call element' do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[obj&.foo, obj&.bar, obj&.foo]
+      RUBY
+    end
 
-  it 'does not register an offense when using duplicate ternary operator element' do
-    expect_no_offenses(<<~RUBY)
-      Set[rand > 0.5 ? 1 : 2, rand > 0.5 ? 1 : 2]
-    RUBY
-  end
+    it 'does not register an offense when using duplicate ternary operator element' do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[rand > 0.5 ? 1 : 2, rand > 0.5 ? 1 : 2]
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate symbol element in `Set.new([...])`' do
-    expect_offense(<<~RUBY)
-      Set.new([:foo, :bar, :foo])
-                           ^^^^ Remove the duplicate element in Set.
-    RUBY
+    it "registers an offense when using duplicate symbol element in `#{class_name}.new([...])`" do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}.new([:foo, :bar, :foo])
+        _{class_name}                  ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set.new([:foo, :bar])
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}.new([:foo, :bar])
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate symbol element in `Set.new(%i[...])`' do
-    expect_offense(<<~RUBY)
-      Set.new(%i[foo bar foo])
-                         ^^^ Remove the duplicate element in Set.
-    RUBY
+    it "registers an offense when using duplicate symbol element in `#{class_name}.new(%i[...])`" do
+      expect_offense(<<~RUBY, class_name: class_name)
+        #{class_name}.new(%i[foo bar foo])
+        _{class_name}                ^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Set.new(%i[foo bar])
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        #{class_name}.new(%i[foo bar])
+      RUBY
+    end
 
-  it 'registers an offense when using duplicate symbol element in `::Set.new([...])`' do
-    expect_offense(<<~RUBY)
-      ::Set.new([:foo, :bar, :foo])
-                             ^^^^ Remove the duplicate element in Set.
-    RUBY
+    it "registers an offense when using duplicate symbol element in `::#{class_name}.new([...])`" do
+      expect_offense(<<~RUBY, class_name: class_name)
+        ::#{class_name}.new([:foo, :bar, :foo])
+          _{class_name}                  ^^^^ Remove the duplicate element in #{class_name}.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      ::Set.new([:foo, :bar])
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        ::#{class_name}.new([:foo, :bar])
+      RUBY
+    end
 
-  it 'does not register an offense when not using duplicate method call element in `Set[...]`' do
-    expect_no_offenses(<<~RUBY)
-      Set[foo, bar]
-    RUBY
-  end
+    it "does not register an offense when not using duplicate method call element in `#{class_name}[...]`" do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[foo, bar]
+      RUBY
+    end
 
-  it 'does not register an offense when not using duplicate symbol element in `Set.new([...])`' do
-    expect_no_offenses(<<~RUBY)
-      Set.new([:foo, :bar])
-    RUBY
+    it "does not register an offense when not using duplicate symbol element in `#{class_name}.new([...])`" do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}.new([:foo, :bar])
+      RUBY
+    end
+
+    it "does not register an offense when using empty element in `#{class_name}[]`" do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[]
+      RUBY
+    end
+
+    it "does not register an offense when using one element in `#{class_name}[...]`" do
+      expect_no_offenses(<<~RUBY)
+        #{class_name}[:foo]
+      RUBY
+    end
   end
 
   it 'registers an offense when using duplicate symbol element in `[...].to_set`' do
@@ -156,18 +170,6 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateSetElement, :config do
 
     expect_correction(<<~RUBY)
       [:foo, :bar]&.to_set
-    RUBY
-  end
-
-  it 'does not register an offense when using empty element in `Set[]`' do
-    expect_no_offenses(<<~RUBY)
-      Set[]
-    RUBY
-  end
-
-  it 'does not register an offense when using one element in `Set[...]`' do
-    expect_no_offenses(<<~RUBY)
-      Set[:foo]
     RUBY
   end
 


### PR DESCRIPTION
`SortedSet` was in Ruby's standard library until 3.0, and I believe some people keep using it as a gem after its removal.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
