### PR TITLE
Add support for safe navigation to `Style/CollectionMethods`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to.md
+++ b/changelog/change_add_support_for_safe_navigation_to.md
@@ -1,0 +1,1 @@
+* [#13673](https://github.com/rubocop/rubocop/pull/13673): Add support for safe navigation to `Style/CollectionMethods`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -49,7 +49,6 @@ module RuboCop
         def on_block(node)
           check_method_node(node.send_node)
         end
-
         alias on_numblock on_block
 
         def on_send(node)
@@ -57,6 +56,7 @@ module RuboCop
 
           check_method_node(node)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -14,94 +14,214 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
   let(:cop_config) { cop_config }
 
   cop_config['PreferredMethods'].each do |method, preferred_method|
-    it "registers an offense for #{method} with block" do
-      expect_offense(<<~RUBY, method: method)
-        [1, 2, 3].%{method} { |e| e + 1 }
-                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        [1, 2, 3].#{preferred_method} { |e| e + 1 }
-      RUBY
-    end
-
-    context 'Ruby 2.7', :ruby27 do
-      it "registers an offense for #{method} with numblock" do
+    context "#{method} with block" do
+      it 'registers an offense' do
         expect_offense(<<~RUBY, method: method)
-          [1, 2, 3].%{method} { _1 + 1 }
+          [1, 2, 3].%{method} { |e| e + 1 }
                     ^{method} Prefer `#{preferred_method}` over `#{method}`.
         RUBY
 
         expect_correction(<<~RUBY)
-          [1, 2, 3].#{preferred_method} { _1 + 1 }
+          [1, 2, 3].#{preferred_method} { |e| e + 1 }
         RUBY
+      end
+
+      context 'safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3]&.%{method} { |e| e + 1 }
+                       ^{method} Prefer `#{preferred_method}` over `#{method}`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3]&.#{preferred_method} { |e| e + 1 }
+          RUBY
+        end
       end
     end
 
-    it "registers an offense for #{method} with proc param" do
-      expect_offense(<<~RUBY, method: method)
-        [1, 2, 3].%{method}(&:test)
-                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
-      RUBY
+    context 'Ruby 2.7', :ruby27 do
+      context "#{method} with numblock" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3].%{method} { _1 + 1 }
+                      ^{method} Prefer `#{preferred_method}` over `#{method}`.
+          RUBY
 
-      expect_correction(<<~RUBY)
-        [1, 2, 3].#{preferred_method}(&:test)
-      RUBY
+          expect_correction(<<~RUBY)
+            [1, 2, 3].#{preferred_method} { _1 + 1 }
+          RUBY
+        end
+
+        context 'with safe navigation' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, method: method)
+              [1, 2, 3]&.%{method} { _1 + 1 }
+                         ^{method} Prefer `#{preferred_method}` over `#{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              [1, 2, 3]&.#{preferred_method} { _1 + 1 }
+            RUBY
+          end
+        end
+      end
     end
 
-    it "registers an offense for #{method} with an argument and proc param" do
-      expect_offense(<<~RUBY, method: method)
-        [1, 2, 3].%{method}(0, &:test)
-                  ^{method} Prefer `#{preferred_method}` over `#{method}`.
-      RUBY
+    context "#{method} with proc param" do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, method: method)
+          [1, 2, 3].%{method}(&:test)
+                    ^{method} Prefer `#{preferred_method}` over `#{method}`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        [1, 2, 3].#{preferred_method}(0, &:test)
-      RUBY
+        expect_correction(<<~RUBY)
+          [1, 2, 3].#{preferred_method}(&:test)
+        RUBY
+      end
+
+      context 'safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3]&.%{method}(&:test)
+                       ^{method} Prefer `#{preferred_method}` over `#{method}`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3]&.#{preferred_method}(&:test)
+          RUBY
+        end
+      end
     end
 
-    it "accepts #{method} without a block" do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].#{method}
-      RUBY
+    context "#{method} with an argument and proc param" do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY, method: method)
+          [1, 2, 3].%{method}(0, &:test)
+                    ^{method} Prefer `#{preferred_method}` over `#{method}`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2, 3].#{preferred_method}(0, &:test)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3]&.%{method}(0, &:test)
+                       ^{method} Prefer `#{preferred_method}` over `#{method}`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3]&.#{preferred_method}(0, &:test)
+          RUBY
+        end
+      end
+    end
+
+    context "#{method} without a block" do
+      it "accepts #{method} without a block" do
+        expect_no_offenses(<<~RUBY)
+          [1, 2, 3].#{method}
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it "accepts #{method} without a block" do
+          expect_no_offenses(<<~RUBY)
+            [1, 2, 3]&.#{method}
+          RUBY
+        end
+      end
     end
   end
 
   context 'for methods that accept a symbol as implicit block' do
-    it 'registers an offense with a final symbol param' do
-      expect_offense(<<~RUBY)
-        [1, 2, 3].inject(:+)
-                  ^^^^^^ Prefer `reduce` over `inject`.
-      RUBY
+    context 'with a final symbol param' do
+      it 'registers an offense with a final symbol param' do
+        expect_offense(<<~RUBY)
+          [1, 2, 3].inject(:+)
+                    ^^^^^^ Prefer `reduce` over `inject`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        [1, 2, 3].reduce(:+)
-      RUBY
+        expect_correction(<<~RUBY)
+          [1, 2, 3].reduce(:+)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'registers an offense with a final symbol param' do
+          expect_offense(<<~RUBY)
+            [1, 2, 3]&.inject(:+)
+                       ^^^^^^ Prefer `reduce` over `inject`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3]&.reduce(:+)
+          RUBY
+        end
+      end
     end
 
-    it 'registers an offense with an argument and final symbol param' do
-      expect_offense(<<~RUBY)
-        [1, 2, 3].inject(0, :+)
-                  ^^^^^^ Prefer `reduce` over `inject`.
-      RUBY
+    context 'with an argument and final symbol param' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          [1, 2, 3].inject(0, :+)
+                    ^^^^^^ Prefer `reduce` over `inject`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        [1, 2, 3].reduce(0, :+)
-      RUBY
+        expect_correction(<<~RUBY)
+          [1, 2, 3].reduce(0, :+)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            [1, 2, 3]&.inject(0, :+)
+                       ^^^^^^ Prefer `reduce` over `inject`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3]&.reduce(0, :+)
+          RUBY
+        end
+      end
     end
   end
 
   context 'for methods that do not accept a symbol as implicit block' do
-    it 'does not register an offense for a final symbol param' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].collect(:+)
-      RUBY
+    context 'for a final symbol param' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [1, 2, 3].collect(:+)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            [1, 2, 3]&.collect(:+)
+          RUBY
+        end
+      end
     end
 
-    it 'does not register an offense for a final symbol param with extra args' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].collect(0, :+)
-      RUBY
+    context 'for a final symbol param with extra args' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [1, 2, 3].collect(0, :+)
+        RUBY
+      end
+
+      context 'with safe navigation' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            [1, 2, 3]&.collect(0, :+)
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Handles safe navigation with non-preferred collection methods:

```
[1, 2, 3].detect { |e| e + 1 }
          ^^^^^^ Prefer `find` over `detect`.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
