### PR TITLE
Support passing the target ruby version through an environment variable

### DIFF
--- a/changelog/new_support_passing_the_target_ruby_version_through_an.md
+++ b/changelog/new_support_passing_the_target_ruby_version_through_an.md
@@ -1,0 +1,1 @@
+* [#13607](https://github.com/rubocop/rubocop/pull/13607): Support passing the target ruby version through an environment variable. ([@elliottt][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -659,6 +659,13 @@ check your project for a series of other files where the Ruby version may be
 specified already. The files that will be checked are (in this order):
 `*.gemspec`, `.ruby-version`, `.tool-versions`, and `Gemfile.lock`.
 
+The target ruby version may also be specified by setting the
+`RUBOCOP_TARGET_RUBY_VERSION` environment variable to the desired version: for
+example, running `RUBOCOP_TARGET_RUBY_VERSION=3.3 rubocop` will
+run rubocop with a target ruby version of 3.3. Using this environment variable
+will override all other sources of version information, including
+`.rubocop.yml`.
+
 If a target Ruby version cannot be found via any of the above sources, then a
 default target Ruby version will be used.
 

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -34,6 +34,20 @@ module RuboCop
       end
     end
 
+    # The target ruby version may be configured by setting the
+    # `RUBOCOP_TARGET_RUBY_VERSION` environment variable.
+    class RuboCopEnvVar < Source
+      def name
+        '`RUBOCOP_TARGET_RUBY_VERSION` environment variable'
+      end
+
+      private
+
+      def find_version
+        ENV.fetch('RUBOCOP_TARGET_RUBY_VERSION', nil)&.to_f
+      end
+    end
+
     # The target ruby version may be configured in RuboCop's config.
     # @api private
     class RuboCopConfig < Source
@@ -246,6 +260,7 @@ module RuboCop
     end
 
     SOURCES = [
+      RuboCopEnvVar,
       RuboCopConfig,
       GemspecFile,
       RubyVersionFile,

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -32,6 +32,41 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
     end
   end
 
+  context 'when RUBOCOP_TARGET_RUBY_VERSION is set' do
+    it 'uses RUBOCOP_TARGET_RUBY_VERSION' do
+      old_version = ENV.fetch('RUBOCOP_TARGET_RUBY_VERSION', nil)
+      begin
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = '2.7'
+        expect(target_ruby.version).to eq 2.7
+      ensure
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = old_version
+      end
+    end
+
+    it 'does not read .ruby-version' do
+      expect(File).not_to receive(:file?).with('.ruby-version')
+      old_version = ENV.fetch('RUBOCOP_TARGET_RUBY_VERSION', nil)
+      begin
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = '2.7'
+        expect(target_ruby.version).to eq 2.7
+      ensure
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = old_version
+      end
+    end
+
+    it 'does not read Gemfile.lock or gems.locked' do
+      expect(File).not_to receive(:file?).with('Gemfile')
+      expect(File).not_to receive(:file?).with('gems.locked')
+      old_version = ENV.fetch('RUBOCOP_TARGET_RUBY_VERSION', nil)
+      begin
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = '2.7'
+        expect(target_ruby.version).to eq 2.7
+      ensure
+        ENV['RUBOCOP_TARGET_RUBY_VERSION'] = old_version
+      end
+    end
+  end
+
   context 'when TargetRubyVersion is not set' do
     context 'when gemspec file is present' do
       let(:base_path) { configuration.base_dir_for_path_parameters }


### PR DESCRIPTION
In version 1.67, the search order for the target ruby version changed to prefer gemspec files over `.ruby-version`. While this is a good change as the gemspec is a better authority on what version of ruby a gem requires, it complicates some internal testing at Stripe where we forbid tests from globbing the filesystem, and finding the gemspec requires globbing in parent directories.

As a workaround, this PR adds a new source for the target ruby version: the `RUBOCOP_TARGET_RUBY_VERSION` environment variable. This is now the first tried source for the target ruby version, giving an environmental override for situations where searching the filesystem isn't permitted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
