### PR TITLE
[DOC] Fix config file locations

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -50,7 +50,6 @@ files:
 * `/path/to/project/.rubocop.yml`
 * `/path/to/project/.config/.rubocop.yml`
 * `/path/to/project/.config/rubocop/config.yml`
-* `/.rubocop.yml`
 * `~/.rubocop.yml`
 * `~/.config/rubocop/config.yml`
 * https://github.com/rubocop/rubocop/blob/master/config/default.yml[RuboCop's default configuration]


### PR DESCRIPTION
RuboCop does not search in the root directory.