### PR TITLE
[Fix #13725] Fix an incorrect autocorrect for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_if_unless_modifier.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#13725](https://github.com/rubocop/rubocop/issues/13725): Fix an incorrect autocorrect for `Style/IfUnlessModifier` when using omitted hash values in an assignment. ([@elliottt][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -55,12 +55,17 @@ module RuboCop
       end
 
       def if_body_source(if_body)
-        if if_body.call_type? &&
-           if_body.last_argument&.hash_type? && if_body.last_argument.pairs.last&.value_omission?
+        if if_body.call_type? && !if_body.method?(:[]=) && omitted_value_in_last_hash_arg?(if_body)
           "#{method_source(if_body)}(#{if_body.arguments.map(&:source).join(', ')})"
         else
           if_body.source
         end
+      end
+
+      def omitted_value_in_last_hash_arg?(if_body)
+        return false unless (last_argument = if_body.last_argument)
+
+        last_argument.hash_type? && last_argument.pairs.last&.value_omission?
       end
 
       def method_source(if_body)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -426,6 +426,21 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     include_examples 'one-line pattern matching'
   end
 
+  context 'when using omitted hash values in an assignment', :ruby31 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        if condition
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          obj[:key] = { foo: }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj[:key] = { foo: } if condition
+      RUBY
+    end
+  end
+
   context 'multiline `if` that fits on one line and using hash value omission syntax', :ruby31 do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/IfUnlessModifier` when using omitted hash values in an assignment.

Fixes #13725.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
