### PR TITLE
Fix leaking `ConfigLoader` state in specs

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -41,6 +41,10 @@ module RuboCop
       def clear_options
         @debug = nil
         @loaded_features = Set.new
+        @disable_pending_cops = nil
+        @enable_pending_cops = nil
+        @ignore_parent_exclusion = nil
+        @ignore_unrecognized_cops = nil
         FileFinder.root_level = nil
       end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
   let(:rubocop) { "#{RuboCop::ConfigLoader::RUBOCOP_HOME}/exe/rubocop" }
 
-  before { RuboCop::ConfigLoader.default_configuration = nil }
+  before do
+    RuboCop::ConfigLoader.default_configuration = nil
+    RuboCop::ConfigLoader.clear_options
+  end
 
   describe '--parallel' do
     if RuboCop::Platform.windows?

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     create_file('dir1/executable', '#!/usr/bin/env ruby')
     create_empty_file('dir2/ruby3.rb')
     create_empty_file('.hidden/ruby4.rb')
+
+    RuboCop::ConfigLoader.clear_options
   end
 
   shared_examples 'common behavior for #find' do


### PR DESCRIPTION
Prior to this change, running `bundle exec rspec ./spec/rubocop/cli/options_spec.rb[1:1:3:1,1:2:1:1] ./spec/rubocop/target_finder_spec.rb[1:1:8:2:2:1,1:2:5:2:2:1] --seed 37240` would cause test failures. Updated to clear `ConfigLoader` state before specs in `cli/options_spec.rb` and `target_finder_spec.rb`.

Fixes #13604.