### PR TITLE
[Fix #12393] Fix false negative in Lint/Void inside of non-modifier if blocks

### DIFF
--- a/changelog/fix_false_negatives_for_lint_void_in_certain_conditionals.md
+++ b/changelog/fix_false_negatives_for_lint_void_in_certain_conditionals.md
@@ -1,0 +1,1 @@
+* [#12393](https://github.com/rubocop/rubocop/issues/12393): Fix false negatives for `Lint/Void` inside of non-modifier conditionals. ([@GabeIsman][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -113,7 +113,7 @@ module RuboCop
         end
 
         def check_expression(expr)
-          expr = expr.body if expr.if_type? && expr.modifier_form?
+          expr = expr.body if expr.if_type?
 
           check_literal(expr)
           check_var(expr)
@@ -229,7 +229,7 @@ module RuboCop
         end
 
         def autocorrect_void_expression(corrector, node)
-          return if node.parent.if_type? && node.parent.modifier_form?
+          return if node.parent.if_type?
 
           corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
         end


### PR DESCRIPTION
False negatives were appearing in non-modifier form of if blocks, e.g.

  ```ruby
  if condition
    42
  end
  something_else
  ```

This likely indicates a missing assignment or return.

Note that this is already the case for the extremely similar
  ```ruby
  42 if condition
  something_else
  ```

I'm not certain why there was previously a check for `expr.modifier_form?` introduced in #12981. The tests all pass without it and its removal fixes the new specs I've introduced as well.

This also fixes the related issue with ternary ifs identified in #13104, although not the more complicated `case` statement variant identified in the comments of that issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
