### PR TITLE
[Doc] Add "Setting the version tracking metadata for cops" section

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1000,6 +1000,26 @@ Sorbet:
   DocumentationExtension: .md
 ----
 
+== Setting the version tracking metadata for cops
+
+This configuration is particularly useful when custom cops are distributed as a gem.
+
+Each cop can have the following additional metadata:
+
+* `VersionAdded` - the RuboCop version in which it was added
+* `VersionChanged` (optional) - the latest RuboCop version in which it was changed in a user-impacting way (new config, updated defaults, etc)
+
+[source,yaml]
+----
+Style/HashSyntax:
+  VersionAdded: '0.9'
+  VersionChanged: '1.67'
+----
+
+NOTE: These values do not include patch versions.
+
+Those will be pretty useful for the documentation (so the manual generation has to be enhanced to include them) and keeping track of changes.
+
 == Enable checking Active Support extensions
 
 Some cops for checking specified methods (e.g. `Style/HashExcept`) supports Active Support extensions.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/13653#discussion_r1907681441.

This PR adds "Setting the version tracking metadata for cops" section to configuration.adoc.

`VersionAdded`, `VersionChanged`, and `VersionRemoved` are only mentioned in #5978 and have not been documented. The content remains as described in #5978.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
