### PR TITLE
Fix `Style/MissingElse` cop error if `Style/EmptyElse`'s style is not `both` and `if` expression contains `elsif`

### DIFF
--- a/changelog/fix_style_missing_else_cop_error_on_configured_empty_else_cop.md
+++ b/changelog/fix_style_missing_else_cop_error_on_configured_empty_else_cop.md
@@ -1,0 +1,1 @@
+* [#13632](https://github.com/rubocop/rubocop/pull/13632): Fix `Style/MissingElse` cop error if `Style/EmptyElse`'s `EnforcedStyle` is not `both` and `if` expression contains `elsif`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -144,6 +144,8 @@ module RuboCop
         end
 
         def autocorrect(corrector, node)
+          node = node.parent unless node.loc.end
+
           case empty_else_style
           when :empty
             corrector.insert_before(node.loc.end, 'else; nil; ')

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -264,6 +264,17 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo else; nil; end
           RUBY
         end
+
+        it 'registers an offense with `elsif` clause' do
+          expect_offense(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; end
+                          ^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; else; nil; end
+          RUBY
+        end
       end
     end
 
@@ -382,6 +393,17 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
             if cond; foo else; end
           RUBY
         end
+
+        it 'registers an offense with `elsif` clause' do
+          expect_offense(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; end
+                          ^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; else; end
+          RUBY
+        end
       end
     end
 
@@ -498,6 +520,17 @@ RSpec.describe RuboCop::Cop::Style::MissingElse, :config do
 
           expect_correction(<<~RUBY)
             if cond; foo else; end
+          RUBY
+        end
+
+        it 'registers an offense with `elsif` clause' do
+          expect_offense(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; end
+                          ^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if cond_1; 1; elsif cond_2; 3; else; end
           RUBY
         end
       end


### PR DESCRIPTION
If enforced style of `Style/EmptyElse` is not `both` cop `Style/MissingElse` raises on expressions with `elsif`.
See new test cases for details.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
