### PR TITLE
Make `Style/RedundantParentheses` aware of parenthesized assignment

### DIFF
--- a/changelog/change_make_style_redundant_parentheses_aware_of_parenthesized_assignment.md
+++ b/changelog/change_make_style_redundant_parentheses_aware_of_parenthesized_assignment.md
@@ -1,0 +1,1 @@
+* [#13724](https://github.com/rubocop/rubocop/pull/13724): Make `Style/RedundantParentheses` aware of parenthesized assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -140,6 +140,9 @@ module RuboCop
           return 'a literal' if disallowed_literal?(begin_node, node)
           return 'a variable' if node.variable?
           return 'a constant' if node.const_type?
+          if node.assignment? && (begin_node.parent.nil? || begin_node.parent.begin_type?)
+            return 'an assignment'
+          end
           if node.lambda_or_proc? && (node.braces? || node.send_node.lambda_literal?)
             return 'an expression'
           end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -182,6 +182,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '(x < y)', 'x < y', 'a comparison expression'
   it_behaves_like 'redundant', '(x <= y)', 'x <= y', 'a comparison expression'
 
+  it_behaves_like 'redundant', '(var = 42)', 'var = 42', 'an assignment'
+  it_behaves_like 'redundant', '(@var = 42)', '@var = 42', 'an assignment'
+  it_behaves_like 'redundant', '(@@var = 42)', '@@var = 42', 'an assignment'
+  it_behaves_like 'redundant', '($var = 42)', '$var = 42', 'an assignment'
+  it_behaves_like 'redundant', '(CONST = 42)', 'CONST = 42', 'an assignment'
+  it_behaves_like 'plausible', 'if (var = 42); end'
+  it_behaves_like 'plausible', 'unless (var = 42); end'
+  it_behaves_like 'plausible', 'while (var = 42); end'
+  it_behaves_like 'plausible', 'until (var = 42); end'
+  it_behaves_like 'plausible', '(var + 42) > do_something'
+
   it_behaves_like 'redundant', '(!x)', '!x', 'a unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'a unary operation'
   it_behaves_like 'redundant', '(-x)', '-x', 'a unary operation'
@@ -213,6 +224,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
     expect_correction(<<~RUBY)
       x.y(z)
+    RUBY
+  end
+
+  it 'registers an offense for parens around parenthesized conditional assignment' do
+    expect_offense(<<~RUBY)
+      if ((var = 42))
+          ^^^^^^^^^^ Don't use parentheses around an assignment.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (var = 42)
+      end
     RUBY
   end
 


### PR DESCRIPTION
This PR makes `Style/RedundantParentheses` aware of parenthesized assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
