### PR TITLE
Add support for safe navigation to `Style/ObjectThen`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to.md
+++ b/changelog/change_add_support_for_safe_navigation_to.md
@@ -1,0 +1,1 @@
+* [#13665](https://github.com/rubocop/rubocop/pull/13665): Add support for safe navigation to `Style/ObjectThen`. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
   context 'EnforcedStyle: then' do
     let(:cop_config) { { 'EnforcedStyle' => 'then' } }
 
+    it 'does not register an offense for method names other than `then`' do
+      expect_no_offenses(<<~RUBY)
+        obj.map { |x| x.foo }
+      RUBY
+    end
+
     context 'Ruby 2.5', :ruby25, unsupported_on: :prism do
       it 'accepts yield_self with block' do
         expect_no_offenses(<<~RUBY)
@@ -23,10 +29,21 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
           obj.then { |e| e.test }
         RUBY
       end
+
+      it 'registers an offense for yield_self with safe navigation and block' do
+        expect_offense(<<~RUBY)
+          obj&.yield_self { |e| e.test }
+               ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.then { |e| e.test }
+        RUBY
+      end
     end
 
     context 'Ruby 2.7', :ruby27 do
-      it 'registers an offense for yield_self with block' do
+      it 'registers an offense for yield_self with numblock' do
         expect_offense(<<~RUBY)
           obj.yield_self { _1.test }
               ^^^^^^^^^^ Prefer `then` over `yield_self`.
@@ -34,6 +51,17 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
 
         expect_correction(<<~RUBY)
           obj.then { _1.test }
+        RUBY
+      end
+
+      it 'registers an offense for yield_self with safe navigation and numblock' do
+        expect_offense(<<~RUBY)
+          obj&.yield_self { _1.test }
+               ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.then { _1.test }
         RUBY
       end
 
@@ -60,15 +88,38 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
       RUBY
     end
 
+    it 'registers an offense for yield_self with safe navigation and proc param' do
+      expect_offense(<<~RUBY)
+        obj&.yield_self(&:test)
+             ^^^^^^^^^^ Prefer `then` over `yield_self`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj&.then(&:test)
+      RUBY
+    end
+
     it 'accepts yield_self with more than 1 param' do
       expect_no_offenses(<<~RUBY)
         obj.yield_self(other, &:test)
       RUBY
     end
 
+    it 'accepts yield_self with safe navigation and more than 1 param' do
+      expect_no_offenses(<<~RUBY)
+        obj&.yield_self(other, &:test)
+      RUBY
+    end
+
     it 'accepts yield_self without a block' do
       expect_no_offenses(<<~RUBY)
         obj.yield_self
+      RUBY
+    end
+
+    it 'accepts yield_self with safe navigation without a block' do
+      expect_no_offenses(<<~RUBY)
+        obj&.yield_self
       RUBY
     end
   end
@@ -87,6 +138,17 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
       RUBY
     end
 
+    it 'registers an offense for then with safe navigation with block' do
+      expect_offense(<<~RUBY)
+        obj&.then { |e| e.test }
+             ^^^^ Prefer `yield_self` over `then`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj&.yield_self { |e| e.test }
+      RUBY
+    end
+
     it 'registers an offense for then with proc param' do
       expect_offense(<<~RUBY)
         obj.then(&:test)
@@ -98,15 +160,38 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
       RUBY
     end
 
+    it 'registers an offense for then with safe navigation and proc param' do
+      expect_offense(<<~RUBY)
+        obj&.then(&:test)
+             ^^^^ Prefer `yield_self` over `then`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj&.yield_self(&:test)
+      RUBY
+    end
+
     it 'accepts then with more than 1 param' do
       expect_no_offenses(<<~RUBY)
         obj.then(other, &:test)
       RUBY
     end
 
+    it 'accepts then with safe navigation and more than 1 param' do
+      expect_no_offenses(<<~RUBY)
+        obj&.then(other, &:test)
+      RUBY
+    end
+
     it 'accepts then without a block' do
       expect_no_offenses(<<~RUBY)
         obj.then
+      RUBY
+    end
+
+    it 'accepts then with safe navigation without a block' do
+      expect_no_offenses(<<~RUBY)
+        obj&.then
       RUBY
     end
   end


### PR DESCRIPTION
Allow `Style/ObjectThen` to detect offenses when `then` or `yield_self` is used with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
