### PR TITLE
[Fix #12430] Fix false negatives in `Style/RedundantLineContinuation` when continuations are inside begin nodes

### DIFF
--- a/changelog/fix_fix_false_negatives_in.md
+++ b/changelog/fix_fix_false_negatives_in.md
@@ -1,0 +1,1 @@
+* [#12430](https://github.com/rubocop/rubocop/issues/12430): Fix false negatives in `Style/RedundantLineContinuation` with multiple line continuations. ([@dvandersluis][])


### PR DESCRIPTION
Fixes the following false negatives for `Style/RedundantLineContinuation`:

```ruby
x do
  foo bar \
    baz
end

y do
  foo(bar, \
    baz)
end
```

```ruby
foo bar \
  baz

foo(bar, \
baz)
```

In both cases, the second continuation is redundant, but was not flagged properly. 

Fixes #12430.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
