### PR TITLE
[Fix #13688] Fix false negative on `Style/RedundantLineContinuation` when the continuation is preceded by an interpolated string

### DIFF
--- a/changelog/fix_fix_false_negative_on.md
+++ b/changelog/fix_fix_false_negative_on.md
@@ -1,0 +1,1 @@
+* [#13688](https://github.com/rubocop/rubocop/issues/13688): Fix false negative on `Style/RedundantLineContinuation` when the continuation is preceded by an interpolated string. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -96,15 +96,20 @@ module RuboCop
         private
 
         def require_line_continuation?(range)
-          !ends_with_backslash_without_comment?(range.source_line) ||
+          !ends_with_uncommented_backslash?(range) ||
             string_concatenation?(range.source_line) ||
             start_with_arithmetic_operator?(processed_source[range.line]) ||
             inside_string_literal_or_method_with_argument?(range) ||
             leading_dot_method_chain_with_blank_line?(range)
         end
 
-        def ends_with_backslash_without_comment?(source_line)
-          source_line.gsub(/#.+/, '').end_with?('\\')
+        def ends_with_uncommented_backslash?(range)
+          # A line continuation always needs to be the last character on the line, which
+          # means that it is impossible to have a comment following a continuation.
+          # Therefore, if the line contains a comment, it cannot end with a continuation.
+          return false if processed_source.line_with_comment?(range.line)
+
+          range.source_line.end_with?(LINE_CONTINUATION)
         end
 
         def string_concatenation?(source_line)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -356,8 +356,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
 
   it 'does not register an offense when line continuations inside comment' do
     expect_no_offenses(<<~'RUBY')
-      # foo \
-      #  .bar
+      class Foo
+        # foo \
+        #   bar
+      end
     RUBY
   end
 
@@ -387,6 +389,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
         'baz')
       foo(bar('string1' \
           'string2')).baz
+    RUBY
+  end
+
+  it 'registers an offense for an interpolated string argument followed by line continuation' do
+    expect_offense(<<~'RUBY')
+      foo("#{bar}", \
+                    ^ Redundant line continuation.
+        baz)
     RUBY
   end
 


### PR DESCRIPTION
Previously, `ends_with_backslash_without_comment?` considered any `#` character in the line to be the start of a comment, however an interpolated string also starts with an `#.` The method is now updated to exclude interpolation, and renamed to `ends_with_uncommented_backslash?`.

Fixes #13688.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
