### PR TITLE
Fix a false positive `Style/AccessModifierDeclarations` when using access modifier in a numblock

### DIFF
--- a/changelog/fix_false_positive_access_mod_numblock.md
+++ b/changelog/fix_false_positive_access_mod_numblock.md
@@ -1,0 +1,1 @@
+* [#13780](https://github.com/rubocop/rubocop/pull/13780): Fix a false positive `Style/AccessModifierDeclarations` when using access modifier in a numblock. ([@earlopain][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -150,8 +150,6 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[private protected public module_function].freeze
 
-        ALLOWED_NODE_TYPES = %i[pair block].freeze
-
         # @!method access_modifier_with_symbol?(node)
         def_node_matcher :access_modifier_with_symbol?, <<~PATTERN
           (send nil? {:private :protected :public :module_function}
@@ -188,7 +186,7 @@ module RuboCop
 
         def allowed?(node)
           !node.access_modifier? ||
-            ALLOWED_NODE_TYPES.include?(node.parent&.type) ||
+            node.parent&.type?(:pair, :any_block) ||
             allow_modifiers_on_symbols?(node) ||
             allow_modifiers_on_attrs?(node) ||
             allow_modifiers_on_alias_method?(node)
@@ -312,7 +310,7 @@ module RuboCop
           argument_less_modifier_node = find_argument_less_modifier_node(node)
           if argument_less_modifier_node
             corrector.insert_after(argument_less_modifier_node, "\n\n#{source}")
-          elsif (ancestor = node.each_ancestor(:block, :class, :module).first)
+          elsif (ancestor = node.each_ancestor(:class, :module).first)
 
             corrector.insert_before(ancestor.loc.end, "#{node.method_name}\n\n#{source}\n")
           else

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -425,6 +425,14 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
+      it "does not register an offense when using #{access_modifier} in a numblock" do
+        expect_no_offenses(<<~RUBY)
+          module MyModule
+            singleton_methods.each { #{access_modifier}(_1) }
+          end
+        RUBY
+      end
+
       context 'when method is modified by inline modifier with disallowed symbol' do
         let(:cop_config) do
           { 'AllowModifiersOnSymbols' => false }


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/pull/11103
Apparently it used to error, now it is just a false positive for these.

There was another block type check during autocorrect. But it seems unnessesary now since there is no offense for blocks. So, I just removed it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
