### PR TITLE
Fix a false positive for `Lint/AssignmentInCondition` when assigning in numblocks

### DIFF
--- a/changelog/fix_false_positive_assign_in_cond_numblock.md
+++ b/changelog/fix_false_positive_assign_in_cond_numblock.md
@@ -1,0 +1,1 @@
+* [#13775](https://github.com/rubocop/rubocop/pull/13775): Fix a false positive for `Lint/AssignmentInCondition` when assigning in numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -53,8 +53,6 @@ module RuboCop
         ASGN_TYPES = [:begin, *AST::Node::EQUALS_ASSIGNMENTS, :send, :csend].freeze
 
         def on_if(node)
-          return if node.condition.block_type?
-
           traverse_node(node.condition) do |asgn_node|
             next :skip_children if skip_children?(asgn_node)
             next if allowed_construct?(asgn_node)
@@ -95,7 +93,7 @@ module RuboCop
 
         def traverse_node(node, &block)
           # if the node is a block, any assignments are irrelevant
-          return if node.block_type?
+          return if node.any_block_type?
 
           result = yield node if ASGN_TYPES.include?(node.type)
 

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -135,6 +135,14 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect_no_offenses('return 1 if any_errors? { o = file }.present?')
   end
 
+  it 'accepts = in a numblock that is called in a condition' do
+    expect_no_offenses('return 1 if any_errors? { o = inspect(_1) }')
+  end
+
+  it 'accepts = in a numblock followed by method call' do
+    expect_no_offenses('return 1 if any_errors? { o = _1 }.present?')
+  end
+
   it 'accepts assignment in a block after ||' do
     expect_no_offenses(<<~RUBY)
       if x?(bar) || y? { z = baz }


### PR DESCRIPTION
The first block check is redundant, since the method already checks for blocks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
