### PR TITLE
Append timestamp to generated changelog files to avoid clobbering

### DIFF
--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Changelog do
       it 'generates correct file name' do
         body = 'Add new `Lint/UselessRescue` cop'
         entry = described_class.new(type: :new, body: body, user: github_user)
-        expect(entry.path).to eq('changelog/new_add_new_lint_useless_rescue_cop.md')
+        expect(entry.path).to match(%r{\Achangelog/new_add_new_lint_useless_rescue_cop_\d+.md\z})
       end
     end
   end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -4,7 +4,7 @@
 class Changelog
   ENTRIES_PATH = 'changelog/'
   FIRST_HEADER = /#{Regexp.escape("## master (unreleased)\n")}/m.freeze
-  ENTRIES_PATH_TEMPLATE = "#{ENTRIES_PATH}%<type>s_%<name>s.md"
+  ENTRIES_PATH_TEMPLATE = "#{ENTRIES_PATH}%<type>s_%<name>s_%<timestamp>s.md"
   TYPE_REGEXP = /#{Regexp.escape(ENTRIES_PATH)}([a-z]+)_/.freeze
   TYPE_TO_HEADER = { new: 'New features', fix: 'Bug fixes', change: 'Changes' }.freeze
   HEADER = /### (.*)/.freeze
@@ -30,7 +30,10 @@ class Changelog
     end
 
     def path
-      format(ENTRIES_PATH_TEMPLATE, type: type, name: str_to_filename(body))
+      format(
+        ENTRIES_PATH_TEMPLATE,
+        type: type, name: str_to_filename(body), timestamp: Time.now.strftime('%Y%m%d%H%M%S')
+      )
     end
 
     def content


### PR DESCRIPTION
When the first 50 characters of a commit message are the same in multiple commits, `rake changelog:*` will generate the same filename for each of the commits, resulting in file clobbering and missed changelog entries.

By appending the current timestamp to the end of the filename, we should avoid this issue.

NB: A byproduct of this is that running `rake changelog:*` again on the same commit will generate an additional changelog entry.