### PR TITLE
[Fix #13720] Fix false positives for `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_false_positives_for_style_block_delimiters.md
+++ b/changelog/fix_false_positives_for_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#13720](https://github.com/rubocop/rubocop/issues/13720): Fix false positives for `Style/BlockDelimiters` when using brace blocks as conditions under `EnforcedStyle: semantic`. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -474,14 +474,10 @@ module RuboCop
         end
 
         def return_value_of_scope?(node)
-          return false unless node.parent
+          return false unless (parent = node.parent)
 
-          conditional?(node.parent) || array_or_range?(node.parent) ||
-            node.parent.children.last == node
-        end
-
-        def conditional?(node)
-          node.if_type? || node.operator_keyword?
+          parent.conditional? || parent.operator_keyword? || array_or_range?(parent) ||
+            parent.children.last == node
         end
 
         def array_or_range?(node)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -281,6 +281,52 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect_no_offenses('return if any? { |x| x }')
     end
 
+    it 'accepts a single line block with {} if used in an `if` condition' do
+      expect_no_offenses(<<~RUBY)
+        if any? { |x| x }
+          return
+        end
+      RUBY
+    end
+
+    it 'accepts a single line block with {} if used in an `unless` condition' do
+      expect_no_offenses(<<~RUBY)
+        unless any? { |x| x }
+          return
+        end
+      RUBY
+    end
+
+    it 'accepts a single line block with {} if used in a `case` condition' do
+      expect_no_offenses(<<~RUBY)
+        case foo { |x| x }
+        when bar
+        end
+      RUBY
+    end
+
+    it 'accepts a single line block with {} if used in a `case` match condition' do
+      expect_no_offenses(<<~RUBY)
+        case foo { |x| x }
+        in bar
+        end
+      RUBY
+    end
+
+    it 'accepts a single line block with {} if used in a `while` condition' do
+      expect_no_offenses(<<~RUBY)
+        while foo { |x| x }
+        end
+      RUBY
+    end
+
+    it 'accepts a single line block with {} if used in an `until` condition' do
+      expect_no_offenses(<<~RUBY)
+        until foo { |x| x }
+        end
+      RUBY
+    end
+
     it 'accepts a single line block with {} if used in a logical or' do
       expect_no_offenses('any? { |c| c } || foo')
     end


### PR DESCRIPTION
This PR fixes false positives for `Style/BlockDelimiters` when using brace blocks as conditions under `EnforcedStyle: semantic`.

Fixes #13720.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
