### PR TITLE
Fix `format` CLI option to accept fully qualified class names

### DIFF
--- a/changelog/fix_cli_format_option_to_accept_fully_qualified_names.md
+++ b/changelog/fix_cli_format_option_to_accept_fully_qualified_names.md
@@ -1,0 +1,1 @@
+* [#13630](https://github.com/rubocop/rubocop/pull/13630): Fix CLI `--format` option to accept fully qualified formatter class names. ([@viralpraxis][])

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -77,7 +77,7 @@ module RuboCop
         case formatter_type
         when Class
           formatter_type
-        when /\A[A-Z]/
+        when /\A(::)?[A-Z]/
           custom_formatter_class(formatter_type)
         else
           builtin_formatter_class(formatter_type)


### PR DESCRIPTION
`FormatterSet#custom_formatter_class` accepts fully qualified constant names and there's even a spec for this (private) method. But since `#formatter_class` uses `/\A[A-Z]/` regexp to determine if provided formatter is custom, fully qualified values do not work with CLI.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
