### PR TITLE
Add support for safe navigation to `Layout/HashAlignment`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_layout_hash_alignment.md
+++ b/changelog/change_add_support_for_safe_navigation_to_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#13657](https://github.com/rubocop/rubocop/pull/13657): Add support for safe navigation to `Layout/HashAlignment`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -202,6 +202,7 @@ module RuboCop
 
           ignore_node(last_argument)
         end
+        alias on_csend on_send
         alias on_super on_send
         alias on_yield on_send
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -146,6 +146,32 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects misaligned keys in implicit hash for safe navigation' do
+      expect_offense(<<~RUBY)
+        foo&.bar(a: 0,
+          b: 1)
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.bar(a: 0,
+                 b: 1)
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned keys in explicit hash for safe navigation' do
+      expect_offense(<<~RUBY)
+        foo&.bar({a: 0,
+          b: 1})
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.bar({a: 0,
+                  b: 1})
+      RUBY
+    end
+
     context 'when using hash value omission', :ruby31 do
       it 'registers offense and corrects misaligned keys in implicit hash' do
         expect_offense(<<~RUBY)
@@ -314,6 +340,20 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           b: 1})
       RUBY
     end
+
+    it 'accepts misaligned keys in implicit hash for safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar({a: 0,
+          b: 1})
+      RUBY
+    end
   end
 
   context 'ignore implicit last argument hash' do
@@ -376,6 +416,26 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       expect_correction(<<~RUBY)
         yield({a: 0,
                b: 1})
+      RUBY
+    end
+
+    it 'accepts misaligned keys in implicit hash for safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar(a: 0,
+          b: 1)
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned keys in explicit hash for safe navigation' do
+      expect_offense(<<~RUBY)
+        foo&.bar({a: 0,
+          b: 1})
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.bar({a: 0,
+                  b: 1})
       RUBY
     end
   end
@@ -461,6 +521,26 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     it 'accepts misaligned keys in explicit hash for yield' do
       expect_no_offenses(<<~RUBY)
         yield({a: 0,
+          b: 1})
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned keys in implicit hash for safe navigation' do
+      expect_offense(<<~RUBY)
+        foo&.bar(a: 0,
+          b: 1)
+          ^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.bar(a: 0,
+                 b: 1)
+      RUBY
+    end
+
+    it 'accepts misaligned keys in explicit hash for safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar({a: 0,
           b: 1})
       RUBY
     end


### PR DESCRIPTION
Previously, `Layout/HashAlignment` ignored certain `send` nodes based on `EnforcedLastArgumentHashStyle` configuration, but this was not applied to safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
