### PR TITLE
Add support for safe navigation to `Style/MethodCallWithoutArgsParentheses`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_method_call_without_args_parens.md
+++ b/changelog/change_add_support_for_safe_navigation_to_method_call_without_args_parens.md
@@ -1,0 +1,1 @@
+* [#13671](https://github.com/rubocop/rubocop/pull/13671): Add support for safe navigation to `Style/MethodCallWithoutArgsParentheses`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -45,6 +45,7 @@ module RuboCop
           register_offense(node)
         end
         # rubocop:enable Metrics/CyclomaticComplexity
+        alias on_csend on_send
 
         private
 
@@ -100,7 +101,7 @@ module RuboCop
             # `obj.method ||= value` parses as (or-asgn (send ...) ...)
             # which IS an `asgn_node`. Similarly, `obj.method += value` parses
             # as (op-asgn (send ...) ...), which is also an `asgn_node`.
-            next if asgn_node.shorthand_asgn? && asgn_node.lhs.send_type?
+            next if asgn_node.shorthand_asgn? && asgn_node.lhs.call_type?
 
             yield asgn_node
           end


### PR DESCRIPTION
Handles safe navigation method calls with unnecessary parens:

```
test = x&.test()
              ^^ Do not use parentheses for method calls with no arguments.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
