### PR TITLE
Simplify some `irange`/`erange` checks to simply `range`

### DIFF
--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -53,8 +53,7 @@ module RuboCop
           (block
             (call
               (begin
-                (${irange erange}
-                  (int $_) (int $_)))
+                ($range (int $_) (int $_)))
               :each)
             (args ...)
             ...)
@@ -65,8 +64,7 @@ module RuboCop
           (block
             (call
               (begin
-                ({irange erange}
-                  (int 0) (int _)))
+                (range (int 0) (int _)))
               :each)
             (args ...)
             ...)
@@ -77,8 +75,7 @@ module RuboCop
           (block
             (call
               (begin
-                ({irange erange}
-                  (int _) (int _)))
+                (range (int _) (int _)))
               :each)
             (args)
             ...)

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -238,7 +238,7 @@ module RuboCop
 
         # @!method range_enclosed_in_parentheses?(node)
         def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
-          (begin ({irange erange} _ _))
+          (begin (range _ _))
         PATTERN
       end
     end

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -36,7 +36,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int (irange int int) (erange int int)}))
+              {int (range int int)}))
         PATTERN
 
         # @!method rand_op_integer?(node)
@@ -45,7 +45,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int (irange int int) (erange int int)})
+              {int (range int int)})
             {:+ :-}
             int)
         PATTERN
@@ -56,7 +56,7 @@ module RuboCop
             (send
               {nil? (const {nil? cbase} :Random) (const {nil? cbase} :Kernel)}
               :rand
-              {int (irange int int) (erange int int)})
+              {int (range int int)})
             {:succ :pred :next})
         PATTERN
 


### PR DESCRIPTION
`rubocop-ast` provides a neat method to make this possible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
