### PR TITLE
Fix `Style/ExactRegexpMatch` cop error on invalid regular expression literal

### DIFF
--- a/changelog/fix_style_exact_regexp_match_cop_error_on_invalid_regexp.md
+++ b/changelog/fix_style_exact_regexp_match_cop_error_on_invalid_regexp.md
@@ -1,0 +1,1 @@
+* [#13574](https://github.com/rubocop/rubocop/pull/13574): Fix `Style/ExactRegexpMatch` cop error on invalid regular expression literal. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -41,8 +41,14 @@ module RuboCop
           return unless (receiver = node.receiver)
           return unless (regexp = exact_regexp_match(node))
 
-          parsed_regexp = Regexp::Parser.parse(regexp)
-          return unless exact_match_pattern?(parsed_regexp)
+          parsed_regexp = begin
+            Regexp::Parser.parse(regexp)
+          rescue Regexp::Parser::Error
+            # Upon encountering an invalid regular expression,
+            # we aim to proceed and identify any remaining potential offenses.
+          end
+
+          return unless parsed_regexp && exact_match_pattern?(parsed_regexp)
 
           prefer = "#{receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
 

--- a/spec/rubocop/cop/style/exact_regexp_match_spec.rb
+++ b/spec/rubocop/cop/style/exact_regexp_match_spec.rb
@@ -100,4 +100,27 @@ RSpec.describe RuboCop::Cop::Style::ExactRegexpMatch, :config do
       string =~ /\Astring\z/i
     RUBY
   end
+
+  context 'invalid regular expressions' do
+    around { |example| RuboCop::Util.silence_warnings(&example) }
+
+    it 'does not register an offense for single invalid regexp' do
+      expect_no_offenses(<<~'RUBY')
+        string =~ /^\P$/
+      RUBY
+    end
+
+    it 'registers an offense for regexp following invalid regexp' do
+      expect_offense(<<~'RUBY')
+        string =~ /^\P$/
+        string.match(/\Astring\z/)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `string == 'string'`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        string =~ /^\P$/
+        string == 'string'
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This is a follow-up to https://github.com/rubocop/rubocop/pull/13573

Upon encounter with invalid regular expression (e.g `/^\P$/`) cop `Style/ExactRegexpMatch` throws an error.

NB: Maybe we should extract `Regexp::Parser.parse ... rescue ...`  to some shared utility module.



-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
