### PR TITLE
Allow .yaml extension for .rubocop.yml file

### DIFF
--- a/changelog/new_allow_yaml_extension_for_rubocop_yml_file.md
+++ b/changelog/new_allow_yaml_extension_for_rubocop_yml_file.md
@@ -1,0 +1,1 @@
+- [#13639](https://github.com/rubocop/rubocop/pull/13639): Allow .yaml extension for .rubocop.yml file. ([@calebmeyer][])

--- a/lib/rubocop/config_finder.rb
+++ b/lib/rubocop/config_finder.rb
@@ -7,6 +7,7 @@ module RuboCop
   # @api private
   class ConfigFinder
     DOTFILE = '.rubocop.yml'
+    ALT_DOTFILE = '.rubocop.yaml'
     XDG_CONFIG = 'config.yml'
     RUBOCOP_HOME = File.realpath(File.join(File.dirname(__FILE__), '..', '..'))
     DEFAULT_FILE = File.join(RUBOCOP_HOME, 'config', 'default.yml')
@@ -38,7 +39,10 @@ module RuboCop
       end
 
       def find_project_dotfile(target_dir)
-        find_file_upwards(DOTFILE, target_dir, project_root)
+        dotfile = find_file_upwards(DOTFILE, target_dir, project_root)
+        return dotfile unless dotfile.nil?
+
+        find_file_upwards(ALT_DOTFILE, target_dir, project_root)
       end
 
       def find_project_root_dot_config


### PR DESCRIPTION
> Be conservative in what you send, be liberal in what you accept
> Postel's Law, aka the Robustness Principle

My work has a (reasonably) strict guideline that we should only use .yaml, never .yml (it's tripped us up a lot on our CI, so I understand the rule).

I was working on a rails project today that uses .rubocop.yaml. I am able to specify that directly to rubocop via the `-c` flag and in our bin/rubocop file (and all other scripts).

However, I looked and could not find a similar way to configure the shopify/ruby-lsp extension. It refused to load my config unless I named it .rubocop.yml

I have opened a discussion over there: https://github.com/Shopify/ruby-lsp/discussions/2999 to see if I could get/write such a configuration. However, I also wanted to see if this project would accept a PR to allow for the four letter extension, as that's a path of lower resistance and more broadly useful.

Notes:
- I didn't add a similar .yaml for the XDG spec, but I'd be willing to make a similar change
- I looked through the spec folder and I don't see a spec for this file. If needed, I can add that as well
- I didn't update any documentation because I think .yml is a reasonable default and most projects should use that if they can

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/dcc32d95-83a3-46fc-8e67-a1e7671bfb11" />
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
