### PR TITLE
[Fix #13667] Maintain precedence in autocorrect for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_maintain_precedence_in_autocorrect_for.md
+++ b/changelog/fix_maintain_precedence_in_autocorrect_for.md
@@ -1,0 +1,1 @@
+* [#13667](https://github.com/rubocop/rubocop/issues/13667): Maintain precedence in autocorrect for `Style/SoleNestedConditional`. ([@tejasbubane][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -243,7 +243,7 @@ module RuboCop
         def replace_condition(condition)
           return condition.source unless wrap_condition?(condition)
 
-          if condition.call_type?
+          if condition.call_type? && !condition.comparison_method?
             parenthesized_method_arguments(condition)
           else
             "(#{condition.source})"

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -280,6 +280,22 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `unless` and `===` without parens in the outer condition ' \
+     'and nested modifier condition' do
+    expect_offense(<<~RUBY)
+      if result
+        do_something unless foo === bar
+                     ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if result && !(foo === bar)
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `unless` and `&&` without parens in the outer condition ' \
      'and nested modifier condition' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
For comparison operators

Closes https://github.com/rubocop/rubocop/issues/13667

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/