### PR TITLE
[Fix #13683] Prevent `ruby-lsp` from failing unrelated tests

### DIFF
--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -5,6 +5,9 @@ return if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby' || RuboCop::Platform.wi
 
 require 'ruby_lsp/internal'
 require 'ruby_lsp/rubocop/addon'
+# NOTE: ruby-lsp enables LSP mode. Ideally the two requires should happen in isolation, but
+# for now this prevents it from failing unrelated tests.
+RuboCop::LSP.disable
 
 describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
   let(:addon) do


### PR DESCRIPTION
Fix #13683

`ruby-lsp` enables LSP mode (makes sense). Ideally the two requires should happen in isolation, but for now this prevents it from failing unrelated tests.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
