### PR TITLE
Add support for safe navigation to `InternalAffairs/RedundantSourceRange`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
@@ -47,7 +47,7 @@ module RuboCop
         # @!method redundant_source_range(node)
         def_node_matcher :redundant_source_range, <<~PATTERN
           {
-            (send $(send _ :source_range) :source)
+            (call $(call _ :source_range) :source)
             (send nil? :add_offense $(send _ :source_range) ...)
             (send _ {
               :replace :insert_before :insert_before_multi :insert_after :insert_after_multi
@@ -67,6 +67,7 @@ module RuboCop
             corrector.remove(source_range.loc.dot.join(selector))
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
@@ -12,9 +12,26 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantSourceRange, :config do
     RUBY
   end
 
+  it 'registers an offense when using `node.source_range&.source`' do
+    expect_offense(<<~RUBY)
+      node&.source_range&.source
+            ^^^^^^^^^^^^ Remove the redundant `source_range`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node&.source
+    RUBY
+  end
+
   it 'does not register an offense when using `node.source`' do
     expect_no_offenses(<<~RUBY)
       node.source
+    RUBY
+  end
+
+  it 'does not register an offense when using `node&.source`' do
+    expect_no_offenses(<<~RUBY)
+      node&.source
     RUBY
   end
 


### PR DESCRIPTION
I only updated the cop for `node&.source_range&.source`, because the other variations (eg. `add_offense(node.source_range)`, `corrector.replace(node.source_range, ...)`, etc.) don't make sense to use when a potentially nil node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
