### PR TITLE
Fix `Style/RedundantCondition` cop error on parentheses and modifier `if`

### DIFF
--- a/changelog/fix_style_redundant_condition_cop_error_on_parentheses_and_modifier_if.md
+++ b/changelog/fix_style_redundant_condition_cop_error_on_parentheses_and_modifier_if.md
@@ -1,0 +1,1 @@
+* [#13596](https://github.com/rubocop/rubocop/pull/13596): Fix `Style/RedundantCondition` cop error on parentheses and modifier `if` in `else`. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -73,6 +73,8 @@ module RuboCop
             node.else_branch.loc.line
           elsif node.elsif?
             node.each_ancestor(:if).find(&:if?).loc.end.line
+          elsif node.if? && node.parent && parentheses?(node.parent)
+            node.parent.loc.end.line
           end
         elsif node.block_type? || node.numblock_type?
           node.loc.end.line

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -93,6 +93,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense with extra parentheses and modifier `if` in `else`' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            ('foo' if $VERBOSE)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || ('foo' if $VERBOSE)
+        RUBY
+      end
+
+      it 'registers an offense with double extra parentheses and modifier `if` in `else`' do
+        expect_offense(<<~RUBY)
+          if b
+          ^^^^ Use double pipes `||` instead.
+            b
+          else
+            (('foo' if $VERBOSE))
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          b || (('foo' if $VERBOSE))
+        RUBY
+      end
+
       it 'registers an offense and corrects when a method without argument parentheses in `else`' do
         expect_offense(<<~RUBY)
           if b
@@ -544,6 +574,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
   context 'ternary expression (?:)' do
     it 'accepts expressions when the condition and if branch do not match' do
       expect_no_offenses('b ? d : c')
+    end
+
+    it 'registers an offense with extra parentheses and modifier `if` in `else`' do
+      expect_offense(<<~RUBY)
+        b ? b : (raise 'foo' if $VERBOSE)
+          ^^^^^ Use double pipes `||` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        b || (raise 'foo' if $VERBOSE)
+      RUBY
     end
 
     context 'when condition and if_branch are same' do


### PR DESCRIPTION
```console
echo 's ? s : (s.succ unless $VERBOSE)' | rubocop --stdin /bin/true --only Style/RedundantCondition -d

An error occurred while Style/RedundantCondition cop was inspecting /bin/true:1:0.
undefined method `line' for nil
lib/rubocop/cop/mixin/comments_help.rb:88:in `find_end_line'
lib/rubocop/cop/mixin/comments_help.rb:22:in `comments_in_range'
lib/rubocop/cop/mixin/comments_help.rb:15:in `contains_comments?'
```

Since I had to patch global `CommentHelper` to fix the bug I tried to keep it somewhat local so it does not break something accidentally.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
