### PR TITLE
Fix false positives for `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_false_positive_for_layout_redundant_line_break_cop.md
+++ b/changelog/fix_false_positive_for_layout_redundant_line_break_cop.md
@@ -1,0 +1,1 @@
+* [#13773](https://github.com/rubocop/rubocop/pull/13773): Fix false positives for `Layout/RedundantLineBreak` when using numbered block parameter. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -103,13 +103,13 @@ module RuboCop
 
         def configured_to_not_be_inspected?(node)
           return true if other_cop_takes_precedence?(node)
+          return false if cop_config['InspectBlocks']
 
-          !cop_config['InspectBlocks'] && (node.block_type? ||
-                                           any_descendant?(node, :block, &:multiline?))
+          node.any_block_type? || any_descendant?(node, :any_block, &:multiline?)
         end
 
         def other_cop_takes_precedence?(node)
-          single_line_block_chain_enabled? && any_descendant?(node, :block) do |block_node|
+          single_line_block_chain_enabled? && any_descendant?(node, :any_block) do |block_node|
             block_node.parent.send_type? && block_node.parent.loc.dot && !block_node.multiline?
           end
         end
@@ -119,8 +119,9 @@ module RuboCop
         end
 
         def convertible_block?(node)
-          parent = node.parent
-          parent&.block_type? && node == parent.send_node &&
+          return false unless (parent = node.parent)
+
+          parent.any_block_type? && node == parent.send_node &&
             (node.parenthesized? || !node.arguments?)
         end
       end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
            .join + []
         RUBY
       end
+
+      it 'accepts a method call chained onto a single line numbered block', :ruby27 do
+        expect_no_offenses(<<~RUBY)
+          e.select { _1.cond? }
+           .join
+          a = e.select { _1.cond? }
+           .join
+          e.select { _1.cond? }
+           .join + []
+        RUBY
+      end
     end
 
     context 'for an expression that fits on a single line' do
@@ -522,6 +533,15 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
           RUBY
         end
 
+        it 'accepts a complex method call on a multiple lines with numbered block', :ruby27 do
+          expect_no_offenses(<<~RUBY)
+            node.each_node(:dstr)
+                .select(&:heredoc?)
+                .map { _1.loc.heredoc_body }
+                .flat_map {  (_1.line..._1.last_line).to_a }
+          RUBY
+        end
+
         it 'accepts method call with a do keyword that would just surpass the max line length' do
           expect_no_offenses(<<~RUBY)
             context 'when the configuration includes ' \\
@@ -646,6 +666,14 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'accepts when the method call has parentheses with numbered block', :ruby27 do
+        expect_no_offenses(<<~RUBY)
+          a = Foo.do_something(arg) do
+            _1
+          end
+        RUBY
+      end
+
       it 'accepts when the method call has no arguments' do
         expect_no_offenses(<<~RUBY)
           RSpec.shared_context do
@@ -663,6 +691,14 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             end
           RUBY
         end
+
+        it 'accepts a multiline numbered block without a chained method call', :ruby27 do
+          expect_no_offenses(<<~RUBY)
+            f do
+              foo(_1)
+            end
+          RUBY
+        end
       end
 
       context 'when Layout/SingleLineBlockChain is disabled' do
@@ -671,6 +707,14 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         it 'accepts a multiline block without a chained method call' do
           expect_no_offenses(<<~RUBY)
             f do
+            end
+          RUBY
+        end
+
+        it 'accepts a multiline numbered block without a chained method call', :ruby27 do
+          expect_no_offenses(<<~RUBY)
+            f do
+              foo(_1)
             end
           RUBY
         end
@@ -685,6 +729,20 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             end.join
             e.select do |i|
               i.cond?
+            end.join + []
+          RUBY
+        end
+
+        it 'accepts a method call chained onto a multiline numbered block', :ruby27 do
+          expect_no_offenses(<<~RUBY)
+            e.select do
+              _1.cond?
+            end.join
+            a = e.select do
+              _1.cond?
+            end.join
+            e.select do
+              _1.cond?
             end.join + []
           RUBY
         end


### PR DESCRIPTION
This PR fixes false positives for `Layout/RedundantLineBreak` when using numbered block parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
