### PR TITLE
Update RSpec 4 CI to the monorepo

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -160,11 +160,11 @@ jobs:
         run: |
           sed -e "/'rspec', '~> 3/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rspec', github: 'rspec/rspec-metagem', branch: '4-0-dev'
-            gem 'rspec-core', github: 'rspec/rspec-core', branch: '4-0-dev'
-            gem 'rspec-expectations', github: 'rspec/rspec-expectations', branch: '4-0-dev'
-            gem 'rspec-mocks', github: 'rspec/rspec-mocks', branch: '4-0-dev'
-            gem 'rspec-support', github: 'rspec/rspec-support', branch: '4-0-dev'
+            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-core', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-expectations', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-mocks', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-support', github: 'rspec/rspec', branch: '4-0-dev'
           EOF
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Rspec now lives under https://github.com/rspec/rspec Also see https://github.com/rspec/rspec/issues/153

Without this change, it will continue to test use stale code. I'll make PRs for other extensions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
