### PR TITLE
Set `RESTRICT_ON_SEND` for `Layout/SpaceAroundKeyword`

### DIFF
--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -36,6 +36,7 @@ module RuboCop
         ACCEPT_LEFT_PAREN = %w[break defined? next not rescue return super yield].freeze
         ACCEPT_LEFT_SQUARE_BRACKET = %w[super yield].freeze
         ACCEPT_NAMESPACE_OPERATOR = 'super'
+        RESTRICT_ON_SEND = %i[!].freeze
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?


### PR DESCRIPTION
`on_send` is only used for `not` keywords, so we can restrict to it to `:!` methods, which is how `not` is parsed.
