### PR TITLE
Fix `Style/FrozenStringLiteralComment` cop false positive in case of non-downcased value literal

### DIFF
--- a/changelog/fix_style_frozen_string_literal_comment_cop_false_positive.md
+++ b/changelog/fix_style_frozen_string_literal_comment_cop_false_positive.md
@@ -1,0 +1,1 @@
+* [#13554](https://github.com/rubocop/rubocop/pull/13554): Fix `Style/FrozenStringLiteralComment` false positive in case of non-downcased value literal. ([@viralpraxis][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -80,13 +80,13 @@ module RuboCop
 
     # Expose the `frozen_string_literal` value coerced to a boolean if possible.
     #
-    # @return [Boolean] if value is `true` or `false`
+    # @return [Boolean] if value is `true` or `false` in any case
     # @return [nil] if frozen_string_literal comment isn't found
     # @return [String] if comment is found but isn't true or false
     def frozen_string_literal
       return unless (setting = extract_frozen_string_literal)
 
-      case setting
+      case setting.downcase
       when 'true'  then true
       when 'false' then false
       else

--- a/spec/rubocop/cop/lint/duplicate_magic_comment_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_magic_comment_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMagicComment, :config do
     RUBY
   end
 
+  it 'registers an offense when frozen magic comments with different case are duplicated' do
+    expect_offense(<<~RUBY)
+      # frozen_string_literal: true
+      # frozen_string_literal: TRUE
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Duplicate magic comment detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # frozen_string_literal: true
+    RUBY
+  end
+
   it 'registers an offense when same encoding magic comments are duplicated' do
     expect_offense(<<~RUBY)
       # encoding: ascii

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -274,6 +274,15 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         puts 1
       RUBY
     end
+
+    %w[TRUE FALSE True False truE falsE].each do |value|
+      it "accepts a frozen string literal with `#{value}` literal" do
+        expect_no_offenses(<<~RUBY)
+          # frozen_string_literal: #{value}
+          puts 1
+        RUBY
+      end
+    end
   end
 
   context 'never' do
@@ -1040,6 +1049,21 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         #!/usr/bin/env ruby
         # frozen_string_literal: true
       RUBY
+    end
+
+    %w[FALSE falsE].each do |value|
+      it "registers an offense for a frozen string literal with `#{value}` literal" do
+        expect_offense(<<~RUBY, value: value)
+          # frozen_string_literal: #{value}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Frozen string literal comment must be set to `true`.
+          puts 1
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # frozen_string_literal: true
+          puts 1
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
```console
$ echo '# frozen_string_literal: TRUE' | rubocop --stdin bug.rb --only Style/FrozenStringLiteralComment
Inspecting 1 file
C

Offenses:

bug.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

Non-downcased literals are checked by `Style/MagicCommentFormat` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
