### PR TITLE
Fix invalid autocorrect for `Style/SlicingWithRange` when calling `.[]` or `&.[]` with a correctable range

### DIFF
--- a/changelog/change_fix_invalid_autocorrect_for.md
+++ b/changelog/change_fix_invalid_autocorrect_for.md
@@ -1,0 +1,1 @@
+* [#13658](https://github.com/rubocop/rubocop/pull/13658): Fix invalid autocorrect for `Style/SlicingWithRange` when calling `.[]` or `&.[]` with a correctable range. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/slicing_with_range_spec.rb
+++ b/spec/rubocop/cop/style/slicing_with_range_spec.rb
@@ -116,6 +116,47 @@ RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
         ary[0..42]
       RUBY
     end
+
+    context 'when calling `[]` with a dot' do
+      it 'reports an offense and removes the entire method call for 0..-1' do
+        expect_offense(<<~RUBY)
+          ary.[](0..-1)
+             ^^^^^^^^^^ Remove the useless `.[](0..-1)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary
+        RUBY
+      end
+
+      it 'reports an offense and removes the entire method call for 0..-1 without parens' do
+        expect_offense(<<~RUBY)
+          ary.[] 0..-1
+             ^^^^^^^^^ Remove the useless `.[] 0..-1`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary
+        RUBY
+      end
+
+      it 'reports an offense and corrects for `1..-1`' do
+        expect_offense(<<~RUBY)
+          ary.[](1..-1)
+             ^^^^^^^^^^ Prefer `1..` over `1..-1`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary.[](1..)
+        RUBY
+      end
+
+      it 'does not register an offense for `1..-1` without parens' do
+        expect_no_offenses(<<~RUBY)
+          ary.[] 1..-1
+        RUBY
+      end
+    end
   end
 
   context '>= Ruby 2.7', :ruby27 do
@@ -140,6 +181,83 @@ RSpec.describe RuboCop::Cop::Style::SlicingWithRange, :config do
       expect_no_offenses(<<~RUBY)
         ary[..-1]
       RUBY
+    end
+
+    context 'when calling `[]` with a dot' do
+      it 'reports an offense and corrects for `nil..42`' do
+        expect_offense(<<~RUBY)
+          ary.[](nil..42)
+             ^^^^^^^^^^^^ Prefer `..42` over `nil..42`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary.[](..42)
+        RUBY
+      end
+
+      it 'does not register an offense for `nil..42` without parens' do
+        expect_no_offenses(<<~RUBY)
+          ary.[] nil..42
+        RUBY
+      end
+    end
+
+    context 'when calling `[]` with a safe navigation' do
+      it 'reports an offense and removes the entire method call for 0..-1' do
+        expect_offense(<<~RUBY)
+          ary&.[](0..-1)
+             ^^^^^^^^^^^ Remove the useless `&.[](0..-1)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary
+        RUBY
+      end
+
+      it 'reports an offense and removes the entire method call for 0..-1 without parens' do
+        expect_offense(<<~RUBY)
+          ary.[] 0..-1
+             ^^^^^^^^^ Remove the useless `.[] 0..-1`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary
+        RUBY
+      end
+
+      it 'reports an offense and corrects for `1..-1`' do
+        expect_offense(<<~RUBY)
+          ary.[](1..-1)
+             ^^^^^^^^^^ Prefer `1..` over `1..-1`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary.[](1..)
+        RUBY
+      end
+
+      it 'does not register an offense for `1..-1` without parens' do
+        expect_no_offenses(<<~RUBY)
+          ary.[] 1..-1
+        RUBY
+      end
+
+      it 'reports an offense and corrects for `nil..42`' do
+        expect_offense(<<~RUBY)
+          ary&.[](nil..42)
+             ^^^^^^^^^^^^^ Prefer `..42` over `nil..42`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ary&.[](..42)
+        RUBY
+      end
+
+      it 'does not register an offense for `nil..42` without parens' do
+        expect_no_offenses(<<~RUBY)
+          ary&.[] nil..42
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, `Style/SlicingWithRange` would autocorrect code such as `ary.[](0..-1)` to `ary.(0..-1)`, which is obviously incorrect. 

This updates the cop to handle `.[]` and `&.[]` correctly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
