### PR TITLE
Update `Style/RedundantSelfAssignment` to handle safe navigation on the right-hand side of the assignment

### DIFF
--- a/changelog/change_update_style_redundant_self_assignment_to_handle.md
+++ b/changelog/change_update_style_redundant_self_assignment_to_handle.md
@@ -1,0 +1,1 @@
+* [#13662](https://github.com/rubocop/rubocop/pull/13662): Update `Style/RedundantSelfAssignment` to handle safe navigation on the right-hand side of the assignment. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -52,7 +52,7 @@ module RuboCop
         # rubocop:disable Metrics/AbcSize
         def on_lvasgn(node)
           return unless (rhs = node.rhs)
-          return unless rhs.send_type? && method_returning_self?(rhs.method_name)
+          return unless rhs.call_type? && method_returning_self?(rhs.method_name)
           return unless (receiver = rhs.receiver)
 
           receiver_type = ASSIGNMENT_TYPE_TO_RECEIVER_TYPE[node.type]
@@ -77,6 +77,7 @@ module RuboCop
             corrector.remove(correction_range(node))
           end
         end
+        alias on_csend on_send
 
         private
 
@@ -88,7 +89,7 @@ module RuboCop
         def_node_matcher :redundant_self_assignment?, <<~PATTERN
           (send
             (self) _
-            (send
+            (call
               (send
                 {(self) nil?} %1) #method_returning_self?
               ...))
@@ -96,10 +97,10 @@ module RuboCop
 
         # @!method redundant_nonself_assignment?(node, receiver, method_name)
         def_node_matcher :redundant_nonself_assignment?, <<~PATTERN
-          (send
+          (call
             %1 _
-            (send
-              (send
+            (call
+              (call
                 %1 %2) #method_returning_self?
               ...))
         PATTERN

--- a/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignment, :config do
         $foo.concat(ary)
       RUBY
     end
+
+    it 'registers an offense and corrects when the rhs uses safe navigation' do
+      expect_offense(<<~RUBY)
+        foo = foo&.concat(ary)
+            ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.concat(ary)
+      RUBY
+    end
   end
 
   it 'does not register an offense when lhs and receiver are different' do
@@ -70,6 +81,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when assigning to attribute of `self` with safe navigation' do
+    expect_offense(<<~RUBY)
+      self.foo = foo&.concat(ary)
+               ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.concat(ary)
+    RUBY
+  end
+
   it 'registers an offense and corrects when assigning to attribute of non `self`' do
     expect_offense(<<~RUBY)
       other.foo = other.foo.concat(ary)
@@ -78,6 +100,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignment, :config do
 
     expect_correction(<<~RUBY)
       other.foo.concat(ary)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when assigning to attribute of non `self` with safe assignment' do
+    expect_offense(<<~RUBY)
+      other.foo = other.foo&.concat(ary)
+                ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      other.foo&.concat(ary)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when assigning to attribute of non `self` with safe assignment chain' do
+    expect_offense(<<~RUBY)
+      other&.foo = other&.foo&.concat(ary)
+                 ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      other&.foo&.concat(ary)
     RUBY
   end
 


### PR DESCRIPTION
Handle safe navigation on the RHS of assignment in `Style/RedundantSelfAssignment`.

For instance:

```ruby
foo = foo&.concat(ary)
self.foo = foo&.concat(ary)
other.foo = other.foo&.concat(ary)
other&.foo = other&.foo&.concat(ary)
```

These cases are now registered and corrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
