### PR TITLE
Fix a false negative for `Lint/AmbiguousBlockAssociation` with numblocks

### DIFF
--- a/changelog/fix_ambig_block_assoc_numblocks.md
+++ b/changelog/fix_ambig_block_assoc_numblocks.md
@@ -1,0 +1,1 @@
+* [#13765](https://github.com/rubocop/rubocop/pull/13765): Fix a false negative for `Lint/AmbiguousBlockAssociation` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -77,7 +77,7 @@ module RuboCop
         private
 
         def ambiguous_block_association?(send_node)
-          send_node.last_argument.block_type? && !send_node.last_argument.send_node.arguments?
+          send_node.last_argument.any_block_type? && !send_node.last_argument.send_node.arguments?
         end
 
         def allowed_method_pattern?(node)

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
   it_behaves_like 'accepts', 'foo == bar { baz a }'
   it_behaves_like 'accepts', 'foo ->(a) { bar a }'
   it_behaves_like 'accepts', 'some_method(a) { |el| puts el }'
+  it_behaves_like 'accepts', 'some_method(a) { puts _1 }'
   it_behaves_like 'accepts', 'some_method(a) do;puts a;end'
   it_behaves_like 'accepts', 'some_method a do;puts "dev";end'
   it_behaves_like 'accepts', 'some_method a do |e|;puts e;end'
@@ -40,6 +41,19 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
 
         expect_correction(<<~RUBY)
           some_method(a { |el| puts el })
+        RUBY
+      end
+    end
+
+    context 'without receiver and numblock' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          some_method a { puts _1 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { puts _1 }` to make sure that the block will be associated with the `a` method call.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(a { puts _1 })
         RUBY
       end
     end


### PR DESCRIPTION
Again, not really much to explain

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
