### PR TITLE
Dont show parser warnings in `Lint/Syntax`

### DIFF
--- a/changelog/fix_dont_show_warnings_when_syntax_error.md
+++ b/changelog/fix_dont_show_warnings_when_syntax_error.md
@@ -1,0 +1,1 @@
+* [#13624](https://github.com/rubocop/rubocop/pull/13624): Don't show warnings from `Lint/Syntax` when a syntax error occurs. ([@earlopain][])

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -6,9 +6,12 @@ module RuboCop
       # Repacks Parser's diagnostics/errors
       # into RuboCop's offenses.
       class Syntax < Base
+        LEVELS = %i[error fatal].freeze
+
         def on_other_file
           add_offense_from_error(processed_source.parser_error) if processed_source.parser_error
-          processed_source.diagnostics.each do |diagnostic|
+          syntax_errors = processed_source.diagnostics.select { |d| LEVELS.include?(d.level) }
+          syntax_errors.each do |diagnostic|
             add_offense_from_diagnostic(diagnostic, processed_source.ruby_version)
           end
           super

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -62,6 +62,27 @@ RSpec.describe RuboCop::Cop::Lint::Syntax, :config do
       end
     end
 
+    context 'with a diagnostic warning and error' do
+      let(:source) { <<~RUBY }
+        # warning: ambiguous `*` has been interpreted as an argument prefix
+        foo *some_array
+        (
+      RUBY
+
+      it 'shows only syntax errors' do
+        expect(processed_source.diagnostics.map(&:level)).to contain_exactly(:warning, :error)
+
+        expect(offenses.size).to eq(1)
+        message = <<~MESSAGE.chomp
+          #{syntax_error_message}
+          (Using Ruby 3.3 parser; configure using `TargetRubyVersion` parameter, under `AllCops`)
+        MESSAGE
+        offense = offenses.first
+        expect(offense.message).to eq(message)
+        expect(offense.severity).to eq(:fatal)
+      end
+    end
+
     context 'with a parser error' do
       let(:source) { <<~RUBY }
         # \xf9


### PR DESCRIPTION
```rb
{ a: a, a: a }

(
```

```
Offenses:

code.rb:1:9: F: Lint/Syntax: key is duplicated and overwritten
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
{ a: a, a: a }
        ^
code.rb:4:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)

1 file inspected, 2 offenses detected
```

This caused me quite the confusion... In prism, the useless literal warning for `/#{"\xcd"}/
` was masking the actual syntax error because they both had the same location, and the parser gem simply doesn't implement that warning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
