### PR TITLE
Fix `Bundler/DuplicatedGem` cop error in case of empty branch

### DIFF
--- a/changelog/fix_bundler_duplicated_gem_cop_error_in_case_of_empty_branch.md
+++ b/changelog/fix_bundler_duplicated_gem_cop_error_in_case_of_empty_branch.md
@@ -1,0 +1,1 @@
+* [#13562](https://github.com/rubocop/rubocop/pull/13562): Fix `Bundler/DuplicatedGem` cop error in case of empty branch. ([@viralpraxis][])

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -73,7 +73,7 @@ module RuboCop
         end
 
         def within_conditional?(node, conditional_node)
-          conditional_node.branches.any? do |branch|
+          conditional_node.branches.compact.any? do |branch|
             branch == node || branch.child_nodes.include?(node)
           end
         end

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -102,5 +102,18 @@ RSpec.describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when gem is duplicated within `case` statement with empty branch' do
+      expect_no_offenses(<<~RUBY, 'Gemfile')
+        case
+        when Dir.exist?(local)
+          gem 'rubocop', path: local
+        when ENV['RUBOCOP_VERSION'] == 'master'
+          # no-op, do nothing club
+        else
+          gem 'rubocop', '~> 0.90.0'
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
An MRE:

```ruby
case
when Dir.exist?(local)
  gem 'rubocop', path: local
when ENV['RUBOCOP_VERSION'] == 'master'
  # no-op, do nothing club
else
  gem 'rubocop', '~> 0.90.0'
end
```

Backtrace:

```
NoMethodError:
       undefined method `child_nodes' for nil
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:77:in `block in within_conditional?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:76:in `any?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:76:in `within_conditional?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:72:in `block in conditional_declaration?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:72:in `all?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:72:in `conditional_declaration?'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:64:in `block in duplicated_gem_nodes'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:64:in `select'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:64:in `duplicated_gem_nodes'
     # ./lib/rubocop/cop/bundler/duplicated_gem.rb:48:in `on_new_investigation'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
