### PR TITLE
Add support for safe navigation to `Lint/FloatComparison`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_20250116114656.md
+++ b/changelog/change_add_support_for_safe_navigation_to_20250116114656.md
@@ -1,0 +1,1 @@
+* [#13709](https://github.com/rubocop/rubocop/pull/13709): Add support for safe navigation to `Lint/FloatComparison`. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -36,7 +36,8 @@ module RuboCop
       #   # https://www.embeddeduse.com/2019/08/26/qt-compare-two-floats/
       #
       class FloatComparison < Base
-        MSG = 'Avoid (in)equality comparisons of floats as they are unreliable.'
+        MSG_EQUALITY = 'Avoid equality comparisons of floats as they are unreliable.'
+        MSG_INEQUALITY = 'Avoid inequality comparisons of floats as they are unreliable.'
 
         EQUALITY_METHODS = %i[== != eql? equal?].freeze
         FLOAT_RETURNING_METHODS = %i[to_f Float fdiv].freeze
@@ -52,8 +53,10 @@ module RuboCop
 
           return if literal_safe?(lhs) || literal_safe?(rhs)
 
-          add_offense(node) if float?(lhs) || float?(rhs)
+          message = node.method?(:!=) ? MSG_INEQUALITY : MSG_EQUALITY
+          add_offense(node, message: message) if float?(lhs) || float?(rhs)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -4,46 +4,46 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
   it 'registers an offense when comparing with float' do
     expect_offense(<<~RUBY)
       x == 0.1
-      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       0.1 == x
-      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       x != 0.1
-      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^ Avoid inequality comparisons of floats as they are unreliable.
       0.1 != x
-      ^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^ Avoid inequality comparisons of floats as they are unreliable.
       x.eql?(0.1)
-      ^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       0.1.eql?(x)
-      ^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 
   it 'registers an offense when comparing with float returning method' do
     expect_offense(<<~RUBY)
       x == Float(1)
-      ^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       x == '0.1'.to_f
-      ^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       x == 1.fdiv(2)
-      ^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 
   it 'registers an offense when comparing with arithmetic operator on floats' do
     expect_offense(<<~RUBY)
       x == 0.1 + y
-      ^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       x == y + Float('0.1')
-      ^^^^^^^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
       x == y + z * (foo(arg) + '0.1'.to_f)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 
   it 'registers an offense when comparing with method on float receiver' do
     expect_offense(<<~RUBY)
       x == 0.1.abs
-      ^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
      'that can return numeric and returns float' do
     expect_offense(<<~RUBY)
       x == 1.1.ceil(1)
-      ^^^^^^^^^^^^^^^^ Avoid (in)equality comparisons of floats as they are unreliable.
+      ^^^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 
@@ -99,6 +99,20 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
       x.!=(0.1, 0.2)
       x.eql?(0.1, 0.2)
       x.equal?(0.1, 0.2)
+    RUBY
+  end
+
+  it 'registers an offense for `eql?` called with safe navigation' do
+    expect_offense(<<~RUBY)
+      x&.eql?(0.1)
+      ^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
+    RUBY
+  end
+
+  it 'registers an offense for `equal?` called with safe navigation' do
+    expect_offense(<<~RUBY)
+      x&.equal?(0.1)
+      ^^^^^^^^^^^^^^ Avoid equality comparisons of floats as they are unreliable.
     RUBY
   end
 end


### PR DESCRIPTION
Adds support to the cop for code such as:

```ruby
x&.eql?(1.0)
x&.equal?(1.0)
```

Also improves the message to be specific about equality/inequality.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
