### PR TITLE
Fix `Lint/UnescapedBracketInRegexp` cop failure with invalid multibyte escape

### DIFF
--- a/changelog/fix_error_unescaped_bracket_scanner_error.md
+++ b/changelog/fix_error_unescaped_bracket_scanner_error.md
@@ -1,0 +1,1 @@
+* [#13573](https://github.com/rubocop/rubocop/pull/13573): Fix `Lint/UnescapedBracketInRegexp` cop failure with invalid multibyte escape. ([@earlopain][])

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -58,7 +58,7 @@ module RuboCop
             Regexp::Parser.parse(text.value)&.each_expression do |expr|
               detect_offenses(text, expr)
             end
-          rescue Regexp::Parser::ParserError
+          rescue Regexp::Parser::Error
             # Upon encountering an invalid regular expression,
             # we aim to proceed and identify any remaining potential offenses.
           end

--- a/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
       end
 
       context 'invalid regular expressions' do
-        %w[+ * {42}].each do |invalid_regexp|
+        %w[+ * {42} \xff].each do |invalid_regexp|
           it "does not register an offense for single invalid `/#{invalid_regexp}/` regexp`" do
             expect_no_offenses(<<~RUBY)
               Regexp.#{method}("#{invalid_regexp}")


### PR DESCRIPTION
This is a followup to #13522. The added regex raises a `ScannerError`, which doesn't inherit from `ParserError`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
