### PR TITLE
Pin JRuby 9.4.10.0 to prevent build error on JRuby 9.4.11.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -52,7 +52,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby' # Latest stable JRuby version
+          # FIXME: When the JRuby issue https://github.com/jruby/jruby/issues/8606 is resolved,
+          # please replace it with the following:
+          # ruby-version: 'jruby' # Latest stable JRuby version
+          ruby-version: 'jruby-9.4.10.0' # The latest JRuby version that passes CI
           bundler-cache: true
       - name: spec
         run: bundle exec rake spec


### PR DESCRIPTION
As a workaround, the JRuby CI matrix is pinned to 9.4.10.0. The issue has been reported at https://github.com/jruby/jruby/issues/8606.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
