### PR TITLE
[Fix #6012] Support RuboCop extension plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 # This is the configuration used to check the rubocop source code.
 
 inherit_from: .rubocop_todo.yml
+
+plugins:
+  - rubocop-internal_affairs
+
 require:
-  - rubocop/cop/internal_affairs
   - rubocop-performance
   - rubocop-rspec
   - rubocop-rake

--- a/changelog/new_support_rubocop_extension_plugin.md
+++ b/changelog/new_support_rubocop_extension_plugin.md
@@ -1,0 +1,1 @@
+* [#6012](https://github.com/rubocop/rubocop/issues/6012): Support RuboCop extension plugin. ([@koic][])

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -22,6 +22,7 @@
 ** xref:cops_security.adoc[Security]
 ** xref:cops_style.adoc[Style]
 ** xref:v1_upgrade_notes.adoc[Upgrade Notes]
+** xref:plugin_migration_guide.adoc[Plugin Migration Guide]
 * xref:extensions.adoc[Extensions]
 * xref:integration_with_other_tools.adoc[Integration with Other Tools]
 * xref:automated_code_review.adoc[Automated Code Review]

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -4,6 +4,43 @@ It's possible to extend RuboCop with custom (third-party) cops and formatters.
 
 == Loading Extensions
 
+Starting with RuboCop 1.72, plugins are provided as a way to load extension cop gems.
+When using gems that support plugins, please update the configuration in `.rubocop.yml`
+from `require` to `plugins`.
+
+Refer to the xref:plugin_migration_guide.adoc[Plugin Migration Guide] when migrating existing configurations.
+
+=== Loading Plugin Extensions
+
+NOTE: The plugin system was introduced in RuboCop 1.72.
+
+Besides the `--plugin` command line option you can also specify ruby
+files that should be loaded with the optional `plugins` directive in the
+`.rubocop.yml` file:
+
+[source,yaml]
+----
+plugins:
+  - rubocop-performance
+----
+
+Most extension gems with plugin support should work with the example above.
+
+The following is an example of a plugin that is not published as a gem:
+
+[source,yaml]
+----
+plugins:
+  - rubocop-extension
+      require_path: path/to/extension/plugin
+      plugin_class_name: RuboCop::Extension::Plugin
+----
+
+There are other ways to specify this. For more details, please refer to the lint_roller documentation.
+The lint_roller plugin specifications follow https://github.com/standardrb/lint_roller[lint_roller].
+
+=== Loading Inject and Relative Path Extensions
+
 Besides the `--require` command line option you can also specify ruby
 files that should be loaded with the optional `require` directive in the
 `.rubocop.yml` file:
@@ -11,9 +48,14 @@ files that should be loaded with the optional `require` directive in the
 [source,yaml]
 ----
 require:
- - ../my/custom/file.rb
- - rubocop-extension
+  - ../my/custom/file.rb
+  - rubocop-extension
 ----
+
+The extension loading via `require` remains compatible with the pre-plugin inject method.
+Since `require` is used for internal extensions such as custom cops and formatters,
+there are no plans to remove it in the future.
+However, it is recommended that publicly available extension cops in gems migrate to the plugin system.
 
 NOTE: The paths are directly passed to `Kernel.require`. If your
 extension file is not in `$LOAD_PATH`, you need to specify the path as
@@ -58,6 +100,8 @@ other cop.
 === Writing your own Cops
 
 If you'd like to create an extension gem, you can use https://github.com/rubocop/rubocop-extension-generator[rubocop-extension-generator].
+
+For plugin specifications, please refer to https://github.com/standardrb/lint_roller[lint_roller].
 
 See xref:development.adoc[development] to learn how to implement a cop.
 

--- a/docs/modules/ROOT/pages/plugin_migration_guide.adoc
+++ b/docs/modules/ROOT/pages/plugin_migration_guide.adoc
@@ -1,0 +1,130 @@
+= Plugin Migration Guide
+
+This page provides guidance on migrating to RuboCop extensions using plugins. Plugins are a feature introduced in RuboCop 1.72.
+
+It is divided into two main sections: one for plugin users and the other for plugin developers.
+
+== For Plugin Users
+
+Please update the RuboCop extension cops specified in configuration files like `.rubocop.yml` from `require` to `plugin`.
+
+[source,yaml]
+----
+plugins:
+  - rubocop-performance
+----
+
+Specifically, those that trigger warnings like the following should be updated:
+
+[source,console]
+----
+$ bundle exec rubocop
+rubocop-performance extension supports plugin, specify `plugins: rubocop-performance`
+instead of `require: rubocop-performance` in /Users/koic/src/github.com/rubocop/rubocop/.rubocop.yml.
+For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
+----
+
+NOTE: Non-plugin extension Ruby files can continue to use `require` for file requiring.
+
+== For Plugin Developers
+
+Converting an existing RuboCop extension using `Inject.defaults!` into a plugin can generally be done in the following three steps.
+
+1. Create `Plugin` class
+2. Update gemspec file
+3. Remove `Inject.defaults!` code
+
+The `rubocop-performance` extension gem is used as an example here.
+Replace "performance" with the name of your extension as appropriate.
+
+=== 1. Create `Plugin` class
+
+Prepare the plugin class. It is typically placed under the department directory, such as `rubocop/performance/plugin.rb`.
+
+[source,ruby]
+----
+# frozen_string_literal: true
+
+require 'lint_roller'
+
+module RuboCop
+  module Performance
+    # A plugin that integrates RuboCop Performance with RuboCop's plugin system.
+    class Plugin < LintRoller::Plugin
+      def about
+        LintRoller::About.new(
+          name: 'rubocop-performance',
+          version: Version::STRING,
+          homepage: 'https://github.com/rubocop/rubocop-performance',
+          description: 'A collection of RuboCop cops to check for performance optimizations in Ruby code.'
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(_context)
+        LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: Pathname.new(__dir__).join('../../../config/default.yml')
+        )
+      end
+    end
+  end
+end
+----
+
+For details on configurations, refer to the lint_roller documentation:
+https://github.com/standardrb/lint_roller?tab=readme-ov-file#how-to-make-a-plugin
+
+=== 2. Update gemspec file
+
+Set the plugin class name in `spec.metadata['default_lint_roller_plugin']` and add a runtime dependency on `lint_roller`.
+
+[source,ruby]
+----
+spec.metadata['default_lint_roller_plugin'] = 'RuboCop::Performance::Plugin'
+
+spec.add_dependency('lint_roller')
+----
+
+Update `rubocop` to a version that supports plugins or higher.
+
+[source,ruby]
+----
+spec.require('rubocop', '>= 1.72.0')
+----
+
+=== 3. Replace `Inject.defaults!` code
+
+Replace `rubocop/performance/inject`, where the `RuboCop::Performance::Inject` class is defined.
+
+[source,console]
+----
+$ rm 'rubocop/performance/inject'
+----
+
+Remove the call to `RuboCop::Performance::Inject.defaults!` and the related `require_relative` code.
+
+[source,ruby]
+----
+require_relative 'rubocop/performance/inject'
+
+RuboCop::Performance::Inject.defaults!
+----
+
+And use `require_relative` for the plugin class file instead of the above.
+
+[source,ruby]
+----
+require_relative 'rubocop/performance/plugin'
+----
+
+In non-runtime environments like `spec/spec_helper.rb`, replace `require_relative 'rubocop/performance/plugin'` with `RuboCop::ConfigLoader.inject_defaults!`.
+
+[source,ruby]
+----
+RuboCop::ConfigLoader.inject_defaults!("#{__dir__}/../config/default.yml")
+----

--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -249,8 +249,11 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--raise-cop-error`
 | Raise cop-related errors with cause and location. This is used to prevent cops from failing silently. Default is false.
 
+| `--plugin`
+| Plugin RuboCop extension file (see xref:extensions.adoc#loading-plugin-extensions[Loading Plugin Extensions]).
+
 | `-r/--require`
-| Require Ruby file (see xref:extensions.adoc#loading-extensions[Loading Extensions]).
+| Require Ruby file (see xref:extensions.adoc#loading-inject-and-relative-path-extensions[Loading Inject and Relative Path Extensions]).
 
 | `--regenerate-todo`
 | Regenerate the TODO list using the same options as the last time it was generated with `--auto-gen-config` (generation options can be overridden).

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -45,6 +45,10 @@ module RuboCop
     end
     # rubocop:enable Metrics/AbcSize
 
+    def loaded_plugins
+      @loaded_plugins ||= ConfigLoader.loaded_plugins
+    end
+
     def loaded_features
       @loaded_features ||= ConfigLoader.loaded_features
     end

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -37,18 +37,3 @@ require_relative 'internal_affairs/style_detected_api_use'
 require_relative 'internal_affairs/undefined_config'
 require_relative 'internal_affairs/useless_message_assertion'
 require_relative 'internal_affairs/useless_restrict_on_send'
-
-module RuboCop
-  # Patch in the InternalAffairs specific config values
-  module InternalAffairs
-    def self.inject!
-      path = File.join(ConfigLoader::RUBOCOP_HOME, 'config', 'internal_affairs.yml')
-      hash = ConfigLoader.load_yaml_configuration(path)
-      config = Config.new(hash, path)
-      config = ConfigLoader.merge_with_default(config, path)
-      ConfigLoader.instance_variable_set(:@default_configuration, config)
-    end
-  end
-end
-
-RuboCop::InternalAffairs.inject!

--- a/lib/rubocop/cop/internal_affairs/plugin.rb
+++ b/lib/rubocop/cop/internal_affairs/plugin.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'lint_roller'
+
+module RuboCop
+  module InternalAffairs
+    # A Plugin for `InternalAffairs` department, which has internal cops.
+    class Plugin < LintRoller::Plugin
+      def about
+        LintRoller::About.new(
+          name: 'rubocop-internal_affairs',
+          version: Version::STRING,
+          homepage: 'https://github.com/rubocop/rubocop/tree/master/lib/rubocop/cop/internal_affairs',
+          description: 'A collection of RuboCop cops to check for internal affairs.'
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(_context)
+        require_relative '../internal_affairs'
+
+        LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: Pathname.new(__dir__).join('../../../../config/internal_affairs.yml')
+        )
+      end
+    end
+  end
+end

--- a/lib/rubocop/plugin.rb
+++ b/lib/rubocop/plugin.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'plugin/configuration_integrator'
+require_relative 'plugin/loader'
+
+module RuboCop
+  # Provides a plugin for RuboCop extensions that conform to lint_roller.
+  # https://github.com/standardrb/lint_roller
+  # @api private
+  module Plugin
+    BUILTIN_INTERNAL_PLUGINS = {
+      'rubocop-internal_affairs' => {
+        'enabled' => true,
+        'require_path' => 'rubocop/cop/internal_affairs/plugin',
+        'plugin_class_name' => 'RuboCop::InternalAffairs::Plugin'
+      }
+    }.freeze
+    INTERNAL_AFFAIRS_PLUGIN_NAME = Plugin::BUILTIN_INTERNAL_PLUGINS.keys.first
+    OBSOLETE_INTERNAL_AFFAIRS_PLUGIN_NAME = 'rubocop/cop/internal_affairs'
+
+    class << self
+      def plugin_capable?(feature_name)
+        return true if BUILTIN_INTERNAL_PLUGINS.key?(feature_name)
+        return true if feature_name == OBSOLETE_INTERNAL_AFFAIRS_PLUGIN_NAME
+        return false unless (gem = Gem.loaded_specs[feature_name])
+
+        !!gem.metadata['default_lint_roller_plugin']
+      end
+
+      def integrate_plugins(rubocop_config, plugins)
+        plugins = Plugin::Loader.load(plugins)
+
+        ConfigurationIntegrator.integrate_plugins_into_rubocop_config(rubocop_config, plugins)
+
+        plugins
+      end
+    end
+  end
+end

--- a/lib/rubocop/plugin/configuration_integrator.rb
+++ b/lib/rubocop/plugin/configuration_integrator.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'lint_roller/context'
+require_relative 'not_supported_error'
+
+module RuboCop
+  module Plugin
+    # A class for integrating plugin configurations into RuboCop.
+    # Handles configuration merging, validation, and compatibility for plugins.
+    # @api private
+    class ConfigurationIntegrator
+      class << self
+        def integrate_plugins_into_rubocop_config(rubocop_config, plugins)
+          default_config = ConfigLoader.default_configuration
+          runner_context = create_context(rubocop_config)
+
+          validate_plugins!(plugins, runner_context)
+
+          plugin_config = combine_rubocop_configs(default_config, runner_context, plugins).to_h
+
+          merge_plugin_config_into_all_cops!(default_config, plugin_config)
+          merge_plugin_config_into_default_config!(default_config, plugin_config)
+        end
+
+        private
+
+        def create_context(rubocop_config)
+          LintRoller::Context.new(
+            runner: :rubocop,
+            runner_version: Version.version,
+            engine: :rubocop,
+            engine_version: Version.version,
+            target_ruby_version: rubocop_config.target_ruby_version
+          )
+        end
+
+        def validate_plugins!(plugins, runner_context)
+          unsupported_plugins = plugins.reject { |plugin| plugin.supported?(runner_context) }
+          return if unsupported_plugins.none?
+
+          raise Plugin::NotSupportedError, unsupported_plugins
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def combine_rubocop_configs(default_config, runner_context, plugins)
+          fake_out_rubocop_default_configuration(default_config) do |fake_config|
+            all_cop_keys_configured_by_plugins = []
+
+            plugins.reduce(fake_config) do |combined_config, plugin|
+              RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, combined_config)
+
+              print 'Plugin ' if ConfigLoader.debug
+
+              plugin_config, plugin_config_path = load_plugin_rubocop_config(plugin, runner_context)
+
+              plugin_config['AllCops'], all_cop_keys_configured_by_plugins = merge_all_cop_settings(
+                combined_config['AllCops'], plugin_config['AllCops'],
+                all_cop_keys_configured_by_plugins
+              )
+              delete_already_configured_keys!(
+                combined_config.keys, plugin_config, dont_delete_keys: ['AllCops']
+              )
+
+              ConfigLoader.merge_with_default(plugin_config, plugin_config_path)
+            end
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def merge_plugin_config_into_all_cops!(rubocop_config, plugin_config)
+          rubocop_config['AllCops'].merge!(plugin_config['AllCops'])
+        end
+
+        def merge_plugin_config_into_default_config!(default_config, plugin_config)
+          plugin_config.each do |key, value|
+            default_config[key] = if default_config[key].is_a?(Hash)
+                                    resolver.merge(default_config[key], value)
+                                  else
+                                    value
+                                  end
+          end
+        end
+
+        def fake_out_rubocop_default_configuration(default_config)
+          orig_default_config = ConfigLoader.instance_variable_get(:@default_configuration)
+
+          result = yield default_config
+
+          ConfigLoader.instance_variable_set(:@default_configuration, orig_default_config)
+
+          result
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def load_plugin_rubocop_config(plugin, runner_context)
+          rules = plugin.rules(runner_context)
+
+          case rules.type
+          when :path
+            [ConfigLoader.load_file(rules.value, check: false), rules.value]
+          when :object
+            path = plugin.method(:rules).source_location[0]
+            [Config.create(rules.value, path, check: true), path]
+          when :error
+            plugin_name = plugin.about&.name || plugin.inspect
+            error_message = rules.value.respond_to?(:message) ? rules.value.message : rules.value
+
+            raise "Plugin `#{plugin_name}' failed to load with error: #{error_message}"
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        # This is how we ensure "first-in wins": plugins can override AllCops settings that are
+        # set by RuboCop's default configuration, but once a plugin sets an AllCop setting, they
+        # have exclusive first-in-wins rights to that setting.
+        #
+        # The one exception to this are array fields, because we don't want to
+        # overwrite the AllCops defaults but rather munge the arrays (`existing |
+        # new`) to allow plugins to add to the array, for example Include and
+        # Exclude paths and patterns.
+        def merge_all_cop_settings(existing_all_cops, new_all_cops, already_configured_keys)
+          return [existing_all_cops, already_configured_keys] unless new_all_cops.is_a?(Hash)
+
+          combined_all_cops = existing_all_cops.dup
+          combined_configured_keys = already_configured_keys.dup
+
+          new_all_cops.each do |key, value|
+            if combined_all_cops[key].is_a?(Array) && value.is_a?(Array)
+              combined_all_cops[key] |= value
+              combined_configured_keys |= [key]
+            elsif !combined_configured_keys.include?(key)
+              combined_all_cops[key] = value
+              combined_configured_keys << key
+            end
+          end
+
+          [combined_all_cops, combined_configured_keys]
+        end
+
+        def delete_already_configured_keys!(configured_keys, next_config, dont_delete_keys: [])
+          duplicate_keys = configured_keys & Array(next_config&.keys)
+
+          (duplicate_keys - dont_delete_keys).each do |key|
+            next_config.delete(key)
+          end
+        end
+
+        def resolver
+          @resolver ||= ConfigLoaderResolver.new
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/plugin/load_error.rb
+++ b/lib/rubocop/plugin/load_error.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Plugin
+    # An exception raised when a plugin fails to load.
+    # @api private
+    class LoadError < Error
+      def initialize(plugin_name)
+        super
+
+        @plugin_name = plugin_name
+      end
+
+      def message
+        <<~MESSAGE
+          Failed loading plugin `#{@plugin_name}` because we couldn't determine the corresponding plugin class to instantiate.
+          First, try upgrading it. If the issue persists, please check with the developer regarding the following points.
+
+          RuboCop plugin class names must either be:
+
+            - If the plugin is a gem, defined in the gemspec as `default_lint_roller_plugin'
+
+              spec.metadata['default_lint_roller_plugin'] = 'MyModule::Plugin'
+
+            - Set in YAML as `plugin_class_name'; example:
+
+              plugins:
+                - incomplete:
+                    require_path: my_module/plugin
+                    plugin_class_name: "MyModule::Plugin"
+        MESSAGE
+      end
+    end
+  end
+end

--- a/lib/rubocop/plugin/loader.rb
+++ b/lib/rubocop/plugin/loader.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative '../feature_loader'
+require_relative 'load_error'
+
+module RuboCop
+  module Plugin
+    # A class for loading and resolving plugins.
+    # @api private
+    class Loader
+      # rubocop:disable Layout/LineLength
+      DEFAULT_PLUGIN_CONFIG = {
+        'enabled' => true,
+        'require_path' => nil, # If not set, will be set to the plugin name
+        'plugin_class_name' => nil # If not set, looks for gemspec `spec.metadata["default_lint_roller_plugin"]`
+      }.freeze
+
+      # rubocop:enable Layout/LineLength
+      class << self
+        def load(plugins)
+          normalized_plugin_configs = normalize(plugins)
+          normalized_plugin_configs.filter_map do |plugin_name, plugin_config|
+            next unless plugin_config['enabled']
+
+            plugin_class = constantize_plugin_from(plugin_name, plugin_config)
+
+            plugin_class.new(plugin_config)
+          end
+        end
+
+        private
+
+        # rubocop:disable Metrics/MethodLength
+        def normalize(plugin_configs)
+          plugin_configs.to_h do |plugin_config|
+            if plugin_config == Plugin::OBSOLETE_INTERNAL_AFFAIRS_PLUGIN_NAME
+              warn Rainbow(<<~MESSAGE).yellow
+                Specify `rubocop-internal_affairs` instead of `rubocop/cop/internal_affairs` in your configuration.
+              MESSAGE
+              plugin_config = Plugin::INTERNAL_AFFAIRS_PLUGIN_NAME
+            end
+
+            if plugin_config.is_a?(Hash)
+              plugin_name = plugin_config.keys.first
+
+              [
+                plugin_name, DEFAULT_PLUGIN_CONFIG.merge(
+                  { 'require_path' => plugin_name }, plugin_config.values.first
+                )
+              ]
+            # NOTE: Compatibility is maintained when `require: rubocop/cop/internal_affairs` remains
+            # specified in `.rubocop.yml`.
+            elsif (builtin_plugin_config = Plugin::BUILTIN_INTERNAL_PLUGINS[plugin_config])
+              [plugin_config, builtin_plugin_config]
+            else
+              [plugin_config, DEFAULT_PLUGIN_CONFIG.merge('require_path' => plugin_config)]
+            end
+          end
+        end
+
+        def constantize_plugin_from(plugin_name, plugin_config)
+          if plugin_name.is_a?(String) || plugin_name.is_a?(Symbol)
+            constantize(plugin_name, plugin_config)
+          else
+            plugin_name
+          end
+        end
+
+        # rubocop:enable Metrics/MethodLength
+        def constantize(plugin_name, plugin_config)
+          require_plugin(plugin_config['require_path'])
+
+          if (constant_name = plugin_config['plugin_class_name'])
+            begin
+              Kernel.const_get(constant_name)
+            rescue StandardError
+              raise <<~MESSAGE
+                Failed while configuring plugin `#{plugin_name}': no constant with name `#{constant_name}' was found.
+              MESSAGE
+            end
+          else
+            constantize_plugin_from_gemspec_metadata(plugin_name)
+          end
+        end
+
+        def require_plugin(require_path)
+          FeatureLoader.load(config_directory_path: Dir.pwd, feature: require_path)
+        end
+
+        def constantize_plugin_from_gemspec_metadata(plugin_name)
+          plugin_class_name = Gem.loaded_specs[plugin_name].metadata['default_lint_roller_plugin']
+
+          Kernel.const_get(plugin_class_name)
+        rescue LoadError, StandardError
+          raise Plugin::LoadError, plugin_name
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/plugin/not_supported_error.rb
+++ b/lib/rubocop/plugin/not_supported_error.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # An exception raised when a plugin is not supported by the RuboCop engine.
+  # @api private
+  class NotSupportedError < Error
+    def initialize(unsupported_plugins)
+      super
+
+      @unsupported_plugins = unsupported_plugins
+    end
+
+    def message
+      if @unsupported_plugins.one?
+        about_plugin = @unsupported_plugins.first.about
+
+        "#{about_plugin.name} #{about_plugin.version} is not a plugin supported by RuboCop engine."
+      else
+        unsupported_plugin_names = @unsupported_plugins.map do |plugin|
+          "#{plugin.about.name} #{plugin.about.version}"
+        end.join(', ')
+
+        "#{unsupported_plugin_names} are not plugins supported by RuboCop engine."
+      end
+    end
+  end
+end

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -12,7 +12,8 @@ module RuboCop
   # Use global Rake namespace here to avoid namespace issues with custom
   # rubocop-rake tasks
   class RakeTask < ::Rake::TaskLib
-    attr_accessor :name, :verbose, :fail_on_error, :patterns, :formatters, :requires, :options
+    attr_accessor :name, :verbose, :fail_on_error, :patterns, :formatters, :plugins, :requires,
+                  :options
 
     def initialize(name = :rubocop, *args, &task_block)
       super()
@@ -54,6 +55,7 @@ module RuboCop
 
     def full_options
       formatters.map { |f| ['--format', f] }.flatten
+                .concat(plugins.map { |plugin| ['--plugin', plugin] }.flatten)
                 .concat(requires.map { |r| ['--require', r] }.flatten)
                 .concat(options.flatten)
                 .concat(patterns)
@@ -64,6 +66,7 @@ module RuboCop
       @verbose = true
       @fail_on_error = true
       @patterns = []
+      @plugins = []
       @requires = []
       @options = []
       @formatters = []

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json', '~> 2.3')
   s.add_dependency('language_server-protocol', '>= 3.17.0')
+  s.add_dependency('lint_roller', '>= 1.1.0')
   s.add_dependency('parallel', '~> 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2047,6 +2047,32 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to match(regexp)
       end
     end
+
+    context 'when using `plugins` to enable a plugin' do
+      it 'exits with 0 without warning' do
+        create_file('.rubocop.yml', <<~YAML)
+          plugins:
+            - rubocop-internal_affairs
+        YAML
+
+        expect(cli.run([])).to eq(0)
+        expect($stderr.string).to be_blank
+      end
+    end
+
+    context 'when using `require` to enable a plugin' do
+      it 'exits with 0 with warning' do
+        create_file('.rubocop.yml', <<~YAML)
+          require:
+            - rubocop/cop/internal_affairs
+        YAML
+
+        expect(cli.run([])).to eq(0)
+        expect($stderr.string).to start_with(
+          'rubocop/cop/internal_affairs extension supports plugin'
+        )
+      end
+    end
   end
 
   describe 'obsolete cops' do

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -277,6 +277,8 @@ RSpec.describe RuboCop::ConfigObsoletion do
     end
 
     context 'when the extensions are loaded via inherit_gem', :restore_registry do
+      include_context 'mock console output'
+
       let(:resolver) { RuboCop::ConfigLoaderResolver.new }
       let(:gem_root) { File.expand_path('gems') }
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -365,12 +365,7 @@ RSpec.describe RuboCop::Cop::Generator do
       RuboCop::Cop::Registry.with_temporary_global(new_global) { example.run }
     end
 
-    let(:config) do
-      config = RuboCop::ConfigStore.new
-      path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME, RuboCop::ConfigFinder::DOTFILE)
-      config.options_config = path
-      config
-    end
+    let(:config) { RuboCop::ConfigStore.new }
     let(:options) { { formatters: [] } }
     let(:runner) { RuboCop::Runner.new(options, config) }
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --init                       Generate a .rubocop.yml file in the current directory.
               -c, --config FILE                Specify configuration file.
               -d, --debug                      Display debug info.
+                  --plugin FILE                Load a RuboCop plugin.
               -r, --require FILE               Require Ruby file.
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.

--- a/spec/rubocop/plugin/configuration_integrator_spec.rb
+++ b/spec/rubocop/plugin/configuration_integrator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Plugin::ConfigurationIntegrator do
+  describe '.integrate_plugins_into_rubocop_config' do
+    before { described_class.integrate_plugins_into_rubocop_config(rubocop_config, plugins) }
+
+    let(:rubocop_config) { RuboCop::Config.new }
+
+    context 'when using plugin' do
+      let(:plugins) { RuboCop::Plugin::Loader.load(['rubocop/cop/internal_affairs']) }
+
+      it 'integrates base cops' do
+        expect(rubocop_config.to_h['Style/HashSyntax']['SupportedStyles']).to eq(
+          %w[ruby19 hash_rockets no_mixed_keys ruby19_no_mixed_keys]
+        )
+      end
+
+      it 'integrates plugin cops' do
+        expect(rubocop_config.to_h['InternalAffairs/CopDescription']).to eq(
+          { 'Include' => ['lib/rubocop/cop/**/*.rb'] }
+        )
+      end
+    end
+  end
+end

--- a/spec/rubocop/plugin/loader_spec.rb
+++ b/spec/rubocop/plugin/loader_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Plugin::Loader do
+  describe '.load' do
+    subject(:plugins) { described_class.load(plugin_configs) }
+
+    context 'when plugin config is a string' do
+      let(:plugin_configs) { ['rubocop/cop/internal_affairs'] }
+      let(:plugin) { plugins.first }
+
+      it 'returns an instance of plugin' do
+        expect(plugin).to be_an_instance_of(RuboCop::InternalAffairs::Plugin)
+      end
+
+      describe 'about' do
+        let(:about) { plugin.about }
+
+        it 'has plugin name' do
+          expect(plugin.about.name).to eq 'rubocop-internal_affairs'
+        end
+      end
+
+      describe 'rules' do
+        let(:runner_context) { LintRoller::Context.new }
+        let(:rules) { plugin.rules(runner_context) }
+
+        it 'has plugin configuration path' do
+          expect(rules.value.to_s).to end_with 'config/internal_affairs.yml'
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/plugin_spec.rb
+++ b/spec/rubocop/plugin_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Plugin do
+  describe '.plugin_capable?' do
+    subject { described_class.plugin_capable?(feature) }
+
+    context 'when feature is a built-in plugin' do
+      let(:feature) { 'rubocop/cop/internal_affairs' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when feature is an unknown extension plugin' do
+      let(:feature) { 'unknown_extension' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '.integrate_plugins' do
+    before { described_class.integrate_plugins(rubocop_config, plugins) }
+
+    let(:rubocop_config) { RuboCop::Config.new }
+
+    context 'when using plugin' do
+      let(:plugins) { ['rubocop/cop/internal_affairs'] }
+
+      it 'integrates base cops' do
+        expect(rubocop_config.to_h['Style/HashSyntax']['SupportedStyles']).to eq(
+          %w[ruby19 hash_rockets no_mixed_keys ruby19_no_mixed_keys]
+        )
+      end
+
+      it 'integrates plugin cops' do
+        expect(rubocop_config.to_h['InternalAffairs/CopDescription']).to eq(
+          { 'Include' => ['lib/rubocop/cop/**/*.rb'] }
+        )
+      end
+    end
+  end
+end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe RuboCop::RakeTask do
       Rake::Task['rubocop'].execute
     end
 
+    it 'allows nested arrays inside formatters, options, and plugins' do
+      described_class.new do |task|
+        task.formatters = [['files']]
+        task.plugins = [['extension-plugin']]
+        task.options = [['--display-cop-names']]
+      end
+
+      cli = instance_double(RuboCop::CLI, run: 0)
+      allow(RuboCop::CLI).to receive(:new).and_return(cli)
+      options = ['--format', 'files', '--plugin', 'extension-plugin', '--display-cop-names']
+
+      expect(cli).to receive(:run).with(options)
+
+      Rake::Task['rubocop'].execute
+    end
+
     it 'does not error when result is not 0 and fail_on_error is false' do
       described_class.new { |task| task.fail_on_error = false }
 

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Version do
       end
 
       before do
-        allow(config).to receive(:loaded_features).and_return(known_features)
+        allow(config).to receive_messages(loaded_plugins: [], loaded_features: known_features)
         allow(config_store).to receive(:for_dir).and_return(config)
 
         stub_const('RuboCop::GraphQL::Version::STRING', '1.0.0')

--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -21,7 +21,8 @@ module StrictWarnings
     /`inspect_file` is deprecated\. Use `investigate` instead\./, # RuboCop's deprecated API in spec
     /`forces` is deprecated./, # RuboCop's deprecated API in spec
     /`support_autocorrect\?` is deprecated\./, # RuboCop's deprecated API in spec
-    /`Cop\.registry` is deprecated\./ # RuboCop's deprecated API in spec
+    /`Cop\.registry` is deprecated\./, # RuboCop's deprecated API in spec
+    /Specify `rubocop-internal_affairs` instead/ # RuboCop's obsolete internal plugin name
   )
 
   def warn(message, ...)


### PR DESCRIPTION
## Summary

Support for extension plugins using lint_roller is introduced.
https://github.com/standardrb/lint_roller

Currently, lint_roller is the plugin mechanism adopted in Standard Ruby:
https://github.com/standardrb/standard/pull/551

And this proposal extends its adoption to RuboCop. This creates a future where extension gems compatible with lint_roller can be reused across linters that adopt lint_roller. It also means relying solely on lint_roller's unified plugin interface, reducing direct dependencies and achieving low coupling, much like how Rack was introduced in Rails 3.0 or how the LSP protocol model works.

Although this change references the first Standard Ruby implementation using lint_roller, some additional elements specific to RuboCop are included, such as the `--plugin` command-line option, enhancements to `RuboCop::RakeTask`, improved versioning display via `-V` command-line option, and linter engine check.

## Updates to .rubocop.yml

For extension gems with plugin support, the specification in `.rubocop.yml` changes from `require` to `plugins`.

```diff
# .rubocop.yml
- require:
+ plugins:
    rubocop-performance
```

As mentioned later, backward compatibility is maintained with the conventional `require`, but a warning will be displayed.

## Handling `InternalAffairs` cops

The `InternalAffairs` department built into RuboCop functions as a built-in plugin. This also serves as dogfooding for RuboCop's plugin mechanism. Although it works with the same specification method as plugin extension gems, it doesn't output redundant information, such as in the `rubocop -V` display.

## Compatibility

Compatibility with the conventional Inject (unofficial plugin) method is ensured, meaning it works not only with extension gems supporting the new plugin system but also with those that still rely on the traditional Inject mechanism.

In the future, the goal is to replace the Inject-based approach in extension gems with the new plugin system, but this is a gradual transition with a strong focus on maintaining compatibility.

For example, rubocop-performance and other extensions will soon have an early release supporting plugins. When using `require` in `.rubocop.yml` for a plugin-enabled extension, the following warning will be displayed:

```console
$ bundle exec rubocop path/to/example.rb
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance`
instead of `require: rubocop-performance` in /Users/koic/src/github.com/rubocop/rubocop/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/extensions.html.
```

This warning simply requires a straightforward change to move to `plugins`. Even with the warning, backward compatibility ensures the plugin works as expected.

## The Future of `require` configuration in .rubocop.yml

The `require` configuration feature will remain, not only for Inject-based extension gems but also for use cases like requiring custom formatters or lightweight cop implementations. Therefore, its usage beyond Inject-based extension gems will persist in the future.

## Making `RuboCop::ConfigLoader.inject_defaults!` a Public API

To support tests and documentation generation for gems like rubocop-performance, `RuboCop::ConfigLoader.inject_defaults!` is now part of the public API. The recommended approach for integrating `config/default.yml` in extension gem development is to call `inject_defaults!` from the extension gem itself, which minimizes its impact. This change mainly affects the development environment of extension gems, as the runtime environment will rely on the plugin mechanism.

Additionally, the API has been modified to allow the `config/default.yml` file to be retrieved from any specified path. Backward compatibility is maintained, so if older methods are used, they will still work but with a warning.

## Moving Forward

The development of plugin support for rubocop-performance and rubocop-rails is already underway. Plugin functionality testing requires coordination between both the changes on the RuboCop side and updates to the corresponding extension gems.

I will continue promoting plugin support across major extension gems and rubocop-extension-generator, which will serve as living examples. Once rubocop-performance with plugin support is released, automated tests for this plugin functionality will also be added.

Closes #6012.

Although it differs from the example presented in #6012, adhering to lint_roller will likely enhance the overall extensibility of the Ruby linter ecosystem.

cc @searls

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
