### PR TITLE
Fix `Style/ClassAndModuleChildren` cop error on `compact` enforced style and unindented body

### DIFF
--- a/changelog/fix_style_class_and_module_children_cop_error_on_unindented_body.md
+++ b/changelog/fix_style_class_and_module_children_cop_error_on_unindented_body.md
@@ -1,0 +1,1 @@
+* [#13634](https://github.com/rubocop/rubocop/pull/13634): Fix `Style/ClassAndModuleChildren` cop error on `compact` enforced style and unindented body. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -126,9 +126,12 @@ module RuboCop
         end
 
         def unindent(corrector, node)
-          return if node.body.children.last.nil?
+          return unless node.body.children.last
 
-          column_delta = configured_indentation_width - leading_spaces(node.body.children.last).size
+          last_child_leading_spaces = leading_spaces(node.body.children.last)
+          return if leading_spaces(node).size == last_child_leading_spaces.size
+
+          column_delta = configured_indentation_width - last_child_leading_spaces.size
           return if column_delta.zero?
 
           AlignmentCorrector.correct(corrector, processed_source, node, column_delta)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -398,5 +398,56 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         end
       RUBY
     end
+
+    context 'with unindented nested nodes' do
+      it 'registers an offense and autocorrects unindented class' do
+        expect_offense(<<~RUBY)
+          module M
+                 ^ Use compact module/class definition instead of nested style.
+          class C
+          end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class M::C
+          end
+        RUBY
+      end
+
+      it 'registers an offense and autocorrects unindented class and method' do
+        expect_offense(<<~RUBY)
+          module M
+                 ^ Use compact module/class definition instead of nested style.
+          class C
+          def foo; 1; end
+          end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class M::C
+          def foo; 1; end
+          end
+        RUBY
+      end
+
+      it 'registers an offense and autocorrects unindented method' do
+        expect_offense(<<~RUBY)
+          module M
+                 ^ Use compact module/class definition instead of nested style.
+            class C
+            def foo; 1; end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class M::C
+            def foo; 1; end
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
If `Style/ClassAndModuleChildren` cop is configured with enforced style `compact`, the following code leads to and error (tree clobbering):

```ruby
module M
class C
def main; TOPLEVEL_BINDING; end
end
end
```

I patched the cop to skip indentation autocorrection in such cases; they should be handled by `Layout/IndentationWidth`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
