### PR TITLE
`Net::HTTPSession` is deprecated now

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,6 @@ require 'rubocop'
 require 'rubocop/cop/internal_affairs'
 require 'rubocop/server'
 
-# FIXME: Remove when https://github.com/bblimke/webmock/pull/1081 is merged and released
-Net::HTTPSession = Net::HTTP unless defined?(Net::HTTPSession)
 require 'webmock/rspec'
 
 require_relative 'core_ext/string'

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -13,6 +13,7 @@ module StrictWarnings
   SUPPRESSED_WARNINGS = Regexp.union(
     %r{lib/parser/builders/default.*Unknown escape},
     %r{lib/parser/builders/default.*character class has duplicated range},
+    %r{lib/webmock/.*Net::HTTPSession}, # https://github.com/bblimke/webmock/pull/1081
     /Float.*out of range/, # also from the parser gem
     /`Process` does not respond to `fork` method/, # JRuby
     /File#readline accesses caller method's state and should not be aliased/, # JRuby, test stub


### PR DESCRIPTION
It was removed beforehand but now emits a warning about that removal. Discussed in https://bugs.ruby-lang.org/issues/20900

Followup to https://github.com/rubocop/rubocop/pull/13466

For green CI when Ruby 3.4 gets added in the not-so-near future. This is the only warning at the current moment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
