### PR TITLE
Fix `Lint/NonAtomicFileOperation` cop to detect offenses with FQ constants

### DIFF
--- a/changelog/fix_add_new_style_it_assignment_cop_to_detect_fq_constants.md
+++ b/changelog/fix_add_new_style_it_assignment_cop_to_detect_fq_constants.md
@@ -1,0 +1,1 @@
+* [#13589](https://github.com/rubocop/rubocop/pull/13589): Fix `Lint/NonAtomicFileOperation` to detect offenses with fully qualified constants. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/non_atomic_file_operation.rb
+++ b/lib/rubocop/cop/lint/non_atomic_file_operation.rb
@@ -59,12 +59,12 @@ module RuboCop
 
         # @!method send_exist_node(node)
         def_node_search :send_exist_node, <<~PATTERN
-          $(send (const nil? {:FileTest :File :Dir :Shell}) {:exist? :exists?} ...)
+          $(send (const {cbase nil?} {:FileTest :File :Dir :Shell}) {:exist? :exists?} ...)
         PATTERN
 
         # @!method receiver_and_method_name(node)
         def_node_matcher :receiver_and_method_name, <<~PATTERN
-          (send (const nil? $_) $_ ...)
+          (send (const {cbase nil?} $_) $_ ...)
         PATTERN
 
         # @!method force?(node)
@@ -116,6 +116,7 @@ module RuboCop
 
         def message_remove_file_exist_check(node)
           receiver, method_name = receiver_and_method_name(node)
+
           format(MSG_REMOVE_FILE_EXIST_CHECK, receiver: receiver, method_name: method_name)
         end
 

--- a/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
+++ b/spec/rubocop/cop/lint/non_atomic_file_operation_spec.rb
@@ -252,6 +252,56 @@ RSpec.describe RuboCop::Cop::Lint::NonAtomicFileOperation, :config do
     RUBY
   end
 
+  context 'with fully-qualified constant names' do
+    it 'registers an offense when existence check uses fully qualified constant name' do
+      expect_offense(<<~RUBY)
+        if ::FileTest.exist?(path)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+          FileUtils.delete(path)
+          ^^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.rm_f`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        #{trailing_whitespace}#{trailing_whitespace}FileUtils.rm_f(path)
+
+      RUBY
+    end
+
+    it 'registers an offense when file method uses fully qualified constant name' do
+      expect_offense(<<~RUBY)
+        if FileTest.exist?(path)
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+          ::FileUtils.delete(path)
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.rm_f`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        #{trailing_whitespace}#{trailing_whitespace}::FileUtils.rm_f(path)
+
+      RUBY
+    end
+
+    it 'registers an offense when both methods use fully qualified constant name' do
+      expect_offense(<<~RUBY)
+        if ::FileTest.exist?(path)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary existence check `FileTest.exist?`.
+          ::FileUtils.delete(path)
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use atomic file operation method `FileUtils.rm_f`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        #{trailing_whitespace}#{trailing_whitespace}::FileUtils.rm_f(path)
+
+      RUBY
+    end
+  end
+
   it 'does not register an offense when not checking for the existence' do
     expect_no_offenses(<<~RUBY)
       FileUtils.mkdir_p(path)


### PR DESCRIPTION
This works fine:

```console
echo 'File.delete(path) if File.exist?(path)' | rubocop --stdin bug.rb --only Lint/NonAtomicFileOperation
Inspecting 1 file
W

Offenses:

bug.rb:1:1: W: Lint/NonAtomicFileOperation: Use atomic file operation method FileUtils.rm_f. (https://rubystyle.guide#atomic-file-operations)
File.delete(path) if File.exist?(path)
```

This does not:

```console
echo 'File.delete(path) if ::File.exist?(path)' | rubocop --stdin bug.rb --only Lint/NonAtomicFileOperation
Inspecting 1 file
.

1 file inspected, no offenses detected

```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
