### PR TITLE
Add support for safe navigation to `Style/BlockDelimiters`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_block_delimiters.md
+++ b/changelog/change_add_support_for_safe_navigation_to_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#13674](https://github.com/rubocop/rubocop/pull/13674): Add support for safe navigation to `Style/BlockDelimiters`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -195,6 +195,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
 
         def on_block(node)
           return if ignored_node?(node)
@@ -348,7 +349,7 @@ module RuboCop
           case node.type
           when :block, :numblock
             yield node
-          when :send
+          when :send, :csend
             # When a method has an argument which is another method with a block,
             # that block needs braces, otherwise a syntax error will be introduced
             # for subsequent arguments.
@@ -369,9 +370,8 @@ module RuboCop
         end
         # rubocop:enable Metrics/CyclomaticComplexity
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def proper_block_style?(node)
-          return true if require_braces?(node) || require_do_end?(node)
+          return true if require_do_end?(node)
           return special_method_proper_block_style?(node) if special_method?(node.method_name)
 
           case style
@@ -379,15 +379,6 @@ module RuboCop
           when :semantic            then semantic_block_style?(node)
           when :braces_for_chaining then braces_for_chaining_style?(node)
           when :always_braces       then braces_style?(node)
-          end
-        end
-        # rubocop:enable Metrics/CyclomaticComplexity
-
-        def require_braces?(node)
-          return false unless node.braces?
-
-          node.each_ancestor(:send).any? do |send|
-            send.arithmetic_operation? && node.source_range.end_pos < send.loc.selector.begin_pos
           end
         end
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -625,6 +625,22 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'accepts braces with safe navigation if do-end would change the meaning' do
+        expect_no_offenses(<<~RUBY)
+          foo&.bar baz {
+            y
+          }
+        RUBY
+      end
+
+      it 'accepts braces with chained safe navigation if do-end would change the meaning' do
+        expect_no_offenses(<<~RUBY)
+          foo.bar baz {
+            y
+          }&.quux
+        RUBY
+      end
+
       it 'accepts a multi-line functional block with {} if it is an ignored method' do
         expect_no_offenses(<<~RUBY)
           foo = proc {
@@ -724,6 +740,13 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       it 'does not register an offense for a multi-line block with `{` and `}` with method chain' do
         expect_no_offenses(<<~RUBY)
           foo bar + baz {
+          }.qux.quux
+        RUBY
+      end
+
+      it 'does not register an offense for a multi-line block with `{` and `}` with method chain and safe navigation' do
+        expect_no_offenses(<<~RUBY)
+          foo x&.bar + baz {
           }.qux.quux
         RUBY
       end


### PR DESCRIPTION
Although a lot of save navigation code was already handled by `Style/BlockDelimiters`, this updates the cop to ignore certain safe navigation method calls that require braces to avoid changing semantics.

For example, changing the braces to do-end in this case:

```ruby
foo&.bar baz {
  y
}
```

This follows #13499.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
