### PR TITLE
Fix `Style/FloatDivision` cop error on implicit receiver

### DIFF
--- a/changelog/fix_style_float_division_cop_error_on_coercion_with_implicit_receiver.md
+++ b/changelog/fix_style_float_division_cop_error_on_coercion_with_implicit_receiver.md
@@ -1,0 +1,1 @@
+* [#13642](https://github.com/rubocop/rubocop/pull/13642): Fix `Style/FloatDivision` cop error if `#to_f` has implicit receiver. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -65,19 +65,23 @@ module RuboCop
 
         # @!method right_coerce?(node)
         def_node_matcher :right_coerce?, <<~PATTERN
-          (send _ :/ (send _ :to_f))
+          (send _ :/ #to_f_method?)
         PATTERN
         # @!method left_coerce?(node)
         def_node_matcher :left_coerce?, <<~PATTERN
-          (send (send _ :to_f) :/ _)
+          (send #to_f_method? :/ _)
         PATTERN
         # @!method both_coerce?(node)
         def_node_matcher :both_coerce?, <<~PATTERN
-          (send (send _ :to_f) :/ (send _ :to_f))
+          (send #to_f_method? :/ #to_f_method?)
         PATTERN
         # @!method any_coerce?(node)
         def_node_matcher :any_coerce?, <<~PATTERN
-          {(send _ :/ (send _ :to_f)) (send (send _ :to_f) :/ _)}
+          {(send _ :/ #to_f_method?) (send #to_f_method? :/ _)}
+        PATTERN
+        # @!method to_f_method?(node)
+        def_node_matcher :to_f_method?, <<~PATTERN
+          (send !nil? :to_f)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
       RUBY
     end
 
+    it 'does not register offense for right coerce with implicit receiver' do
+      expect_no_offenses('a / to_f')
+    end
+
     it 'does not register offense for left coerce' do
       expect_no_offenses('a.to_f / b')
     end
@@ -78,6 +82,10 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
       RUBY
     end
 
+    it 'does not register offense for left coerce with implicit receiver' do
+      expect_no_offenses('to_f / b')
+    end
+
     it 'does not register offense for right coerce' do
       expect_no_offenses('a / b.to_f')
     end
@@ -114,6 +122,18 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
 
     it 'does not register offense for right coerce only' do
       expect_no_offenses('a / b.to_f')
+    end
+
+    it 'does not register offense for left coerce with implicit receiver' do
+      expect_no_offenses('a / to_f')
+    end
+
+    it 'does not register offense for rigjt coerce with implicit receiver' do
+      expect_no_offenses('to_f / b')
+    end
+
+    it 'does not register offense for coercions with implicit receivers' do
+      expect_no_offenses('to_f / to_f')
     end
   end
 
@@ -166,6 +186,14 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
 
     it 'does not register offense on usage of fdiv' do
       expect_no_offenses('a.fdiv(b)')
+    end
+
+    it 'does not register offense for left coerce with implicit receiver' do
+      expect_no_offenses('to_f / b')
+    end
+
+    it 'does not register offense for right coerce with implicit receiver' do
+      expect_no_offenses('a / to_f')
     end
   end
 end


### PR DESCRIPTION
Cop `Style/FloatDivision` fails on implicit `#to_f` receiver.

With `single_coerce` style:

```console
echo 'a.to_f / to_f' | rubocop --only Style/FloatDivision -c <(echo 'Style/FloatDivision:\n EnforcedStyle: single_coerce') --stdin bug.rb -d

An error occurred while Style/FloatDivision cop was inspecting bug.rb:1:0.
Expected a Parser::Source::Range, Comment or RuboCop::AST::Node, got NilClass
lib/rubocop/cop/corrector.rb:111:in `to_range'
lib/rubocop/cop/corrector.rb:120:in `check_range_validity'
lib/parser/source/tree_rewriter.rb:398:in `combine'
lib/parser/source/tree_rewriter.rb:194:in `replace'
lib/parser/source/tree_rewriter.rb:218:in `remove'
lib/rubocop/cop/style/float_division.rb:126:in `remove_to_f_method'
lib/rubocop/cop/style/float_division.rb:90:in `block in on_send'
```

With `left_coerce` or `right_coerce` or `fdiv`:

```console
echo 'a / to_f' | rubocop --only Style/FloatDivision -c <(echo 'Style/FloatDivision:\n EnforcedStyle: left_coerce') --stdin bug.rb -d

An error occurred while Style/FloatDivision cop was inspecting bug.rb:1:0.
Expected a Parser::Source::Range, Comment or RuboCop::AST::Node, got NilClass
```

I think the best way to handle this is not to detect such code.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
