### PR TITLE
[DOC] Quote class/method names with backticks

### DIFF
--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -3,23 +3,23 @@
 module RuboCop
   module Cop
     module Layout
-      # Checks if the code style follows the ExpectedOrder configuration:
+      # Checks if the code style follows the `ExpectedOrder` configuration:
       #
       # `Categories` allows us to map macro names into a category.
       #
       # Consider an example of code style that covers the following order:
       #
-      # * Module inclusion (include, prepend, extend)
+      # * Module inclusion (`include`, `prepend`, `extend`)
       # * Constants
-      # * Associations (has_one, has_many)
-      # * Public attribute macros (attr_accessor, attr_writer, attr_reader)
-      # * Other macros (validates, validate)
+      # * Associations (`has_one`, `has_many`)
+      # * Public attribute macros (`attr_accessor`, `attr_writer`, `attr_reader`)
+      # * Other macros (`validates`, `validate`)
       # * Public class methods
       # * Initializer
       # * Public instance methods
-      # * Protected attribute macros (attr_accessor, attr_writer, attr_reader)
+      # * Protected attribute macros (`attr_accessor`, `attr_writer`, `attr_reader`)
       # * Protected instance methods
-      # * Private attribute macros (attr_accessor, attr_writer, attr_reader)
+      # * Private attribute macros (`attr_accessor`, `attr_writer`, `attr_reader`)
       # * Private instance methods
       #
       # You can configure the following order:

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -7,7 +7,7 @@ module RuboCop
       # where the opening brace and the first key are on separate lines. The
       # other keys' indentations are handled by the HashAlignment cop.
       #
-      # By default, Hash literals that are arguments in a method call with
+      # By default, `Hash` literals that are arguments in a method call with
       # parentheses, and where the opening curly brace of the hash is on the
       # same line as the opening parenthesis of the method call, shall have
       # their first key indented one step (two spaces) more than the position

--- a/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
+++ b/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for duplicate elements in Regexp character classes.
+      # Checks for duplicate elements in `Regexp` character classes.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/duplicate_set_element.rb
+++ b/lib/rubocop/cop/lint/duplicate_set_element.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for duplicate literal, constant, or variable elements in Set and SortedSet.
+      # Checks for duplicate literal, constant, or variable elements in `Set` and `SortedSet`.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Identifies Float literals which are, like, really really really
+      # Identifies `Float` literals which are, like, really really really
       # really really really really really big. Too big. No-one needs Floats
       # that big. If you need a float that big, something is wrong with you.
       #

--- a/lib/rubocop/cop/lint/mixed_case_range.rb
+++ b/lib/rubocop/cop/lint/mixed_case_range.rb
@@ -8,7 +8,7 @@ module RuboCop
       # Offenses are registered for regexp character classes like `/[A-z]/`
       # as well as range objects like `('A'..'z')`.
       #
-      # NOTE: Range objects cannot be autocorrected.
+      # NOTE: `Range` objects cannot be autocorrected.
       #
       # @safety
       #   The cop autocorrects regexp character classes

--- a/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
+++ b/lib/rubocop/cop/lint/mixed_regexp_capture_types.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Do not mix named captures and numbered captures in a Regexp literal
+      # Do not mix named captures and numbered captures in a `Regexp` literal
       # because numbered capture is ignored if they're mixed.
       # Replace numbered captures with non-capturing groupings or
       # named captures.

--- a/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
+++ b/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
@@ -12,7 +12,7 @@ module RuboCop
       # are handled by Lint/UselessNumericOperation.
       #
       # NOTE: This cop doesn't detect offenses for the `-` and `%` operator because it
-      # can't determine the type of `x`. If `x` is an Array or String, it doesn't perform
+      # can't determine the type of `x`. If `x` is an `Array` or `String`, it doesn't perform
       # a numeric operation.
       #
       # @example

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Looks for references of Regexp captures that are out of range
+      # Looks for references of `Regexp` captures that are out of range
       # and thus always returns nil.
       #
       # @safety

--- a/lib/rubocop/cop/lint/redundant_regexp_quantifiers.rb
+++ b/lib/rubocop/cop/lint/redundant_regexp_quantifiers.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for redundant quantifiers inside Regexp literals.
+      # Checks for redundant quantifiers inside `Regexp` literals.
       #
       # It is always allowed when interpolation is used in a regexp literal,
       # because it's unknown what kind of string will be expanded as a result:

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for `rescue` blocks targeting the Exception class.
+      # Checks for `rescue` blocks targeting the `Exception` class.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/shared_mutable_default.rb
+++ b/lib/rubocop/cop/lint/shared_mutable_default.rb
@@ -3,11 +3,11 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for Hash creation with a mutable default value.
-      # Creating a Hash in such a way will share the default value
+      # Checks for `Hash` creation with a mutable default value.
+      # Creating a `Hash` in such a way will share the default value
       # across all keys, causing unexpected behavior when modifying it.
       #
-      # For example, when the Hash was created with an Array as the argument,
+      # For example, when the `Hash` was created with an `Array` as the argument,
       # calling `hash[:foo] << 'bar'` will also change the value of all
       # other keys that have not been explicitly assigned to.
       #

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -17,7 +17,7 @@ module RuboCop
       # rescue, ensure, etc.
       #
       # This cop's autocorrection avoids cases like `a ||= 1` because removing assignment from
-      # operator assignment can cause NameError if this assignment has been used to declare
+      # operator assignment can cause `NameError` if this assignment has been used to declare
       # a local variable. For example, replacing `a ||= 1` with `a || 1` may cause
       # "undefined local variable or method `a' for main:Object (NameError)".
       #

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       # Checks for loops which iterate a constant number of times,
-      # using a Range literal and `#each`. This can be done more readably using
+      # using a `Range` literal and `#each`. This can be done more readably using
       # `Integer#times`.
       #
       # This check only applies if the block takes no parameters.

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for exact regexp match inside Regexp literals.
+      # Checks for exact regexp match inside `Regexp` literals.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Suggests `ENV.fetch` for the replacement of `ENV[]`.
       # `ENV[]` silently fails and returns `nil` when the environment variable is unset,
       # which may cause unexpected behaviors when the developer forgets to set it.
-      # On the other hand, `ENV.fetch` raises KeyError or returns the explicitly
+      # On the other hand, `ENV.fetch` raises `KeyError` or returns the explicitly
       # specified default value.
       #
       # @example

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of `each_key` and `each_value` Hash methods.
+      # Checks for uses of `each_key` and `each_value` `Hash` methods.
       #
       # NOTE: If you have an array of two-element arrays, you can put
       #   parentheses around the block arguments to indicate that you're not

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -19,7 +19,7 @@ module RuboCop
       # acceptable value other than none, it will suppress the offenses
       # raised by this cop. It enforces frozen state.
       #
-      # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
+      # NOTE: `Regexp` and `Range` literals are frozen objects since Ruby 3.0.
       #
       # NOTE: From Ruby 3.0, interpolated strings are not frozen when
       # `# frozen-string-literal: true` is used, so this cop enforces explicit

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -14,7 +14,7 @@ module RuboCop
       # passed multiple arguments.
       #
       # The exploded style has an `AllowedCompactTypes` configuration
-      # option that takes an Array of exception name Strings.
+      # option that takes an `Array` of exception name Strings.
       #
       # @safety
       #   This cop is unsafe because `raise Foo` calls `Foo.exception`, not `Foo.new`.

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for RuntimeError as the argument of raise/fail.
+      # Checks for `RuntimeError` as the argument of `raise`/`fail`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # Check for uses of `Object#freeze` on immutable objects.
       #
-      # NOTE: Regexp and Range literals are frozen objects since Ruby 3.0.
+      # NOTE: `Regexp` and `Range` literals are frozen objects since Ruby 3.0.
       #
       # NOTE: From Ruby 3.0, this cop allows explicit freezing of interpolated
       # string literals when `# frozen-string-literal: true` is used.

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for unnecessary single-element Regexp character classes.
+      # Checks for unnecessary single-element `Regexp` character classes.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for redundant escapes inside Regexp literals.
+      # Checks for redundant escapes inside `Regexp` literals.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -10,7 +10,7 @@ module RuboCop
       # parameters.
       #
       # Configuration option: Methods
-      # Should be set to use this cop. Array of hashes, where each key is the
+      # Should be set to use this cop. `Array` of hashes, where each key is the
       # method name and value - array of argument names.
       #
       # @example Methods: [{reduce: %w[a b]}]

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       # Enforces the use of consistent method names
-      # from the String class.
+      # from the `String` class.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This PR quotes class/method names with backticks to properly marked up.