### PR TITLE
[DOC] Fix `Layout/ArgumentAlignment`

### DIFF
--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Check that the arguments on a multi-line method definition are aligned.
+      # Check that the arguments on a multi-line method call are aligned.
       #
       # @example EnforcedStyle: with_first_argument (default)
       #   # good


### PR DESCRIPTION
`Layout/ArgumentAlignment` checks method calls, not definitions.