### PR TITLE
Add support for safe navigation to `Layout/MultilineMethodArgumentLineBreaks`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_20250116124756.md
+++ b/changelog/change_add_support_for_safe_navigation_to_20250116124756.md
@@ -1,0 +1,1 @@
+* [#13712](https://github.com/rubocop/rubocop/pull/13712): Add support for safe navigation to `Layout/MultilineMethodArgumentLineBreaks`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_argument_line_breaks.rb
@@ -99,6 +99,7 @@ module RuboCop
 
           check_line_breaks(node, args, ignore_last: ignore_last_element?)
         end
+        alias on_csend on_send
 
         private
 


### PR DESCRIPTION
Allows `Layout/MultilineMethodArgumentLineBreaks` to register offenses on methods called with safe navigation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
