### PR TITLE
Fix `Metrics/ClassLength` cop error with chained assignments

### DIFF
--- a/changelog/fix_metrics_class_length_cop_error_with_chained_assignments.md
+++ b/changelog/fix_metrics_class_length_cop_error_with_chained_assignments.md
@@ -1,0 +1,1 @@
+* [#13564](https://github.com/rubocop/rubocop/pull/13564): Fix `Metrics/ClassLength` cop error in case of chained assignments. ([@viralpraxis][])

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -51,15 +51,7 @@ module RuboCop
         end
 
         def on_casgn(node)
-          parent = node.parent
-
-          block_node = if parent&.assignment?
-                         parent.expression
-                       elsif parent&.parent&.masgn_type?
-                         parent.parent.expression
-                       else
-                         node.expression
-                       end
+          block_node = node.expression || find_expression_within_parent(node.parent)
 
           return unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
 
@@ -70,6 +62,14 @@ module RuboCop
 
         def message(length, max_length)
           format('Class has too many lines. [%<length>d/%<max>d]', length: length, max: max_length)
+        end
+
+        def find_expression_within_parent(parent)
+          if parent&.assignment?
+            parent.expression
+          elsif parent&.parent&.masgn_type?
+            parent.parent.expression
+          end
         end
       end
     end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -302,6 +302,38 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
+  context 'when inspecting a class defined with Class.new with chained assignments' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        Foo = Bar = Class.new do
+                    ^^^^^^^^^^^^ Class has too many lines. [6/5]
+          a(_1)
+          b(_1)
+          c(_1)
+          d(_1)
+          e(_1)
+          f(_1)
+        end
+      RUBY
+    end
+  end
+
+  context 'when inspecting a class defined with Class.new with chained assignments in class body' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        Foo = Class.new do
+              ^^^^^^^^^^^^ Class has too many lines. [6/5]
+          self.a = self::B = 1
+          b(_1)
+          c(_1)
+          d(_1)
+          e(_1)
+          f(_1)
+        end
+      RUBY
+    end
+  end
+
   context 'when inspecting a class defined with Struct.new' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
The following code leads to an error for `Metrics/ClassLength` cop:

```ruby
class BSc < MSc
  self.f = A = 1
  a = 1
  a = 2
  a = 3
  a = 4
  a = 5
  a = 6
end
```

Backtrace:

```console
undefined method `expression' for an instance of RuboCop::AST::SendNode
  ./lib/rubocop/cop/metrics/class_length.rb:57:in `on_casgn'
```

This patch also (unintentionally) fixed unreported offenses for dynamic class definitions with chained assignments:

```ruby
Foo = Bar = Class.new do # there were no offenses before
  a(_1)
  b(_1)
  c(_1)
  d(_1)
  e(_1)
  f(_1)
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
