### PR TITLE
[Fix #13787] Fix incorrect autocorrect for `Style/ExplicitBlockArgument`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_explicit_block_argument.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_explicit_block_argument.md
@@ -1,0 +1,1 @@
+* [#13787](https://github.com/rubocop/rubocop/issues/13787): Fix incorrect autocorrect for `Style/ExplicitBlockArgument` when using arguments of `zsuper` in method definition. ([@koic][])

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -236,4 +236,34 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when using arguments with zsuper in a method definition' do
+    expect_offense(<<~RUBY)
+      def my_method(x, y = 42, *args, **options)
+        super { yield }
+        ^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def my_method(x, y = 42, *args, **options, &block)
+        super(x, y, *args, **options, &block)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using arguments with zsuper in a singleton method definition' do
+    expect_offense(<<~RUBY)
+      def self.my_method(x, y = 42, *args, **options)
+        super { yield }
+        ^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.my_method(x, y = 42, *args, **options, &block)
+        super(x, y, *args, **options, &block)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Style/ExplicitBlockArgument` when using arguments of `zsuper` in method definition.

Fixes #13787

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
