### PR TITLE
Permit indentation whitespace after `"...\n" \`

### DIFF
--- a/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_leading_space_spec.rb
@@ -136,6 +136,26 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationLeadingSpace, :config do
       RUBY
     end
 
+    it 'registers no offense when last character is a newline and next line is indented' do
+      expect_no_offenses(<<~'RUBY')
+        "foo\n" \
+        "  bar"
+      RUBY
+    end
+
+    it 'registers an offense when using trailing style after newline' do
+      expect_offense(<<~'RUBY')
+        "foo\n  " \
+              ^^ Move leading spaces after newline to the beginning of next line.
+        "bar"
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "foo\n" \
+        "  bar"
+      RUBY
+    end
+
     describe 'interpolated strings' do
       it 'registers no offense on interpolated string alone' do
         expect_no_offenses(<<~'RUBY')


### PR DESCRIPTION
This is a proof of concept for #13571, which alters `Layout/LineContinuationLeadingSpace` to behave differently if the first line has a newline before the line continuation.

<table><thead><tr><th>Before</th><th>After</th></tr></thead><tbody><tr><td

RuboCop enforces trailing whitespace, despite the newline
```ruby
"List:\n    " \
  "- item"
```

</td><td>

RuboCop understands this whitespace is indentation
```ruby
"List:\n" \
  "    - item"
```

</td></tr><tr><td>

RuboCop enforces trailing whitespace
```ruby
"A very " \
  "long string"
```

</td><td>

RuboCop **still** enforces trailing whitespace, as there is no newline
```ruby
"A very " \
  "long string"
```

</td></tr></tbody></table>

> [!NOTE]  
> This PR is in draft while the proposal is discussed in #13571. If it is decided to move forward, I will clean up the implementation, flesh out the tests, and improve the description.

-----------------

<details><summary>Checklist I will check before marking this PR as ready for review</summary>

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

</details>