### PR TITLE
Fix `Style/MethodCallWithoutArgsParentheses` cop error in case of mass hash assignment

### DIFF
--- a/changelog/fix_style_method_call_without_args_parentheses_cop.md
+++ b/changelog/fix_style_method_call_without_args_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#13569](https://github.com/rubocop/rubocop/pull/13569): Fix `Style/MethodCallWithoutArgsParentheses` cop error in case of mass hash assignment. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -107,7 +107,7 @@ module RuboCop
         end
 
         def variable_in_mass_assignment?(variable_name, node)
-          node.assignments.any? { |n| n.name == variable_name }
+          node.assignments.reject(&:send_type?).any? { |n| n.name == variable_name }
         end
 
         def offense_range(node)

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -131,6 +131,23 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
         end
       RUBY
     end
+
+    it 'registers an empty parens offense for array mass assignment with same name' do
+      expect_offense(<<~RUBY)
+        A = [1, 2]
+        def c; A; end
+
+        c[2], x = c()
+                   ^^ Do not use parentheses for method calls with no arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        A = [1, 2]
+        def c; A; end
+
+        c[2], x = c
+      RUBY
+    end
   end
 
   it 'registers an offense for `obj.method ||= func()`' do
@@ -211,5 +228,31 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
         _a, _b, _c = d(e)
       RUBY
     end
+  end
+
+  it 'registers an empty parens offense for hash mass assignment' do
+    expect_offense(<<~RUBY)
+      h = {}
+      h[:a], h[:b] = c()
+                      ^^ Do not use parentheses for method calls with no arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      h = {}
+      h[:a], h[:b] = c
+    RUBY
+  end
+
+  it 'registers an empty parens offense for array mass assignment' do
+    expect_offense(<<~RUBY)
+      a = []
+      a[0], a[10] = c()
+                     ^^ Do not use parentheses for method calls with no arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = []
+      a[0], a[10] = c
+    RUBY
   end
 end


### PR DESCRIPTION
```console
echo 'h[:a], h[:b] = f()' | rubocop --stdin bug.rb --only Style/MethodCallWithoutArgsParentheses -d

Inspecting 1 file
Scanning bug.rb
An error occurred while Style/MethodCallWithoutArgsParentheses cop was inspecting bug.rb:1:15.
undefined method `name' for an instance of RuboCop::AST::SendNode
lib/rubocop/cop/style/method_call_without_args_parentheses.rb:111:in `block in variable_in_mass_assignment?'
lib/rubocop/cop/style/method_call_without_args_parentheses.rb:110:in `any?'
lib/rubocop/cop/style/method_call_without_args_parentheses.rb:110:in `variable_in_mass_assignment?'
lib/rubocop/cop/style/method_call_without_args_parentheses.rb:75:in `block in same_name_assignment?'
lib/rubocop/cop/style/method_call_without_args_parentheses.rb:105:in `block in any_assignment?'
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
