### PR TITLE
Add support for safe navigation to `Style/MapToSet`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_map_to_set.md
+++ b/changelog/change_add_support_for_safe_navigation_to_map_to_set.md
@@ -1,0 +1,1 @@
+* [#13672](https://github.com/rubocop/rubocop/pull/13672): Add support for safe navigation to `Style/MapToSet`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/map_to_set.rb
+++ b/lib/rubocop/cop/style/map_to_set.rb
@@ -33,8 +33,8 @@ module RuboCop
         # @!method map_to_set?(node)
         def_node_matcher :map_to_set?, <<~PATTERN
           {
-            $(send ({block numblock} $(send _ {:map :collect}) ...) :to_set)
-            $(send $(send _ {:map :collect} (block_pass sym)) :to_set)
+            $(call ({block numblock} $(call _ {:map :collect}) ...) :to_set)
+            $(call $(call _ {:map :collect} (block_pass sym)) :to_set)
           }
         PATTERN
 
@@ -49,6 +49,7 @@ module RuboCop
             autocorrect(corrector, to_set_node, map_node)
           end
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/map_to_set_spec.rb
+++ b/spec/rubocop/cop/style/map_to_set_spec.rb
@@ -144,5 +144,40 @@ RSpec.describe RuboCop::Cop::Style::MapToSet, :config do
         RUBY
       end
     end
+
+    context 'with safe navigation' do
+      it "registers an offense and corrects for `foo&.#{method}.to_set" do
+        expect_offense(<<~RUBY, method: method)
+          foo&.#{method} { |x| [x, x * 2] }.to_set
+               ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.to_set { |x| [x, x * 2] }
+        RUBY
+      end
+
+      it "registers an offense and corrects for `foo.#{method}&.to_set" do
+        expect_offense(<<~RUBY, method: method)
+          foo.#{method} { |x| [x, x * 2] }&.to_set
+              ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.to_set { |x| [x, x * 2] }
+        RUBY
+      end
+
+      it "registers an offense and corrects for `foo&.#{method}&.to_set" do
+        expect_offense(<<~RUBY, method: method)
+          foo&.#{method} { |x| [x, x * 2] }&.to_set
+               ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.to_set { |x| [x, x * 2] }
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Handles safe navigation in `map.to_set` method chains:

```
foo&.map { |x| [x, x * 2] }&.to_set
     ^^^ Pass a block to `to_set` instead of calling `map.to_set`.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
