### PR TITLE
Fix a false positive for `Style/SuperArguments` when calling super in a numblock

### DIFF
--- a/changelog/fix_false_positive_super_arguments_numblock.md
+++ b/changelog/fix_false_positive_super_arguments_numblock.md
@@ -1,0 +1,1 @@
+* [#13761](https://github.com/rubocop/rubocop/pull/13761): Fix a false positive for `Style/SuperArguments` when calling super in a numblock. ([@earlopain][])

--- a/lib/rubocop/cop/style/super_arguments.rb
+++ b/lib/rubocop/cop/style/super_arguments.rb
@@ -98,7 +98,7 @@ module RuboCop
             # When defining dynamic methods, implicitly calling `super` is not possible.
             # Since there is a possibility of delegation to `define_method`,
             # `super` used within the block is always allowed.
-            break if node.block_type? && !block_sends_to_super?(super_node, node)
+            break if node.any_block_type? && !block_sends_to_super?(super_node, node)
 
             break node if DEF_TYPES.include?(node.type)
           end

--- a/spec/rubocop/cop/style/super_arguments_spec.rb
+++ b/spec/rubocop/cop/style/super_arguments_spec.rb
@@ -332,13 +332,12 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
     RUBY
   end
 
-  it 'registers an offense when the scope changes because of a numblock' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when calling super in a numblock' do
+    expect_no_offenses(<<~RUBY)
       def foo(a)
-        bar do
-          baz(_1)
+        delegate_to_define_method do
+          bar(_1)
           super(a)
-          ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
         end
       end
     RUBY


### PR DESCRIPTION
Pretty much https://github.com/rubocop/rubocop/pull/12959/https://github.com/rubocop/rubocop/issues/12957

The existing test was wrong (same as the normal block one), adapt it

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
