### PR TITLE
Disable `Lint/ShadowingOuterLocalVariable` by default

### DIFF
--- a/changelog/change_disable_lint_shadowing_outer_local_variable_by_20250203115238.md
+++ b/changelog/change_disable_lint_shadowing_outer_local_variable_by_20250203115238.md
@@ -1,0 +1,1 @@
+* [#13788](https://github.com/rubocop/rubocop/pull/13788): Disable `Lint/ShadowingOuterLocalVariable` by default. ([@nekketsuuu][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2410,8 +2410,9 @@ Lint/ShadowingOuterLocalVariable:
   Description: >-
                  Do not use the same name as outer local variable
                  for block arguments or block local variables.
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.9'
+  VersionChanged: <<next>>
 
 Lint/SharedMutableDefault:
   Description: 'Checks for mutable literals used as default arguments during Hash initialization.'


### PR DESCRIPTION
Lint/ShadowingOuterLocalVariable cop was initially added as Syntax cop, which warns if the Ruby system issues warnings.

- https://github.com/rubocop/rubocop/commit/fd4eabea8b5b81e5bd742bfe7030d7e0ca242ecb
- https://github.com/rubocop/rubocop/commit/72d278959b40e08271afc102cd29626f16c58030

However, the Ruby warning corresponding to Lint/ShadowingOuterLocalVariable was removed in Ruby 2.6. This is because:

> It was introduced to ruby 1.9, a version which changes behaviors on conflicts of local vars and block param. I understand it is to tell the user the change, and let them fix if their program depends on 1.8 behavior. ruby 1.9.1 is released in 2009, almost seven years ago, and most ruby programmers today would have correct understanding of current behavior. In my opinion, the warning does not make sense now but just annoying.

(Citation from https://bugs.ruby-lang.org/issues/12490)

Therefore I believe there are no reasons to keep disallowing shadowing by RuboCop. So in this pull request, I'm trying to change the cop not to be enabled by default. What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
