### PR TITLE
Fix a false positive for `Style/RedundantInitialize`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_initialize.md
+++ b/changelog/fix_false_positives_for_style_redundant_initialize.md
@@ -1,0 +1,1 @@
+* [#13654](https://github.com/rubocop/rubocop/pull/13654): Fix false positives for `Style/RedundantInitialize` when empty initialize method has arguments. ([@marocchino][])

--- a/spec/rubocop/cop/style/redundant_initialize_spec.rb
+++ b/spec/rubocop/cop/style/redundant_initialize_spec.rb
@@ -138,18 +138,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantInitialize, :config do
     RUBY
   end
 
-  it 'registers an offense for an `initialize` method with a default argument that does nothing' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for an `initialize` method with a default argument that does nothing' do
+    expect_no_offenses(<<~RUBY)
       def initialize(a, b = 5)
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
       end
     RUBY
   end
 
-  it 'registers an offense for an `initialize` method with a default keyword argument that does nothing' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for an `initialize` method with a default keyword argument that does nothing' do
+    expect_no_offenses(<<~RUBY)
       def initialize(a, b: 5)
-      ^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary empty `initialize` method.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an empty `initialize` method with an argument`' do
+    expect_no_offenses(<<~RUBY)
+      def initialize(_)
       end
     RUBY
   end


### PR DESCRIPTION
This fixes a false positive in the `Style/RedundantInitialize` cop when an empty initialize method is defined to accept arguments for duck typing purposes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
