### PR TITLE
Fix `Style/EachWithObject` cop error in case if single block argument

### DIFF
--- a/changelog/fix_style_each_with_object_cop_error_in_case_of_single_block_argument.md
+++ b/changelog/fix_style_each_with_object_cop_error_in_case_of_single_block_argument.md
@@ -1,0 +1,1 @@
+* [#13785](https://github.com/rubocop/rubocop/pull/13785): Fix `Style/EachWithObject` cop error in case of single block argument. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -58,7 +58,7 @@ module RuboCop
 
         # @!method each_with_object_block_candidate?(node)
         def_node_matcher :each_with_object_block_candidate?, <<~PATTERN
-          (block $(call _ {:inject :reduce} _) $_ $_)
+          (block $(call _ {:inject :reduce} _) $(args _ _) $_)
         PATTERN
 
         # @!method each_with_object_numblock_candidate?(node)
@@ -71,8 +71,7 @@ module RuboCop
 
           first_arg, second_arg = *node.arguments
 
-          corrector.replace(first_arg, second_arg.source)
-          corrector.replace(second_arg, first_arg.source)
+          corrector.swap(first_arg, second_arg)
 
           if return_value_occupies_whole_line?(return_value)
             corrector.remove(whole_line_expression(return_value))

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -101,6 +101,28 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject, :config do
     RUBY
   end
 
+  it 'ignores inject and reduce with block without arguments' do
+    expect_no_offenses(<<~RUBY)
+      [].inject({}) { $GLOBAL[rand] = rand; $GLOBAL }
+
+      [].reduce({}) do
+         $GLOBAL[rand] = rand
+         $GLOBAL
+      end
+    RUBY
+  end
+
+  it 'ignores inject and reduce with block with single argument' do
+    expect_no_offenses(<<~RUBY)
+      [].inject({}) { |h| h[rand] = rand; h }
+
+      [].reduce({}) do |h|
+         h[rand] = rand
+         h
+      end
+    RUBY
+  end
+
   it 'ignores inject and reduce with passed in, but not returned hash' do
     expect_no_offenses(<<~RUBY)
       [].inject({}) do |a, e|


### PR DESCRIPTION
The following code leads to an error:

```console
echo '[].inject({}) { |h| h[rand] = rand; h }' | rubocop --stdin bug.rb --only Style/EachWithObject -d
An error occurred while Style/EachWithObject cop was inspecting bug.rb:1:0.
undefined method `source' for nil
lib/rubocop/cop/style/each_with_object.rb:74:in `autocorrect_block'
lib/rubocop/cop/style/each_with_object.rb:38:in `block (2 levels) in on_block'
```

This issue was found by [rubocop-nightly](https://github.com/viralpraxis/rubocop-nightly) in [nvim](https://rubygems.org/gems/nvim) gem.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
