### PR TITLE
Fix a false negative for `Layout/SingleLineBlockChain` with numblocks

### DIFF
--- a/changelog/fix_single_line_block_chain_numblock.md
+++ b/changelog/fix_single_line_block_chain_numblock.md
@@ -1,0 +1,1 @@
+* [#13764](https://github.com/rubocop/rubocop/pull/13764): Fix a false negative for `Layout/SingleLineBlockChain` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/layout/single_line_block_chain.rb
+++ b/lib/rubocop/cop/layout/single_line_block_chain.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         def offending_range(node)
           receiver = node.receiver
-          return unless receiver&.block_type?
+          return unless receiver&.any_block_type?
 
           receiver_location = receiver.loc
           closing_block_delimiter_line_num = receiver_location.end.line

--- a/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
+++ b/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe RuboCop::Cop::Layout::SingleLineBlockChain, :config do
     RUBY
   end
 
+  it 'registers an offense for method call chained on the same line as a numblock' do
+    expect_offense(<<~RUBY)
+      example.select { _1.cond? }.join('-')
+                                 ^^^^^ Put method call on a separate line if chained to a single line block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      example.select { _1.cond? }
+      .join('-')
+    RUBY
+  end
+
   it 'registers an offense for safe navigation method call chained on the same line as a block' do
     expect_offense(<<~RUBY)
       example.select { |item| item.cond? }&.join('-')


### PR DESCRIPTION
Not much to say about this one

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
