### PR TITLE
Fix `Style/IdenticalConditionalBranches` autocorrect when condition is inside assignment

### DIFF
--- a/changelog/fix_fix_style_identical_conditional_branches_20250129114423.md
+++ b/changelog/fix_fix_style_identical_conditional_branches_20250129114423.md
@@ -1,0 +1,1 @@
+* [#13767](https://github.com/rubocop/rubocop/pull/13767): Fix `Style/IdenticalConditionalBranches` autocorrect when condition is inside assignment. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -747,4 +747,188 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
       expect_no_corrections
     end
   end
+
+  context 'when the result of the conditional is assigned' do
+    context 'with identical trailing lines' do
+      context 'with `if`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = if foo
+              bar
+              ^^^ Move `bar` out of the conditional.
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo
+            else
+            end
+            x = bar
+          RUBY
+        end
+      end
+
+      context 'with a ternary' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = foo ? bar : bar
+                      ^^^ Move `bar` out of the conditional.
+                            ^^^ Move `bar` out of the conditional.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `case`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = case something
+            when :a
+              bar
+              ^^^ Move `bar` out of the conditional.
+            when :b
+              bar
+              ^^^ Move `bar` out of the conditional.
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case something
+            when :a
+            when :b
+            else
+            end
+            x = bar
+          RUBY
+        end
+      end
+
+      context 'with pattern matching', :ruby27 do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = case something
+            in :a
+              bar
+              ^^^ Move `bar` out of the conditional.
+            in :b
+              bar
+              ^^^ Move `bar` out of the conditional.
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case something
+            in :a
+            in :b
+            else
+            end
+            x = bar
+          RUBY
+        end
+      end
+    end
+
+    context 'with identical leading lines' do
+      context 'with `if`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = if foo
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(1)
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(2)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar
+            x = if foo
+              do_x(1)
+            else
+              do_x(2)
+            end
+          RUBY
+        end
+      end
+
+      context 'with `case`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = case something
+            when :a
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(1)
+            when :b
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(2)
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(3)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar
+            x = case something
+            when :a
+              do_x(1)
+            when :b
+              do_x(2)
+            else
+              do_x(3)
+            end
+          RUBY
+        end
+      end
+
+      context 'with pattern matching', :ruby27 do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            x = case something
+            in :a
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(1)
+            in :b
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(2)
+            else
+              bar
+              ^^^ Move `bar` out of the conditional.
+              do_x(3)
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            bar
+            x = case something
+            in :a
+              do_x(1)
+            in :b
+              do_x(2)
+            else
+              do_x(3)
+            end
+          RUBY
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, `Style/IdenticalConditionalBranches` would autocorrect inside an assignment improperly:

```ruby
y = if foo
      bar
    else
      bar
    end

# ... autocorrects to...
y = if foo
    else
    end
bar
```

Before the correction, `y` would be assigned `bar`, but after `y` would be assigned `nil`.

This fixed the correction to correct to this instead:

```
if foo
    else
    end
y = bar
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
