### PR TITLE
[Fix #13553] Fix an incorrect autocorrect for `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiple_comparison.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#13553](https://github.com/rubocop/rubocop/issues/13553): Fix an incorrect autocorrect for `Style/MultipleComparison` when a variable is compared multiple times after a method call. ([@koic][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -63,11 +63,13 @@ module RuboCop
           return unless (variable, values = find_offending_var(node))
           return if values.size < comparisons_threshold
 
-          add_offense(node) do |corrector|
+          range = offense_range(values)
+
+          add_offense(range) do |corrector|
             elements = values.map(&:source).join(', ')
             prefer_method = "[#{elements}].include?(#{variable_name(variable)})"
 
-            corrector.replace(node, prefer_method)
+            corrector.replace(range, prefer_method)
           end
         end
 
@@ -105,6 +107,10 @@ module RuboCop
           [variables.first, values] if variables.any?
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def offense_range(values)
+          values.first.parent.source_range.begin.join(values.last.parent.source_range.end)
+        end
 
         def variable_name(node)
           node.children[0]

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -208,6 +208,19 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
         end
       RUBY
     end
+
+    it 'registers an offense and corrects when `var` is compared multiple times after a method call' do
+      expect_offense(<<~RUBY)
+        var = do_something
+        var == foo || var == 'bar' || var == 'baz'
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = do_something
+        var == foo || ['bar', 'baz'].include?(var)
+      RUBY
+    end
   end
 
   it 'does not register an offense when comparing two sides of the disjunction is unrelated' do
@@ -235,6 +248,19 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
         if [before.column, after.column].include?(col)
           do_something
         end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `var` is compared multiple times after a method call' do
+      expect_offense(<<~RUBY)
+        var = do_something
+        var == foo || var == 'bar' || var == 'baz'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = do_something
+        [foo, 'bar', 'baz'].include?(var)
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #13553.

This PR fixes an incorrect autocorrect for `Style/MultipleComparison` when a variable is compared multiple times after a method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
