### PR TITLE
[Fix #13599] Fix incorrect autocorrect for `Layout/HashAlignment` when there is a multiline positional argument and `Layout/ArgumentAlignment` is configured with `EnforcedStyle: with_fixed_indentation`

### DIFF
--- a/changelog/fix_fix_incorrect_autocorrect_for.md
+++ b/changelog/fix_fix_incorrect_autocorrect_for.md
@@ -1,0 +1,1 @@
+* [#13599](https://github.com/rubocop/rubocop/issues/13599): Fix incorrect autocorrect for `Layout/HashAlignment` when there is a multiline positional argument and `Layout/ArgumentAlignment` is configured with `EnforcedStyle: with_fixed_indentation`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -227,6 +227,7 @@ module RuboCop
           left_sibling = argument_before_hash(node)
           parent_loc = node.parent.loc
           selector = left_sibling || parent_loc.selector || parent_loc.expression
+
           same_line?(selector, node.pairs.first)
         end
 
@@ -384,6 +385,11 @@ module RuboCop
         def enforce_first_argument_with_fixed_indentation?
           argument_alignment_config = config.for_enabled_cop('Layout/ArgumentAlignment')
           argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def same_line?(node1, node2)
+          # Override `Util#same_line?`
+          super || node1.last_line == line(node2)
         end
       end
     end

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -268,6 +268,33 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
         proc.(key: value)
       RUBY
     end
+
+    it 'does not register an offense for a method with a positional argument' do
+      expect_no_offenses(<<~RUBY)
+        do_something(
+          foo, baz: true,
+          quux: false
+        )
+      RUBY
+    end
+
+    it 'does not register an offense for a method with a positional argument that spans multiple lines' do
+      expect_no_offenses(<<~RUBY)
+        do_something(
+          foo(
+            bar
+          ), baz: true,
+          quux: false
+        )
+      RUBY
+    end
+
+    it 'does not register an offense when a multiline hash starts on the same line as an implicit `call`' do
+      expect_no_offenses(<<~RUBY)
+        do_something.(foo: bar, baz: qux,
+          quux: corge)
+      RUBY
+    end
   end
 
   context 'always ignore last argument hash' do


### PR DESCRIPTION
Update `Layout/HashAlignment` to not autocorrect when `Layout/ArgumentAlignment` is configured with `EnforcedStyle: with_fixed_indentation` and there is a multiline positional argument.

```ruby
do_something(
  foo(
    bar
  ), baz: true,
  quux: false
)
```

This aligns with the existing behaviour for singleline arguments, and prevents an infinite loop between `Layout/HashAlignment` and `Layout/ArgumentAlignment`.

Fixes #13599.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
