### PR TITLE
Fix a false negative for `Style/RedundantParentheses` with numblocks

### DIFF
--- a/changelog/fix_false_negative_redundant_parens_numblock.md
+++ b/changelog/fix_false_negative_redundant_parens_numblock.md
@@ -1,0 +1,1 @@
+* [#13769](https://github.com/rubocop/rubocop/pull/13769): Fix a false negative for `Style/RedundantParentheses` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -72,7 +72,7 @@ module RuboCop
           ancestor = node.ancestors.first
           return false unless ancestor
 
-          !ancestor.begin_type? && !ancestor.def_type? && !ancestor.block_type?
+          !ancestor.type?(:begin, :def, :any_block)
         end
 
         def allowed_ternary?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -604,6 +604,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for parens around a numblock body' do
+    expect_offense(<<~RUBY)
+      x do
+        (_1; bar)
+        ^^^^^^^^^ Don't use parentheses around a variable.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x do
+        _1; bar
+      end
+    RUBY
+  end
+
   it 'registers an offense for parens around last expressions in block body' do
     expect_offense(<<~RUBY)
       x do


### PR DESCRIPTION
Use `type?` to make it more concise

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
