### PR TITLE
Fix a false positive for `Lint/UnmodifiedReduceAccumulator` when omitting the accumulator in a nested numblock

### DIFF
--- a/changelog/fix_unmod_reduce_numblock.md
+++ b/changelog/fix_unmod_reduce_numblock.md
@@ -1,0 +1,1 @@
+* [#13781](https://github.com/rubocop/rubocop/pull/13781): Fix a false positive for `Lint/UnmodifiedReduceAccumulator` when omitting the accumulator in a nested numblock. ([@earlopain][])

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -130,7 +130,7 @@ module RuboCop
 
           block_body_node.each_descendant(:next, :break) do |n|
             # Ignore `next`/`break` inside an inner block
-            next if n.each_ancestor(:block).first != block_body_node.parent
+            next if n.each_ancestor(:any_block).first != block_body_node.parent
             next unless n.first_argument
 
             nodes << n.first_argument

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -577,6 +577,17 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
         RUBY
       end
 
+      it 'does not look inside inner numblocks' do
+        expect_no_offenses(<<~RUBY)
+          foo.#{method}(bar) do |acc, el|
+            values.map do
+              next el if something?
+              _1
+            end
+          end
+        RUBY
+      end
+
       it 'allows break with no value' do
         expect_no_offenses(<<~RUBY)
           foo.#{method}([]) do |acc, el|


### PR DESCRIPTION


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
