### PR TITLE
Update `Metrics/MethodLength` to make use of `AllowedMethods` and `AllowedPatterns` for methods defined dynamically with `define_method`

### DIFF
--- a/changelog/change_update_metrics_method_length_to_make_use_of.md
+++ b/changelog/change_update_metrics_method_length_to_make_use_of.md
@@ -1,0 +1,1 @@
+* [#13652](https://github.com/rubocop/rubocop/pull/13652): Update `Metrics/MethodLength` to make use of `AllowedMethods` and `AllowedPatterns` for methods defined dynamically with `define_method`. ([@dvandersluis][])

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -48,7 +48,7 @@ module RuboCop
         LABEL = 'Method'
 
         def on_def(node)
-          return if allowed_method?(node.method_name) || matches_allowed_pattern?(node.method_name)
+          return if allowed?(node.method_name)
 
           check_code_length(node)
         end
@@ -56,6 +56,9 @@ module RuboCop
 
         def on_block(node)
           return unless node.method?(:define_method)
+
+          method_name = node.send_node.first_argument
+          return if method_name.basic_literal? && allowed?(method_name.value)
 
           check_code_length(node)
         end
@@ -65,6 +68,10 @@ module RuboCop
 
         def cop_label
           LABEL
+        end
+
+        def allowed?(method_name)
+          allowed_method?(method_name) || matches_allowed_pattern?(method_name)
         end
       end
     end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   context 'when method is an instance method' do
+    it 'does not register an offense when there are exactly `Max` lines' do
+      expect_no_offenses(<<~RUBY)
+        def m
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      RUBY
+    end
+
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         def m
@@ -20,10 +32,50 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   context 'when method is defined with `define_method`' do
-    it 'registers an offense' do
+    it 'does not register an offense when there are exactly `Max` lines' do
+      expect_no_offenses(<<~RUBY)
+        define_method(:m) do
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      RUBY
+    end
+
+    it 'registers an offense when there are more than `Max` lines' do
       expect_offense(<<~RUBY)
         define_method(:m) do
         ^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'registers an offense for an over-long dynamically defined method with a dynamic symbol name' do
+      expect_offense(<<~'RUBY')
+        define_method(:"#{method_name}=") do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    it 'registers an offense for an over-long dynamically defined method with a dynamic string name' do
+      expect_offense(<<~'RUBY')
+        define_method("#{method_name}=") do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
           a = 1
           a = 2
           a = 3
@@ -247,6 +299,32 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
           end
         RUBY
       end
+
+      it 'accepts dynamically defined matching method name with more than 5 lines' do
+        expect_no_offenses(<<~RUBY)
+          define_method(:foo) do
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+            a = 6
+          end
+        RUBY
+      end
+
+      it 'accepts dynamically defined matching method name with a numblock' do
+        expect_no_offenses(<<~RUBY)
+          define_method(:foo) do
+            a = _1
+            a = _2
+            a = _3
+            a = _4
+            a = _5
+            a = _6
+          end
+        RUBY
+      end
     end
 
     context 'AllowedPatterns is enabled' do
@@ -261,6 +339,32 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
             a = 4
             a = 5
             a = 6
+          end
+        RUBY
+      end
+
+      it 'accepts dynamically defined matching method name with more than 5 lines' do
+        expect_no_offenses(<<~RUBY)
+          define_method(:user_name) do
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+            a = 6
+          end
+        RUBY
+      end
+
+      it 'accepts dynamically defined matching method name with a numblock' do
+        expect_no_offenses(<<~RUBY)
+          define_method(:user_name) do
+            a = _1
+            a = _2
+            a = _3
+            a = _4
+            a = _5
+            a = _6
           end
         RUBY
       end


### PR DESCRIPTION
Previously, `AllowedMethods` and `AllowedPatterns` were added to `Metrics/MethodLength` to allow specified methods to be longer than the configured maximum. However, this was not also applied to dynamic methods defined with `define_method`, which the cop also covers.

This change allows the allow lists to apply to dynamic methods as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
