### PR TITLE
Fix `Style/FrozenStringLiteralComment` cop error on unnormalized magic comment and `never` enforced style

### DIFF
--- a/changelog/fix_style_frozen_string_literal_comment_cop_error_on_weird_magic_comment.md
+++ b/changelog/fix_style_frozen_string_literal_comment_cop_error_on_weird_magic_comment.md
@@ -1,0 +1,1 @@
+* [#13669](https://github.com/rubocop/rubocop/pull/13669): Fix `Style/FrozenStringLiteralComment` cop error on unnormalized magic comment and `never` enforced style. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -6,7 +6,7 @@ module RuboCop
     module FrozenStringLiteral
       module_function
 
-      FROZEN_STRING_LITERAL = '# frozen_string_literal:'
+      FROZEN_STRING_LITERAL_REGEXP = /#\s*frozen[-_]?string[-_]?literal:/i.freeze
       FROZEN_STRING_LITERAL_ENABLED = '# frozen_string_literal: true'
       FROZEN_STRING_LITERAL_TYPES_RUBY27 = %i[str dstr].freeze
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -151,7 +151,7 @@ module RuboCop
 
         def frozen_string_literal_comment(processed_source)
           processed_source.tokens.find do |token|
-            token.text.start_with?(FROZEN_STRING_LITERAL)
+            token.text.start_with?(FROZEN_STRING_LITERAL_REGEXP)
           end
         end
 

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -499,6 +499,42 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         # frozen_string_literal: true
       RUBY
     end
+
+    [
+      '# frozen-string-literal: true',
+      '# frozen_string_literal: TRUE',
+      '# frozen-string_literal: true',
+      '# frozen-string_literal: TRUE',
+      '# frozen_string-literal: true',
+      '# FROZEN-STRING-LITERAL: true',
+      '# FROZEN_STRING_LITERAL: true'
+    ].each do |magic_comment|
+      it "registers an offense for having a `#{magic_comment}` frozen string literal comment" do
+        expect_offense(<<~RUBY, magic_comment: magic_comment)
+          #{magic_comment}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+
+          puts 1
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts 1
+        RUBY
+      end
+    end
+
+    it 'registers an offense for having a frozen string literal comment with multiple spaces at beginning' do
+      expect_offense(<<~RUBY)
+        #   frozen_string_literal: true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary frozen string literal comment.
+
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts 1
+      RUBY
+    end
   end
 
   context 'always_true' do


### PR DESCRIPTION
If `Style/FrozenStringLiteralComment` is configured with enforced style `never` any unnormalized magic comment (e.g. `frozen-string-literal: true`) leads to an error:

```
NoMethodError:
       undefined method `pos' for nil
     # ./lib/rubocop/cop/style/frozen_string_literal_comment.rb:173:in `unnecessary_comment_offense'
     # ./lib/rubocop/cop/style/frozen_string_literal_comment.rb:117:in `ensure_no_comment'
     # ./lib/rubocop/cop/style/frozen_string_literal_comment.rb:104:in `on_new_investigation'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
