### PR TITLE
[Fix #13739] Fix false positive for `Style/HashExcept` and `Style/HashSlice` when checking for inclusion with a range

### DIFF
--- a/changelog/fix_fix_false_positive_for_style_hash_except_and_20250123131635.md
+++ b/changelog/fix_fix_false_positive_for_style_hash_except_and_20250123131635.md
@@ -1,0 +1,1 @@
+* [#13739](https://github.com/rubocop/rubocop/issues/13739): Fix false positive for `Style/HashExcept` and `Style/HashSlice` when checking for inclusion with a range. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -191,6 +191,18 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
           {foo: 1, bar: 2, baz: 3}.reject { |k, v| !k.include?('oo') }
         RUBY
       end
+
+      it 'does not register an offense when using `reject` with `!include?` with an inclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.reject { |k, v| (:baa..:bbb).include?(k) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `reject` with `!include?` with an exclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.reject { |k, v| (:baa...:bbb).include?(k) }
+        RUBY
+      end
     end
 
     context 'using `exclude?`' do
@@ -464,6 +476,18 @@ RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
         it 'does not register an offense when using `reject` and calling `in?` method with symbol array and second block value' do
           expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.reject { |k, v| v.in?([1, 2]) }
+          RUBY
+        end
+
+        it 'does not register an offense when using `reject` with `!in?` with an inclusive range argument' do
+          expect_no_offenses(<<~RUBY)
+            { foo: 1, bar: 2, baz: 3 }.reject{ |k, v| k.in?(:baa..:bbb) }
+          RUBY
+        end
+
+        it 'does not register an offense when using `reject` with `!in?` with an exclusive range argument' do
+          expect_no_offenses(<<~RUBY)
+            { foo: 1, bar: 2, baz: 3 }.reject{ |k, v| k.in?(:baa...:bbb) }
           RUBY
         end
       end

--- a/spec/rubocop/cop/style/hash_slice_spec.rb
+++ b/spec/rubocop/cop/style/hash_slice_spec.rb
@@ -182,13 +182,25 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
 
       it 'does not register an offense when using `select` and calling `include?` method on a key' do
         expect_no_offenses(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| k.include?('oo') }
+          { 'foo' => 1, 'bar' => 2, 'baz' => 3 }.select { |k, v| k.include?('oo') }
         RUBY
       end
 
       it 'does not register an offense when using `select` and calling `!include?` method on a key' do
         expect_no_offenses(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| !k.include?('oo') }
+          { 'foo' => 1, 'bar' => 2, 'baz' => 3 }.select { |k, v| !k.include?('oo') }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` with an inclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa..:bbb).include?(k) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` with an exclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa...:bbb).include?(k) }
         RUBY
       end
     end
@@ -464,6 +476,18 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
         it 'does not register an offense when using `select` and calling `in?` method with symbol array and second block value' do
           expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.select { |k, v| v.in?([1, 2]) }
+          RUBY
+        end
+
+        it 'does not register an offense when using `select` with `in?` with an inclusive range argument' do
+          expect_no_offenses(<<~RUBY)
+            { foo: 1, bar: 2, baz: 3 }.select{ |k, v| k.in?(:baa..:bbb) }
+          RUBY
+        end
+
+        it 'does not register an offense when using `select` with `in?` with an exclusive range argument' do
+          expect_no_offenses(<<~RUBY)
+            { foo: 1, bar: 2, baz: 3 }.select{ |k, v| k.in?(:baa...:bbb) }
           RUBY
         end
       end


### PR DESCRIPTION
`Style/HashExcept` and `Style/HashSlice` look for instances where `select` or `reject` blocks called on a hash can be replaced with `slice` or `except`. However, when the receiver of `include?` or the argument of `in?` is a range, this replacement can definitely not be made.

Fixes #13739.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
