### PR TITLE
Add support for safe navigation to `Lint/RedundantStringCoercion`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_redundant_string_coercion.md
+++ b/changelog/change_add_support_for_safe_navigation_to_redundant_string_coercion.md
@@ -1,0 +1,1 @@
+* [#13700](https://github.com/rubocop/rubocop/pull/13700): Add support for safe navigation to `Lint/RedundantStringCoercion`. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/redundant_string_coercion.rb
+++ b/lib/rubocop/cop/lint/redundant_string_coercion.rb
@@ -29,7 +29,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[print puts warn].freeze
 
         # @!method to_s_without_args?(node)
-        def_node_matcher :to_s_without_args?, '(send _ :to_s)'
+        def_node_matcher :to_s_without_args?, '(call _ :to_s)'
 
         def on_interpolation(begin_node)
           final_node = begin_node.children.last
@@ -42,7 +42,7 @@ module RuboCop
         def on_send(node)
           return if node.receiver
 
-          node.each_child_node(:send) do |child|
+          node.each_child_node(:send, :csend) do |child|
             next if !child.method?(:to_s) || child.arguments.any?
 
             register_offense(child, "`#{node.method_name}`")

--- a/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
@@ -21,6 +21,26 @@ RSpec.describe RuboCop::Cop::Lint::RedundantStringCoercion, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects `to_s` in interpolation with safe navigation' do
+    expect_offense(<<~'RUBY')
+      "this is the #{result&.to_s}"
+                             ^^^^ Redundant use of `Object#to_s` in interpolation.
+      /regexp #{result&.to_s}/
+                        ^^^^ Redundant use of `Object#to_s` in interpolation.
+      :"symbol #{result&.to_s}"
+                         ^^^^ Redundant use of `Object#to_s` in interpolation.
+      `backticks #{result&.to_s}`
+                           ^^^^ Redundant use of `Object#to_s` in interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "this is the #{result}"
+      /regexp #{result}/
+      :"symbol #{result}"
+      `backticks #{result}`
+    RUBY
+  end
+
   it 'registers an offense and corrects `to_s` in an interpolation with several expressions' do
     expect_offense(<<~'RUBY')
       "this is the #{top; result.to_s}"
@@ -84,6 +104,18 @@ RSpec.describe RuboCop::Cop::Lint::RedundantStringCoercion, :config do
       puts first.to_s, second.to_s
                  ^^^^ Redundant use of `Object#to_s` in `puts`.
                               ^^^^ Redundant use of `Object#to_s` in `puts`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      puts first, second
+    RUBY
+  end
+
+  it 'registers an offense and corrects `to_s` with safe naviagation in `puts` arguments' do
+    expect_offense(<<~RUBY)
+      puts first&.to_s, second&.to_s
+                  ^^^^ Redundant use of `Object#to_s` in `puts`.
+                                ^^^^ Redundant use of `Object#to_s` in `puts`.
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
Registers a `Lint/RedundantStringCoercion` for code such as:

```ruby
"this is the #{result&.to_s}"
puts result&.to_s
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
