### PR TITLE
Add support for safe navigation to `Style/SendWithLiteralMethodName`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_style_send_with_literal.md
+++ b/changelog/change_add_support_for_safe_navigation_to_style_send_with_literal.md
@@ -1,0 +1,1 @@
+* [#13662](https://github.com/rubocop/rubocop/pull/13662): Add support for safe navigation to `Style/SendWithLiteralMethodName`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/send_with_literal_method_name.rb
+++ b/lib/rubocop/cop/style/send_with_literal_method_name.rb
@@ -68,7 +68,7 @@ module RuboCop
         def on_send(node)
           return if allow_send? && !node.method?(:public_send)
           return unless (first_argument = node.first_argument)
-          return unless STATIC_METHOD_NAME_NODE_TYPES.include?(first_argument.type)
+          return unless first_argument.type?(*STATIC_METHOD_NAME_NODE_TYPES)
 
           offense_range = offense_range(node)
           method_name = first_argument.value
@@ -83,6 +83,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private

--- a/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
+++ b/spec/rubocop/cop/style/send_with_literal_method_name_spec.rb
@@ -1,179 +1,418 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::SendWithLiteralMethodName, :config do
-  it 'registers an offense when using `public_send` with symbol literal argument' do
-    expect_offense(<<~RUBY)
-      obj.public_send(:foo)
-          ^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-    RUBY
+  context 'when calling `public_send` with a symbol literal argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.public_send(:foo)
+            ^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      obj.foo
-    RUBY
+      expect_correction(<<~RUBY)
+        obj.foo
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj&.public_send(:foo)
+               ^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.foo
+        RUBY
+      end
+    end
   end
 
-  it 'registers an offense when using `public_send` with symbol literal argument and some arguments with parentheses' do
-    expect_offense(<<~RUBY)
-      obj.public_send(:foo, bar, 42)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-    RUBY
+  context 'when calling `public_send` with a symbol literal argument and some arguments with parentheses' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.public_send(:foo, bar, 42)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      obj.foo(bar, 42)
-    RUBY
+      expect_correction(<<~RUBY)
+        obj.foo(bar, 42)
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj&.public_send(:foo, bar, 42)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.foo(bar, 42)
+        RUBY
+      end
+    end
   end
 
-  it 'registers an offense when using `public_send` with symbol literal argument and some arguments without parentheses' do
-    expect_offense(<<~RUBY)
-      obj.public_send :foo, bar, 42
-          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-    RUBY
+  context 'when calling `public_send` with a symbol literal argument and some arguments without parentheses' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.public_send :foo, bar, 42
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      obj.foo bar, 42
-    RUBY
+      expect_correction(<<~RUBY)
+        obj.foo bar, 42
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj&.public_send :foo, bar, 42
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.foo bar, 42
+        RUBY
+      end
+    end
   end
 
-  it 'registers an offense when using `public_send` with symbol literal argument without receiver' do
-    expect_offense(<<~RUBY)
-      public_send(:foo)
-      ^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-    RUBY
+  context 'when calling `public_send` with a symbol literal argument without a receiver' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        public_send(:foo)
+        ^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      foo
-    RUBY
-  end
-
-  it 'registers an offense when using `public_send` with string literal argument' do
-    expect_offense(<<~RUBY)
-      obj.public_send('foo')
-          ^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      obj.foo
-    RUBY
-  end
-
-  it 'registers an offense when using `public_send` with method name with underscore' do
-    expect_offense(<<~RUBY)
-      obj.public_send("name_with_underscore")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `name_with_underscore` method call directly instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      obj.name_with_underscore
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with variable argument' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send(variable)
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with interpolated string argument' do
-    expect_no_offenses(<<~'RUBY')
-      obj.public_send("#{interpolated}string")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with method name with space' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send("name with space")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with method name with hyphen' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send("name-with-hyphen")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with writer method name' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send("name=")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with method name with brackets' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send("{brackets}")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with method name with square brackets' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send("[square_brackets]")
-    RUBY
-  end
-
-  it 'does not register an offense when using `public_send` with reserved word argument' do
-    described_class::RESERVED_WORDS.each do |reserved_word|
-      expect_no_offenses(<<~RUBY)
-        obj.public_send(:#{reserved_word})
+      expect_correction(<<~RUBY)
+        foo
       RUBY
     end
   end
 
-  it 'does not register an offense when using `public_send` with integer literal argument' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send(42)
-    RUBY
+  context 'when calling `public_send` with a string literal argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.public_send('foo')
+            ^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj.foo
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj&.public_send('foo')
+               ^^^^^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.foo
+        RUBY
+      end
+    end
   end
 
-  it 'does not register an offense when using `public_send` with no arguments' do
-    expect_no_offenses(<<~RUBY)
-      obj.public_send
-    RUBY
+  context 'when calling `public_send` with a method name with underscore' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        obj.public_send("name_with_underscore")
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `name_with_underscore` method call directly instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj.name_with_underscore
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj&.public_send("name_with_underscore")
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `name_with_underscore` method call directly instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.name_with_underscore
+        RUBY
+      end
+    end
   end
 
-  it 'does not register an offense when using method call without `public_send`' do
-    expect_no_offenses(<<~RUBY)
-      obj.foo
-    RUBY
+  context 'when calling `public_send` with a method name with a variable argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send(variable)
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send(variable)
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a method name with an interpolated string argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~'RUBY')
+        obj.public_send("#{interpolated}string")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          obj&.public_send("#{interpolated}string")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a method name with a space' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send("name with space")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send("name with space")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a method name with a hyphen' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send("name-with-hyphen")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send("name-with-hyphen")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a writer method name' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send("name=")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send("name=")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a method name with braces' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send("{brackets}")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send("{brackets}")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a method name with square brackets' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send("[square_brackets]")
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send("[square_brackets]")
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a reserved word' do
+    it 'does not register an offense' do
+      described_class::RESERVED_WORDS.each do |reserved_word|
+        expect_no_offenses(<<~RUBY)
+          obj.public_send(:#{reserved_word})
+        RUBY
+      end
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        described_class::RESERVED_WORDS.each do |reserved_word|
+          expect_no_offenses(<<~RUBY)
+            obj&.public_send(:#{reserved_word})
+          RUBY
+        end
+      end
+    end
+  end
+
+  context 'when calling `public_send` with a integer literal argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send(42)
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send(42)
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling `public_send` without arguments' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.public_send
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.public_send
+        RUBY
+      end
+    end
+  end
+
+  context 'when calling another method other than `public_send`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        obj.foo
+      RUBY
+    end
+
+    context 'with safe navigation' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj&.foo
+        RUBY
+      end
+    end
   end
 
   context 'when `AllowSend: true`' do
     let(:cop_config) { { 'AllowSend' => true } }
 
-    it 'does not register an offense when using `send` with symbol literal argumen' do
-      expect_no_offenses(<<~RUBY)
-        obj.send(:foo)
-      RUBY
+    context 'when calling `send` with a symbol literal argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj.send(:foo)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            obj&.send(:foo)
+          RUBY
+        end
+      end
     end
 
-    it 'does not register an offense when using `__send__` with symbol literal argument' do
-      expect_no_offenses(<<~RUBY)
-        obj.__send__(:foo)
-      RUBY
+    context 'when calling `__send__` with a symbol literal argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          obj.__send__(:foo)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            obj&.__send__(:foo)
+          RUBY
+        end
+      end
     end
   end
 
   context 'when `AllowSend: false`' do
     let(:cop_config) { { 'AllowSend' => false } }
 
-    it 'registers an offense when using `send` with symbol literal argument' do
-      expect_offense(<<~RUBY)
-        obj.send(:foo)
-            ^^^^^^^^^^ Use `foo` method call directly instead.
-      RUBY
+    context 'when calling `send` with a symbol literal argument' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj.send(:foo)
+              ^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        obj.foo
-      RUBY
+        expect_correction(<<~RUBY)
+          obj.foo
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            obj&.send(:foo)
+                 ^^^^^^^^^^ Use `foo` method call directly instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            obj&.foo
+          RUBY
+        end
+      end
     end
 
-    it 'registers an offense when using `__send__` with symbol literal argument' do
-      expect_offense(<<~RUBY)
-        obj.__send__(:foo)
-            ^^^^^^^^^^^^^^ Use `foo` method call directly instead.
-      RUBY
+    context 'when calling `__send__` with a symbol literal argument' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          obj.__send__(:foo)
+              ^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        obj.foo
-      RUBY
+        expect_correction(<<~RUBY)
+          obj.foo
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            obj&.__send__(:foo)
+                 ^^^^^^^^^^^^^^ Use `foo` method call directly instead.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            obj&.foo
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Handle `obj&.public_send` in `Style/SendWithLiteralMethodName`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
