### PR TITLE
new cop: Single Line Complexity

### DIFF
--- a/changelog/new_setting_version_to_next.md
+++ b/changelog/new_setting_version_to_next.md
@@ -1,0 +1,1 @@
+adding a new Metrics/SingleLineComplexity cop. ([@kallin][])

--- a/changelog/new_setting_version_to_next.md
+++ b/changelog/new_setting_version_to_next.md
@@ -1,1 +1,1 @@
-adding a new Metrics/SingleLineComplexity cop. ([@kallin][])
+* Adding a new Metrics/SingleLineComplexity cop. ([@kallin][])

--- a/changelog/new_setting_version_to_next.md
+++ b/changelog/new_setting_version_to_next.md
@@ -1,1 +1,0 @@
-* Adding a new Metrics/SingleLineComplexity cop. ([@kallin][])

--- a/changelog/new_single_line_complexity_cop.md
+++ b/changelog/new_single_line_complexity_cop.md
@@ -1,1 +1,1 @@
-* [#13595](https://github.com/rubocop/rubocop/pull/13595): Adding a new `Metrics/SingleLineComplexity` cop. ([@kallin][])
+* [#13595](https://github.com/rubocop/rubocop/pull/13595): Add a new `Metrics/SingleLineComplexity` cop. ([@kallin][])

--- a/changelog/new_single_line_complexity_cop.md
+++ b/changelog/new_single_line_complexity_cop.md
@@ -1,0 +1,1 @@
+* [#13595](https://github.com/rubocop/rubocop/pull/13595): Adding a new `Metrics/SingleLineComplexity` cop. ([@kallin][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2745,7 +2745,7 @@ Metrics/PerceivedComplexity:
 Metrics/SingleLineComplexity:
   Description: 'Metrics/AbcSize, calculated per line instead of per method.'
   Enabled: true
-  VersionAdded: '0.?'
+  VersionAdded: '1.69.3'
   Max: 10
 
 ################## Migration #############################

--- a/config/default.yml
+++ b/config/default.yml
@@ -2742,6 +2742,12 @@ Metrics/PerceivedComplexity:
   AllowedPatterns: []
   Max: 8
 
+Metrics/SingleLineComplexity:
+  Description: 'Metrics/AbcSize, calculated per line instead of per method.'
+  Enabled: true
+  VersionAdded: '0.?'
+  Max: 10
+
 ################## Migration #############################
 
 Migration/DepartmentName:

--- a/config/default.yml
+++ b/config/default.yml
@@ -2745,7 +2745,7 @@ Metrics/PerceivedComplexity:
 Metrics/SingleLineComplexity:
   Description: 'Metrics/AbcSize, calculated per line instead of per method.'
   Enabled: true
-  VersionAdded: '1.69.3'
+  VersionAdded: '<<next>>'
   Max: 10
 
 ################## Migration #############################

--- a/config/default.yml
+++ b/config/default.yml
@@ -2746,7 +2746,7 @@ Metrics/SingleLineComplexity:
   Description: 'Metrics/AbcSize, calculated per line instead of per method.'
   Enabled: true
   VersionAdded: '<<next>>'
-  Max: 10
+  Max: 14
 
 ################## Migration #############################
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -445,6 +445,7 @@ require_relative 'rubocop/cop/metrics/method_length'
 require_relative 'rubocop/cop/metrics/module_length'
 require_relative 'rubocop/cop/metrics/parameter_lists'
 require_relative 'rubocop/cop/metrics/perceived_complexity'
+require_relative 'rubocop/cop/metrics/single_line_complexity'
 
 require_relative 'rubocop/cop/naming/accessor_method_name'
 require_relative 'rubocop/cop/naming/ascii_identifiers'

--- a/lib/rubocop/cop/metrics/single_line_complexity.rb
+++ b/lib/rubocop/cop/metrics/single_line_complexity.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       class SingleLineComplexity < Base
         MSG = 'Assignment Branch Condition size too high for line %<line>d. ' \
-              '[%<complexity>d/%<max>d]'
+              '[%<abc_vector>s %<complexity>.4g/%<max>.4g]'
 
         def on_new_investigation
           return unless (root = processed_source.ast)
@@ -17,13 +17,15 @@ module RuboCop
           top_level_nodes_per_line = top_level_nodes_per_line(root)
 
           top_level_nodes_per_line.each do |line, nodes|
-            abc_score, = abc_score_for_nodes(nodes)
+            complexity, abc_vector = abc_score_for_nodes(nodes)
 
-            next unless abc_score > max_score_allowed
+            next unless complexity > max
 
-            add_offense(nodes.first,
-                        message: format(MSG, line: line, complexity: abc_score,
-                                             max: max_score_allowed))
+            msg = format(
+              self.class::MSG, line: line, complexity: complexity, abc_vector: abc_vector, max: max
+            )
+
+            add_offense(nodes.first, message: msg)
           end
         end
 
@@ -88,7 +90,7 @@ module RuboCop
           nodes_per_line
         end
 
-        def max_score_allowed
+        def max
           cop_config['Max']
         end
       end

--- a/lib/rubocop/cop/metrics/single_line_complexity.rb
+++ b/lib/rubocop/cop/metrics/single_line_complexity.rb
@@ -1,0 +1,88 @@
+module RuboCop
+  module Cop
+    module Metrics
+      class SingleLineComplexity < Base
+
+        MSG = 'Assignment Branch Condition size too high for line %<line>d. [%<complexity>d/%<max>d]'
+
+        def on_new_investigation
+          return unless (root = processed_source.ast)
+
+          root_nodes_per_line = map_nodes_to_lines(root)
+
+          root_nodes_per_line.each do |line, nodes|
+            abc_score, _ = abc_score_for_nodes(nodes)
+
+            add_offense(nodes.first, message: format(MSG, line: line, complexity: abc_score, max: max_score_allowed)) if abc_score > max_score_allowed
+          end
+        end
+
+        private
+
+        def abc_score_for_nodes(nodes)
+          scores = nodes.map do |node|
+            calculator = RuboCop::Cop::Metrics::Utils::AbcSizeCalculator.new(node)
+            calculator.calculate
+          end
+
+          sum_complexity_scores(scores)
+        end
+
+        def sum_complexity_scores(scores)
+          vector_sums = []
+
+          scores.each do |score|
+            _, vector = score
+
+            # Parse and sum vector components
+            vector_values = vector[1..-2].split(',').map(&:to_f) # Remove < > and split by comma
+            vector_values.each_with_index do |value, i|
+              vector_sums[i] = (vector_sums[i] || 0) + value
+            end
+          end
+
+          total_score = Math.sqrt(vector_sums.sum { |sum| sum**2 }).round(2)
+
+          [total_score, "<#{vector_sums.join(', ')}>"]
+        end
+
+        def map_nodes_to_lines(root)
+          nodes_per_line = {}
+
+          root.each_node do |child|
+            next unless child.source_range
+
+            line_range = child.source_range.first_line..child.source_range.last_line
+
+            # Skip nodes that span multiple lines
+            next if line_range.size > 1
+
+            line_range.each do |line|
+              nodes_per_line[line] ||= []
+              nodes_per_line[line] << child
+            end
+          end
+
+          # Filter nodes to only include root nodes for each line
+          nodes_per_line.transform_values do |nodes|
+            nodes.reject do |node|
+              # Reject nodes where the parent is also in the list of nodes for this line
+              nodes.include?(node.parent)
+            end
+          end
+        end
+
+        def calculate_abc(nodes)
+          nodes.sum do |node|
+            calculator = Utils::AbcSizeCalculator.new(node)
+            calculator.calculate
+          end
+        end
+
+        def max_score_allowed
+          cop_config['Max'] || 10
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/metrics/single_line_complexity.rb
+++ b/lib/rubocop/cop/metrics/single_line_complexity.rb
@@ -62,11 +62,10 @@ module RuboCop
         def top_level_nodes_per_line(root)
           nodes_per_line = nodes_per_line(root)
 
-          # Filter nodes to only include top-level nodes for each line
-          # (i.e. nodes that are not children of other nodes on the same line)
-          nodes_per_line.transform_values do |nodes|
-            nodes.reject do |node|
-              nodes.include?(node.parent)
+          nodes_per_line.transform_values do |nodes_on_line|
+            nodes_on_line.reject do |node|
+              # if the node's parent is on this line, then this node is not top-level for the line
+              nodes_on_line.include?(node.parent)
             end
           end
         end
@@ -82,12 +81,18 @@ module RuboCop
             # Skip nodes that span multiple lines
             next if line_range.size > 1
 
+            next if heredoc_node?(child)
+
             line_range.each do |line|
               nodes_per_line[line] ||= []
               nodes_per_line[line] << child
             end
           end
           nodes_per_line
+        end
+
+        def heredoc_node?(node)
+          node.dstr_type?
         end
 
         def max

--- a/lib/rubocop/cop/metrics/single_line_complexity.rb
+++ b/lib/rubocop/cop/metrics/single_line_complexity.rb
@@ -89,7 +89,7 @@ module RuboCop
         end
 
         def max_score_allowed
-          cop_config.fetch('Max', 10)
+          cop_config['Max']
         end
       end
     end

--- a/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
     it 'registers an offense when ABC per line > 2' do
       expect_offense(<<~RUBY)
         a ? b : c
-        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [<0.0, 3.0, 1.0> 3.16/2]
       RUBY
     end
   end
@@ -16,10 +16,10 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
     it 'registers two offenses when 2 of 4 lines have ABC > 2' do
       expect_offense(<<~RUBY)
         a ? b : c
-        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [<0.0, 3.0, 1.0> 3.16/2]
         x = 1
         c ? d : e
-        ^^^^^^^^^ Assignment Branch Condition size too high for line 3. [3/2]
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 3. [<0.0, 3.0, 1.0> 3.16/2]
         y = 2
       RUBY
     end
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
     it 'rejects an offense when ABC > 2' do
       expect_offense(<<~RUBY)
         x = 1; y = 2; z = 3;
-        ^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+        ^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size too high for line 1. [<3.0, 0.0, 0.0> 3/2]
       RUBY
     end
 

--- a/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
       RUBY
     end
   end
+
+  it 'does not register an offense for a multiline heredoc' do
+    expect_no_offenses(<<~'RUBY')
+      <<~STRING
+        #{foo}
+        #{bar}
+        #{baz}
+        #{quux}
+      STRING
+    RUBY
+  end
+
+  it 'registers an offense for a complex line within a heredoc' do
+    expect_offense(<<~'RUBY')
+      <<~STRING
+
+        Heredoc with multiple lines
+        #{foo.bar.baz.quux}
+        ^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size too high for line 4. [<0.0, 4.0, 0.0> 4/2]
+      STRING
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
     end
   end
 
-
   context 'inline statements' do
     it 'rejects an offense when ABC > 2' do
       expect_offense(<<~RUBY)
@@ -47,6 +46,4 @@ RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
       RUBY
     end
   end
-
-
 end

--- a/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/single_line_complexity_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Metrics::SingleLineComplexity, :config do
+  let(:cop_config) { { 'Max' => 2 } }
+
+  context 'single line code' do
+    it 'registers an offense when ABC per line > 2' do
+      expect_offense(<<~RUBY)
+        a ? b : c
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+      RUBY
+    end
+  end
+
+  context 'multi line code' do
+    it 'registers two offenses when 2 of 4 lines have ABC > 2' do
+      expect_offense(<<~RUBY)
+        a ? b : c
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+        x = 1
+        c ? d : e
+        ^^^^^^^^^ Assignment Branch Condition size too high for line 3. [3/2]
+        y = 2
+      RUBY
+    end
+
+    it 'accepts all lines when ABC per line always <= 2' do
+      expect_no_offenses(<<~RUBY)
+        x = 1 + 1
+        y = 2
+      RUBY
+    end
+  end
+
+
+  context 'inline statements' do
+    it 'rejects an offense when ABC > 2' do
+      expect_offense(<<~RUBY)
+        x = 1; y = 2; z = 3;
+        ^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size too high for line 1. [3/2]
+      RUBY
+    end
+
+    it 'accepts when ABC == 2' do
+      expect_no_offenses(<<~RUBY)
+        x = 1; y = 2;
+      RUBY
+    end
+  end
+
+
+end


### PR DESCRIPTION
A new type of Metric cop.

This uses the existing ABC complexity logic but applies it per line instead of per method.

This is a novel check, as there is currently no way to check the 'density' of complexity within the analyzed source. We have checks like ABC that verify that no method contains ABC > 17, but what if that method is just one line? In that case, the code is likely difficult to read, with too much logic crammed into a small space.

This check ensures that the maximum ABC of any given line is at max 10, by default. 

I'd love to hear any feedback from the team about what would be helpful in terms of getting this cop or one like it included in future versions of rubocop.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
