### PR TITLE
Fix a false positive for `Layout/EmptyLinesAroundAccessModifier`

### DIFF
--- a/changelog/fix_false_positive_for_layout_empty_lines_around_access_modifier.md
+++ b/changelog/fix_false_positive_for_layout_empty_lines_around_access_modifier.md
@@ -1,0 +1,1 @@
+* [#13644](https://github.com/rubocop/rubocop/pull/13644): Fix a false positive for `Layout/EmptyLinesAroundAccessModifier` when an access modifier and an expression are on the same line. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -86,6 +86,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.bare_access_modifier? && !node.block_literal?
+          return if same_line?(node, node.right_sibling)
           return if expected_empty_lines?(node)
 
           message = message(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -334,6 +334,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           #{access_modifier}
         RUBY
       end
+
+      it 'accepts when an access modifier and an expression are on the same line' do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}; foo
+          .bar
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes a false positive for `Layout/EmptyLinesAroundAccessModifier` when an access modifier and an expression are on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
