### PR TITLE
make `NodePattern` available for use throughout the tutorial

### DIFF
--- a/changelog/fix_reset_the_docs_version.md
+++ b/changelog/fix_reset_the_docs_version.md
@@ -1,1 +1,0 @@
-* Fixed tutorial to alias `RuboCop::AST::NodePattern`. ([@Kallin][])

--- a/changelog/fix_reset_the_docs_version.md
+++ b/changelog/fix_reset_the_docs_version.md
@@ -1,0 +1,1 @@
+* Fixed tutorial to alias `RuboCop::AST::NodePattern`. ([@Kallin][])

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -122,6 +122,12 @@ and use patterns to match with specific nodes that you want to match.
 
 You can learn more about Node Pattern https://github.com/rubocop/rubocop-ast/blob/master/docs/modules/ROOT/pages/node_pattern.adoc[here].
 
+Alias `NodePattern` to `RuboCop::AST::NodePattern` to make it easier to use:
+[source,ruby]
+----
+NodePattern = RuboCop::AST::NodePattern
+----
+
 Node pattern matches something very similar to the current output from AST
 representation, then let's start with something very generic:
 


### PR DESCRIPTION
The development tutorial [here](https://docs.rubocop.org/rubocop/1.69/development.html#implementation) does not work as written. `NodePattern` is not available in the root namespace. This fix should help others who get tripped up when trying to use `NodePattern`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
