### PR TITLE
Remove workaround gem dependency from Gemfile for JRuby CI matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,3 @@ gem 'rubocop-ast', path: local_ast if Dir.exist? local_ast
 
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile local_gemfile if File.exist?(local_gemfile)
-
-# TODO: remove when JRuby 9.4.10.0 will be released and available on CI
-# Ref: https://github.com/jruby/jruby/issues/7262
-gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM.include?('java')


### PR DESCRIPTION
This reverts commit b3c80614d9922d9e2d0e376e6464af1b6e85a196.

JRuby 9.4.11.0 has been released and it is available on CI. https://www.jruby.org/2025/01/29/jruby-9-4-11-0

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
