### PR TITLE
Make `Style/MultipleComparison` respect `AllowMethodComparison: true`

### DIFF
--- a/changelog/fix_false_negatives_for_style_multiple_comparison.md
+++ b/changelog/fix_false_negatives_for_style_multiple_comparison.md
@@ -1,1 +1,1 @@
-* [#13623](https://github.com/rubocop/rubocop/issues/13623): Fix false negatives for `Style/MultipleComparison` when comparing with simple method calls. ([@koic][])
+* [#13623](https://github.com/rubocop/rubocop/issues/13623): Fix false negatives for `Style/MultipleComparison` when setting `AllowMethodComparison: false` and comparing with simple method calls. ([@koic][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -100,7 +100,7 @@ module RuboCop
             find_offending_var(node.rhs, variables, values)
           elsif simple_double_comparison?(node)
             return
-          elsif (var, obj = simple_comparison?(node))
+          elsif (var, obj = simple_comparison(node))
             return if allow_method_comparison? && obj.call_type?
 
             variables << var
@@ -130,11 +130,13 @@ module RuboCop
         end
 
         def comparison?(node)
-          simple_comparison?(node) || nested_comparison?(node)
+          !!simple_comparison(node) || nested_comparison?(node)
         end
 
-        def simple_comparison?(node)
+        def simple_comparison(node)
           if (var, obj = simple_comparison_lhs(node)) || (obj, var = simple_comparison_rhs(node))
+            return if var.call_type? && !allow_method_comparison?
+
             [var, obj]
           end
         end

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -132,66 +132,6 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when comparing with hash access on rhs' do
-    expect_offense(<<~RUBY)
-      if a[:key] == 'a' || a[:key] == 'b'
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
-        print a
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      if ['a', 'b'].include?(a[:key])
-        print a
-      end
-    RUBY
-  end
-
-  it 'registers an offense and corrects when comparing with hash access on lhs' do
-    expect_offense(<<~RUBY)
-      if 'a' == a[:key] || 'b' == a[:key]
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
-        print a
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      if ['a', 'b'].include?(a[:key])
-        print a
-      end
-    RUBY
-  end
-
-  it 'registers an offense and corrects when comparing with safe navigation method call on rhs' do
-    expect_offense(<<~RUBY)
-      if a&.do_something == 'a' || a&.do_something == 'b'
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
-        print a
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      if ['a', 'b'].include?(a&.do_something)
-        print a
-      end
-    RUBY
-  end
-
-  it 'registers an offense and corrects when comparing with safe navigation method call on lhs' do
-    expect_offense(<<~RUBY)
-      if 'a' == a&.do_something || 'b' == a&.do_something
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
-        print a
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      if ['a', 'b'].include?(a&.do_something)
-        print a
-      end
-    RUBY
-  end
-
   it 'does not register an offense for comparing multiple literal strings' do
     expect_no_offenses(<<~RUBY)
       if "a" == "a" || "a" == "c"
@@ -290,6 +230,66 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
         var == foo || ['bar', 'baz'].include?(var)
       RUBY
     end
+
+    it 'registers an offense and corrects when comparing with hash access on rhs' do
+      expect_offense(<<~RUBY)
+        if a[:key] == 'a' || a[:key] == 'b'
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+          print a
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if ['a', 'b'].include?(a[:key])
+          print a
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing with hash access on lhs' do
+      expect_offense(<<~RUBY)
+        if 'a' == a[:key] || 'b' == a[:key]
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+          print a
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if ['a', 'b'].include?(a[:key])
+          print a
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing with safe navigation method call on rhs' do
+      expect_offense(<<~RUBY)
+        if a&.do_something == 'a' || a&.do_something == 'b'
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+          print a
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if ['a', 'b'].include?(a&.do_something)
+          print a
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when comparing with safe navigation method call on lhs' do
+      expect_offense(<<~RUBY)
+        if 'a' == a&.do_something || 'b' == a&.do_something
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+          print a
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if ['a', 'b'].include?(a&.do_something)
+          print a
+        end
+      RUBY
+    end
   end
 
   it 'does not register an offense when comparing two sides of the disjunction is unrelated' do
@@ -330,6 +330,38 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
       expect_correction(<<~RUBY)
         var = do_something
         [foo, 'bar', 'baz'].include?(var)
+      RUBY
+    end
+
+    it 'does not register an offense when comparing with hash access on rhs' do
+      expect_no_offenses(<<~RUBY)
+        if a[:key] == 'a' || a[:key] == 'b'
+          print a
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when comparing with hash access on lhs' do
+      expect_no_offenses(<<~RUBY)
+        if 'a' == a[:key] || 'b' == a[:key]
+          print a
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when comparing with safe navigation method call on rhs' do
+      expect_no_offenses(<<~RUBY)
+        if a&.do_something == 'a' || a&.do_something == 'b'
+          print a
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when comparing with safe navigation method call on lhs' do
+      expect_no_offenses(<<~RUBY)
+        if 'a' == a&.do_something || 'b' == a&.do_something
+          print a
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR makes `Style/MultipleComparison` respect `AllowMethodComparison: true (default)` when comparing with simple method calls.

#13627 resolved #13623, but to maintain the default `AllowMethodComparison: true`, comparisons involving method calls should always respect `AllowMethodComparison`.

This PR updates things so that the default `AllowMethodComparison: true` behavior remains compatible with what was released in 1.69.2, and if someone wants to address the issue from #13623, they can explicitly set `AllowMethodComparison: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
