### PR TITLE
[DOC] Fix typo in `Style/ExponentialNotation`

### DIFF
--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # * `scientific` which enforces a mantissa between 1 (inclusive) and 10 (exclusive).
       # * `engineering` which enforces the exponent to be a multiple of 3 and the mantissa
-      #   to be between 0.1 (inclusive) and 10 (exclusive).
+      #   to be between 0.1 (inclusive) and 1000 (exclusive).
       # * `integral` which enforces the mantissa to always be a whole number without
       #   trailing zeroes.
       #


### PR DESCRIPTION
The allowed mantissa for `engineering` is < 1000, not 10.
(The example below is correct.)