### PR TITLE
Add Ruby 3.4 to spec matrix

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'head']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Now that Ruby 3.4 is out, `head` will relate to the 3.5 development branch, so 3.4 needs to be explicitly given.

PR for setup-ruby is here: https://github.com/ruby/setup-ruby/pull/677. Even though it's not yet merged (although I assume it will be shortly), an explicit "3.4" will still work (but refer to the release candidate for now).

`head` already is 3.5, as seen here: https://github.com/rubocop/rubocop/actions/runs/12496246734/job/34867800491?pr=13624#step:3:18 (can be seen in the GH actions of this PR as well)