### PR TITLE
[Fix #13606] Update `Style/AccessModifierDeclarations` to add `AllowModifiersOnAliasMethod` configuration (default `true`)

### DIFF
--- a/changelog/change_update_style_access_modifier_declarations_to_add.md
+++ b/changelog/change_update_style_access_modifier_declarations_to_add.md
@@ -1,0 +1,1 @@
+* [#13606](https://github.com/rubocop/rubocop/issues/13606): Update `Style/AccessModifierDeclarations` to add `AllowModifiersOnAliasMethod` configuration (default `true`). ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3142,13 +3142,14 @@ Style/AccessModifierDeclarations:
   Description: 'Checks style of how access modifiers are used.'
   Enabled: true
   VersionAdded: '0.57'
-  VersionChanged: '0.81'
+  VersionChanged: '<<next>>'
   EnforcedStyle: group
   SupportedStyles:
     - inline
     - group
   AllowModifiersOnSymbols: true
   AllowModifiersOnAttrs: true
+  AllowModifiersOnAliasMethod: true
   SafeAutoCorrect: false
 
 Style/AccessorGrouping:

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -271,6 +271,39 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
     end
+
+    context 'allow access modifiers on alias_method' do
+      let(:cop_config) { { 'AllowModifiersOnAliasMethod' => true } }
+
+      it "accepts when argument to #{access_modifier} is an alias_method" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            #{access_modifier} alias_method :bar, :foo
+          end
+        RUBY
+      end
+    end
+
+    context 'do not allow access modifiers on alias_method' do
+      let(:cop_config) { { 'AllowModifiersOnAliasMethod' => false } }
+
+      it "registers an offense when argument to #{access_modifier} is an alias_method" do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          class Foo
+            #{access_modifier} alias_method :bar, :foo
+            ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+          #{access_modifier}
+
+          alias_method :bar, :foo
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when `group` is configured' do


### PR DESCRIPTION
Since `alias_method` returns a symbol of the new alias, it can be chained with an access modifier. This change allows code such as (or disallows it, if `AllowModifiersOnAliasMethod` is set to `false`):

```ruby
private alias_method :foo, :bar
```

Fixes #13606.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
