### PR TITLE
Add support for safe navigation to `InternalAffairs/LocationExpression`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/location_expression.rb
+++ b/lib/rubocop/cop/internal_affairs/location_expression.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           return unless (parent = node.parent)
-          return unless parent.send_type? && parent.method?(:expression)
+          return unless parent.call_type? && parent.method?(:expression)
           return unless parent.receiver.receiver
 
           offense = node.loc.selector.join(parent.source_range.end)
@@ -31,6 +31,7 @@ module RuboCop
             corrector.replace(offense, 'source_range')
           end
         end
+        alias on_csend on_send
       end
     end
   end

--- a/spec/rubocop/cop/internal_affairs/location_expression_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_expression_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExpression, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `node&.location&.expression`' do
+    expect_offense(<<~RUBY)
+      node&.location&.expression
+            ^^^^^^^^^^^^^^^^^^^^ Use `source_range` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node&.source_range
+    RUBY
+  end
+
   it 'registers and corrects an offense when using `loc.expression`' do
     expect_offense(<<~RUBY)
       node.loc.expression
@@ -20,6 +31,17 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExpression, :config do
 
     expect_correction(<<~RUBY)
       node.source_range
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `node&.loc&.expression`' do
+    expect_offense(<<~RUBY)
+      node&.loc&.expression
+            ^^^^^^^^^^^^^^^ Use `source_range` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node&.source_range
     RUBY
   end
 
@@ -34,9 +56,26 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExpression, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `node&.loc&.expression&.end_pos`' do
+    expect_offense(<<~RUBY)
+      node&.loc&.expression&.end_pos
+            ^^^^^^^^^^^^^^^ Use `source_range` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node&.source_range&.end_pos
+    RUBY
+  end
+
   it 'does not register an offense when using `location.expression` without a receiver' do
     expect_no_offenses(<<~RUBY)
       location.expression
+    RUBY
+  end
+
+  it 'does not register an offense when using `location&.expression` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      location&.expression
     RUBY
   end
 
@@ -46,9 +85,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExpression, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `loc&.expression` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      loc&.expression
+    RUBY
+  end
+
   it 'does not register an offense when assigning `node.location`' do
     expect_no_offenses(<<~RUBY)
       loc = node.location
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `node&.location`' do
+    expect_no_offenses(<<~RUBY)
+      loc = node&.location
     RUBY
   end
 end


### PR DESCRIPTION
Registers an `InternalAffairs/LocationExpression` offense for code such as:

```ruby
node&.location&.expression
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
