### PR TITLE
Fix invalid autocorrect for `Style/ArrayFirstLast` when calling `.[]` or `&.[]` with 0 or -1

### DIFF
--- a/changelog/fix_fix_invalid_autocorrect_for_style_array_first_last.md
+++ b/changelog/fix_fix_invalid_autocorrect_for_style_array_first_last.md
@@ -1,0 +1,1 @@
+* [#13675](https://github.com/rubocop/rubocop/pull/13675): Fix invalid autocorrect for `Style/ArrayFirstLast` when calling `.[]` or `&.[]` with 0 or -1. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/array_first_last_spec.rb
+++ b/spec/rubocop/cop/style/array_first_last_spec.rb
@@ -58,4 +58,92 @@ RSpec.describe RuboCop::Cop::Style::ArrayFirstLast, :config do
       arr[0][-1]
     RUBY
   end
+
+  it 'registers an offense when using `arr.[](0)`' do
+    expect_offense(<<~RUBY)
+      arr.[](0)
+          ^^^^^ Use `first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.first
+    RUBY
+  end
+
+  it 'registers an offense when using `arr&.[](0)`' do
+    expect_offense(<<~RUBY)
+      arr&.[](0)
+           ^^^^^ Use `first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr&.first
+    RUBY
+  end
+
+  it 'registers an offense when using `arr.[] 0`' do
+    expect_offense(<<~RUBY)
+      arr.[] 0
+          ^^^^ Use `first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.first
+    RUBY
+  end
+
+  it 'registers an offense when using `arr&.[] 0`' do
+    expect_offense(<<~RUBY)
+      arr&.[] 0
+           ^^^^ Use `first`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr&.first
+    RUBY
+  end
+
+  it 'registers an offense when using `arr.[](-1)`' do
+    expect_offense(<<~RUBY)
+      arr.[](-1)
+          ^^^^^^ Use `last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.last
+    RUBY
+  end
+
+  it 'registers an offense when using `arr&.[](-1)`' do
+    expect_offense(<<~RUBY)
+      arr&.[](-1)
+           ^^^^^^ Use `last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr&.last
+    RUBY
+  end
+
+  it 'registers an offense when using `arr.[] -1`' do
+    expect_offense(<<~RUBY)
+      arr.[] -1
+          ^^^^^ Use `last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.last
+    RUBY
+  end
+
+  it 'registers an offense when using `arr&.[] -1`' do
+    expect_offense(<<~RUBY)
+      arr&.[] -1
+           ^^^^^ Use `last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr&.last
+    RUBY
+  end
 end


### PR DESCRIPTION
`Style/ArrayFirstLast` previously mistakenly autocorrected code such as `ary.[](0)` to `ary..first(0)`.

This updates the autocorrection to handle `.[](0)` and `&.[](0)` correctly with `first`, and `.[](-1)` and `&.[](-1)` correctly with `last`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
