### PR TITLE
Fix crash when running `rubocop -d` on a config with a remote `inherit_from` that causes a duplicate setting warning

### DIFF
--- a/changelog/fix_fix_crash_when_running_rubocop_d_on_a_config_with.md
+++ b/changelog/fix_fix_crash_when_running_rubocop_d_on_a_config_with.md
@@ -1,0 +1,1 @@
+* [#13608](https://github.com/rubocop/rubocop/pull/13608): Fix crash when running `rubocop -d` on a config with a remote `inherit_from` that causes a duplicate setting warning. ([@dvandersluis][])

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -32,16 +32,19 @@ module RuboCop
     private_constant :SMART_PATH_CACHE
 
     def smart_path(path)
-      SMART_PATH_CACHE[path] ||= begin
-        # Ideally, we calculate this relative to the project root.
-        base_dir = Dir.pwd
-
-        if path.start_with? base_dir
-          relative_path(path, base_dir)
+      SMART_PATH_CACHE[path] ||=
+        if path.is_a?(RemoteConfig)
+          path.uri.to_s
         else
-          path
+          # Ideally, we calculate this relative to the project root.
+          base_dir = Dir.pwd
+
+          if path.start_with? base_dir
+            relative_path(path, base_dir)
+          else
+            path
+          end
         end
-      end
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -105,4 +105,27 @@ RSpec.describe RuboCop::PathUtil do
       expect(described_class).not_to be_match_path(/^d.*$/, "dir/file\xBF")
     end
   end
+
+  describe '#smart_path', :isolated_environment do
+    subject(:smart_path) { described_class.smart_path(path) }
+
+    context 'when given a path relative to Dir.pwd' do
+      let(:path) { File.join(Dir.pwd, 'relative') }
+
+      it { is_expected.to eq('relative') }
+    end
+
+    context 'when given a path that is not relative to Dir.pwd' do
+      let(:path) { '/src/rubocop/foo' }
+
+      it { is_expected.to eq(path) }
+    end
+
+    context 'when given a RuboCop::RemoteConfig object' do
+      let(:uri) { 'https://www.example.com/rubocop.yml' }
+      let(:path) { RuboCop::RemoteConfig.new(uri, Dir.pwd) }
+
+      it { is_expected.to eq(uri) }
+    end
+  end
 end


### PR DESCRIPTION
When you use `inherit_from` with a remote config, and that config inherits itself, it's possible a overridden config warning would be triggered. However, `PathUtil#smart_path` does not expect a `RemoteConfig`, and thus was crashing.

```
undefined method `start_with?' for an instance of RuboCop::RemoteConfig
/src/rubocop/lib/rubocop/path_util.rb:42:in `smart_path'
/src/rubocop/lib/rubocop/config_loader_resolver.rb:178:in `duplicate_setting_warning'
/src/rubocop/lib/rubocop/config_loader_resolver.rb:174:in `warn_on_duplicate_setting'
```

I made two changes:
1. `PathUtil#smart_path` will no longer crash when given a `RemoteConfig`
2. The warning is no longer shown when looking at remote inheritence, because these files are not changable within the project. We already do the inverse when a local configuration is overridden remotely.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
