### PR TITLE
Fix rubocop error on provided glob pattern matching directory

### DIFF
--- a/changelog/fix_rubocop_error_on_glob_pattern_and_matching_directory.md
+++ b/changelog/fix_rubocop_error_on_glob_pattern_and_matching_directory.md
@@ -1,0 +1,1 @@
+* [#13728](https://github.com/rubocop/rubocop/pull/13728): Fix a RuboCop error on provided glob pattern which matches directory. ([@viralpraxis][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -127,6 +127,7 @@ module RuboCop
       if mode == :only_recognized_file_types || force_exclusion?
         files.select! { |file| included_file?(file) }
       end
+      files.reject! { |file| FileTest.directory?(file) }
 
       force_exclusion? ? without_excluded(files) : files
     end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -116,6 +116,16 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when a pattern with matching folders is passed' do
+      before { create_empty_file('app/dir.rb/ruby.rb') }
+
+      let(:args) { ['app/**/*.rb'] }
+
+      it 'finds only files which match the pattern' do
+        expect(found_basenames).to eq(['ruby.rb'])
+      end
+    end
+
     context 'when same paths are passed' do
       let(:args) { %w[dir1 dir1] }
 


### PR DESCRIPTION
For this project layout

```console
app/        # dir
  data.rb/  # dir
    ruby.rb # file
```

when running rubocop with explicit glob pattern (e.g. `rubocop '/app/**/*.rb'`) it fails with the following error

```
Is a directory @ io_fread - <snip>/app/data.rb
lib/ruby/3.4.0/digest.rb:66:in 'IO#read'
lib/ruby/3.4.0/digest.rb:66:in 'block in Digest::Instance#file'
lib/ruby/3.4.0/digest.rb:64:in 'IO.open'
lib/ruby/3.4.0/digest.rb:64:in 'Digest::Instance#file'
lib/rubocop/result_cache.rb:161:in 'RuboCop::ResultCache#file_checksum'
lib/rubocop/result_cache.rb:95:in 'RuboCop::ResultCache#initialize'
lib/rubocop/runner.rb:175:in 'Class#new'
lib/rubocop/runner.rb:175:in 'RuboCop::Runner#cached_result'
lib/rubocop/runner.rb:180:in 'RuboCop::Runner#file_offense_cache'
lib/rubocop/runner.rb:167:in 'RuboCop::Runner#file_offenses'
lib/rubocop/runner.rb:103:in 'block in RuboCop::Runner#warm_cache'
```

The problem is that `process_explicit_path` does not check if files are actually files and not directories.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
