### PR TITLE
Fix `Style/ConditionalAssignment` cop error on `unless` without `else` and `assign_inside_condition` enforced style

### DIFF
--- a/changelog/fix_style_conditional_assignment_cop_error_on_unless_without_else_and_assign_inside_condition_enforced_style.md
+++ b/changelog/fix_style_conditional_assignment_cop_error_on_unless_without_else_and_assign_inside_condition_enforced_style.md
@@ -1,0 +1,1 @@
+* [#13693](https://github.com/rubocop/rubocop/pull/13693): Fix `Style/ConditionalAssignment` cop error on `unless` without `else` and `assign_inside_condition` enforced style. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -309,7 +309,7 @@ module RuboCop
         end
 
         def allowed_single_line?(branches)
-          single_line_conditions_only? && branches.any?(&:begin_type?)
+          single_line_conditions_only? && branches.compact.any?(&:begin_type?)
         end
 
         def assignment_node(node)
@@ -445,6 +445,8 @@ module RuboCop
           end
 
           [condition.loc.else, condition.loc.end].each do |loc|
+            next unless loc
+
             corrector.remove_preceding(loc, loc.column - column)
           end
         end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -633,6 +633,21 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    it 'corrects assignment to an unless condition' do
+      expect_offense(<<~RUBY)
+        value = unless condition
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+                      1
+                    end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless condition
+          value = 1
+        end
+      RUBY
+    end
+
     it 'corrects assignment to an unless else condition' do
       expect_offense(<<~RUBY)
         bar = unless foo


### PR DESCRIPTION
If `Style/ConditionalAssignment` cop is configured with `assign_inside_condition` enforced style and `unless` node does not have `else` branch and error occurs.

```console
NoMethodError:
       undefined method `begin_type?' for nil
     Shared Example Group: "single line condition autocorrect" called from ./spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb:920
     # ./lib/rubocop/cop/style/conditional_assignment.rb:312:in `any?'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:312:in `allowed_single_line?'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:293:in `check_assignment_to_condition'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:236:in `block (2 levels) in <class:ConditionalAssignment>'
```

There are actually two bugs, depending on `SingleLineConditionsOnly` confiuration option. Both are fixed.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
