### PR TITLE
Fix a false positive for `Lint/Void` when `each` numblock with conditional expressions that has multiple statements

### DIFF
--- a/changelog/fix_false_positive_lint_void_numblock.md
+++ b/changelog/fix_false_positive_lint_void_numblock.md
@@ -1,0 +1,1 @@
+* [#13783](https://github.com/rubocop/rubocop/pull/13783): Fix a false positive for `Lint/Void` when `each` numblock with conditional expressions that has multiple statements. ([@earlopain][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -103,7 +103,7 @@ module RuboCop
           expressions.pop unless in_void_context?(node)
           expressions.each do |expr|
             check_void_op(expr) do
-              block_node = node.each_ancestor(:block).first
+              block_node = node.each_ancestor(:any_block).first
 
               block_node&.method?(:each)
             end
@@ -200,11 +200,6 @@ module RuboCop
           return unless (body = node.branch)
           # NOTE: the `begin` node case is already handled via `on_begin`
           return if body.begin_type?
-
-          check_void_op(body) do
-            block_node = node.each_ancestor(:block).first
-            block_node&.method?(:each)
-          end
 
           check_expression(body)
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -894,6 +894,18 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'does not register `#each` numblock with conditional expressions that has multiple statements' do
+    expect_no_offenses(<<~RUBY)
+      enumerator_as_filter.each do
+        puts _1
+
+        # The `filter` method is used to filter for matches with `42`.
+        # In this case, it's not void.
+        _1 == 42
+      end
+    RUBY
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'registers two offenses for void literals in `#tap` method' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Followup https://github.com/rubocop/rubocop/pull/12688

Also remove a different block check that I don't think is doing anything. It was added in https://github.com/rubocop/rubocop/pull/13131 but all tests still pass

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
