### PR TITLE
Naming/PredicateName: Optionally use Sorbet to detect predicate methods

### DIFF
--- a/changelog/new_naming_predicate_name_optionally_use_sorbet_to_20250116223555.md
+++ b/changelog/new_naming_predicate_name_optionally_use_sorbet_to_20250116223555.md
@@ -1,0 +1,1 @@
+* [#13721](https://github.com/rubocop/rubocop/pull/13721): `Naming/PredicateName`: Optionally use Sorbet to detect predicate methods. ([@issyl0][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3035,6 +3035,8 @@ Naming/PredicateName:
   MethodDefinitionMacros:
     - define_method
     - define_singleton_method
+  # Use Sorbet's T::Boolean return type to detect predicate methods.
+  UseSorbetSigs: false
   # Exclude Rspec specs because there is a strong convention to write spec
   # helpers in the form of `have_something` or `be_something`.
   Exclude:

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -128,7 +128,7 @@ module RuboCop
             method_name = node.method_name.to_s
 
             next if allowed_method_name?(method_name, prefix)
-            next if use_sorbet_sigs? && !sorbet_sig?(node, return_type: "T::Boolean")
+            next if use_sorbet_sigs? && !sorbet_sig?(node, return_type: 'T::Boolean')
 
             add_offense(
               node.loc.name,
@@ -150,6 +150,7 @@ module RuboCop
 
         private
 
+        # @!method sorbet_return_type(node)
         def_node_matcher :sorbet_return_type, <<~PATTERN
           (block (send nil? :sig) args (send _ :returns $_type))
         PATTERN

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -151,7 +151,7 @@ module RuboCop
         private
 
         def_node_matcher :sorbet_return_type, <<~PATTERN
-          (block (send nil? :sig) args (send nil? :returns $_type))
+          (block (send nil? :sig) args (send _ :returns $_type))
         PATTERN
 
         def sorbet_sig?(node, return_type: nil)

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -128,7 +128,7 @@ module RuboCop
             method_name = node.method_name.to_s
 
             next if allowed_method_name?(method_name, prefix)
-            next if sorbet? && !boolean_sorbet_sig?(node)
+            next if use_sorbet_sigs? && !boolean_sorbet_sig?(node)
 
             add_offense(
               node.loc.name,
@@ -152,11 +152,10 @@ module RuboCop
 
         def boolean_sorbet_sig?(node)
           # Select if it's a `sig` block with a `returns(T::Boolean)` directly above the method.
-          node.parent.each_descendant(:block).any? do |block_node|
-            block_node.method?(:sig) &&
-              block_node.source.include?('returns(T::Boolean)') &&
-              block_node.loc.end.line == node.loc.line - 1
-          end
+          left_sibling = node.left_sibling
+          return false unless left_sibling&.block_type?
+
+          left_sibling.method?(:sig) && left_sibling.source.include?('returns(T::Boolean)')
         end
 
         def allowed_method_name?(method_name, prefix)
@@ -189,7 +188,7 @@ module RuboCop
           cop_config['NamePrefix']
         end
 
-        def sorbet?
+        def use_sorbet_sigs?
           cop_config['UseSorbetSigs']
         end
 

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -19,7 +19,7 @@ module RuboCop
       #
       # When `UseSorbetSigs` set to true (optional), the cop will only report
       # offenses if the method has a Sorbet `sig` with a return type of
-      # `T::Boolean`.
+      # `T::Boolean`. Dynamic methods are not supported with this configuration.
       #
       # @example NamePrefix: ['is_', 'has_', 'have_'] (default)
       #   # bad
@@ -69,7 +69,7 @@ module RuboCop
       #    "yes"
       #  end
       #
-      #  # good
+      #  # good - Sorbet signature is not evaluated
       #  sig { returns(String) }
       #  def is_this_thing_on?
       #    "yes"

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -150,16 +150,14 @@ module RuboCop
 
         private
 
+        def_node_matcher :sorbet_return_type, <<~PATTERN
+          (block (send nil? :sig) args (send nil? :returns $_type))
+        PATTERN
+
         def sorbet_sig?(node, return_type: nil)
-          left_sibling = node.left_sibling
-          return false unless left_sibling&.block_type?
-          return false if return_type.nil?
+          return false unless (type = sorbet_return_type(node.left_sibling))
 
-          returns_node = left_sibling.children.find do |child|
-            child.type == :send && child.method_name == :returns
-          end
-
-          returns_node&.arguments&.first&.source == return_type
+          type.source == return_type
         end
 
         def allowed_method_name?(method_name, prefix)

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
       RUBY
     end
 
-    it "works correctly when returns is chained on params" do
+    it 'works correctly when returns is chained on params' do
       expect_offense(<<~RUBY)
         sig { params(x: Integer).returns(T::Boolean) }
         def is_even(x); end

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -200,10 +200,16 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
         sig { returns(T::Boolean) }
         def is_attr?; end
 
-        sig { returns(T::Array[String]) }
+        sig { returns(String) }
         def has_caused_error
           errors.add(:base, 'This has caused an error')
         end
+      RUBY
+    end
+
+    it 'does not register an offense if no ? when no sigs but the config is enabled' do
+      expect_no_offenses(<<~RUBY)
+        def is_attr; end
       RUBY
     end
   end

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -155,15 +155,38 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
       }
     end
 
-    it 'registers an offense if no ? when `sig { returns(T::Boolean) }`' do
+    it 'registers an offense if no ? when `sig { returns(T::Boolean) }` and variants' do
       expect_offense(<<~RUBY)
         sig { returns(T::Boolean) }
         def is_attr; end
             ^^^^^^^ Rename `is_attr` to `is_attr?`.
       RUBY
+
+      expect_offense(<<~RUBY)
+        sig { returns(T::Boolean) }
+        # Comment here.
+        def is_attr; end
+            ^^^^^^^ Rename `is_attr` to `is_attr?`.
+      RUBY
+
+      expect_offense(<<~RUBY)
+        sig { returns(T::Boolean) }
+
+
+        def is_attr; end
+            ^^^^^^^ Rename `is_attr` to `is_attr?`.
+      RUBY
+
+      expect_offense(<<~RUBY)
+        sig do
+          returns(T::Boolean)
+        end
+        def is_attr; end
+            ^^^^^^^ Rename `is_attr` to `is_attr?`.
+      RUBY
     end
 
-    it 'does not register an offense if no ? when `sig { returns(T::Array[String])`' do
+    it 'does not register an offense if no ? when `sig { returns(T::Array[String]) }`' do
       expect_no_offenses(<<~RUBY)
         sig { returns(T::Array[String]) }
         def has_caused_error

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -207,6 +207,14 @@ RSpec.describe RuboCop::Cop::Naming::PredicateName, :config do
       RUBY
     end
 
+    it "works correctly when returns is chained on params" do
+      expect_offense(<<~RUBY)
+        sig { params(x: Integer).returns(T::Boolean) }
+        def is_even(x); end
+            ^^^^^^^ Rename `is_even` to `is_even?`.
+      RUBY
+    end
+
     it 'does not register an offense if no ? when no sigs but the config is enabled' do
       expect_no_offenses(<<~RUBY)
         def is_attr; end


### PR DESCRIPTION
- At the moment, the `Naming/PredicateName` cop checks for predicate methods based on the presence of a prefix in the method name. This is a common convention, but, for better or for worse, not all `has_` and `is_` methods, over time, return booleans.
- So, I had an idea to use Sorbet's `sig` to detect predicate methods based on the return type. If a method has a `sig` with a return type of `T::Boolean`, and the method name does not end with `?`, then it needs one.
- Add a `UseSorbetSigs` configuration option to the `Naming/PredicateName` cop. When set to `true`, the cop will check for predicate methods based on the presence of a Sorbet `sig` for the method with a return type of `T::Boolean` instead of based on method naming.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
