### PR TITLE
Stabilize `help` command line option test

### DIFF
--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
   describe 'option' do
     describe '-h/--help' do
+      # HACK: `help` option is implemented with OptionParser, if the environment vars
+      # `RUBY_PAGER` or `PAGER` are set, the mock for stdout will not be applied.
+      # To ensure stdout is mocked, a simple way is to temporarily delete these environment vars.
+      # https://github.com/ruby/optparse/blob/v0.6.0/lib/optparse.rb#L1053-L1071
+      around do |example|
+        original_ruby_pager = ENV.delete('RUBY_PAGER')
+        original_pager = ENV.delete('PAGER')
+        begin
+          example.run
+        ensure
+          ENV['RUBY_PAGER'] = original_ruby_pager
+          ENV['PAGER'] = original_pager
+        end
+      end
+
       it 'exits cleanly `-h`' do
         expect { options.parse ['-h'] }.to exit_with_code(0)
       end


### PR DESCRIPTION
This PR stabilizes the following `help` command line option test.

```console
$ echo $PAGER
less

$ bundle exec rspec spec/rubocop/options_spec.rb
(snip)

Failed examples:

rspec ./spec/rubocop/options_spec.rb:221 # RuboCop::Options option -h/--help lists all builtin formatters
rspec ./spec/rubocop/options_spec.rb:25 # RuboCop::Options option -h/--help shows help text
```

`help` option is implemented with OptionParser, if the environment vars `RUBY_PAGER` or `PAGER` are set, the mock for stdout will not be applied. 
https://github.com/ruby/optparse/blob/v0.6.0/lib/optparse.rb#L1053-L1071

To ensure stdout is mocked, a simple way is to temporarily delete these environment vars.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
