### PR TITLE
Add full-width space to `Layout/TrailingWhitespace`

### DIFF
--- a/changelog/change_update_layout_trailing_whitespace_to_support_blank_characters_other_than_space_and_tab.md
+++ b/changelog/change_update_layout_trailing_whitespace_to_support_blank_characters_other_than_space_and_tab.md
@@ -1,0 +1,1 @@
+* [#13646](https://github.com/rubocop/rubocop/pull/13646): Update `Layout/TrailingWhitespace` to support blank characters other than space and tab. ([@krororo][])

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -48,7 +48,7 @@ module RuboCop
 
         def on_new_investigation
           processed_source.lines.each_with_index do |line, index|
-            next unless line.end_with?(' ', "\t")
+            next unless line.match?(/[[:blank:]]\z/)
 
             process_line(line, index + 1)
           end
@@ -84,7 +84,7 @@ module RuboCop
         end
 
         def whitespace_is_indentation?(range, level)
-          range.source[/[ \t]+/].length <= level
+          range.source[/[[:blank:]]+/].length <= level
         end
 
         def whitespace_only?(range)
@@ -123,7 +123,9 @@ module RuboCop
         end
 
         def offense_range(lineno, line)
-          source_range(processed_source.buffer, lineno, (line.rstrip.length)...(line.length))
+          source_range(
+            processed_source.buffer, lineno, (line.sub(/[[:blank:]]+\z/, '').length)...(line.length)
+          )
         end
       end
     end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     RUBY
   end
 
+  it 'registers an offense for a line ending with full-width space' do
+    expect_offense(<<~RUBY)
+      x = :a\u3000
+            ^ Trailing whitespace detected.
+    RUBY
+  end
+
   it 'registers an offense for trailing whitespace in a heredoc string' do
     expect_offense(<<~RUBY)
       x = <<HEREDOC
@@ -37,6 +44,15 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
     expect_offense(<<~RUBY)
       <<~X
       \t
+      ^ Trailing whitespace detected.
+      X
+    RUBY
+  end
+
+  it 'registers an offense for a full-width space in a heredoc' do
+    expect_offense(<<~RUBY)
+      <<~X
+      \u3000
       ^ Trailing whitespace detected.
       X
     RUBY
@@ -104,11 +120,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
            ^ Trailing whitespace detected.
       x = 0\t
            ^ Trailing whitespace detected.
+      x = :a\u3000
+            ^ Trailing whitespace detected.
     RUBY
 
     expect_correction(<<~RUBY)
       x = 0
       x = 0
+      x = :a
     RUBY
   end
 


### PR DESCRIPTION
This PR adds full-width spaces to `Layout/TrailingWhitespace`.

For example, in a Japanese IME, pressing the space key will enter a full-width space. This may cause unintentional full-width spaces to be entered, resulting in unexpected behavior.

It is unlikely that one would want to enter a trailing full-width space and should be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
