### PR TITLE
Omit an empty configurable attributes section in documentation

### DIFF
--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -181,13 +181,13 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   end
 
   def configurations(department, pars, cop)
-    return '' if pars.empty?
-
     header = ['Name', 'Default value', 'Configurable values']
     configs = pars
               .each_key
               .reject { |key| key.start_with?('Supported') }
               .reject { |key| key.start_with?('AllowMultipleStyles') }
+    return '' if configs.empty?
+
     content = configs.map do |name|
       configurable = configurable_values(pars, name)
       default = format_table_value(pars[name])


### PR DESCRIPTION
In the [documentation](https://docs.rubocop.org/rubocop/cops_style.html#styleyodaexpression) of `Style/YodaExpression`, an empty table appears in the Configurable attributes section.
This PR removes it.

<img width="831" alt="screenshot 2025-01-16 16 25 11" src="https://github.com/user-attachments/assets/76597d75-c290-45c4-b540-4304bdd1d8cf" />


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
