### PR TITLE
Fix `Style/YodaExpression` cop error on suffix form of operator

### DIFF
--- a/changelog/fix_style_yoda_expression_cop_error_on_suffix_form_of_operator.md
+++ b/changelog/fix_style_yoda_expression_cop_error_on_suffix_form_of_operator.md
@@ -1,0 +1,1 @@
+* [#13619](https://github.com/rubocop/rubocop/pull/13619): Fix `Style/YodaExpression` cop error in case of suffix form of operator. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/yoda_expression.rb
+++ b/lib/rubocop/cop/style/yoda_expression.rb
@@ -50,6 +50,7 @@ module RuboCop
 
         def on_send(node)
           return unless supported_operators.include?(node.method_name.to_s)
+          return unless node.arguments?
 
           lhs = node.receiver
           rhs = node.first_argument

--- a/spec/rubocop/cop/style/yoda_expression_spec.rb
+++ b/spec/rubocop/cop/style/yoda_expression_spec.rb
@@ -70,4 +70,26 @@ RSpec.describe RuboCop::Cop::Style::YodaExpression, :config do
       1 | x
     RUBY
   end
+
+  it 'registers an offense and corrects when using suffix form of operator with constant receiver' do
+    expect_offense(<<~RUBY)
+      1 + CONST.+(ary)
+      ^^^^^^^^^^^^^^^^ Non-literal operand (`CONST.+(ary)`) should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ary.+(CONST) + 1
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using suffix form of nullary operator with constant receiver' do
+    expect_offense(<<~RUBY)
+      1 + CONST.*
+      ^^^^^^^^^^^ Non-literal operand (`CONST.*`) should be first.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      CONST.* + 1
+    RUBY
+  end
 end


### PR DESCRIPTION
```console
echo '1 + C.+' | be rubocop --stdin bug.rb --only Style/YodaExpression -d

An error occurred while Style/YodaExpression cop was inspecting bug.rb:1:4.
undefined method `numeric_type?' for nil
lib/rubocop/cop/style/yoda_expression.rb:74:in `constant_portion?'
lib/rubocop/cop/style/yoda_expression.rb:70:in `yoda_expression_constant?'
lib/rubocop/cop/style/yoda_expression.rb:56:in `on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
