### PR TITLE
[Fix #13578] Update `Layout/LineContinuationSpacing` to ignore continuations inside a `regexp` or `xstr`

### DIFF
--- a/changelog/fix_update_layout_line_continuation_spacing_to_ignore.md
+++ b/changelog/fix_update_layout_line_continuation_spacing_to_ignore.md
@@ -1,0 +1,1 @@
+* [#13578](https://github.com/rubocop/rubocop/issues/13578): Update `Layout/LineContinuationSpacing` to ignore continuations inside a `regexp` or `xstr`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -101,7 +101,7 @@ module RuboCop
               ranges << loc.expression
             elsif literal.heredoc?
               ranges << loc.heredoc_body
-            elsif loc.respond_to?(:begin) && loc.begin
+            elsif (loc.respond_to?(:begin) && loc.begin) || ignored_parent?(literal)
               ranges << loc.expression
             end
           end
@@ -125,6 +125,12 @@ module RuboCop
         def ignored_ranges
           @ignored_ranges ||= ignored_literal_ranges(processed_source.ast) +
                               comment_ranges(processed_source.comments)
+        end
+
+        def ignored_parent?(node)
+          return false unless node.parent
+
+          node.parent.type?(:regexp, :xstr)
         end
 
         def no_space_style?

--- a/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/line_continuation_spacing_spec.rb
@@ -116,6 +116,48 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
     it 'ignores empty code' do
       expect_no_offenses('')
     end
+
+    it 'does not register an offense for a continuation inside a multiline string' do
+      expect_no_offenses(<<~'RUBY')
+        'foo\
+        bar'
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a %q string' do
+      expect_no_offenses(<<~'RUBY')
+        %q{foo\
+        bar}
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a regexp' do
+      expect_no_offenses(<<~'RUBY')
+        /foo\
+        bar/
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a %r regexp' do
+      expect_no_offenses(<<~'RUBY')
+        %r{foo\
+        bar}
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside an xstr' do
+      expect_no_offenses(<<~'RUBY')
+        `foo\
+        bar`
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside an %x xstr' do
+      expect_no_offenses(<<~'RUBY')
+        %x{foo\
+        bar}
+      RUBY
+    end
   end
 
   context 'EnforcedStyle: no_space' do
@@ -232,6 +274,55 @@ RSpec.describe RuboCop::Cop::Layout::LineContinuationSpacing, :config do
 
     it 'ignores empty code' do
       expect_no_offenses('')
+    end
+
+    it 'does not register an offense for a continuation inside a multiline string' do
+      expect_no_offenses(<<~'RUBY')
+        'foo     \
+        bar'
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a %q string' do
+      expect_no_offenses(<<~'RUBY')
+        %q{foo     \
+        bar}
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a multiline string with interpolation' do
+      expect_no_offenses(<<~'RUBY')
+        "#{foo}     \
+        bar"
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a regexp' do
+      expect_no_offenses(<<~'RUBY')
+        /foo     \
+        bar/
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside a %r regexp' do
+      expect_no_offenses(<<~'RUBY')
+        %r{foo     \
+        bar}
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside an xstr' do
+      expect_no_offenses(<<~'RUBY')
+        `foo     \
+        bar`
+      RUBY
+    end
+
+    it 'does not register an offense for a continuation inside an %x xstr' do
+      expect_no_offenses(<<~'RUBY')
+        %x{foo     \
+        bar}
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Changing the spacing around a continuation inside a regexp will change the regexp, so they are now ignored by `Layout/LineContinuationSpacing`.

Fixes #13578.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
