### PR TITLE
Update example for the `AllowMultilineFinalElement` configurable attribute for `Layout/MultilineMethodArgumentLineBreaks`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -33,6 +33,18 @@ module RuboCop
       #
       # @example AllowMultilineFinalElement: false (default)
       #
+      #   # bad
+      #   foo(a, b,
+      #     c
+      #   )
+      #
+      #   # bad
+      #   foo(
+      #     a, b, {
+      #       foo: "bar",
+      #     }
+      #   )
+      #
       #   # good
       #   foo(
       #     a,
@@ -43,6 +55,18 @@ module RuboCop
       #   )
       #
       # @example AllowMultilineFinalElement: true
+      #
+      #   # bad
+      #   foo(a, b,
+      #     c
+      #   )
+      #
+      #   # good
+      #   foo(
+      #     a, b, {
+      #       foo: "bar",
+      #     }
+      #   )
       #
       #   # good
       #   foo(


### PR DESCRIPTION
This pr updates the example for the `AllowMultilineFinalElement` configurable attribute for `Layout/MultilineMethodArgumentLineBreaks` to be `good` when `AllowMultilineFinalElement: true` and `bad` when `AllowMultilineFinalElement: false`

Before:

The example was

```
a,
b,
{
  foo: "bar",
}
```

This is `good` in both cases and thus not particularly helpful

After:

I went with the example

```
a, b, {
  foo: "bar",
}
```

This is `good` when `AllowMultilineFinalElement: true` and `bad` when `AllowMultilineFinalElement: false`

This matches the style the docs are currently in and is also close to the spec in `spec/rubocop/cop/layout/multiline_method_argument_line_breaks_spec.rb`

```
let(:cop_config) { { 'AllowMultilineFinalElement' => true } }

it 'ignores last argument that is a multiline hash' do
  expect_no_offenses(<<~RUBY)
    foo(1, 2, 3, {
      a: 1,
    })
  RUBY
end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
