### PR TITLE
Fix false positive for Naming/BlockForwarding

### DIFF
--- a/changelog/fix_fix_false_positive_for_naming_block_forwarding.md
+++ b/changelog/fix_fix_false_positive_for_naming_block_forwarding.md
@@ -1,0 +1,1 @@
+* [#13638](https://github.com/rubocop/rubocop/pull/13638): Fix false positive for `Naming/BlockForwarding` when method just returns the block argument. ([@mvz][])

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -138,7 +138,7 @@ module RuboCop
         def use_block_argument_as_local_variable?(node, last_argument)
           return false if node.body.nil?
 
-          node.body.each_descendant(:lvar, :lvasgn).any? do |lvar|
+          node.body.each_node(:lvar, :lvasgn).any? do |lvar|
             !lvar.parent.block_pass_type? && lvar.node_parts[0].to_s == last_argument
           end
         end

--- a/spec/rubocop/cop/naming/block_forwarding_spec.rb
+++ b/spec/rubocop/cop/naming/block_forwarding_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe RuboCop::Cop::Naming::BlockForwarding, :config do
         RUBY
       end
 
+      it 'does not register an offense when method just returns the block argument' do
+        expect_no_offenses(<<~RUBY)
+          def foo(&block)
+            block
+          end
+        RUBY
+      end
+
       it 'does not register an offense when defining without block argument method' do
         expect_no_offenses(<<~RUBY)
           def foo(arg1, arg2)


### PR DESCRIPTION
This change fixes a false positive for Naming/BlockForwarding with anonymous style, in the case where the method body just consists of the block argument, like so:

```
def foo(&block)
  block
end
```

The actual change simply replaces `each_descendent` with `each_node`. This works because the method body in the problematic case consists just of the lvar node that should prevent an offense from being registered.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
