### PR TITLE
Validate that Cops’ configs are Hashes

### DIFF
--- a/changelog/fix_validate_that_cops_configs_are_hashes.md
+++ b/changelog/fix_validate_that_cops_configs_are_hashes.md
@@ -1,0 +1,1 @@
+* [#13568](https://github.com/rubocop/rubocop/pull/13568): Fix `NoMethodError` in `ConfigValidator` when a Cop's config is not a `Hash` and raise `ValidationError` instead. ([@amomchilov][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -80,10 +80,7 @@ module RuboCop
 
     def make_excludes_absolute
       each_key do |key|
-        @validator.validate_section_presence(key)
-        next unless self[key]['Exclude']
-
-        self[key]['Exclude'].map! do |exclude_elem|
+        dig(key, 'Exclude')&.map! do |exclude_elem|
           if exclude_elem.is_a?(String) && !absolute?(exclude_elem)
             File.expand_path(File.join(base_dir_for_path_parameters, exclude_elem))
           else

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -96,7 +96,20 @@ RSpec.describe RuboCop::Config do
       it 'raises validation error' do
         expect { configuration.validate }
           .to raise_error(RuboCop::ValidationError,
-                          %r{^empty section Layout/LineLength})
+                          %r{^empty section "Layout/LineLength"})
+      end
+    end
+
+    context 'when the configuration has the wrong type' do
+      before { create_file(configuration_path, ['Layout/LineLength: Enabled']) }
+
+      it 'raises validation error' do
+        expect { configuration.validate }.to(
+          raise_error(
+            RuboCop::ValidationError,
+            %r{^The configuration for "Layout/LineLength" in .* is not a Hash.\n\nFound: "Enabled"}
+          )
+        )
       end
     end
 
@@ -105,7 +118,7 @@ RSpec.describe RuboCop::Config do
 
       it 'raises validation error' do
         expect { configuration.validate }
-          .to raise_error(RuboCop::ValidationError, /^empty section AllCops/)
+          .to raise_error(RuboCop::ValidationError, /^empty section "AllCops"/)
       end
     end
 


### PR DESCRIPTION
Our team encountered a malformed configuration like:

```yaml
require:
  - rubocop-demo1
  - rubocop-demo2

Demo1: Enabled # ❌ Treated as the String "Enabled"

Demo2:
  Enabled: true # ✅ Has to be a Hash
```

Which leads to this `NoMethodError` in `config_validator.rb`:

<details><summary>Stacktrace</summary>

```sh
$ bundle exec rubocop --parallel --cache-root tmp/cache/rubocop | 2s

undefined method `each_key' for an instance of String
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_validator.rb:198:in `each_invalid_parameter'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_validator.rb:183:in `block in validate_parameter_names'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_validator.rb:181:in `each'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_validator.rb:181:in `validate_parameter_names'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_validator.rb:48:in `validate'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config.rb:53:in `check'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config.rb:24:in `create'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader.rb:64:in `load_file'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader_resolver.rb:214:in `block in base_configs'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader_resolver.rb:213:in `map'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader_resolver.rb:213:in `base_configs'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader_resolver.rb:21:in `resolve_inheritance'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader.rb:57:in `load_file'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_loader.rb:111:in `configuration_from_file'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_store.rb:68:in `for_dir'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/config_store.rb:47:in `for_pwd'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/cli.rb:138:in `validate_options_vs_config'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/cli.rb:48:in `block in run'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/cli.rb:81:in `profile_if_needed'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/lib/rubocop/cli.rb:43:in `run'
/tmp/bundle/ruby/3.3.0/gems/rubocop-1.69.1/exe/rubocop:19:in `<top (required)>'
/tmp/bundle/ruby/3.3.0/bin/rubocop:25:in `load'
/tmp/bundle/ruby/3.3.0/bin/rubocop:25:in `<top (required)>'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli.rb:456:in `exec'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli.rb:35:in `dispatch'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/cli.rb:29:in `start'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/exe/bundle:28:in `block in <top (required)>'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/usr/local/ruby/lib/ruby/gems/3.3.0/gems/bundler-2.5.23/exe/bundle:20:in `<top (required)>'
/usr/local/ruby/bin/bundle:25:in `load'
/usr/local/ruby/bin/bundle:25:in `<main>'
```

</details> 

The cause is non-obvious, so I think it's worth improving the `RuboCop::ConfigValidator` to better diagnose this issue.

This new validation will print:

```
$ bundle exec rubocop

Error: The configuration for "Demo1" in rubocop.yml is not a Hash.

Found: "Enabled"
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
