### PR TITLE
[Fix #13751] Fix false positive in `Layout/ExtraSpacing` with `ForceEqualSignAlignment: true` for endless methods

### DIFF
--- a/changelog/fix_fix_false_positive_in_layout_extra_spacing_with_20250130132538.md
+++ b/changelog/fix_fix_false_positive_in_layout_extra_spacing_with_20250130132538.md
@@ -1,0 +1,1 @@
+* [#13751](https://github.com/rubocop/rubocop/issues/13751): Fix false positive in `Layout/ExtraSpacing` with `ForceEqualSignAlignment: true` for endless methods. ([@dvandersluis][])

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -628,6 +628,24 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         opt.ssh_config[e] = f
       RUBY
     end
+
+    context 'endless methods', :ruby30 do
+      it 'does not register an offense when not aligned' do
+        expect_no_offenses(<<~RUBY)
+          def deleted = do_something
+          def updated = do_something
+          def added = do_something
+        RUBY
+      end
+
+      it 'does not register an offense with optional values' do
+        expect_no_offenses(<<~RUBY)
+          def deleted(x = true) = do_something(x)
+          def updated(x = true) = do_something(x)
+          def added(x = true) = do_something(x)
+        RUBY
+      end
+    end
   end
 
   context 'when exactly two comments have extra spaces' do


### PR DESCRIPTION
Stops `Layout/ExtraSpacing` from considering the `=` that separates the method signature from body in an endless method.

Fixes #13751.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
