### PR TITLE
Update stale GH action to only run on the original repo, and not forks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   close-issues:
+    if: (github.repository == 'rubocop/rubocop')
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Every night the stale action runs on my fork (and everyone else's whose fork is up to date), so let's just limit it to the main repository.