### PR TITLE
[Fix #13557] Fix false positives for `Lint/NumericOperationWithConstantResult`

### DIFF
--- a/changelog/change_false_positives_numeric_result_constant.md
+++ b/changelog/change_false_positives_numeric_result_constant.md
@@ -1,0 +1,1 @@
+* [#13557](https://github.com/rubocop/rubocop/issues/13557): Fix false positives for `Lint/NumericOperationWithConstantResult`. ([@earlopain][])

--- a/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
+++ b/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
@@ -1,42 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config do
-  it 'registers an offense when a variable is subtracted from itself' do
-    expect_offense(<<~RUBY)
-      x - x
-      ^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      0
-    RUBY
-  end
-
   it 'registers an offense when a variable is multiplied by 0' do
     expect_offense(<<~RUBY)
       x * 0
-      ^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      0
-    RUBY
-  end
-
-  it 'registers an offense when the modulo of variable and 1 is taken' do
-    expect_offense(<<~RUBY)
-      x % 1
-      ^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      0
-    RUBY
-  end
-
-  it 'registers an offense when the modulo of variable and itself is taken' do
-    expect_offense(<<~RUBY)
-      x % x
       ^^^^^ Numeric operation with a constant result detected.
     RUBY
 
@@ -67,42 +34,9 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     RUBY
   end
 
-  it 'registers an offense when a variable is subtracted from itself via abbreviated assignment' do
-    expect_offense(<<~RUBY)
-      x -= x
-      ^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x = 0
-    RUBY
-  end
-
   it 'registers an offense when a variable is multiplied by 0 via abbreviated assignment' do
     expect_offense(<<~RUBY)
       x *= 0
-      ^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x = 0
-    RUBY
-  end
-
-  it 'registers an offense when the modulo of variable and 1 is taken via abbreviated assignment' do
-    expect_offense(<<~RUBY)
-      x %= 1
-      ^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x = 0
-    RUBY
-  end
-
-  it 'registers an offense when the modulo of variable and itself is taken via abbreviated assignment' do
-    expect_offense(<<~RUBY)
-      x %= x
       ^^^^^^ Numeric operation with a constant result detected.
     RUBY
 
@@ -131,5 +65,18 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     expect_correction(<<~RUBY)
       x = 1
     RUBY
+  end
+
+  [
+    'x - x',
+    'x -= x',
+    'x % x',
+    'x %= x',
+    'x % 1',
+    'x %= 1'
+  ].each do |expression|
+    it "registers no offense for `#{expression}`" do
+      expect_no_offenses(expression)
+    end
   end
 end


### PR DESCRIPTION
Fix #13557. In addition to this, I also stumbled across https://github.com/rubocop/rubocop-jp/issues/70 which is about `x -= x` where x is an Array.

There's also `x - x` where `x` is a float (https://github.com/rubocop/rubocop/pull/13533#issuecomment-2513480793) but I don't feel that is worth documenting.

Crude machine-translation from (https://github.com/rubocop/rubocop-jp/issues/70):
> If mistakes and debug leftover code are expected, I have a feeling that the 0s and 1s that remain after auto-fixing are garbage after all.
I could imagine cases where I would be happy to be warned about leftover debugging or typos, but I couldn't think of a case where I would be happy to be auto-fixed to 0 or 1.
So I think it would be okay to simply stop supporting auto-fixes.

I think this makes sense? Ruby is too dynamic for this cop to really work out I think so no autocorrect makse sense to me.

I'd even go one step further and disable it by default, it's about debug code and I don't see one variant being more prevalent than the other (i.e. it seems like both false and true positives are equally likely). Of course I don't have evidence, just how I think about it.

Let me know anyone has opinions about those two points. At the very least, I feel like it should be unsafe.

cc @Zopolis4 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
