### PR TITLE
Add support for safe navigation to `Layout/MultilineMethodCallBraceLayout`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_20250116122319.md
+++ b/changelog/change_add_support_for_safe_navigation_to_20250116122319.md
@@ -1,0 +1,1 @@
+* [#13711](https://github.com/rubocop/rubocop/pull/13711): Add support for safe navigation to `Layout/MultilineMethodCallBraceLayout`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
@@ -109,6 +109,7 @@ module RuboCop
         def on_send(node)
           check_brace_layout(node)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
-  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
+  let(:enforced_style) { 'symmetrical' }
+  let(:cop_config) { { 'EnforcedStyle' => enforced_style } }
 
   it 'ignores implicit calls' do
     expect_no_offenses(<<~RUBY)
@@ -80,7 +81,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
   end
 
   context 'when EnforcedStyle is new_line' do
-    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
+    let(:enforced_style) { 'new_line' }
 
     it 'still ignores single-line calls' do
       expect_no_offenses('puts("Hello world!")')
@@ -115,6 +116,66 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
         super(bar(baz,
           ham)) # comment
       RUBY
+    end
+  end
+
+  context 'with safe navigation' do
+    it 'ignores single-line calls' do
+      expect_no_offenses('foo&.bar(1,2)')
+    end
+
+    context 'with EnforcedStyle: symmetrical' do
+      let(:enforced_style) { 'symmetrical' }
+
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo&.bar(
+            baz)
+               ^ Closing method call brace must be on the line after the last argument when opening brace is on a separate line from the first argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.bar(
+            baz
+          )
+        RUBY
+      end
+    end
+
+    context 'with EnforcedStyle: new_line' do
+      let(:enforced_style) { 'new_line' }
+
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo&.bar(
+            baz)
+               ^ Closing method call brace must be on the line after the last argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.bar(
+            baz
+          )
+        RUBY
+      end
+    end
+
+    context 'with EnforcedStyle: same_line' do
+      let(:enforced_style) { 'same_line' }
+
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo&.bar(
+            baz
+          )
+          ^ Closing method call brace must be on the same line as the last argument.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.bar(
+            baz)
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Allows `Layout/MultilineMethodCallBraceLayout` to register offenses on methods called with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
