### PR TITLE
Add support for safe navigation to `Security/CompoundHash`

### DIFF
--- a/changelog/change_add_support_for_safe_navigation_to_20250116130920.md
+++ b/changelog/change_add_support_for_safe_navigation_to_20250116130920.md
@@ -1,0 +1,1 @@
+* [#13714](https://github.com/rubocop/rubocop/pull/13714): Add support for safe navigation to `Security/CompoundHash`. ([@dvandersluis][])

--- a/lib/rubocop/cop/security/compound_hash.rb
+++ b/lib/rubocop/cop/security/compound_hash.rb
@@ -100,6 +100,7 @@ module RuboCop
             add_offense(node, message: REDUNDANT_HASH_MSG)
           end
         end
+        alias on_csend on_send
         alias on_op_asgn on_send
       end
     end

--- a/spec/rubocop/cop/security/compound_hash_spec.rb
+++ b/spec/rubocop/cop/security/compound_hash_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe RuboCop::Cop::Security::CompoundHash, :config do
     RUBY
   end
 
+  it 'registers an offense if .hash is called on any elements of a hashed array with safe navigation' do
+    expect_offense(<<~RUBY)
+      def hash
+        [foo&.hash, bar&.hash].hash
+                    ^^^^^^^^^ Calling .hash on elements of a hashed array is redundant.
+         ^^^^^^^^^ Calling .hash on elements of a hashed array is redundant.
+      end
+    RUBY
+  end
+
   it 'does not register an offense when delegating to Array#hash' do
     expect_no_offenses(<<~RUBY)
       def hash


### PR DESCRIPTION
Registers a `Security/CompoundHash` for code such as:

```ruby
[foo&.hash, bar&.hash].hash
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
