### PR TITLE
Fix `ExpectOffense` when a source line contains an escaped caret

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -190,8 +190,10 @@ module RuboCop
       def expect_no_offenses(source, file = nil)
         offenses = inspect_source(source, file)
 
-        # Carets given in `expect_no_offenses` should not be treated as annotations so are escaped
-        expected_annotations = AnnotatedSource.parse(source.gsub('^', '\^'))
+        # Since source given `expect_no_offenses` does not have annotations, we do not need to parse
+        # for them, and can just build an `AnnotatedSource` object from the source lines.
+        # This also prevents treating source lines that begin with a caret as an annotation.
+        expected_annotations = AnnotatedSource.new(source.each_line.to_a, [])
         actual_annotations = expected_annotations.with_offense_annotations(offenses)
         expect(actual_annotations.to_s).to eq(source)
       end
@@ -240,7 +242,7 @@ module RuboCop
             if ANNOTATION_PATTERN.match?(source_line)
               annotations << [source.size, source_line]
             else
-              source << source_line.gsub('\^', '^')
+              source << source_line
             end
           end
           annotations.each { |a| a[0] = 1 } if source.empty?


### PR DESCRIPTION
Previously in f450f62, In order to be able to handle lines that start with a caret, I updated `expect_no_offense` to escape carets, since there are no annotations expected with that method, in order to allow lines that start with a caret. Then in `AnnotatedSource.parse`, the caret was unescaped so that the source actually matches what was given.

However, this caused tests to fail in rubocop-performance, which contains escaped carets inside a regexp.

I've updated again to not add any escaping, but rather not parse the source given to `expect_no_offenses` for annotations, as there should not be any in the first place.