### PR TITLE
Make it easy to stub gem versions for tests

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -440,10 +440,37 @@ class MyCop < Base
   requires_gem "my-gem"
 
   def on_send(node)
-    if target_gem_version("my-gem) < "1.0"
+    if target_gem_version("my-gem) < "2.0"
       # ...
     else
       # ...
+    end
+  end
+end
+```
+
+When writing tests, you can specify the gem version to run your example against through the `gem_versions` RSpec helper:
+
+```Ruby
+describe RuboCop::Cop::Style::MyCop, :config do
+  context 'when `my-gem` is at version `1.X`' do
+    let(:gem_versions) { { 'my-gem' => '1.0.0' } }
+
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        MyGem.foo
+      RUBY
+    end
+  end
+
+  context 'when `my-gem` is at version `2.X`' do
+    let(:gem_versions) { { 'my-gem' => '2.0.0' } }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        MyGem.foo
+        ^^^^^^^^^ Instead of `foo`, use the newer `bar` method.
+      RUBY
     end
   end
 end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -98,6 +98,8 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
 
   let(:cop_options) { {} }
 
+  let(:gem_versions) { {} }
+
   ### Utilities
 
   def source_range(range, buffer: source_buffer)
@@ -136,13 +138,12 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
       rails_version || RuboCop::Config::DEFAULT_RAILS_VERSION
     )
 
-    allow(config).to receive(:gem_versions_in_target).and_wrap_original do |method|
-      result = method.call
-      next unless result
-
-      result['railties'] = rails_version_in_gemfile
-      result
-    end
+    allow(config).to receive(:gem_versions_in_target).and_return(
+      {
+        'railties' => rails_version_in_gemfile,
+        **gem_versions.transform_values { |value| Gem::Version.new(value) }
+      }
+    )
 
     config
   end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -146,6 +146,11 @@ RSpec.describe RuboCop::Cop::Cop, :config do
   describe '#target_gem_version', :isolated_environment do
     let(:cop_class) { RuboCop::Cop::Style::HashSyntax }
 
+    before do
+      # Call the original to actually look at the provided Gemfile.lock
+      allow(config).to receive(:gem_versions_in_target).and_call_original
+    end
+
     it 'returns nil when no lockfile exists' do
       expect(cop.target_gem_version('foo')).to be_nil
     end


### PR DESCRIPTION
Followup to #13543

This also fixes an issue I introduced by using `and_call_original`. Right now it actually parses the projects real gemfile which is certainly unexpected.

So instead, just unstub it that one specific case where it actually matters.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
