### PR TITLE
Remove useless suppressed WebMock warning

### DIFF
--- a/spec/support/strict_warnings.rb
+++ b/spec/support/strict_warnings.rb
@@ -13,7 +13,6 @@ module StrictWarnings
   SUPPRESSED_WARNINGS = Regexp.union(
     %r{lib/parser/builders/default.*Unknown escape},
     %r{lib/parser/builders/default.*character class has duplicated range},
-    %r{lib/webmock/.*Net::HTTPSession}, # https://github.com/bblimke/webmock/pull/1081
     /Float.*out of range/, # also from the parser gem
     /`Process` does not respond to `fork` method/, # JRuby
     /File#readline accesses caller method's state and should not be aliased/, # JRuby, test stub


### PR DESCRIPTION
This issue has been resolved in the latest WebMock 3.25.0: https://rubygems.org/gems/webmock/versions/3.25.0

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
