### PR TITLE
Fix crash in `Layout/EmptyLinesAroundMethodBody` for endless methods

### DIFF
--- a/changelog/fix_fix_crash_in_layout_empty_lines_around_method_body_20250205120556.md
+++ b/changelog/fix_fix_crash_in_layout_empty_lines_around_method_body_20250205120556.md
@@ -1,0 +1,1 @@
+* [#13796](https://github.com/rubocop/rubocop/pull/13796): Fix crash in `Layout/EmptyLinesAroundMethodBody` for endless methods. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
@@ -27,9 +27,14 @@ module RuboCop
         KIND = 'method'
 
         def on_def(node)
-          first_line = node.arguments.source_range&.last_line
+          if node.endless?
+            return unless offending_endless_method?(node)
 
-          check(node, node.body, adjusted_first_line: first_line)
+            register_offense_for_endless_method(node)
+          else
+            first_line = node.arguments.source_range&.last_line
+            check(node, node.body, adjusted_first_line: first_line)
+          end
         end
         alias on_defs on_def
 
@@ -37,6 +42,21 @@ module RuboCop
 
         def style
           :no_empty_lines
+        end
+
+        def offending_endless_method?(node)
+          node.body.first_line > node.loc.assignment.line + 1 &&
+            processed_source.lines[node.loc.assignment.line].empty?
+        end
+
+        def register_offense_for_endless_method(node)
+          range = processed_source.buffer.line_range(node.loc.assignment.line + 1).resize(1)
+
+          msg = message(MSG_EXTRA, 'beginning')
+
+          add_offense(range, message: msg) do |corrector|
+            corrector.remove(range)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -111,4 +111,68 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody, :config do
       end
     RUBY
   end
+
+  context 'endless methods', :ruby30 do
+    it 'does not register an offense for a single-line endless method' do
+      expect_no_offenses(<<~RUBY)
+        def foo = quux
+      RUBY
+    end
+
+    it 'does not register an offense for multiline endless method where the body is on the same line as the `=`' do
+      expect_no_offenses(<<~RUBY)
+        def foo(bar,
+          baz) = quux
+      RUBY
+    end
+
+    it 'does not register an offense for multiline endless method where the body is on the next line' do
+      expect_no_offenses(<<~RUBY)
+        def foo(bar, baz) =
+          quux
+      RUBY
+    end
+
+    it 'does not register an offense for multiline endless method when there is a comment before the body' do
+      expect_no_offenses(<<~RUBY)
+        def foo(bar, baz) =
+          # comment
+          quux
+      RUBY
+    end
+
+    it 'registers an offense and corrects for multiline endless method with extra lines' do
+      expect_offense(<<~RUBY)
+        def foo(bar,
+          baz) =
+
+        #{beginning_offense_annotation}
+          quux
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(bar,
+          baz) =
+          quux
+      RUBY
+    end
+
+    it 'registers an offense and corrects for multiline endless method with a comment and extra lines' do
+      expect_offense(<<~RUBY)
+        def foo(bar,
+          baz) =
+
+        #{beginning_offense_annotation}
+          # comment
+          quux
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(bar,
+          baz) =
+          # comment
+          quux
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes crash in `Layout/EmptyLinesAroundMethodBody` when encountering an endless method on multiple lines.

```ruby
# test.rb
def foo(bar,
  baz) = quux
```

```
$ rubocop -d test.rb

An error occurred while Layout/EmptyLinesAroundMethodBody cop was inspecting /Users/daniel/src/rubocop/test.rb:1:0.
  The range 27...28 is outside the bounds of the source
/Users/daniel/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:406:in 'Parser::Source::TreeRewriter#check_range_validity'
/Users/daniel/src/rubocop/lib/rubocop/cop/corrector.rb:120:in 'RuboCop::Cop::Corrector#check_range_validity'
/Users/daniel/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:398:in 'Parser::Source::TreeRewriter#combine'
/Users/daniel/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:194:in 'Parser::Source::TreeRewriter#replace'
/Users/daniel/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/parser-3.3.6.0/lib/parser/source/tree_rewriter.rb:218:in 'Parser::Source::TreeRewriter#remove'
/Users/daniel/src/rubocop/lib/rubocop/cop/correctors/empty_line_corrector.rb:13:in 'RuboCop::Cop::EmptyLineCorrector.correct'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:104:in 'block in RuboCop::Cop::Layout::EmptyLinesAroundBody#check_line'
/Users/daniel/src/rubocop/lib/rubocop/cop/base.rb:426:in 'RuboCop::Cop::Base#correct'
/Users/daniel/src/rubocop/lib/rubocop/cop/base.rb:210:in 'RuboCop::Cop::Base#add_offense'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:103:in 'RuboCop::Cop::Layout::EmptyLinesAroundBody#check_line'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:92:in 'RuboCop::Cop::Layout::EmptyLinesAroundBody#check_source'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:82:in 'RuboCop::Cop::Layout::EmptyLinesAroundBody#check_beginning'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:76:in 'RuboCop::Cop::Layout::EmptyLinesAroundBody#check_both'
/Users/daniel/src/rubocop/lib/rubocop/cop/mixin/empty_lines_around_body.rb:39:in 'RuboCop::Cop::Layout::EmptyLinesAroundBody#check'
/Users/daniel/src/rubocop/lib/rubocop/cop/layout/empty_lines_around_method_body.rb:32:in 'RuboCop::Cop::Layout::EmptyLinesAroundMethodBody#on_def'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
