### PR TITLE
Fix a false negative for `Lint/ConstantDefinitionInBlock` with numblocks

### DIFF
--- a/changelog/fix_constant_definition_in_block_false_negative.md
+++ b/changelog/fix_constant_definition_in_block_false_negative.md
@@ -1,0 +1,1 @@
+* [#13759](https://github.com/rubocop/rubocop/pull/13759): Fix a false negative for `Lint/ConstantDefinitionInBlock` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/lint/constant_definition_in_block.rb
+++ b/lib/rubocop/cop/lint/constant_definition_in_block.rb
@@ -68,12 +68,12 @@ module RuboCop
 
         # @!method constant_assigned_in_block?(node)
         def_node_matcher :constant_assigned_in_block?, <<~PATTERN
-          ({^block_type? [^begin_type? ^^block_type?]} nil? ...)
+          ({^any_block [^begin ^^any_block]} nil? ...)
         PATTERN
 
         # @!method module_defined_in_block?(node)
         def_node_matcher :module_defined_in_block?, <<~PATTERN
-          ({^block_type? [^begin_type? ^^block_type?]} ...)
+          ({^any_block [^begin ^^any_block]} ...)
         PATTERN
 
         def on_casgn(node)
@@ -92,7 +92,7 @@ module RuboCop
         private
 
         def method_name(node)
-          node.ancestors.find(&:block_type?).method_name
+          node.ancestors.find(&:any_block_type?).method_name
         end
       end
     end

--- a/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
+++ b/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
     RUBY
   end
 
+  it 'registers an offense for a class defined within a numblock' do
+    expect_offense(<<~RUBY)
+      describe do
+        class Foo; end
+        ^^^^^^^^^^^^^^ Do not define constants this way within a block.
+        _1
+      end
+    RUBY
+  end
+
   it 'does not register an offense for a top-level module' do
     expect_no_offenses(<<~RUBY)
       module Foo; end
@@ -93,6 +103,16 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
         module Foo; end
         ^^^^^^^^^^^^^^^ Do not define constants this way within a block.
         bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a module defined within a numblock' do
+    expect_offense(<<~RUBY)
+      describe do
+        module Foo; end
+        ^^^^^^^^^^^^^^^ Do not define constants this way within a block.
+        _1
       end
     RUBY
   end
@@ -158,6 +178,16 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
         enums do
           module Foo
           end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a module defined within a numblock of `enums` method' do
+      expect_no_offenses(<<~RUBY)
+        enums do
+          module Foo
+          end
+          _1
         end
       RUBY
     end


### PR DESCRIPTION
Use the new `any_block` group

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
