### PR TITLE
[Fix #13704] Fix false positives for `Lint/OutOfRangeRegexpRef`

### DIFF
--- a/changelog/fix_false_positives_for_lint_out_of_range_regexp_ref.md
+++ b/changelog/fix_false_positives_for_lint_out_of_range_regexp_ref.md
@@ -1,0 +1,1 @@
+* [#13704](https://github.com/rubocop/rubocop/issues/13704): Fix false positives for `Lint/OutOfRangeRegexpRef` when matching with `match` using safe navigation. ([@koic][])

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -61,6 +61,7 @@ module RuboCop
             check_regexp(node.receiver)
           end
         end
+        alias after_csend after_send
 
         def on_when(node)
           regexp_conditions = node.conditions.select(&:regexp_type?)

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -522,5 +522,29 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef, :config do
         RUBY
       end
     end
+
+    context "matching with #{method} using safe navigation" do
+      it 'does not register an offense when in range references are used' do
+        expect_no_offenses(<<~RUBY)
+          "foobar"&.#{method}(/(foo)(bar)/)
+          puts $2
+        RUBY
+      end
+
+      it 'registers an offense when out of range references are used' do
+        expect_offense(<<~RUBY)
+          "foobar"&.#{method}(/(foo)(bar)/)
+          puts $3
+               ^^ $3 is out of range (2 regexp capture groups detected).
+        RUBY
+      end
+
+      it 'only registers an offense when the regexp is matched as a literal' do
+        expect_no_offenses(<<~RUBY)
+          "foobar"&.#{method}(some_regexp)
+          puts $3
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #13704.

This PR fixes false positives for `Lint/OutOfRangeRegexpRef` when matching with `match` using safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
