### PR TITLE
[Fix #13614] Fix false positives for `Style/RaiseArgs` with anonymous splat and triple dot forwarding

### DIFF
--- a/changelog/fix_false_positive_raise_args_forwarding.md
+++ b/changelog/fix_false_positive_raise_args_forwarding.md
@@ -1,0 +1,1 @@
+* [#13614](https://github.com/rubocop/rubocop/issues/13614): Fix false positives for `Style/RaiseArgs` with anonymous splat and triple dot forwarding. ([@earlopain][])

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -50,6 +50,9 @@ module RuboCop
 
         EXPLODED_MSG = 'Provide an exception class and message as arguments to `%<method>s`.'
         COMPACT_MSG = 'Provide an exception object as an argument to `%<method>s`.'
+        ACCEPTABLE_ARG_TYPES = %i[
+          hash forwarded_restarg splat forwarded_restarg forwarded_args
+        ].freeze
 
         RESTRICT_ON_SEND = %i[raise fail].freeze
 
@@ -138,9 +141,8 @@ module RuboCop
 
           arg = args.first
 
-          # Allow code like `raise Ex.new(kw: arg)`.
-          # Allow code like `raise Ex.new(*args)`.
-          arg.hash_type? || arg.splat_type?
+          # Allow nodes that may forward more than one argument
+          ACCEPTABLE_ARG_TYPES.include?(arg.type)
         end
 
         def allowed_non_exploded_type?(arg)

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -322,6 +322,22 @@ RSpec.describe RuboCop::Cop::Style::RaiseArgs, :config do
       expect_no_offenses('raise MyCustomError.new(*args)')
     end
 
+    context 'when Ruby >= 3.2', :ruby32 do
+      it 'accepts a raise with anonymous splatted arguments' do
+        expect_no_offenses('def foo(*) raise MyCustomError.new(*) end')
+      end
+
+      it 'accepts a raise with anonymous keyword splatted arguments' do
+        expect_no_offenses('def foo(**) raise MyCustomError.new(**) end')
+      end
+    end
+
+    context 'when Ruby >= 27', :ruby27 do
+      it 'accepts a raise with triple dot forwarding' do
+        expect_no_offenses('def foo(...) raise MyCustomError.new(...) end')
+      end
+    end
+
     it 'ignores a raise with an exception argument' do
       expect_no_offenses('raise Ex.new(entity), message')
     end


### PR DESCRIPTION
Fixes #13614

I also found out that `...` results in the same error, so ignore it as well. `**` was already correctly ignored, I just added a test.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
