### PR TITLE
Dup possibly frozen string in `to_string_literal` helper

### DIFF
--- a/changelog/fix_dup_possibly_frozen_string_in_to_string_literal.md
+++ b/changelog/fix_dup_possibly_frozen_string_in_to_string_literal.md
@@ -1,0 +1,1 @@
+* [#13605](https://github.com/rubocop/rubocop/pull/13605): Fix `RuboCop::Cop::Util.to_string_literal` to work correctly with frozen strings. ([@viralpraxis][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -204,8 +204,7 @@ module RuboCop
       private
 
       def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_ENGINE == 'jruby'
-        src.force_encoding(Encoding.default_external).valid_encoding?
+        src.dup.force_encoding(Encoding.default_external).valid_encoding?
       end
 
       def include_or_equal?(source, target)

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -86,4 +86,14 @@ RSpec.describe RuboCop::Cop::Util do
       expect(described_class.parse_regexp('+')).to be_nil
     end
   end
+
+  describe '#to_string_literal' do
+    it 'returns literal for normal string' do
+      expect(TestUtil.new.send(:to_string_literal, 'foo')).to eq("'foo'")
+    end
+
+    it 'returns literal for string which requires escaping' do
+      expect(TestUtil.new.send(:to_string_literal, 'foo\'')).to eq('"foo\'"')
+    end
+  end
 end


### PR DESCRIPTION
Currently, there are exactly three instances where the receiver-mutating
`String#force_encoding` method is used. In all cases except for
`to_string_literal`, a `String#dup` call is included to ensure compatibility
with frozen strings. I couldn't identify any counterexamples in rubocop core that would result
in a runtime error, but there is at least one instance in `rubocop-performance` [1]
where a frozen string might be passed. To ensure everything works correctly,
we need to add a `#dup` call in the implementation of `to_string_literal`.

For additional context, it's worth noting that the Prism parser might start
freezing AST leaf nodes in the future [2],
and whitequark's parser has some unpredictability in this regard [3].

[1] https://github.com/rubocop/rubocop-performance/pull/480
[2] https://github.com/ruby/prism/issues/3309
[3] https://github.com/rubocop/rubocop-ast/issues/342

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
