### PR TITLE
Fix false positives for `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_false_positives_for_style_multiple_comparison.md
+++ b/changelog/fix_false_positives_for_style_multiple_comparison.md
@@ -1,0 +1,1 @@
+* [#13594](https://github.com/rubocop/rubocop/pull/13594): Fix false positives for `Style/MultipleComparison` when using multiple safe navigation method calls. ([@koic][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -96,7 +96,7 @@ module RuboCop
           elsif simple_double_comparison?(node)
             return
           elsif (var, obj = simple_comparison?(node))
-            return if allow_method_comparison? && obj.send_type?
+            return if allow_method_comparison? && obj.call_type?
 
             variables << var
             return if variables.size > 1

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
       RUBY
     end
 
+    it 'does not register an offense when using multiple safe navigation method calls' do
+      expect_no_offenses(<<~RUBY)
+        col = loc.column
+        if col == before&.column || col == after&.column
+          do_something
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when `var` is compared multiple times after a method call' do
       expect_offense(<<~RUBY)
         var = do_something


### PR DESCRIPTION
This PR fixes false positives for `Style/MultipleComparison` when using multiple safe navigation method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
