### PR TITLE
[Fix #13645] Fix false positives for `Style/MethodCallWithArgsParentheses` and `omit_parentheses`

### DIFF
--- a/changelog/fix_false_positive_omit_parentheses.md
+++ b/changelog/fix_false_positive_omit_parentheses.md
@@ -1,0 +1,1 @@
+* [#13645](https://github.com/rubocop/rubocop/issues/13645): Fix a false positive for `Style/MethodCallWithArgsParentheses` when setting `EnforcedStyle: omit_parentheses` and last argument is an endless range. ([@earlopain][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -61,6 +61,8 @@ module RuboCop
       #   https://bugs.ruby-lang.org/issues/18396.
       # - Parentheses are required in anonymous arguments, keyword arguments
       #   and block passing in Ruby 3.2.
+      # - Parentheses are required when the first argument is a beginless range or
+      #   the last argument is an endless range.
       #
       # @example EnforcedStyle: require_parentheses (default)
       #

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -935,6 +935,44 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    context 'range literals' do
+      it 'accepts parens when no end node and last argument' do
+        expect_no_offenses(<<~RUBY)
+          foo(2..)
+          foo(1, 2...)
+        RUBY
+      end
+
+      it 'registers an offense no end node and not last argument' do
+        expect_offense(<<~RUBY)
+          foo(2.., 1)
+             ^^^^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo 2.., 1
+        RUBY
+      end
+
+      it 'accepts parens when no begin node and first argument' do
+        expect_no_offenses(<<~RUBY)
+          foo(..2, 1)
+          foo(...2)
+        RUBY
+      end
+
+      it 'registers an offense no begin node and not first argument' do
+        expect_offense(<<~RUBY)
+          foo(1, ..2)
+             ^^^^^^^^ Omit parentheses for method calls with arguments.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo 1, ..2
+        RUBY
+      end
+    end
+
     it 'accepts parens in assignment in conditions' do
       expect_no_offenses(<<-RUBY)
         case response = get("server/list")


### PR DESCRIPTION
When the range is open towards either the begin or ending, removing the parens can change meaning.
After the parens have been removed, either `Lint/RequireRangeParentheses`  or `Layout/SpaceInsideRangeLiteral` will complain further.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
