### PR TITLE
Fix cop spec generator not to produce internal affairs offenses

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -92,7 +92,8 @@ module RuboCop
         # frozen_string_literal: true
 
         RSpec.describe RuboCop::Cop::%<department>s::%<cop_name>s, :config do
-          let(:config) { RuboCop::Config.new }
+          # You can override RuboCop's default configuration:
+          # let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code
           #

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -122,7 +122,8 @@ RSpec.describe RuboCop::Cop::Generator do
         # frozen_string_literal: true
 
         RSpec.describe RuboCop::Cop::Style::FakeCop, :config do
-          let(:config) { RuboCop::Config.new }
+          # You can override RuboCop's default configuration:
+          # let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code
           #


### PR DESCRIPTION
Not a big issue, but I find it ironic that rubocop's generator produces spec template that violates its own linting rule (namely, `InternalAffairs/RedundantLetRuboCopConfigNew`)


Maybe we should just comment this line and add an explaining comment

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
