### PR TITLE
Fix `Style/RedundantLineContinuation` false negatives when a redundant continuation follows a required continuation

### DIFF
--- a/changelog/fix_fix_style_redundant_line_continuation_false.md
+++ b/changelog/fix_fix_style_redundant_line_continuation_false.md
@@ -1,0 +1,1 @@
+* [#13565](https://github.com/rubocop/rubocop/pull/13565): Fix `Style/RedundantLineContinuation` false negatives when a redundant continuation follows a required continuation. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -129,11 +129,10 @@ module RuboCop
           return true unless (node = find_node_for_line(range.last_line))
           return false if argument_newline?(node)
 
-          source = node.source
-          while (node = node.parent)
-            source = node.source
-          end
-          parse(source.gsub("\\\n", "\n")).valid_syntax?
+          # Check if source is still valid without the continuation
+          source = processed_source.raw_source.dup
+          source[range.begin_pos, range.length] = "\n"
+          parse(source).valid_syntax?
         end
 
         def inspect_end_of_ruby_code_line_continuation

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
-  it 'does not register an offense when string concatenation' do
+  it 'does not register an offense for string concatenation' do
     expect_no_offenses(<<~'RUBY')
       foo('bar' \
         'baz')
@@ -621,6 +621,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
       def do_something
         foo \
           || bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for an extra continuation after a required continuation' do
+    expect_offense(<<~'RUBY')
+      def do_something
+        foo \
+          || bar \
+                 ^ Redundant line continuation.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def do_something
+        foo \\
+          || bar#{trailing_whitespace}
       end
     RUBY
   end


### PR DESCRIPTION
For example:

```
def do_something
  foo \
    || bar \
end
```

The first continuation is required but the second is redundant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
