### PR TITLE
Update `Style/RedundantCondition` cop to detect conditional expressions where the true branch is `true` and suggest replacing them with a logical OR

### DIFF
--- a/changelog/change_update_style_redundant_condition_cop_to_detect_20250121092813.md
+++ b/changelog/change_update_style_redundant_condition_cop_to_detect_20250121092813.md
@@ -1,0 +1,1 @@
+* [#13729](https://github.com/rubocop/rubocop/pull/13729): Update `Style/RedundantCondition` cop to detect conditional expressions where the true branch is `true` and suggest replacing them with a logical OR. ([@datpmt][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -81,21 +81,16 @@ module RuboCop
           (node.numeric_type? && node.value.zero?) || node.nil_type?
         end
 
-        # rubocop:disable Metrics/PerceivedComplexity
         def check_send(node)
           if node.arithmetic_operation?
             float?(node.receiver) || float?(node.first_argument)
           elsif FLOAT_RETURNING_METHODS.include?(node.method_name)
             true
           elsif node.receiver&.float_type?
-            if FLOAT_INSTANCE_METHODS.include?(node.method_name)
-              true
-            else
+            FLOAT_INSTANCE_METHODS.include?(node.method_name) ||
               check_numeric_returning_method(node)
-            end
           end
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def check_numeric_returning_method(node)
           return false unless node.receiver


### PR DESCRIPTION
Checks for ternary expressions that use `true` as the true branch and suggest replacing them with a logical OR (`||`) expression.
For example, a ternary like `condition ? true : variable` is considered redundant because it can be simplified to `condition || variable`. The cop promotes the use of more concise and readable code by encouraging the use of logical OR in such cases, improving both clarity and maintainability.

```ruby
#   # bad
#   a.nil? ? true : a
#
#   # good
#   a.nil? || a
#
#   # bad
#   if a.nil?
#     true
#   else
#     a
#   end
#
#   # good
#   a.nil? || a
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
