### PR TITLE
Fix `Lint/NonAtomicFileOperation` cop error in case of implicit receiver

### DIFF
--- a/changelog/fix_lint_non_actomic_file_operation_in_case_of_implicit_receiver.md
+++ b/changelog/fix_lint_non_actomic_file_operation_in_case_of_implicit_receiver.md
@@ -1,0 +1,1 @@
+* [#13558](https://github.com/rubocop/rubocop/pull/13558): Fix `Lint/NonAtomicFileOperation` cop error in case of implicit receiver. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -78,6 +78,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless node.receiver
           return unless if_node_child?(node)
           return if explicit_not_force?(node)
           return unless (exist_node = send_exist_node(node.parent).first)

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -325,4 +325,10 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense without explicit receiver' do
+    expect_no_offenses(<<~RUBY)
+      mkdir(path) unless FileTest.exist?(path)
+    RUBY
+  end
 end


### PR DESCRIPTION
```console
echo 'mkdir(path) unless FileTest.exist?(path)' | rubocop --stdin bug.rb --only Lint/NonAtomicFileOperation -d

An error occurred while Lint/NonAtomicFileOperation cop was inspecting bug.rb:1:0.
undefined method `name' for an instance of Parser::Source::Map::Send
lib/rubocop/cop/lint/non_atomic_file_operation.rb:135:in `autocorrect_replace_method'
lib/rubocop/cop/lint/non_atomic_file_operation.rb:123:in `autocorrect'
lib/rubocop/cop/lint/non_atomic_file_operation.rb:108:in `block in register_offense'
```

This patch removes offenses for IO-related methods without implicit receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
