### PR TITLE
Fix `Lint/Void` cop error on `if` without body

### DIFF
--- a/changelog/fix_lint_void_cop_error_on_if_without_body.md
+++ b/changelog/fix_lint_void_cop_error_on_if_without_body.md
@@ -1,0 +1,1 @@
+* [#13598](https://github.com/rubocop/rubocop/pull/13598): Fix `Lint/Void` cop error on `if` without body. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -114,6 +114,7 @@ module RuboCop
 
         def check_expression(expr)
           expr = expr.body if expr.if_type?
+          return unless expr
 
           check_literal(expr)
           check_var(expr)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1097,4 +1097,13 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for `if` without body' do
+    expect_no_offenses(<<~RUBY)
+      if some_condition
+      end
+
+      puts :ok
+    RUBY
+  end
 end


### PR DESCRIPTION
```console
echo 'if false; end; p :ok' | rubocop --stdin /bin/true --only Lint/Void -d

For /bin: An error occurred while Lint/Void cop was inspecting /bin/true:1:0.
undefined method `type' for nil
lib/rubocop/cop/lint/void.rb:248:in `entirely_literal?'
lib/rubocop/cop/lint/void.rb:158:in `check_literal'
lib/rubocop/cop/lint/void.rb:119:in `check_expression'
lib/rubocop/cop/lint/void.rb:111:in `block in check_begin'
lib/rubocop/cop/lint/void.rb:104:in `each'
lib/rubocop/cop/lint/void.rb:104:in `check_begin'
lib/rubocop/cop/lint/void.rb:91:in `on_begin'
```


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
