### PR TITLE
Extract regexp parsing to utilities module

### DIFF
--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -55,12 +55,9 @@ module RuboCop
           return if node.each_descendant(:dstr).any?
 
           regexp_constructor(node) do |text|
-            Regexp::Parser.parse(text.value)&.each_expression do |expr|
+            parse_regexp(text.value)&.each_expression do |expr|
               detect_offenses(text, expr)
             end
-          rescue Regexp::Parser::Error
-            # Upon encountering an invalid regular expression,
-            # we aim to proceed and identify any remaining potential offenses.
           end
         end
 

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -40,15 +40,8 @@ module RuboCop
         def on_send(node)
           return unless (receiver = node.receiver)
           return unless (regexp = exact_regexp_match(node))
-
-          parsed_regexp = begin
-            Regexp::Parser.parse(regexp)
-          rescue Regexp::Parser::Error
-            # Upon encountering an invalid regular expression,
-            # we aim to proceed and identify any remaining potential offenses.
-          end
-
-          return unless parsed_regexp && exact_match_pattern?(parsed_regexp)
+          return unless (parsed_regexp = parse_regexp(regexp))
+          return unless exact_match_pattern?(parsed_regexp)
 
           prefer = "#{receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -193,6 +193,14 @@ module RuboCop
           enforced_style.sub(/^Enforced/, 'Supported').sub('Style', 'Styles')
       end
 
+      def parse_regexp(text)
+        Regexp::Parser.parse(text)
+      rescue Regexp::Parser::Error
+        # Upon encountering an invalid regular expression,
+        # we aim to proceed and identify any remaining potential offenses.
+        nil
+      end
+
       private
 
       def compatible_external_encoding_for?(src)

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -76,4 +76,14 @@ RSpec.describe RuboCop::Cop::Util do
       expect(described_class).not_to be_same_line(5, ivar_bar_node)
     end
   end
+
+  describe '#parse_regexp' do
+    it 'returns parsed expression structure on valid regexp' do
+      expect(described_class.parse_regexp('a+')).to be_a(Regexp::Expression::Root)
+    end
+
+    it 'returns `nil` on invalid regexp' do
+      expect(described_class.parse_regexp('+')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/13574#issuecomment-2538620973

Since we have two cops that need to safely parse regular expressions, it makes sense to add a specific method to the RuboCop::Cop::Util module.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
