### PR TITLE
Fix false positives for `Lint/NestedMethodDefinition`

### DIFF
--- a/changelog/fix_false_positives_for_lint_nested_method_definition_cop.md
+++ b/changelog/fix_false_positives_for_lint_nested_method_definition_cop.md
@@ -1,0 +1,1 @@
+* [#13591](https://github.com/rubocop/rubocop/pull/13591): Fix false positives for `Lint/NestedMethodDefinition` when defining a method on a constant or a method call. ([@koic][])

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -96,7 +96,7 @@ module RuboCop
 
         def on_def(node)
           subject, = *node # rubocop:disable InternalAffairs/NodeDestructuring
-          return if node.defs_type? && subject.variable?
+          return if node.defs_type? && allowed_subject_type?(subject)
 
           def_ancestor = node.each_ancestor(:def, :defs).first
           return unless def_ancestor
@@ -115,6 +115,10 @@ module RuboCop
         def scoping_method_call?(child)
           child.sclass_type? || eval_call?(child) || exec_call?(child) ||
             child.class_constructor? || allowed_method_name?(child)
+        end
+
+        def allowed_subject_type?(subject)
+          subject.variable? || subject.const_type? || subject.call_type?
         end
 
         def allowed_method_name?(node)

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -121,6 +121,39 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register offense for definition of method on constant' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def Const.y
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offense for definition of method on method call' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def do_something.y
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offense for definition of method on safe navigation method call' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        def x
+          def (do_something&.y).z
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'does not register offense for nested definition inside class_eval' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
This PR fixes false positives for `Lint/NestedMethodDefinition` when defining a method on a constant or a method call.
It follows the same reasoning as #12961. This should respect the intent of the code and should not be linted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
