### PR TITLE
[Doc] Improve documentation of `Style/RedundantCurrentDirectoryInPath` to point out that it only applies to `require_relative`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5070,7 +5070,7 @@ Style/RedundantConstantBase:
   VersionAdded: '1.40'
 
 Style/RedundantCurrentDirectoryInPath:
-  Description: 'Checks for uses a redundant current directory in path.'
+  Description: 'Checks for a redundant current directory in a path given to `require_relative`.'
   Enabled: pending
   VersionAdded: '1.53'
 

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -3,7 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses a redundant current directory in path.
+      # Checks for paths given to `require_relative` that start with
+      # the current directory (`./`), which can be omitted.
       #
       # @example
       #


### PR DESCRIPTION
`Style/RedundantCurrentDirectoryInPath` only considers paths given to `require_relative`, but this was not made clear from the documentation. 