### PR TITLE
[Fix #13257] Don't consider cops to be opted in for department enables

### DIFF
--- a/changelog/fix_disable_department_ignores_excludes.md
+++ b/changelog/fix_disable_department_ignores_excludes.md
@@ -1,0 +1,1 @@
+* [#13257](https://github.com/rubocop/rubocop/issues/13257): Fix department disable/enable comments enabling the cop for the whole file even if that file is excluded by the cop. ([@earlopain][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -87,7 +87,7 @@ module RuboCop
           next unless directive.enabled?
           next if directive.all_cops?
 
-          cops.merge(directive.cop_names)
+          cops.merge(directive.raw_cop_names)
         end
         cops
       end

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -88,10 +88,15 @@ module RuboCop
       @cop_names ||= all_cops? ? all_cop_names : parsed_cop_names
     end
 
+    # Returns an array of cops for this directive comment, without resolving departments
+    def raw_cop_names
+      @raw_cop_names ||= (cops || '').split(/,\s*/)
+    end
+
     # Returns array of specified in this directive department names
     # when all department disabled
     def department_names
-      splitted_cops_string.select { |cop| department?(cop) }
+      raw_cop_names.select { |cop| department?(cop) }
     end
 
     # Checks if directive departments include cop
@@ -101,11 +106,11 @@ module RuboCop
 
     # Checks if cop department has already used in directive comment
     def overridden_by_department?(cop)
-      in_directive_department?(cop) && splitted_cops_string.include?(cop)
+      in_directive_department?(cop) && raw_cop_names.include?(cop)
     end
 
     def directive_count
-      splitted_cops_string.count
+      raw_cop_names.count
     end
 
     # Returns line number for directive
@@ -115,12 +120,8 @@ module RuboCop
 
     private
 
-    def splitted_cops_string
-      (cops || '').split(/,\s*/)
-    end
-
     def parsed_cop_names
-      cops = splitted_cops_string.map do |name|
+      cops = raw_cop_names.map do |name|
         department?(name) ? cop_names_for_department(name) : name
       end.flatten
       cops - [LINT_SYNTAX_COP]

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -430,4 +430,14 @@ RSpec.describe RuboCop::DirectiveComment do
       it { is_expected.to be(false) }
     end
   end
+
+  describe '#raw_cop_names' do
+    subject { directive_comment.raw_cop_names }
+
+    context 'when there are departments' do
+      let(:text) { '# rubocop:enable Style, Lint/Void' }
+
+      it { is_expected.to eq(%w[Style Lint/Void]) }
+    end
+  end
 end


### PR DESCRIPTION
Fix #13257

When a whole department is enabled, then that cop would also run for code outside of that block, even if it is explicitly excluded via cop config.
This comes from https://github.com/rubocop/rubocop/pull/11603 were cops didn't run when explicitly enabled via `Department/Cop` but that logic should only apply when the cop is fully qualified.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
