### PR TITLE
Add support for safe navigation to `Lint/NumericOperationWithConstantResult`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_numeric_operation_with_constant_result.md
+++ b/changelog/change_add_support_for_safe_navigation_to_numeric_operation_with_constant_result.md
@@ -1,0 +1,1 @@
+* [#13701](https://github.com/rubocop/rubocop/pull/13701): Add support for safe navigation to `Lint/NumericOperationWithConstantResult`. ([@dvandersluis][])

--- a/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
+++ b/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     RUBY
   end
 
-  it 'egisters an offense when a variable is raised to the power of 0 via abbreviated assignment' do
+  it 'registers an offense when a variable is raised to the power of 0 via abbreviated assignment' do
     expect_offense(<<~RUBY)
       x **= 0
       ^^^^^^^ Numeric operation with a constant result detected.
@@ -78,5 +78,49 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     it "registers no offense for `#{expression}`" do
       expect_no_offenses(expression)
     end
+  end
+
+  it 'registers an offense when a variable is multiplied by 0 using dot notation' do
+    expect_offense(<<~RUBY)
+      x.*(0)
+      ^^^^^^ Numeric operation with a constant result detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0
+    RUBY
+  end
+
+  it 'registers an offense when a variable is divided by using dot notation' do
+    expect_offense(<<~RUBY)
+      x./(x)
+      ^^^^^^ Numeric operation with a constant result detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1
+    RUBY
+  end
+
+  it 'registers an offense when a variable is multiplied by 0 using safe navigation' do
+    expect_offense(<<~RUBY)
+      x&.*(0)
+      ^^^^^^^ Numeric operation with a constant result detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0
+    RUBY
+  end
+
+  it 'registers an offense when a variable is divided by using safe navigation' do
+    expect_offense(<<~RUBY)
+      x&./(x)
+      ^^^^^^^ Numeric operation with a constant result detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      1
+    RUBY
   end
 end


### PR DESCRIPTION
Registers a `Lint/NumericOperationWithConstantResult` offense for code such as:

```ruby
x&.*(0)
x&./(x)
```

Also did a small refactor to avoid calling node pattern matchers more than once unnecessarily.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
