### PR TITLE
Fix wrong autocorrect for `Style/SoleNestedConditional` when using numblocks

### DIFF
--- a/changelog/fix_wrong_autocorrect_sole_nested_cond_numblock.md
+++ b/changelog/fix_wrong_autocorrect_sole_nested_cond_numblock.md
@@ -1,0 +1,1 @@
+* [#13771](https://github.com/rubocop/rubocop/pull/13771): Fix wrong autocorrect for `Style/SoleNestedConditional` when using numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -156,7 +156,7 @@ module RuboCop
           # Handle `send` and `block` nodes that need to be wrapped in parens
           # FIXME: autocorrection prevents syntax errors by wrapping the entire node in parens,
           #        but wrapping the argument list would be a more ergonomic correction.
-          node_to_check = condition&.block_type? ? condition.send_node : condition
+          node_to_check = condition&.any_block_type? ? condition.send_node : condition
           return unless wrap_condition?(node_to_check)
 
           if condition.call_type?

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -793,6 +793,27 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
           RUBY
         end
       end
+
+      context 'with a numblock' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            if foo
+              if ok? bar do
+              ^^ Consider merging nested conditions into outer `if` conditions.
+                  _1
+                end
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo && (ok? bar do
+                  _1
+                end)
+              end
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/pull/10886

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
