### PR TITLE
Correctly handle anonymous block forwarding in blocks for Ruby >= 3.4

### DIFF
--- a/changelog/fix_false_negative_block_forwading_34.md
+++ b/changelog/fix_false_negative_block_forwading_34.md
@@ -1,0 +1,1 @@
+* [#13741](https://github.com/rubocop/rubocop/pull/13741): Register an offense for `Naming/BlockForwarding` and `Style/ArgumentsForwarding` with Ruby >= 3.4 when the block argument is referenced inside a block. This was previously disabled because of a bug in Ruby 3.3.0. ([@earlopain][])

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -2677,4 +2677,98 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       end
     end
   end
+
+  context 'TargetRubyVersion >= 3.4', :ruby34 do
+    it 'registers an offense when rest arguments forwarding to a method in numbered block' do
+      expect_offense(<<~RUBY)
+        def foo(*args, &block)
+                       ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+          do_something do
+            bar(*args, &block)
+                       ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+            baz(_1)
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, &)
+          do_something do
+            bar(*, &)
+            baz(_1)
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when keyword rest arguments forwarding to a method in block' do
+      expect_offense(<<~RUBY)
+        def foo(**kwargs, &block)
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+          do_something do
+            bar(**kwargs, &block)
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(**, &)
+          do_something do
+            bar(**, &)
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when keyword rest arguments forwarding to a method in numbered block' do
+      expect_offense(<<~RUBY)
+        def foo(**kwargs, &block)
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+          do_something do
+            bar(**kwargs, &block)
+                          ^^^^^^ Use anonymous block arguments forwarding (`&`).
+                ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+            baz(_1)
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(**, &)
+          do_something do
+            bar(**, &)
+            baz(_1)
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when rest arguments and keyword rest arguments forwarding to a method in block' do
+      expect_offense(<<~RUBY)
+        def foo(*args, **kwargs)
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+          block_method do
+            bar(*args, **kwargs)
+                       ^^^^^^^^ Use anonymous keyword arguments forwarding (`**`).
+                ^^^^^ Use anonymous positional arguments forwarding (`*`).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*, **)
+          block_method do
+            bar(*, **)
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This worked around a bug in Ruby 3.3.0, where this syntax was accidentally disallowed. This check can now be reenabled for 3.4 where all versions accept it.

Reference:
* https://github.com/rubocop/rubocop/issues/12571
* https://github.com/rubocop/rubocop/pull/12577
* https://github.com/rubocop/rubocop/pull/12578
* https://bugs.ruby-lang.org/issues/20090

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
