### PR TITLE
Add support for safe navigation to `Layout/LineLength`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_layout_line_length.md
+++ b/changelog/change_add_support_for_safe_navigation_to_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#13655](https://github.com/rubocop/rubocop/pull/13655): Add support for safe navigation to `Layout/LineLength`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -90,6 +90,7 @@ module RuboCop
         alias on_array on_potential_breakable_node
         alias on_hash on_potential_breakable_node
         alias on_send on_potential_breakable_node
+        alias on_csend on_potential_breakable_node
         alias on_def on_potential_breakable_node
 
         def on_new_investigation


### PR DESCRIPTION
`Layout/LineLength` can currently autocorrect send nodes but not csend nodes, this extends the same correction to all method calls regardless of dot type. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
