### PR TITLE
[Fix #12995] Fix --disable-uncorrectable to not insert directives inside a string

### DIFF
--- a/changelog/fix_fix_disable_uncorrectable_to_not_insert_directives.md
+++ b/changelog/fix_fix_disable_uncorrectable_to_not_insert_directives.md
@@ -1,0 +1,1 @@
+* [#12995](https://github.com/rubocop/rubocop/issues/12995): Fix `--disable-uncorrectable` to not insert directives inside a string. ([@dvandersluis][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -49,14 +49,28 @@ module RuboCop
       private
 
       def disable_offense(offense_range)
-        range = surrounding_heredoc(offense_range) ||
-                surrounding_percent_array(offense_range) ||
-                string_continuation(offense_range)
+        unbreakable_range = multiline_ranges(offense_range)&.find do |range|
+          range_overlaps_offense?(offense_range, range)
+        end
 
-        if range
-          disable_offense_before_and_after(range_by_lines(range))
+        if unbreakable_range
+          disable_offense_before_and_after(range_by_lines(unbreakable_range))
         else
           disable_offense_with_eol_or_surround_comment(offense_range)
+        end
+      end
+
+      def multiline_ranges(offense_range)
+        return if offense_range.empty?
+
+        processed_source.ast.each_node.filter_map do |node|
+          if surrounding_heredoc?(node)
+            heredoc_range(node)
+          elsif string_continuation?(node)
+            range_by_lines(node.source_range)
+          elsif surrounding_percent_array?(node)
+            node.source_range
+          end
         end
       end
 
@@ -71,41 +85,20 @@ module RuboCop
         end
       end
 
-      def surrounding_heredoc(offense_range)
-        # The empty offense range is an edge case that can be reached from the Lint/Syntax cop.
-        return nil if offense_range.empty?
-
-        heredoc_nodes = processed_source.ast.each_descendant.select do |node|
-          node.respond_to?(:heredoc?) && node.heredoc?
-        end
-        heredoc_nodes.map { |node| node.source_range.join(node.loc.heredoc_end) }
-                     .find { |range| range.contains?(offense_range) }
-      end
-
-      def surrounding_percent_array(offense_range)
-        return nil if offense_range.empty?
-
-        percent_array = processed_source.ast.each_descendant.select do |node|
-          node.array_type? && node.percent_literal?
-        end
-
-        percent_array.map(&:source_range).find do |range|
-          range_overlaps_offense?(offense_range, range)
-        end
-      end
-
-      def string_continuation(offense_range)
-        return nil if offense_range.empty?
-
-        string_continuation_nodes = processed_source.ast.each_descendant.filter_map do |node|
-          range_by_lines(node.source_range) if string_continuation?(node)
-        end
-
-        string_continuation_nodes.find { |range| range_overlaps_offense?(offense_range, range) }
-      end
-
       def range_overlaps_offense?(offense_range, range)
         offense_range.begin_pos > range.begin_pos && range.overlaps?(offense_range)
+      end
+
+      def surrounding_heredoc?(node)
+        node.type?(:str, :dstr, :xstr) && node.heredoc?
+      end
+
+      def heredoc_range(node)
+        node.source_range.join(node.loc.heredoc_end)
+      end
+
+      def surrounding_percent_array?(node)
+        node.array_type? && node.percent_literal?
       end
 
       def string_continuation?(node)

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -68,7 +68,7 @@ module RuboCop
             heredoc_range(node)
           elsif string_continuation?(node)
             range_by_lines(node.source_range)
-          elsif surrounding_percent_array?(node)
+          elsif surrounding_percent_array?(node) || multiline_string?(node)
             node.source_range
           end
         end
@@ -103,6 +103,10 @@ module RuboCop
 
       def string_continuation?(node)
         (node.str_type? || node.dstr_type? || node.xstr_type?) && node.source.match?(/\\\s*$/)
+      end
+
+      def multiline_string?(node)
+        node.dstr_type? && node.multiline?
       end
 
       def range_of_first_line(range)

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
   include_context 'cli spec behavior'
 
   describe '--disable-uncorrectable' do
-    let(:exit_code) { cli.run(%w[--autocorrect-all --format simple --disable-uncorrectable]) }
+    let(:cli_opts) { %w[--autocorrect-all --format simple --disable-uncorrectable] }
+    let(:exit_code) { cli.run(cli_opts) }
 
     let(:setup_long_line) do
       create_file('.rubocop.yml', <<~YAML)
@@ -397,6 +398,169 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
               key1: 'bar' # rubocop:todo Lint/DuplicateHashKey
             }
           RUBY
+        end
+      end
+
+      context 'and the offense is within a single-line string' do
+        before do
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/LineLength:
+              Max: 40
+          YAML
+        end
+
+        it 'adds before-and-after disable statements' do
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            'the quick brown fox jumps over the lazy dog.'
+          RUBY
+          expect(exit_code).to eq(0)
+          expect($stderr.string).to eq('')
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            C:  3: 41: [Todo] Layout/LineLength: Line is too long. [46/40]
+
+            1 file inspected, 1 offense detected, 1 offense corrected
+          OUTPUT
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            # rubocop:todo Layout/LineLength
+            'the quick brown fox jumps over the lazy dog.'
+            # rubocop:enable Layout/LineLength
+          RUBY
+        end
+      end
+
+      context 'and the offense is within a multi-line string' do
+        before do
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/LineLength:
+              Max: 40
+          YAML
+        end
+
+        context 'with quotes' do
+          it 'adds before-and-after disable statements' do
+            create_file('example.rb', <<~RUBY)
+              # frozen_string_literal: true
+
+              "
+                the quick brown fox jumps over the lazy dog.
+              "
+            RUBY
+            expect(exit_code).to eq(0)
+            expect($stderr.string).to eq('')
+            expect($stdout.string).to eq(<<~OUTPUT)
+              == example.rb ==
+              C:  4: 41: [Todo] Layout/LineLength: Line is too long. [46/40]
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            OUTPUT
+            expect(File.read('example.rb')).to eq(<<~RUBY)
+              # frozen_string_literal: true
+
+              # rubocop:todo Layout/LineLength
+              "
+                the quick brown fox jumps over the lazy dog.
+              "
+              # rubocop:enable Layout/LineLength
+            RUBY
+          end
+        end
+
+        context 'with %()' do
+          it 'adds before-and-after disable statements' do
+            create_file('example.rb', <<~RUBY)
+              # frozen_string_literal: true
+
+              %(
+                the quick brown fox jumps over the lazy dog.
+              )
+            RUBY
+            expect(exit_code).to eq(0)
+            expect($stderr.string).to eq('')
+            expect($stdout.string).to eq(<<~OUTPUT)
+              == example.rb ==
+              C:  4: 41: [Todo] Layout/LineLength: Line is too long. [46/40]
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            OUTPUT
+            expect(File.read('example.rb')).to eq(<<~RUBY)
+              # frozen_string_literal: true
+
+              # rubocop:todo Layout/LineLength
+              %(
+                the quick brown fox jumps over the lazy dog.
+              )
+              # rubocop:enable Layout/LineLength
+            RUBY
+          end
+        end
+
+        context 'with %q()' do
+          let(:cli_opts) { super().push('--except', 'Style/RedundantPercentQ') }
+
+          it 'adds before-and-after disable statements' do
+            create_file('example.rb', <<~RUBY)
+              # frozen_string_literal: true
+
+              %q(
+                the quick brown fox jumps over the lazy dog.
+              )
+            RUBY
+            expect(exit_code).to eq(0)
+            expect($stderr.string).to eq('')
+            expect($stdout.string).to eq(<<~OUTPUT)
+              == example.rb ==
+              C:  4: 41: [Todo] Layout/LineLength: Line is too long. [46/40]
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            OUTPUT
+            expect(File.read('example.rb')).to eq(<<~RUBY)
+              # frozen_string_literal: true
+
+              # rubocop:todo Layout/LineLength
+              %q(
+                the quick brown fox jumps over the lazy dog.
+              )
+              # rubocop:enable Layout/LineLength
+            RUBY
+          end
+        end
+
+        context 'with %Q()' do
+          let(:cli_opts) do
+            super().push('--except', 'Style/BarePercentLiterals,Style/RedundantPercentQ')
+          end
+
+          it 'adds before-and-after disable statements' do
+            create_file('example.rb', <<~RUBY)
+              # frozen_string_literal: true
+
+              %Q(
+                the quick brown fox jumps over the lazy dog.
+              )
+            RUBY
+            expect(exit_code).to eq(0)
+            expect($stderr.string).to eq('')
+            expect($stdout.string).to eq(<<~OUTPUT)
+              == example.rb ==
+              C:  4: 41: [Todo] Layout/LineLength: Line is too long. [46/40]
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            OUTPUT
+            expect(File.read('example.rb')).to eq(<<~RUBY)
+              # frozen_string_literal: true
+
+              # rubocop:todo Layout/LineLength
+              %Q(
+                the quick brown fox jumps over the lazy dog.
+              )
+              # rubocop:enable Layout/LineLength
+            RUBY
+          end
         end
       end
     end


### PR DESCRIPTION
Update `--disable-uncorrectable` to wrap directives around a string rather than inserting them into the string. 

I also refactored to avoid iterating over the AST repeatedly for each type of check.

Fixes #12995.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
