### PR TITLE
Fix crash in `InternalAffairs/RedundantSourceRange` when `source_range` has no receiver

### DIFF
--- a/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_source_range.rb
@@ -59,6 +59,7 @@ module RuboCop
 
         def on_send(node)
           return unless (source_range = redundant_source_range(node))
+          return unless source_range.receiver
           return if source_range.receiver.send_type? && source_range.receiver.method?(:buffer)
 
           selector = source_range.loc.selector

--- a/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_source_range_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::InternalAffairs::RedundantSourceRange, :config do
+  it 'does not register an offense when using `source_range.source`' do
+    expect_no_offenses(<<~RUBY)
+      source_range.source
+    RUBY
+  end
+
   it 'registers an offense when using `node.source_range.source`' do
     expect_offense(<<~RUBY)
       node.source_range.source


### PR DESCRIPTION
`InternalAffairs/RedundantSourceRange` expects a receiver for `source_range`, so when one is not present, it was crashing. This updates the cop to ignore instances without a receiver.