### PR TITLE
Fix `Lint/LiteralInInterpolation` cop error on invalid string literal

### DIFF
--- a/changelog/fix_lint_literal_in_interpolation_error_on_invalid_string.md
+++ b/changelog/fix_lint_literal_in_interpolation_error_on_invalid_string.md
@@ -1,0 +1,1 @@
+* [#13603](https://github.com/rubocop/rubocop/pull/13603): Fix `Lint/LiteralInInterpolation` cop error on invalid string literal. ([@viralpraxis][])

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -507,5 +507,18 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
         RUBY
       end
     end
+
+    context 'with invalid string literal' do
+      it 'registers an offense' do
+        expect_offense(<<~'RUBY')
+          "#{"\201\203"}"
+             ^^^^^^^^^^ Literal interpolation detected.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          "\201\203"
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
```console
echo '"#{"\201\203"}"' | rubocop --stdin bug.rb --only Lint/LiteralInInterpolation -d

An error occurred while Lint/LiteralInInterpolation cop was inspecting bug.rb:1:0.
invalid byte sequence in UTF-8
lib/active_support/core_ext/object/blank.rb:159:in `match?'
lib/active_support/core_ext/object/blank.rb:159:in `blank?'
lib/rubocop/cop/lint/literal_in_interpolation.rb:171:in `space_literal?'
lib/rubocop/cop/lint/literal_in_interpolation.rb:51:in `offending?'
lib/rubocop/cop/lint/literal_in_interpolation.rb:26:in `on_interpolation'
```

Co-authored-by: Koichi ITO <koic.ito@gmail.com>

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
