### PR TITLE
Revert "CI: Use arm64 runners"

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   lint-ruby:
     name: Ruby
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   spec-ubuntu:
     name: Spec - ubuntu ${{ matrix.ruby }}
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -47,7 +47,7 @@ jobs:
 
   spec-jruby:
     name: Spec - JRuby
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -103,7 +103,7 @@ jobs:
 
   ascii_spec:
     name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os == 'ubuntu' && 'ubuntu-24.04-arm' || matrix.os == 'windows' && 'windows-latest' }}
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       fail-fast: false
@@ -126,7 +126,7 @@ jobs:
 
   documentation_check:
     name: Documentation Check
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -137,7 +137,7 @@ jobs:
         run: bundle exec rake documentation_syntax_check
 
   prism:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     name: Prism
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
         run: bundle exec rake prism_spec
 
   rspec4:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     name: RSpec 4
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   codespell:
     name: Check spelling of all files with codespell
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   close-issues:
     if: (github.repository == 'rubocop/rubocop')
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
This reverts commit be6c04c9947a23b359acbde7b94417f8b666d8a7.

Unfortunately, the arm64 runners are not stable enough yet. To prioritize CI stability over speed improvements, https://github.com/rubocop/rubocop/pull/13731 will be reverted.

cc @bquorning 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
