### PR TITLE
[Fix #13750] Fix false positives for `Style/RedundantSelfAssignment`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_self_assignment.md
+++ b/changelog/fix_false_positives_for_style_redundant_self_assignment.md
@@ -1,0 +1,1 @@
+* [#13750](https://github.com/rubocop/rubocop/issues/13750): Fix false positives for `Style/RedundantSelfAssignment` when assigning to attribute of `self`. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
@@ -70,25 +70,15 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignment, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when assigning to attribute of `self`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when assigning to attribute of `self`' do
+    expect_no_offenses(<<~RUBY)
       self.foo = foo.concat(ary)
-               ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo.concat(ary)
     RUBY
   end
 
-  it 'registers an offense and corrects when assigning to attribute of `self` with safe navigation' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when assigning to attribute of `self` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
       self.foo = foo&.concat(ary)
-               ^ Redundant self assignment detected. Method `concat` modifies its receiver in place.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.concat(ary)
     RUBY
   end
 


### PR DESCRIPTION
Fixes #13750.

This PR fixes false positives for `Style/RedundantSelfAssignment` when assigning to attribute of `self`.

As mentioned in the feedback on #13750, `self.foo = foo.concat(ary)` is an assignment through a method call, which differs from a variable assignment like `foo = foo.concat(ary)`.

Although the original example suggests replacing `self.foo = foo.concat(ary)` with `self.foo += arg`, the autocorrect implementation didn't account for this. Furthermore, methods other than `concat`, such as `delete_if` or `unshift`, cannot be resolved by replacing them with `+=`. As a result, providing a simple autocorrect solution is not feasible. Furthermore, it is doubtful whether such a change can be regarded as an improvement to good style.

Given this, better approach would likely be to avoid detecting assignments to `self.foo` in such cases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
