### PR TITLE
Fix `Naming/RescueExceptionsVariableName` cop error in case of arbitrary expression

### DIFF
--- a/changelog/fix_naming_rescue_exceptions_variable_name_cop_error.md
+++ b/changelog/fix_naming_rescue_exceptions_variable_name_cop_error.md
@@ -1,0 +1,1 @@
+* [#13570](https://github.com/rubocop/rubocop/pull/13570): Fix `Naming/RescuedExceptionsVariableName` cop error when exception is assigned with writer method. ([@viralpraxis][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -154,7 +154,7 @@ module RuboCop
         end
 
         def variable_name(node)
-          node.exception_variable&.name
+          node.exception_variable.name if node.exception_variable.respond_to?(:name)
         end
 
         def message(node)

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -511,6 +511,18 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
         RUBY
       end
     end
+
+    context 'when exception is assigned with writer method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          begin
+            something
+          rescue => storage.exception
+            # do something
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with the `PreferredName` setup' do


### PR DESCRIPTION
This code

```ruby
S = Struct.new(:exception)
s = S.new

begin
  raise RuntimeError.new
rescue => s.exception
end

p s.exception
```

leads to an error:

```
An error occurred while Naming/RescuedExceptionsVariableName cop was inspecting test.rb:6:0.
    undefined method `name' for an instance of RuboCop::AST::SendNode
    lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:157:in `variable_name'
    lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb:67:in `on_resbody'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
