### PR TITLE
Fix an error `Layout/ElseAlignment` when `else` is part of a numblock

### DIFF
--- a/changelog/fix_else_alignment_numblock.md
+++ b/changelog/fix_else_alignment_numblock.md
@@ -1,0 +1,1 @@
+* [#13782](https://github.com/rubocop/rubocop/pull/13782): Fix an error `Layout/ElseAlignment` when `else` is part of a numblock. ([@earlopain][])

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -92,7 +92,7 @@ module RuboCop
           case parent.type
           when :def, :defs then base_for_method_definition(parent)
           when :kwbegin then parent.loc.begin
-          when :block
+          when :block, :numblock
             assignment_node = assignment_node(parent)
             if same_line?(parent, assignment_node)
               assignment_node.source_range

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -582,6 +582,21 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
       RUBY
     end
 
+    it 'accepts a correctly aligned else from numblock' do
+      expect_no_offenses(<<~RUBY)
+        array_like.each do
+          _1
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
     it 'accepts a correctly aligned else with assignment' do
       expect_no_offenses(<<~RUBY)
         result = array_like.each do |n|


### PR DESCRIPTION
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
