### PR TITLE
Add missing test for string concatenation using continuations in `spec/rubocop/cop/style/redundant_line_continuation_spec.rb`

### DIFF
--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -361,7 +361,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
-  it 'does not register an offense for string concatenation' do
+  it 'does not register an offense for string concatenation with single quotes' do
+    expect_no_offenses(<<~'RUBY')
+      'bar' \
+        'baz'
+    RUBY
+  end
+
+  it 'does not register an offense for string concatenation with double quotes' do
+    expect_no_offenses(<<~'RUBY')
+      "bar" \
+        "baz"
+    RUBY
+  end
+
+  it 'does not register an offense for string concatenation inside a method call' do
     expect_no_offenses(<<~'RUBY')
       foo('bar' \
         'baz')


### PR DESCRIPTION
There was no test covering `string_concatenation?`, but the code is critical, `rubocop` detects 291 offenses without it. I added tests to cover.

Thanks to @Earlopain for pointing it out.
