### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_if_with_semicolon.md
+++ b/changelog/fix_incorrect_autocorrect_for_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#13551](https://github.com/rubocop/rubocop/pull/13551): Fix an incorrect autocorrect for `Style/IfWithSemicolon` when using multi value assignment in `if` with a semicolon is used. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -43,7 +43,7 @@ module RuboCop
           template = if require_newline?(node)
                        MSG_NEWLINE
                      elsif node.else_branch&.if_type? || node.else_branch&.begin_type? ||
-                           use_block_in_branches?(node)
+                           use_masgn_or_block_in_branches?(node)
                        MSG_IF_ELSE
                      else
                        MSG_TERNARY
@@ -53,7 +53,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, node)
-          if require_newline?(node) || use_block_in_branches?(node)
+          if require_newline?(node) || use_masgn_or_block_in_branches?(node)
             corrector.replace(node.loc.begin, "\n")
           else
             corrector.replace(node, replacement(node))
@@ -64,8 +64,10 @@ module RuboCop
           node.branches.compact.any?(&:begin_type?) || use_return_with_argument?(node)
         end
 
-        def use_block_in_branches?(node)
-          node.branches.compact.any? { |branch| branch.block_type? || branch.numblock_type? }
+        def use_masgn_or_block_in_branches?(node)
+          node.branches.compact.any? do |branch|
+            branch.masgn_type? || branch.block_type? || branch.numblock_type?
+          end
         end
 
         def use_return_with_argument?(node)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -285,6 +285,30 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
       RUBY
     end
 
+    it 'registers an offense when using multi value assignment in `if` with a semicolon is used' do
+      expect_offense(<<~RUBY)
+        if foo; bar, baz = qux else quux end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo
+         bar, baz = qux else quux end
+      RUBY
+    end
+
+    it 'registers an offense when using multi value assignment in `else` with a semicolon is used' do
+      expect_offense(<<~RUBY)
+        if foo; bar else baz, qux = quux end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if foo;` - use `if/else` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo
+         bar else baz, qux = quux end
+      RUBY
+    end
+
     it 'registers an offense when using `return` with value in `if` with a semicolon is used' do
       expect_offense(<<~RUBY)
         if cond; return value end


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/IfWithSemicolon` when using multi value assignment in `if` with a semicolon is used:

```console
$ echo 'if foo; bar, baz = qux else quux end' | bundle exec rubocop --stdin dummy.rb -a --only Style/IfWithSemicolon
Inspecting 1 file
F

Offenses:

dummy.rb:1:1: C: [Corrected] Style/IfWithSemicolon: Do not use if foo; - use a ternary operator instead.
if foo; bar, baz = qux else quux end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:1:10: F: Lint/Syntax: unexpected token tCOMMA
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
foo ? bar, baz = qux : quux
^
dummy.rb:1:22: F: Lint/Syntax: unexpected token tCOLON
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
foo ? bar, baz = qux : quux
^

1 file inspected, 3 offenses detected, 1 offense corrected
====================
foo ? bar, baz = qux : quux
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
