### PR TITLE
Fix a false negative for `Layout/EmptyLineBetweenDefs` with `DefLikeMacros` and numblocks

### DIFF
--- a/changelog/fix_false_negative_empty_line_defs_numblock.md
+++ b/changelog/fix_false_negative_empty_line_defs_numblock.md
@@ -1,0 +1,1 @@
+* [#13777](https://github.com/rubocop/rubocop/pull/13777): Fix a false negative for `Layout/EmptyLineBetweenDefs` with `DefLikeMacros` and numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -162,7 +162,7 @@ module RuboCop
         private
 
         def def_location(correction_node)
-          if correction_node.block_type?
+          if correction_node.any_block_type?
             correction_node.source_range.join(correction_node.children.first.source_range)
           else
             correction_node.loc.keyword.join(correction_node.loc.name)
@@ -181,7 +181,7 @@ module RuboCop
         end
 
         def macro_candidate?(node)
-          node.block_type? && node.children.first.macro? &&
+          node.any_block_type? && node.children.first.macro? &&
             empty_line_between_macros.include?(node.children.first.method_name)
         end
 
@@ -246,7 +246,7 @@ module RuboCop
         end
 
         def def_start(node)
-          if node.block_type? && node.children.first.send_type?
+          if node.any_block_type? && node.children.first.send_type?
             node.source_range.line
           else
             node.loc.keyword.line
@@ -283,6 +283,8 @@ module RuboCop
           case node.type
           when :def, :defs
             :method
+          when :numblock
+            :block
           else
             node.type
           end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -706,6 +706,28 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       RUBY
     end
 
+    it 'registers offense if next to numblock' do
+      expect_offense(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+        foo 'second foo' do
+        ^^^^^^^^^^^^^^^^^^^ Expected 1 empty line between block definitions; found 0.
+          _1
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+
+        foo 'second foo' do
+          _1
+        end
+      RUBY
+    end
+
     it 'does not register offense' do
       expect_no_offenses(<<~RUBY)
         foo 'first foo' do


### PR DESCRIPTION

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
