### PR TITLE
Update `Metrics/CollectionLiteralLength` to only register for `[]` when called on `Set`

### DIFF
--- a/changelog/fix_update_metrics_collection_literal_length_to_only.md
+++ b/changelog/fix_update_metrics_collection_literal_length_to_only.md
@@ -1,0 +1,1 @@
+* [#13696](https://github.com/rubocop/rubocop/pull/13696): Update `Metrics/CollectionLiteralLength` to only register for `[]` when called on `Set`. ([@dvandersluis][])

--- a/lib/rubocop/cop/metrics/collection_literal_length.rb
+++ b/lib/rubocop/cop/metrics/collection_literal_length.rb
@@ -52,12 +52,19 @@ module RuboCop
               'Prefer reading the data from an external source.'
         RESTRICT_ON_SEND = [:[]].freeze
 
+        # @!method set_const?(node)
+        def_node_matcher :set_const?, <<~PATTERN
+          (const {cbase nil?} :Set)
+        PATTERN
+
         def on_array(node)
           add_offense(node) if node.children.length >= collection_threshold
         end
         alias on_hash on_array
 
         def on_index(node)
+          return unless set_const?(node.receiver)
+
           add_offense(node) if node.arguments.length >= collection_threshold
         end
 

--- a/spec/rubocop/cop/metrics/collection_literal_length_spec.rb
+++ b/spec/rubocop/cop/metrics/collection_literal_length_spec.rb
@@ -103,4 +103,12 @@ RSpec.describe RuboCop::Cop::Metrics::CollectionLiteralLength, :config do
       ]
     RUBY
   end
+
+  it 'does not register an offense when `[]` is called on something other than `Set`' do
+    expect_no_offenses(<<~RUBY)
+      foo[
+        #{large_array.join(",\n  ")}
+      ]
+    RUBY
+  end
 end


### PR DESCRIPTION
As per #11584, `Metrics/CollectionLiteralLength` was only intended to apply to collection literals (`[]`, `{}` and `Set[]`), but the cop was too restrictive, so `foo[...]` would register an offense with more than `LengthThreshold` elements.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
