### PR TITLE
[Fix #13586] Fix regression in `Layout/SpaceAroundOperators` when different comparison operators were aligned with each other

### DIFF
--- a/changelog/fix_fix_regression_in_layout_space_around_operators.md
+++ b/changelog/fix_fix_regression_in_layout_space_around_operators.md
@@ -1,0 +1,1 @@
+* [#13586](https://github.com/rubocop/rubocop/issues/13586): Fix regression in `Layout/SpaceAroundOperators` when different comparison operators were aligned with each other. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -70,7 +70,7 @@ module RuboCop
         end
 
         def check_assignment(token)
-          return unless aligned_with_preceding_assignment(token) == :no
+          return unless aligned_with_preceding_equals_operator(token) == :no
 
           message = format(MSG_UNALIGNED_ASGN, location: 'preceding')
           add_offense(token.pos, message: message) do |corrector|

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -242,12 +242,12 @@ module RuboCop
           return !aligned_with_operator?(operator) unless type == :assignment
 
           token            = Token.new(operator, nil, operator.source)
-          align_preceding  = aligned_with_preceding_assignment(token)
+          align_preceding  = aligned_with_preceding_equals_operator(token)
 
           return false if align_preceding == :yes ||
-                          aligned_with_subsequent_assignment(token) == :none
+                          aligned_with_subsequent_equals_operator(token) == :none
 
-          aligned_with_subsequent_assignment(token) != :yes
+          aligned_with_subsequent_equals_operator(token) != :yes
         end
 
         def excess_trailing_space?(right_operand, with_space)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     RUBY
   end
 
+  it 'accepts vertical alignment with different operators that end with `=`' do
+    expect_no_offenses(<<~RUBY)
+      var.foo       = a
+      var.bar      != b
+      var.quux     <= c
+      var.garply   >= d
+      var.corge    == e
+      var.fred     += f
+      var.baz     === g
+    RUBY
+  end
+
   it 'accepts an operator called with method syntax' do
     expect_no_offenses('Date.today.+(1).to_s')
   end


### PR DESCRIPTION
A regression was introduced in #13516, which caused different operators ending in an `=` character to no longer be handled properly. 

Previously to that PR, the `aligned_assignment?` method in `PrecedingFollowingAlignment` only looked that there was a literal `=` character on the line being checked in the same column. This was changed to ensure that that character was actually part of an operator token, however, a byproduct of the previous version is that non-assignment operators ending in `=` (namely, comparison operators `>=`, `<=`, `!=`, etc.) would be considered aligned. With the change, this was no longer the case, and when a number of different of these operators were aligned, `Layout/SpaceAroundOperators` would now register an offense.

I have updated the check to now consider all comparison operators ending with `=`, and renamed the method `aligned_assignment?` to reflect the breadth of operators it actually covers. This restores the behaviour previous to v1.69.2.

Fixes #13586.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
