### PR TITLE
Add missing ExpectOffense include

### DIFF
--- a/changelog/fix_add_the_missing_include_20250127124604.md
+++ b/changelog/fix_add_the_missing_include_20250127124604.md
@@ -1,0 +1,1 @@
+* [#10081](https://github.com/rubocop/rubocop/issues/10081): Add the missing `include RuboCop::RSpec::ExpectOffense` in rubocop/rspec/support.rb. ([@d4rky-pl][])

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -10,6 +10,7 @@ require_relative 'shared_contexts'
 
 RSpec.configure do |config|
   config.include CopHelper
+  config.include RuboCop::RSpec::ExpectOffense
   config.include HostEnvironmentSimulatorHelper
   config.include_context 'config', :config
   config.include_context 'isolated environment', :isolated_environment

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,8 +40,6 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = 'spec/examples.txt'
 
-  config.include RuboCop::RSpec::ExpectOffense
-
   config.order = :random
   Kernel.srand config.seed
 


### PR DESCRIPTION
This PR adds missing `config.include RuboCop::RSpec::ExpectOffense`. This fixes #10081 

The `ExpectOffense` class is not referenced anywhere else in the code (other than rubocop's own spec_helper) and is not mentioned in the documentation so I assume it should be added automatically like this. If not, let me know and I'll send a PR updating the docs and mentioning it needs to be enabled explicitly instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
