### PR TITLE
Update `EnforcedStyle` of `RSpec/ExampleWithoutDescription`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,9 @@ RSpec:
       - expect_no_offenses
       - expect_offense
 
+RSpec/ExampleWithoutDescription:
+  EnforcedStyle: single_line_only
+
 RSpec/PredicateMatcher:
   # Also consider `be(true)` and `be(false)` as offenses, instead of only `be_truthy` and `be_falsy`
   Strict: false

--- a/spec/rubocop/lsp/severity_spec.rb
+++ b/spec/rubocop/lsp/severity_spec.rb
@@ -7,52 +7,37 @@ RSpec.describe RuboCop::LSP::Severity do
     context 'when RuboCop severity is fatal' do
       let(:rubocop_severity) { 'fatal' }
 
-      it {
-        expect(lsp_severity).to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR)
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR) }
     end
 
     context 'when RuboCop severity is error' do
       let(:rubocop_severity) { 'error' }
 
-      it {
-        expect(lsp_severity).to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR)
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR) }
     end
 
     context 'when RuboCop severity is warning' do
       let(:rubocop_severity) { 'warning' }
 
-      it {
-        expect(lsp_severity).to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::WARNING)
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::WARNING) }
     end
 
     context 'when RuboCop severity is convention' do
       let(:rubocop_severity) { 'convention' }
 
-      it {
-        expect(lsp_severity).to eq(
-          LanguageServer::Protocol::Constant::DiagnosticSeverity::INFORMATION
-        )
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::INFORMATION) }
     end
 
     context 'when RuboCop severity is refactor' do
       let(:rubocop_severity) { 'refactor' }
 
-      it {
-        expect(lsp_severity).to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::HINT)
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::HINT) }
     end
 
     context 'when RuboCop severity is unknown severity' do
       let(:rubocop_severity) { 'UNKNOWN' }
 
-      it {
-        expect { lsp_severity }.to output("[server] Unknown severity: UNKNOWN\n").to_stderr
-        expect(lsp_severity).to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::HINT)
-      }
+      it { is_expected.to eq(LanguageServer::Protocol::Constant::DiagnosticSeverity::HINT) }
     end
   end
 end

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -18,6 +18,7 @@ module StrictWarnings
     /`Process` does not respond to `fork` method/, # JRuby
     /File#readline accesses caller method's state and should not be aliased/, # JRuby, test stub
     /instance variable @.* not initialized/, # Ruby 2.7
+    /\[server\] Unknown severity: UNKNOWN/, # RuboCop's built-in LSP API in spec
     /`inspect_file` is deprecated\. Use `investigate` instead\./, # RuboCop's deprecated API in spec
     /`forces` is deprecated./, # RuboCop's deprecated API in spec
     /`support_autocorrect\?` is deprecated\./, # RuboCop's deprecated API in spec


### PR DESCRIPTION
This PR updates `EnforcedStyle` of `RSpec/ExampleWithoutDescription` from `always_allow` (default) to `single_line_only` for development.

This repository typically does not use the following style.

```ruby
it do
  ...
end
```

In this case, descriptions are always written in `it`.

Follow up https://github.com/rubocop/rubocop/pull/13729#discussion_r1925634885.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
