### PR TITLE
Fix a false positive for `Lint/UnreachableCode` with `instance_eval` numblock

### DIFF
--- a/changelog/fix_false_positive_unreachable_code_numblock.md
+++ b/changelog/fix_false_positive_unreachable_code_numblock.md
@@ -1,0 +1,1 @@
+* [#13768](https://github.com/rubocop/rubocop/pull/13768): Fix a false positive for `Lint/UnreachableCode` with `instance_eval` numblock. ([@earlopain][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def instance_eval_block?(node)
-          node.block_type? && node.method?(:instance_eval)
+          node.any_block_type? && node.method?(:instance_eval)
         end
 
         def report_on_flow_command?(node)

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -282,6 +282,20 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
 
+    it "accepts `#{t}` if called in `instance_eval` with numblock" do
+      expect_no_offenses <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          #{t}
+          _1
+        end
+      RUBY
+    end
+
     it "accepts `#{t}` if called in nested `instance_eval`" do
       expect_no_offenses <<~RUBY
         class Dummy


### PR DESCRIPTION
Another one

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
