### PR TITLE
Show infinite loop errors through the runner

### DIFF
--- a/lib/rubocop/cli/command/execute_runner.rb
+++ b/lib/rubocop/cli/command/execute_runner.rb
@@ -71,11 +71,11 @@ module RuboCop
 
           warn Rainbow("\n#{pluralize(errors.size, 'error')} occurred:").red
 
-          errors.each { |error| warn error }
+          errors.each { |error| warn Rainbow(error).red }
 
-          warn <<~WARNING
+          warn Rainbow(<<~WARNING.strip).yellow
             Errors are usually caused by RuboCop bugs.
-            Please, report your problems to RuboCop's issue tracker.
+            Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
             #{bug_tracker_uri}
             Mention the following information in the issue report:
             #{RuboCop::Version.verbose}

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -20,11 +20,7 @@ module RuboCop
         message = 'Infinite loop detected'
         message += " in #{path}" if path
         message += " and caused by #{root_cause}" if root_cause
-        message += "\n"
-        hint = 'Hint: Please update to the latest RuboCop version if not already in use, ' \
-               "and report a bug if the issue still occurs on this version.\n" \
-               'Please check the latest version at https://rubygems.org/gems/rubocop.'
-        super(Rainbow(message).red + Rainbow(hint).yellow)
+        super(message)
       end
     end
 
@@ -157,8 +153,11 @@ module RuboCop
       file_started(file)
       offenses = file_offenses(file)
     rescue InfiniteCorrectionLoop => e
+      raise e if @options[:raise_cop_error]
+
+      errors << e
+      warn Rainbow(e.message).red
       offenses = e.offenses.compact.sort.freeze
-      raise
     ensure
       file_finished(file, offenses || [])
     end

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -315,9 +315,11 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
   end
 
   describe '#run with cops autocorrecting each-other' do
-    let(:source_file_path) { create_file('example.rb', source) }
+    include_context 'mock console output'
 
-    let(:options) { { autocorrect: true, formatters: [['progress', formatter_output_path]] } }
+    let!(:source_file_path) { create_file('example.rb', source) }
+
+    let(:options) { { autocorrect: true } }
 
     context 'with two conflicting cops' do
       subject(:runner) do
@@ -341,17 +343,27 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end
         RUBY
 
-        it 'aborts because of an infinite loop' do
-          expect do
-            runner.run([])
-          end.to raise_error(
-            described_class::InfiniteCorrectionLoop,
+        it 'records the infinite loop error' do
+          runner.run([])
+          expect(runner.errors.size).to be(1)
+          expect(runner.errors[0].message).to eq(
             "Infinite loop detected in #{source_file_path} and caused by " \
-            "Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop\n" \
-            'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            "and report a bug if the issue still occurs on this version.\n" \
-            'Please check the latest version at https://rubygems.org/gems/rubocop.'
+            'Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop'
           )
+        end
+
+        context 'when `raise_cop_error` is set' do
+          let(:options) { { autocorrect: true, raise_cop_error: true } }
+
+          it 'raises the infinite loop error' do
+            expect do
+              runner.run([])
+            end.to raise_error(
+              described_class::InfiniteCorrectionLoop,
+              "Infinite loop detected in #{source_file_path} and caused by " \
+              'Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop'
+            )
+          end
         end
       end
 
@@ -364,16 +376,13 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end
         RUBY
 
-        it 'aborts because of an infinite loop' do
-          expect do
-            runner.run([])
-          end.to raise_error(
-            described_class::InfiniteCorrectionLoop,
+        it 'records the infinite loop error' do
+          runner.run([])
+
+          expect(runner.errors.size).to be(1)
+          expect(runner.errors[0].message).to eq(
             "Infinite loop detected in #{source_file_path} and caused by " \
-            "Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop\n" \
-            'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            "and report a bug if the issue still occurs on this version.\n" \
-            'Please check the latest version at https://rubygems.org/gems/rubocop.'
+            'Test/ClassMustBeAModuleCop -> Test/ModuleMustBeAClassCop'
           )
         end
       end
@@ -403,16 +412,13 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
           end
         RUBY
 
-        it 'aborts because of an infinite loop' do
-          expect do
-            runner.run([])
-          end.to raise_error(
-            described_class::InfiniteCorrectionLoop,
+        it 'records the infinite loop error' do
+          runner.run([])
+
+          expect(runner.errors.size).to be(1)
+          expect(runner.errors[0].message).to eq(
             "Infinite loop detected in #{source_file_path} and caused by " \
-            "Test/ClassMustBeAModuleCop, Test/AtoB -> Test/ModuleMustBeAClassCop, Test/BtoA\n" \
-            'Hint: Please update to the latest RuboCop version if not already in use, ' \
-            "and report a bug if the issue still occurs on this version.\n" \
-            'Please check the latest version at https://rubygems.org/gems/rubocop.'
+            'Test/ClassMustBeAModuleCop, Test/AtoB -> Test/ModuleMustBeAClassCop, Test/BtoA'
           )
         end
       end
@@ -440,16 +446,13 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             end
           RUBY
 
-          it 'aborts because of an infinite loop' do
-            expect do
-              runner.run([])
-            end.to raise_error(
-              described_class::InfiniteCorrectionLoop,
+          it 'records the infinite correction error' do
+            runner.run([])
+
+            expect(runner.errors.size).to be(1)
+            expect(runner.errors[0].message).to eq(
               "Infinite loop detected in #{source_file_path} and caused by " \
-              "Test/AtoB -> Test/BtoC -> Test/CtoA\n" \
-              'Hint: Please update to the latest RuboCop version if not already in use, ' \
-              "and report a bug if the issue still occurs on this version.\n" \
-              'Please check the latest version at https://rubygems.org/gems/rubocop.'
+              'Test/AtoB -> Test/BtoC -> Test/CtoA'
             )
           end
         end


### PR DESCRIPTION
Currently, these show a pretty useless backtrace at the end and stop further analysing.

Now it shows these errors at the end, like normal cop errors

<details><summary>Before</summary>
<p>

```
Inspecting 1 file
C

Offenses:

test.rb:8:3: C: [Corrected] Layout/HashAlignment: Align the keys and values of a hash literal if they span more than one line.
  "deep" => { ...
  ^^^^^^^^^^^
test.rb:8:11: C: [Corrected] Layout/SpaceAroundOperators: Operator => should be surrounded by a single space.
  "deep"  => {
          ^^

0 files inspected, 2 offenses detected, 2 offenses corrected
Infinite loop detected in /home/earlopain/Documents/test/test.rb and caused by Layout/HashAlignment -> Layout/SpaceAroundOperators
Hint: Please update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
Please check the latest version at https://rubygems.org/gems/rubocop.
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:336:in `check_for_infinite_loop'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:319:in `block in iterate_until_no_changes'
<internal:kernel>:187:in `loop'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:318:in `iterate_until_no_changes'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:287:in `do_inspection_loop'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:168:in `block in file_offenses'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:193:in `file_offense_cache'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:167:in `file_offenses'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:158:in `process_file'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:139:in `block in each_inspected_file'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:138:in `each'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:138:in `reduce'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:138:in `each_inspected_file'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:124:in `inspect_files'
/home/earlopain/Documents/rubocop/lib/rubocop/runner.rb:77:in `run'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/command.rb:11:in `run'
/home/earlopain/Documents/rubocop/lib/rubocop/cli/environment.rb:18:in `run'
/home/earlopain/Documents/rubocop/lib/rubocop/cli.rb:122:in `run_command'
/home/earlopain/Documents/rubocop/lib/rubocop/cli.rb:129:in `execute_runners'
/home/earlopain/Documents/rubocop/lib/rubocop/cli.rb:51:in `block in run'
/home/earlopain/Documents/rubocop/lib/rubocop/cli.rb:81:in `profile_if_needed'
/home/earlopain/Documents/rubocop/lib/rubocop/cli.rb:43:in `run'
/home/earlopain/Documents/rubocop/exe/rubocop:19:in `<top (required)>'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/bin/rubocop:25:in `load'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/bin/rubocop:25:in `<top (required)>'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli/exec.rb:59:in `load'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli/exec.rb:59:in `kernel_load'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli/exec.rb:23:in `run'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli.rb:452:in `exec'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli.rb:35:in `dispatch'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/cli.rb:29:in `start'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/exe/bundle:28:in `block in <top (required)>'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/home/earlopain/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.6.1/exe/bundle:20:in `<top (required)>'
/home/earlopain/.rbenv/versions/3.3.6/bin/bundle:25:in `load'
/home/earlopain/.rbenv/versions/3.3.6/bin/bundle:25:in `<main>'
```

</p>
</details> 

<details><summary>After</summary>
<p>

```
Inspecting 1 file
Infinite loop detected in /home/earlopain/Documents/test/test.rb and caused by Layout/HashAlignment -> Layout/SpaceAroundOperators
C

Offenses:

test.rb:8:3: C: [Corrected] Layout/HashAlignment: Align the keys and values of a hash literal if they span more than one line.
  "deep" => { ...
  ^^^^^^^^^^^
test.rb:8:11: C: [Corrected] Layout/SpaceAroundOperators: Operator => should be surrounded by a single space.
  "deep"  => {
          ^^

1 file inspected, 2 offenses detected, 2 offenses corrected

1 error occurred:
Infinite loop detected in /home/earlopain/Documents/test/test.rb and caused by Layout/HashAlignment -> Layout/SpaceAroundOperators
Errors are usually caused by RuboCop bugs.
Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.69.2 (using Parser 3.3.6.0, rubocop-ast 1.37.0, analyzing as Ruby 3.3, running on ruby 3.3.6) [x86_64-linux]
```

</p>
</details> 

I also colored the final error summary at the end in yellow. The infinite loop error did this, and it just looks better that way:
![image](https://github.com/user-attachments/assets/3a69f760-c6be-45fc-8972-a538eb1f8e01)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
