### PR TITLE
Add support for Ruby LSP as a built-in add-on

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.23.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 3.3.0'
+# Ruby LSP supports Ruby 3.0+.
+gem 'ruby-lsp', '~> 0.17', platform: :mri if RUBY_VERSION >= '3.0'
 gem 'simplecov', '~> 0.20'
 gem 'stackprof', platform: :mri
 gem 'test-queue'

--- a/changelog/new_make_lsp_server_support_quick_fix_code_aciton.md
+++ b/changelog/new_make_lsp_server_support_quick_fix_code_aciton.md
@@ -1,0 +1,1 @@
+* [#13628](https://github.com/rubocop/rubocop/pull/13628): Make LSP server support quick fix code action. ([@koic][])

--- a/changelog/new_support_ruby_lsp_addon.md
+++ b/changelog/new_support_ruby_lsp_addon.md
@@ -1,0 +1,1 @@
+* [#13628](https://github.com/rubocop/rubocop/pull/13628): Add support for Ruby LSP as a built-in add-on. ([@koic][])

--- a/lib/rubocop/lsp/diagnostic.rb
+++ b/lib/rubocop/lsp/diagnostic.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require_relative 'severity'
+
+#
+# This code is based on https://github.com/standardrb/standard.
+#
+# Copyright (c) 2023 Test Double, Inc.
+#
+# The MIT License (MIT)
+#
+# https://github.com/standardrb/standard/blob/main/LICENSE.txt
+#
+module RuboCop
+  module LSP
+    # Diagnostic for Language Server Protocol of RuboCop.
+    # @api private
+    class Diagnostic
+      def initialize(document_encoding, offense, uri, cop_class)
+        @document_encoding = document_encoding
+        @offense = offense
+        @uri = uri
+        @cop_class = cop_class
+      end
+
+      def to_lsp_code_actions
+        code_actions = []
+
+        code_actions << autocorrect_action if correctable?
+        code_actions << disable_line_action
+
+        code_actions
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def to_lsp_diagnostic(config)
+        highlighted = @offense.highlighted_area
+
+        LanguageServer::Protocol::Interface::Diagnostic.new(
+          message: message,
+          source: 'RuboCop',
+          code: @offense.cop_name,
+          code_description: code_description(config),
+          severity: severity,
+          range: LanguageServer::Protocol::Interface::Range.new(
+            start: LanguageServer::Protocol::Interface::Position.new(
+              line: @offense.line - 1,
+              character: highlighted.begin_pos
+            ),
+            end: LanguageServer::Protocol::Interface::Position.new(
+              line: @offense.line - 1,
+              character: highlighted.end_pos
+            )
+          ),
+          data: {
+            correctable: correctable?,
+            code_actions: to_lsp_code_actions
+          }
+        )
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      private
+
+      def message
+        message = @offense.message
+        message += "\n\nThis offense is not autocorrectable.\n" unless correctable?
+        message
+      end
+
+      def severity
+        Severity.find_by(@offense.severity.name)
+      end
+
+      def code_description(config)
+        return unless @cop_class
+        return unless (doc_url = @cop_class.documentation_url(config))
+
+        LanguageServer::Protocol::Interface::CodeDescription.new(href: doc_url)
+      end
+
+      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      def autocorrect_action
+        LanguageServer::Protocol::Interface::CodeAction.new(
+          title: "Autocorrect #{@offense.cop_name}",
+          kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
+          edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+            document_changes: [
+              LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+                text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                  uri: ensure_uri_scheme(@uri.to_s).to_s,
+                  version: nil
+                ),
+                edits: correctable? ? offense_replacements : []
+              )
+            ]
+          ),
+          is_preferred: true
+        )
+      end
+      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+
+      # rubocop:disable Metrics/MethodLength
+      def offense_replacements
+        @offense.corrector.as_replacements.map do |range, replacement|
+          LanguageServer::Protocol::Interface::TextEdit.new(
+            range: LanguageServer::Protocol::Interface::Range.new(
+              start: LanguageServer::Protocol::Interface::Position.new(
+                line: range.line - 1,
+                character: range.column
+              ),
+              end: LanguageServer::Protocol::Interface::Position.new(
+                line: range.last_line - 1,
+                character: range.last_column
+              )
+            ),
+            new_text: replacement
+          )
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      def disable_line_action
+        LanguageServer::Protocol::Interface::CodeAction.new(
+          title: "Disable #{@offense.cop_name} for this line",
+          kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
+          edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+            document_changes: [
+              LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+                text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                  uri: ensure_uri_scheme(@uri.to_s).to_s,
+                  version: nil
+                ),
+                edits: line_disable_comment
+              )
+            ]
+          )
+        )
+      end
+      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+
+      def line_disable_comment
+        new_text = if @offense.source_line.include?(' # rubocop:disable ')
+                     ",#{@offense.cop_name}"
+                   else
+                     " # rubocop:disable #{@offense.cop_name}"
+                   end
+
+        eol = LanguageServer::Protocol::Interface::Position.new(
+          line: @offense.line - 1,
+          character: length_of_line(@offense.source_line)
+        )
+
+        # TODO: fails for multiline strings - may be preferable to use block
+        # comments to disable some offenses
+        inline_comment = LanguageServer::Protocol::Interface::TextEdit.new(
+          range: LanguageServer::Protocol::Interface::Range.new(start: eol, end: eol),
+          new_text: new_text
+        )
+
+        [inline_comment]
+      end
+
+      def length_of_line(line)
+        if @document_encoding == Encoding::UTF_16LE
+          line_length = 0
+          line.codepoints.each do |codepoint|
+            line_length += 1
+            line_length += 1 if codepoint > RubyLsp::Document::Scanner::SURROGATE_PAIR_START
+          end
+          line_length
+        else
+          line.length
+        end
+      end
+
+      def correctable?
+        !@offense.corrector.nil?
+      end
+
+      def ensure_uri_scheme(uri)
+        uri = URI.parse(uri)
+        uri.scheme = 'file' if uri.scheme.nil?
+        uri
+      end
+    end
+  end
+end

--- a/lib/rubocop/lsp/logger.rb
+++ b/lib/rubocop/lsp/logger.rb
@@ -14,8 +14,8 @@ module RuboCop
     # Log for Language Server Protocol of RuboCop.
     # @api private
     class Logger
-      def self.log(message)
-        warn("[server] #{message}")
+      def self.log(message, prefix: '[server]')
+        warn("#{prefix} #{message}")
       end
     end
   end

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'stringio'
+require_relative 'diagnostic'
+require_relative 'stdin_runner'
 
 #
 # This code is based on https://github.com/standardrb/standard.
@@ -19,24 +20,14 @@ module RuboCop
       attr_writer :safe_autocorrect, :lint_mode, :layout_mode
 
       def initialize(config_store)
-        @config_store = config_store
-        @logged_paths = []
+        @runner = RuboCop::Lsp::StdinRunner.new(config_store)
+        @cop_registry = RuboCop::Cop::Registry.global.to_h
+
         @safe_autocorrect = true
         @lint_mode = false
         @layout_mode = false
       end
 
-      # This abuses the `--stdin` option of rubocop and reads the formatted text
-      # from the `options[:stdin]` that rubocop mutates. This depends on
-      # `parallel: false` as well as the fact that RuboCop doesn't otherwise dup
-      # or reassign that options object. Risky business!
-      #
-      # Reassigning `options[:stdin]` is done here:
-      #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/cop/team.rb#L131
-      # Printing `options[:stdin]`
-      #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/cli/command/execute_runner.rb#L95
-      # Setting `parallel: true` would break this here:
-      #   https://github.com/rubocop/rubocop/blob/v1.52.0/lib/rubocop/runner.rb#L72
       def format(path, text, command:)
         safe_autocorrect = if command
                              command == 'rubocop.formatAutocorrects'
@@ -44,34 +35,23 @@ module RuboCop
                              @safe_autocorrect
                            end
 
-        formatting_options = {
-          stdin: text, force_exclusion: true, autocorrect: true, safe_autocorrect: safe_autocorrect
-        }
+        formatting_options = { autocorrect: true, safe_autocorrect: safe_autocorrect }
         formatting_options[:only] = config_only_options if @lint_mode || @layout_mode
 
-        redirect_stdout { run_rubocop(formatting_options, path) }
-
-        formatting_options[:stdin]
+        @runner.run(path, text, formatting_options)
+        @runner.formatted_source
       end
 
-      def offenses(path, text)
-        diagnostic_options = {
-          stdin: text, force_exclusion: true, formatters: ['json'], format: 'json'
-        }
+      def offenses(path, text, document_encoding = nil)
+        diagnostic_options = {}
         diagnostic_options[:only] = config_only_options if @lint_mode || @layout_mode
 
-        json = redirect_stdout { run_rubocop(diagnostic_options, path) }
-        results = JSON.parse(json, symbolize_names: true)
-
-        if results[:files].empty?
-          unless @logged_paths.include?(path)
-            Logger.log "Ignoring file, per configuration: #{path}"
-            @logged_paths << path
-          end
-          return []
+        @runner.run(path, text, diagnostic_options)
+        @runner.offenses.map do |offense|
+          Diagnostic.new(
+            document_encoding, offense, path, @cop_registry[offense.cop_name]&.first
+          ).to_lsp_diagnostic(@runner.config_for_working_directory)
         end
-
-        results.dig(:files, 0, :offenses)
       end
 
       private
@@ -81,20 +61,6 @@ module RuboCop
         only_options << 'Lint' if @lint_mode
         only_options << 'Layout' if @layout_mode
         only_options
-      end
-
-      def redirect_stdout(&block)
-        stdout = StringIO.new
-
-        RuboCop::Server::Helper.redirect(stdout: stdout, &block)
-
-        stdout.string
-      end
-
-      def run_rubocop(options, path)
-        runner = RuboCop::Runner.new(options, @config_store)
-
-        runner.run([path])
       end
     end
   end

--- a/lib/rubocop/lsp/stdin_runner.rb
+++ b/lib/rubocop/lsp/stdin_runner.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#
+# This code is based on https://github.com/standardrb/standard.
+#
+# Copyright (c) 2023 Test Double, Inc.
+#
+# The MIT License (MIT)
+#
+# https://github.com/standardrb/standard/blob/main/LICENSE.txt
+#
+module RuboCop
+  module Lsp
+    # Originally lifted from:
+    # https://github.com/Shopify/ruby-lsp/blob/8d4c17efce4e8ecc8e7c557ab2981db6b22c0b6d/lib/ruby_lsp/requests/support/rubocop_runner.rb#L20
+    # @api private
+    class StdinRunner < RuboCop::Runner
+      class ConfigurationError < StandardError; end
+
+      attr_reader :offenses, :config_for_working_directory
+
+      DEFAULT_RUBOCOP_OPTIONS = {
+        stderr: true,
+        force_exclusion: true,
+        formatters: ['RuboCop::Formatter::BaseFormatter'],
+        raise_cop_error: true,
+        todo_file: nil,
+        todo_ignore_files: []
+      }.freeze
+
+      def initialize(config_store)
+        @options = {}
+
+        @offenses = []
+        @warnings = []
+        @errors = []
+
+        @config_for_working_directory = config_store.for_pwd
+
+        super(@options, config_store)
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def run(path, contents, options)
+        @options = options.merge(DEFAULT_RUBOCOP_OPTIONS)
+        @options[:stdin] = contents
+
+        @offenses = []
+        @warnings = []
+        @errors = []
+
+        super([path])
+
+        raise Interrupt if aborting?
+      rescue RuboCop::Runner::InfiniteCorrectionLoop => e
+        if defined?(::RubyLsp::Requests::Formatting::Error)
+          raise ::RubyLsp::Requests::Formatting::Error, e.message
+        end
+
+        raise e
+      rescue RuboCop::ValidationError => e
+        raise ConfigurationError, e.message
+      rescue StandardError => e
+        if defined?(::RubyLsp::Requests::Formatting::Error)
+          raise ::RubyLsp::Requests::Support::InternalRuboCopError, e
+        end
+
+        raise e
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def formatted_source
+        @options[:stdin]
+      end
+
+      private
+
+      def file_finished(_file, offenses)
+        @offenses = offenses
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative '../../rubocop'
+require_relative '../../rubocop/lsp/logger'
+require_relative 'wraps_built_in_lsp_runtime'
+
+module RubyLsp
+  module RuboCop
+    # A Ruby LSP add-on for RuboCop.
+    class Addon < RubyLsp::Addon
+      def initializer
+        @wraps_built_in_lsp_runtime = nil
+      end
+
+      def name
+        'RuboCop'
+      end
+
+      def activate(global_state, message_queue)
+        ::RuboCop::LSP::Logger.log("Activating RuboCop LSP addon #{::RuboCop::Version::STRING}.")
+
+        @wraps_built_in_lsp_runtime = WrapsBuiltinLspRuntime.new
+
+        global_state.register_formatter('rubocop', @wraps_built_in_lsp_runtime)
+
+        register_additional_file_watchers(global_state, message_queue)
+
+        ::RuboCop::LSP::Logger.log("Initialized RuboCop LSP addon #{::RuboCop::Version::STRING}.")
+      end
+
+      def deactivate
+        @wraps_built_in_lsp_runtime = nil
+      end
+
+      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      def register_additional_file_watchers(global_state, message_queue)
+        return unless global_state.supports_watching_files
+
+        message_queue << Request.new(
+          id: 'rubocop-file-watcher',
+          method: 'client/registerCapability',
+          params: Interface::RegistrationParams.new(
+            registrations: [
+              Interface::Registration.new(
+                id: 'workspace/didChangeWatchedFilesRuboCop',
+                method: 'workspace/didChangeWatchedFiles',
+                register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
+                  watchers: [
+                    Interface::FileSystemWatcher.new(
+                      glob_pattern: '**/.rubocop.yml',
+                      kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE
+                    )
+                  ]
+                )
+              )
+            ]
+          )
+        )
+      end
+      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+
+      def workspace_did_change_watched_files(changes)
+        return unless changes.any? { |change| change[:uri].end_with?('.rubocop.yml') }
+
+        @wraps_built_in_lsp_runtime.init!
+
+        ::RuboCop::LSP::Logger(<<~MESSAGE)
+          Re-initialized RuboCop LSP addon #{::RuboCop::Version::STRING} due to .rubocop.yml file change.
+        MESSAGE
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -17,15 +17,20 @@ module RubyLsp
       end
 
       def activate(global_state, message_queue)
-        ::RuboCop::LSP::Logger.log("Activating RuboCop LSP addon #{::RuboCop::Version::STRING}.")
+        ::RuboCop::LSP::Logger.log(
+          "Activating RuboCop LSP addon #{::RuboCop::Version::STRING}.", prefix: '[RuboCop]'
+        )
 
+        ::RuboCop::LSP.enable
         @wraps_built_in_lsp_runtime = WrapsBuiltinLspRuntime.new
 
         global_state.register_formatter('rubocop', @wraps_built_in_lsp_runtime)
 
         register_additional_file_watchers(global_state, message_queue)
 
-        ::RuboCop::LSP::Logger.log("Initialized RuboCop LSP addon #{::RuboCop::Version::STRING}.")
+        ::RuboCop::LSP::Logger.log(
+          "Initialized RuboCop LSP addon #{::RuboCop::Version::STRING}.", prefix: '[RuboCop]'
+        )
       end
 
       def deactivate
@@ -47,7 +52,7 @@ module RubyLsp
                 register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
                   watchers: [
                     Interface::FileSystemWatcher.new(
-                      glob_pattern: '**/.rubocop.yml',
+                      glob_pattern: '**/.rubocop{,_todo}.yml',
                       kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE
                     )
                   ]
@@ -64,7 +69,7 @@ module RubyLsp
 
         @wraps_built_in_lsp_runtime.init!
 
-        ::RuboCop::LSP::Logger(<<~MESSAGE)
+        ::RuboCop::LSP::Logger(<<~MESSAGE, prefix: '[RuboCop]')
           Re-initialized RuboCop LSP addon #{::RuboCop::Version::STRING} due to .rubocop.yml file change.
         MESSAGE
       end

--- a/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
+++ b/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../rubocop/lsp/runtime'
+
 module RubyLsp
   module RuboCop
     # Wrap RuboCop's built-in runtime for Ruby LSP's add-on.
@@ -12,71 +14,13 @@ module RubyLsp
 
       def init!
         config = ::RuboCop::ConfigStore.new
+
         @runtime = ::RuboCop::LSP::Runtime.new(config)
-        @rubocop_config = config.for_pwd
-        @cop_registry = ::RuboCop::Cop::Registry.global.to_h
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def run_diagnostic(uri, document)
-        offenses = @runtime.offenses(uri_to_path(uri), document.source)
-
-        # rubocop:disable Metrics/BlockLength
-        offenses.map do |o|
-          cop_name = o[:cop_name]
-
-          msg = o[:message].delete_prefix(cop_name)
-          loc = o[:location]
-
-          severity = case o[:severity]
-                     when 'error', 'fatal'
-                       RubyLsp::Constant::DiagnosticSeverity::ERROR
-                     when 'warning'
-                       RubyLsp::Constant::DiagnosticSeverity::WARNING
-                     when 'convention'
-                       RubyLsp::Constant::DiagnosticSeverity::INFORMATION
-                     when 'refactor', 'info'
-                       RubyLsp::Constant::DiagnosticSeverity::HINT
-                     else # the above cases fully cover what RuboCop sends at this time
-                       logger.puts "Unknown severity: #{severity.inspect}"
-                       RubyLsp::Constant::DiagnosticSeverity::HINT
-                     end
-
-          RubyLsp::Interface::Diagnostic.new(
-            code: cop_name,
-            code_description: code_description(cop_name),
-            message: msg,
-            source: 'RuboCop',
-            severity: severity,
-            range: RubyLsp::Interface::Range.new(
-              start: RubyLsp::Interface::Position.new(
-                line: loc[:start_line] - 1, character: loc[:start_column] - 1
-              ),
-
-              end: RubyLsp::Interface::Position.new(
-                line: loc[:last_line] - 1, character: loc[:last_column]
-              )
-            )
-            # TODO: We need to do something like to support quickfixes thru code actions
-            # See: https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L62
-            # data: {
-            #   correctable: correctable?(offense),
-            #   code_actions: to_lsp_code_actions
-            # }
-            #
-            # Right now, our offenses are all just JSON parsed from stdout shelling to RuboCop, so
-            # it seems we don't have the corrector available to us.
-            #
-            # Lifted from:
-            # https://github.com/Shopify/ruby-lsp/blob/8d4c17efce4e8ecc8e7c557ab2981db6b22c0b6d/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L201
-            # def correctable?(offense)
-            #   !offense.corrector.nil?
-            # end
-          )
-        end
-        # rubocop:enable Metrics/BlockLength
+        @runtime.offenses(uri_to_path(uri), document.source, document.encoding)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def run_formatting(uri, document)
         @runtime.format(uri_to_path(uri), document.source, command: 'rubocop.formatAutocorrects')
@@ -92,15 +36,6 @@ module RubyLsp
         else
           uri.to_s.delete_prefix('file://')
         end
-      end
-
-      # lifted from:
-      # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L84
-      def code_description(cop_name)
-        return unless (cop_class = @cop_registry[cop_name]&.first)
-        return unless (doc_url = cop_class.documentation_url(@rubocop_config))
-
-        Interface::CodeDescription.new(href: doc_url)
       end
     end
   end

--- a/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
+++ b/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module RubyLsp
+  module RuboCop
+    # Wrap RuboCop's built-in runtime for Ruby LSP's add-on.
+    class WrapsBuiltinLspRuntime
+      include RubyLsp::Requests::Support::Formatter
+
+      def initialize
+        init!
+      end
+
+      def init!
+        config = ::RuboCop::ConfigStore.new
+        @runtime = ::RuboCop::LSP::Runtime.new(config)
+        @rubocop_config = config.for_pwd
+        @cop_registry = ::RuboCop::Cop::Registry.global.to_h
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def run_diagnostic(uri, document)
+        offenses = @runtime.offenses(uri_to_path(uri), document.source)
+
+        # rubocop:disable Metrics/BlockLength
+        offenses.map do |o|
+          cop_name = o[:cop_name]
+
+          msg = o[:message].delete_prefix(cop_name)
+          loc = o[:location]
+
+          severity = case o[:severity]
+                     when 'error', 'fatal'
+                       RubyLsp::Constant::DiagnosticSeverity::ERROR
+                     when 'warning'
+                       RubyLsp::Constant::DiagnosticSeverity::WARNING
+                     when 'convention'
+                       RubyLsp::Constant::DiagnosticSeverity::INFORMATION
+                     when 'refactor', 'info'
+                       RubyLsp::Constant::DiagnosticSeverity::HINT
+                     else # the above cases fully cover what RuboCop sends at this time
+                       logger.puts "Unknown severity: #{severity.inspect}"
+                       RubyLsp::Constant::DiagnosticSeverity::HINT
+                     end
+
+          RubyLsp::Interface::Diagnostic.new(
+            code: cop_name,
+            code_description: code_description(cop_name),
+            message: msg,
+            source: 'RuboCop',
+            severity: severity,
+            range: RubyLsp::Interface::Range.new(
+              start: RubyLsp::Interface::Position.new(
+                line: loc[:start_line] - 1, character: loc[:start_column] - 1
+              ),
+
+              end: RubyLsp::Interface::Position.new(
+                line: loc[:last_line] - 1, character: loc[:last_column]
+              )
+            )
+            # TODO: We need to do something like to support quickfixes thru code actions
+            # See: https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L62
+            # data: {
+            #   correctable: correctable?(offense),
+            #   code_actions: to_lsp_code_actions
+            # }
+            #
+            # Right now, our offenses are all just JSON parsed from stdout shelling to RuboCop, so
+            # it seems we don't have the corrector available to us.
+            #
+            # Lifted from:
+            # https://github.com/Shopify/ruby-lsp/blob/8d4c17efce4e8ecc8e7c557ab2981db6b22c0b6d/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L201
+            # def correctable?(offense)
+            #   !offense.corrector.nil?
+            # end
+          )
+        end
+        # rubocop:enable Metrics/BlockLength
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def run_formatting(uri, document)
+        @runtime.format(uri_to_path(uri), document.source, command: 'rubocop.formatAutocorrects')
+      end
+
+      private
+
+      # duplicated from: lib/standard/lsp/routes.rb
+      # modified to incorporate Ruby LSP's to_standardized_path method
+      def uri_to_path(uri)
+        if uri.respond_to?(:to_standardized_path) && (standardized_path = uri.to_standardized_path)
+          standardized_path
+        else
+          uri.to_s.delete_prefix('file://')
+        end
+      end
+
+      # lifted from:
+      # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb#L84
+      def code_description(cop_name)
+        return unless (cop_class = @cop_registry[cop_name]&.first)
+        return unless (doc_url = cop_class.documentation_url(@rubocop_config))
+
+        Interface::CodeDescription.new(href: doc_url)
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
+++ b/lib/ruby_lsp/rubocop/wraps_built_in_lsp_runtime.rb
@@ -26,6 +26,14 @@ module RubyLsp
         @runtime.format(uri_to_path(uri), document.source, command: 'rubocop.formatAutocorrects')
       end
 
+      def run_range_formatting(_uri, _partial_source, _base_indentation)
+        # Not yet supported. Should return the formatted version of `partial_source` which is
+        # a partial selection of the entire document. For example, it should not try to add
+        # a frozen_string_literal magic comment and all style corrections should start from
+        # the `base_indentation`.
+        nil
+      end
+
       private
 
       # duplicated from: lib/standard/lsp/routes.rb

--- a/spec/fixtures/ruby_lsp/example.rb
+++ b/spec/fixtures/ruby_lsp/example.rb
@@ -1,0 +1,2 @@
+s = 'hi'
+puts s

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -74,20 +74,107 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           diagnostics: [
             {
               code: 'Style/FrozenStringLiteralComment',
-              message: 'Missing frozen string literal comment.',
+              codeDescription: {
+                href: 'https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment'
+              },
+              data: {
+                code_actions: [
+                  {
+                    edit: {
+                      documentChanges: [
+                        edits: [
+                          {
+                            newText: "# frozen_string_literal: true\n",
+                            range: {
+                              start: { character: 0, line: 0 },
+                              end: { character: 0, line: 0 }
+                            }
+                          }
+                        ],
+                        textDocument: { uri: 'file:///path/to/file.rb', version: nil }
+                      ]
+                    },
+                    kind: 'quickfix',
+                    title: 'Autocorrect Style/FrozenStringLiteralComment',
+                    isPreferred: true
+                  }, {
+                    edit: {
+                      documentChanges: [
+                        edits: [
+                          {
+                            newText: ' # rubocop:disable Style/FrozenStringLiteralComment',
+                            range: {
+                              start: { character: 6, line: 0 },
+                              end: { character: 6, line: 0 }
+                            }
+                          }
+                        ],
+                        textDocument: { uri: 'file:///path/to/file.rb', version: nil }
+                      ]
+                    },
+                    kind: 'quickfix',
+                    title: 'Disable Style/FrozenStringLiteralComment for this line'
+                  }
+                ],
+                correctable: true
+              },
+              message: 'Style/FrozenStringLiteralComment: Missing frozen string literal comment.',
               range: {
-                start: { character: 0, line: 0 }, end: { character: 1, line: 0 }
+                start: { character: 0, line: 0 },
+                end: { character: 1, line: 0 }
               },
               severity: 3,
-              source: 'rubocop'
+              source: 'RuboCop'
             }, {
               code: 'Layout/SpaceInsideArrayLiteralBrackets',
-              message: 'Do not use space inside array brackets.',
+              codeDescription: {
+                href: 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutspaceinsidearrayliteralbrackets'
+              },
+              data: {
+                code_actions: [
+                  {
+                    edit: {
+                      documentChanges: [
+                        edits: [
+                          newText: '', range: {
+                            end: { character: 6, line: 2 },
+                            start: { character: 4, line: 2 }
+                          }
+                        ],
+                        textDocument: { uri: 'file:///path/to/file.rb', version: nil }
+                      ]
+                    },
+                    kind: 'quickfix',
+                    title: 'Autocorrect Layout/SpaceInsideArrayLiteralBrackets',
+                    isPreferred: true
+                  }, {
+                    edit: {
+                      documentChanges: [
+                        edits: [
+                          newText: ' # rubocop:disable Layout/SpaceInsideArrayLiteralBrackets',
+                          range: {
+                            end: { character: 7, line: 2 },
+                            start: {
+                              character: 7, line: 2
+                            }
+                          }
+                        ],
+                        textDocument: { uri: 'file:///path/to/file.rb', version: nil }
+                      ]
+                    },
+                    kind: 'quickfix',
+                    title: 'Disable Layout/SpaceInsideArrayLiteralBrackets for this line'
+                  }
+                ],
+                correctable: true
+              },
+              message: 'Layout/SpaceInsideArrayLiteralBrackets: Do not use space inside array brackets.', # rubocop:disable Layout/LineLength
               range: {
-                start: { character: 4, line: 2 }, end: { character: 6, line: 2 }
+                start: { character: 4, line: 2 },
+                end: { character: 6, line: 2 }
               },
               severity: 3,
-              source: 'rubocop'
+              source: 'RuboCop'
             }
           ], uri: 'file:///path/to/file.rb'
         }
@@ -1185,9 +1272,6 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           uri: "file://#{Dir.pwd}/tmp/foo/bar.rb"
         }
       )
-      expect(stderr.chomp).to eq(
-        "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/foo/bar.rb"
-      )
     end
   end
 
@@ -1232,9 +1316,6 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           }
         }
       )
-      expect(stderr.chomp).to eq(
-        "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/baz.rb"
-      )
     end
   end
 
@@ -1278,9 +1359,6 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     it 'handles requests' do
       format_result = messages.last
       expect(format_result).to eq(jsonrpc: '2.0', id: 20, result: [])
-      expect(stderr.chomp).to eq(
-        "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/zzz.rb"
-      )
     end
   end
 

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# NOTE: These don't work in Ruby LSP.
+return if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby' || RuboCop::Platform.windows?
+
+require 'ruby_lsp/internal'
+require 'ruby_lsp/rubocop/addon'
+
+describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
+  let(:addon) do
+    RubyLsp::RuboCop::Addon.new
+  end
+
+  let(:source) do
+    <<~RUBY
+      s = "hello"
+      puts s
+    RUBY
+  end
+
+  before do
+    # Suppress Ruby LSP's add-on logging.
+    allow(RuboCop::LSP::Logger).to receive(:log)
+  end
+
+  describe 'Add-on name' do
+    it 'is RuboCop' do
+      expect(addon.name).to eq 'RuboCop'
+    end
+  end
+
+  describe 'textDocument/diagnostic' do
+    subject(:result) do
+      with_server(source, 'example.rb') do |server, uri|
+        server.process_message(
+          id: 2,
+          method: 'textDocument/diagnostic',
+          params: {
+            textDocument: {
+              uri: uri
+            }
+          }
+        )
+
+        server.pop_response
+      end
+    end
+
+    let(:first_item) { result.response.items.first }
+    let(:second_item) { result.response.items[1] }
+
+    it 'has basic result information' do
+      expect(result).to be_an_instance_of(RubyLsp::Result)
+      expect(result.response.kind).to eq 'full'
+      expect(result.response.items.size).to eq 2
+    end
+
+    it 'has first diagnostic information' do
+      expect(first_item.range.start.to_hash).to eq({ line: 0, character: 0 })
+      expect(first_item.range.end.to_hash).to eq({ line: 0, character: 1 })
+      expect(first_item.severity).to eq RubyLsp::Constant::DiagnosticSeverity::INFORMATION
+      expect(first_item.code).to eq 'Style/FrozenStringLiteralComment'
+      expect(first_item.code_description.href).to eq 'https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment'
+      expect(first_item.source).to eq 'RuboCop'
+      expect(first_item.message).to eq 'Missing frozen string literal comment.'
+    end
+
+    it 'has second diagnostic information' do
+      second_item = result.response.items[1]
+      expect(second_item.range.start.to_hash).to eq({ line: 0, character: 4 })
+      expect(second_item.range.end.to_hash).to eq({ line: 0, character: 11 })
+      expect(second_item.severity).to eq RubyLsp::Constant::DiagnosticSeverity::INFORMATION
+      expect(second_item.code).to eq 'Style/StringLiterals'
+      expect(second_item.code_description.href).to eq 'https://docs.rubocop.org/rubocop/cops_style.html#stylestringliterals'
+      expect(second_item.source).to eq 'RuboCop'
+      expect(second_item.message).to eq <<~MESSAGE.chop
+        Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      MESSAGE
+    end
+  end
+
+  describe 'textDocument/formatting' do
+    subject(:result) do
+      with_server(source, 'example.rb') do |server, uri|
+        server.process_message(
+          id: 2,
+          method: 'textDocument/formatting',
+          params: {
+            textDocument: { uri: uri },
+            position: { line: 0, character: 0 }
+          }
+        )
+
+        server.pop_response
+      end
+    end
+
+    it 'has basic result information' do
+      expect(result).to be_an_instance_of(RubyLsp::Result)
+      expect(result.response.size).to eq 1
+    end
+
+    it 'has autocorrected code' do
+      expect(result.response.first.new_text).to eq <<~RUBY
+        s = 'hello'
+        puts s
+      RUBY
+    end
+  end
+
+  private
+
+  # Lifted from here, because we need to override the formatter to RuboCop in the spec helper:
+  # https://github.com/Shopify/ruby-lsp/blob/4c1906172add4d5c39c35d3396aa29c768bfb898/lib/ruby_lsp/test_helper.rb#L20
+  #
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def with_server(
+    source = nil, path = 'fake.rb', pwd: '..', stub_no_typechecker: false, load_addons: true
+  )
+    Dir.chdir(pwd) do
+      server = RubyLsp::Server.new(test_mode: true)
+      uri = URI(File.join(server.global_state.workspace_path, path))
+      server.global_state.formatter = 'rubocop'
+      server.global_state.instance_variable_set(:@linters, ['rubocop'])
+      server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
+
+      if source
+        server.process_message(
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              uri: uri,
+              text: source,
+              version: 1
+            }
+          }
+        )
+      end
+
+      server.global_state.index.index_single(
+        RubyIndexer::IndexablePath.new(nil, uri.to_standardized_path), source
+      )
+      server.load_addons if load_addons
+
+      yield server, uri
+    end
+  ensure
+    if load_addons
+      RubyLsp::Addon.addons.each(&:deactivate)
+      RubyLsp::Addon.addons.clear
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end


### PR DESCRIPTION
## Summary

This PR adds support for the Ruby LSP Add-on:
https://shopify.github.io/ruby-lsp/add-ons.html

Ruby LSP is widely used among Ruby developers.

This Add-on resolves the current dependency of Ruby LSP on RuboCop's internal APIs by allowing RuboCop itself to provide the features related to Ruby LSP, marking the start of potentially removing these dependencies in the future.

It may also be possible to integrate the Standard Ruby's LSP implementation into this RuboCop's LSP implementation at a later time. A future is envisioned in which Ruby LSP, Standard Ruby, and RuboCop don't each need to implement their own RuboCop runner for LSP but instead unify that functionality.

An option is available so it can work with both RuboCop's built-in LSP and Ruby LSP. RuboCop's built-in LSP will continue to serve as a lightweight LSP for users who only need RuboCop.

## Quick Fix Support

As a side effect, the quick fix code action feature supported by Ruby LSP is also enabled as a language server feature.
If the vscode-rubocop client is updated in the future, quick fix code action will likely become available.
https://github.com/rubocop/vscode-rubocop/issues/12

## References

- https://github.com/standardrb/standard/pull/630
- https://github.com/standardrb/standard/wiki/IDE:-vscode#using-ruby-lsp

## NOTE

This PR is split into multiple commits around three core PRs related to Standard Ruby.
Please don't squash these commits, as the separation is intentional.

Documentation will likely be covered later in conjunction with Ruby LSP.

cc @vinistock @searls

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
