### PR TITLE
Fix false positive in `Style/RedundantLineContinuation` when the ruby  code ends with a commented continuation

### DIFF
--- a/changelog/fix_fix_false_positive_in_redundant_line_continuation_eof.md
+++ b/changelog/fix_fix_false_positive_in_redundant_line_continuation_eof.md
@@ -1,0 +1,1 @@
+* [#13692](https://github.com/rubocop/rubocop/pull/13692): Fix false positive in `Style/RedundantLineContinuation` when the ruby code ends with a commented continuation. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -140,7 +140,7 @@ module RuboCop
 
         def inspect_end_of_ruby_code_line_continuation
           last_line = processed_source.lines[processed_source.ast.last_line - 1]
-          return unless last_line.end_with?(LINE_CONTINUATION)
+          return unless code_ends_with_continuation?(last_line)
 
           last_column = last_line.length
           line_continuation_range = range_between(last_column - 1, last_column)
@@ -148,6 +148,12 @@ module RuboCop
           add_offense(line_continuation_range) do |corrector|
             corrector.remove_trailing(line_continuation_range, 1)
           end
+        end
+
+        def code_ends_with_continuation?(last_line)
+          return false if processed_source.line_with_comment?(processed_source.ast.last_line)
+
+          last_line.end_with?(LINE_CONTINUATION)
         end
 
         def inside_string_literal?(range, token)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -361,6 +361,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense for a backslash in a comment at EOF' do
+    expect_no_offenses(<<~'RUBY')
+      foo # \
+    RUBY
+  end
+
   it 'does not register an offense for string concatenation with single quotes' do
     expect_no_offenses(<<~'RUBY')
       'bar' \


### PR DESCRIPTION
If a commented out continuation is at the end of ruby code, a false positive for `Style/RedundantLineContinuation` is registered.

```ruby
foo # /
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
