### PR TITLE
[Fix #13684] Fix a false positive for `Style/FrozenStringLiteralComment`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_frozen_string_literal_comment.md
+++ b/changelog/fix_a_false_positive_for_style_frozen_string_literal_comment.md
@@ -1,0 +1,1 @@
+* [#13684](https://github.com/rubocop/rubocop/issues/13684): Fix a false positive for `Style/FrozenStringLiteralComment` when using the frozen string literal magic comment in Active Admin's arb files. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4063,6 +4063,9 @@ Style/FrozenStringLiteralComment:
     # exist in a file.
     - never
   SafeAutoCorrect: false
+  Exclude:
+    # Prevent the Ruby warning: `'frozen_string_literal' is ignored after any tokens` when using Active Admin.
+    - '**/*.arb'
 
 Style/GlobalStdStream:
   Description: 'Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.'

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
                 Exclude:
+                  - '**/*.arb'
                   - 'example.rb'
             YAML
           expect(File.read('.rubocop.yml')).to eq(<<~YAML)
@@ -213,6 +214,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
                 Exclude:
+                  - '**/*.arb'
                   - 'example.rb'
 
               # Offense count: 1
@@ -262,6 +264,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               # SupportedStyles: always, always_true, never
               Style/FrozenStringLiteralComment:
                 Exclude:
+                  - '**/*.arb'
                   - 'example.rb'
 
               # Offense count: 1
@@ -391,6 +394,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '# SupportedStyles: always, always_true, never',
                 'Style/FrozenStringLiteralComment:',
                 '  Exclude:',
+                "    - '**/*.arb'",
                 "    - 'example1.rb'",
                 '',
                 '# Offense count: 1',
@@ -520,6 +524,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'example1.rb'
 
           # Offense count: 1
@@ -592,6 +597,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'example1.rb'
         YAML
         expect(File.read('cop_config.yml')).to eq(<<~YAML)
@@ -628,6 +634,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'example1.rb'
         YAML
         expect(File.read('.rubocop.yml')).to eq(<<~YAML)
@@ -698,6 +705,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'example1.rb'
         YAML
         expect(File.read('.rubocop.yml')).to eq(<<~YAML)
@@ -736,6 +744,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           # SupportedStyles: always, always_true, never
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'example1.rb'
 
           # Offense count: 1
@@ -1501,6 +1510,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
             # SupportedStyles: always, always_true, never
             Style/FrozenStringLiteralComment:
               Exclude:
+                - '**/*.arb'
                 - 'example1.rb'
                 - 'example2.rb'
                 - 'example3.rb'
@@ -1689,6 +1699,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               - 'file.rb'
           Style/FrozenStringLiteralComment:
             Exclude:
+              - '**/*.arb'
               - 'file.rb'
         YAML
         expect(cli.run([])).to eq(0)


### PR DESCRIPTION
This PR fixes a false positive for `Style/FrozenStringLiteralComment` when using the frozen string literal magic comment in Active Admin's arb files.

Fixes #13684.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
