### PR TITLE
[Fix #13685] Fix syntax error introduced by `Lint/SafeNavigationChain` when adding safe navigation to an operator call inside a hash

### DIFF
--- a/changelog/fix_fix_syntax_error_introduced_by.md
+++ b/changelog/fix_fix_syntax_error_introduced_by.md
@@ -1,0 +1,1 @@
+* [#13685](https://github.com/rubocop/rubocop/issues/13685): Fix syntax error introduced by `Lint/SafeNavigationChain` when adding safe navigation to an operator call inside a hash. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -97,11 +97,18 @@ module RuboCop
         end
 
         def require_parentheses?(send_node)
+          return true if operator_inside_hash?(send_node)
           return false unless send_node.comparison_method?
           return false unless (node = send_node.parent)
 
           (node.respond_to?(:logical_operator?) && node.logical_operator?) ||
             (node.respond_to?(:comparison_method?) && node.comparison_method?)
+        end
+
+        def operator_inside_hash?(send_node)
+          # If an operator call (without a dot) is inside a hash, it needs
+          # to be parenthesized when converted to safe navigation.
+          send_node.parent&.pair_type? && !send_node.loc.dot
         end
       end
     end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -398,6 +398,17 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for safe navigation on the left-hand side of a `-` operator when inside a hash' do
+      expect_offense(<<~RUBY)
+        { foo: a&.baz - 1 }
+                     ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        { foo: (a&.baz&. - 1) }
+      RUBY
+    end
+
     context 'proper highlighting' do
       it 'when there are methods before' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
When an operator called without a dot is inside a hash, parentheses are needed in order to ensure valid syntax.

```
$ ruby -cwe '{ foo: a&.baz&.+ 1 }'
-e:1: warning: possibly useless use of a literal in void context
ruby: -e:1: syntax errors found (SyntaxError)
> 1 | { foo: a&.baz&.+ 1 }
    |                 ^ expected a `}` to close the hash literal
    |                  ^ unexpected integer, expecting end-of-input
    |                    ^ unexpected '}', ignoring it
    |                    ^ unexpected '}', expecting end-of-input
```

```
$ ruby -cwe '{ foo: (a&.baz&.+ 1) }'
Syntax OK
```

Fixes #13685.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
