### PR TITLE
Add support for safe navigation to `InternalAffairs/SingleLineComparison`

### DIFF
--- a/spec/rubocop/cop/internal_affairs/single_line_comparison_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/single_line_comparison_spec.rb
@@ -122,4 +122,20 @@ RSpec.describe RuboCop::Cop::InternalAffairs::SingleLineComparison, :config do
       nodes.first.first_line == nodes.last.last_line
     RUBY
   end
+
+  context 'with safe navigation' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        node&.first_line == node&.last_line
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.single_line?`.
+        node&.first_line != node&.last_line
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!node&.single_line?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        node&.single_line?
+        !node&.single_line?
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Registers a `InternalAffairs/SingleLineComparison`for code such as:

```ruby
node&.first_line == node&.last_line
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
