### PR TITLE
Fix `Style/HashSyntax` cop error in case of implicit `call` message

### DIFF
--- a/changelog/fix_style_hash_syntax_cop_error_on_implicit_call_message.md
+++ b/changelog/fix_style_hash_syntax_cop_error_on_implicit_call_message.md
@@ -1,0 +1,1 @@
+* [#13585](https://github.com/rubocop/rubocop/pull/13585): Fix `Style/HashSyntax` cop error on implicit `call` method. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -272,7 +272,9 @@ module RuboCop
         end
 
         def argument_without_space?(node)
-          node.argument? && node.source_range.begin_pos == node.parent.loc.selector.end_pos
+          return false if !node.argument? || !node.parent.loc.selector
+
+          node.source_range.begin_pos == node.parent.loc.selector.end_pos
         end
 
         def autocorrect_hash_rockets(corrector, pair_node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -208,6 +208,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           RUBY
         end
       end
+
+      it 'registers an offense for implicit `call` method' do
+        expect_offense(<<~RUBY)
+          method(:puts).(:key => value)
+                         ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          method(:puts).(key: value)
+        RUBY
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do
@@ -336,6 +347,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
     end
+
+    it 'registers an offense for implicit `call` method' do
+      expect_offense(<<~RUBY)
+        method(:puts).(:key=>value)
+                       ^^^^^^ Use the new Ruby 1.9 hash syntax.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        method(:puts).(key: value)
+      RUBY
+    end
   end
 
   context 'configured to enforce hash rockets style' do
@@ -405,6 +427,17 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       it 'does not register an offense when there is a symbol value' do
         expect_no_offenses('{ :a => :b, :c => :d }')
       end
+    end
+
+    it 'registers an offense for implicit `call` method' do
+      expect_offense(<<~RUBY)
+        method(:puts).(a: 0)
+                       ^^ Use hash rockets syntax.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        method(:puts).(:a => 0)
+      RUBY
     end
   end
 


### PR DESCRIPTION
```console
echo 'JSON.method(:dump).(:a => 1)' | rubocop --stdin bug.rb --only Style/HashSyntax -d

An error occurred while Style/HashSyntax cop was inspecting bug.rb:1:20.
undefined method `end_pos' for nil
lib/rubocop/cop/style/hash_syntax.rb:275:in `argument_without_space?'
lib/rubocop/cop/style/hash_syntax.rb:256:in `autocorrect_ruby19'
lib/rubocop/cop/style/hash_syntax.rb:202:in `autocorrect'
lib/rubocop/cop/style/hash_syntax.rb:243:in `block (2 levels) in check'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
