### PR TITLE
Add support for safe navigation to `InternalAffairs/NodeFirstOrLastArgument`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/node_first_or_last_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/node_first_or_last_argument.rb
@@ -27,8 +27,8 @@ module RuboCop
         # @!method arguments_first_or_last?(node)
         def_node_matcher :arguments_first_or_last?, <<~PATTERN
           {
-            (send (send !nil? :arguments) ${:first :last})
-            (send (send !nil? :arguments) :[] (int ${0 -1}))
+            (call (call !nil? :arguments) ${:first :last})
+            (call (call !nil? :arguments) :[] (int ${0 -1}))
           }
         PATTERN
 
@@ -47,6 +47,7 @@ module RuboCop
             end
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/internal_affairs/node_first_or_last_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_first_or_last_argument_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::InternalAffairs::NodeFirstOrLastArgument, :config do
-  shared_examples 'registers an offense' do |receiver:, position:, accessor:|
+  shared_examples 'registers an offense' do |receiver:, position:, accessor:, dot: '.'|
     offending_source = "#{receiver}.arguments#{accessor}"
-    correction_source = "#{receiver}.#{position}_argument"
+    correction_source = "#{receiver}#{dot}#{position}_argument"
 
     it "registers an offense when using `#{offending_source}`" do
-      expect_offense(<<~RUBY, receiver: receiver, accessor: accessor)
-        %{receiver}.arguments%{accessor}
-        _{receiver} ^^^^^^^^^^{accessor} Use `##{position}_argument` instead of `#arguments#{accessor}`.
+      expect_offense(<<~RUBY, receiver: receiver, accessor: accessor, dot: dot)
+        %{receiver}%{dot}arguments%{accessor}
+        _{receiver}_{dot}^^^^^^^^^^{accessor} Use `##{position}_argument` instead of `#arguments#{accessor}`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -27,6 +27,17 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodeFirstOrLastArgument, :config d
   include_examples 'registers an offense', receiver: 'node', position: 'first', accessor: '[0]'
   include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '.last'
   include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '[-1]'
+
+  include_examples 'registers an offense', receiver: 'node', position: 'first', accessor: '&.first'
+  include_examples 'registers an offense', receiver: 'node', position: 'first', accessor: '&.[](0)'
+  include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '&.last'
+  include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '&.[](-1)'
+
+  include_examples 'registers an offense', receiver: 'node', position: 'first', accessor: '&.first', dot: '&.'
+  include_examples 'registers an offense', receiver: 'node', position: 'first', accessor: '&.[](0)', dot: '&.'
+  include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '&.last', dot: '&.'
+  include_examples 'registers an offense', receiver: 'node', position: 'last', accessor: '&.[](-1)', dot: '&.'
+
   include_examples 'registers an offense', receiver: 'some_node', position: 'first', accessor: '.first'
   include_examples 'registers an offense', receiver: 'some_node', position: 'first', accessor: '[0]'
   include_examples 'registers an offense', receiver: 'some_node', position: 'last', accessor: '.last'


### PR DESCRIPTION
Registers an `InternalAffairs/NodeFirstOrLastArgument` offense for code such as:

```ruby
node.arguments&.first
node&.arguments&.last
node&.arguments[0]
node&.arguments[-1]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
