### PR TITLE
Centralize `RuboCop::LSP.enable` activation and rename adapter class

### DIFF
--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -20,6 +20,8 @@ module RuboCop
       attr_writer :safe_autocorrect, :lint_mode, :layout_mode
 
       def initialize(config_store)
+        RuboCop::LSP.enable
+
         @runner = RuboCop::Lsp::StdinRunner.new(config_store)
         @cop_registry = RuboCop::Cop::Registry.global.to_h
 

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -22,8 +22,6 @@ module RuboCop
       def initialize(config_store)
         $PROGRAM_NAME = "rubocop --lsp #{ConfigFinder.project_root}"
 
-        RuboCop::LSP.enable
-
         @reader = LanguageServer::Protocol::Transport::Io::Reader.new($stdin)
         @writer = LanguageServer::Protocol::Transport::Io::Writer.new($stdout)
         @runtime = RuboCop::LSP::Runtime.new(config_store)

--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -4,18 +4,15 @@ require_relative '../../rubocop/lsp/runtime'
 
 module RubyLsp
   module RuboCop
-    # Wrap RuboCop's built-in runtime for Ruby LSP's add-on.
-    class WrapsBuiltinLspRuntime
+    # Provides an adapter to bridge RuboCop's built-in LSP runtime with Ruby LSP's add-on.
+    # @api private
+    class RuntimeAdapter
       include RubyLsp::Requests::Support::Formatter
 
       def initialize
-        init!
-      end
+        config_store = ::RuboCop::ConfigStore.new
 
-      def init!
-        config = ::RuboCop::ConfigStore.new
-
-        @runtime = ::RuboCop::LSP::Runtime.new(config)
+        @runtime = ::RuboCop::LSP::Runtime.new(config_store)
       end
 
       def run_diagnostic(uri, document)


### PR DESCRIPTION
The activation of `RuboCop::LSP.enable` is now centralized by enabling it during the instantiation of `RuboCop::LSP::Runtime`. This change brings together the spread-out calls to `LSP.enable` when using LSP, making them more organized.

As part of a long-term direction, the aim is to eventually remove the spread-out `RuboCop::LSP.enable` calls within Ruby LSP and the LSP feature of Standard Ruby.

Additionally, `RubyLSP::RuboCop::WrapsBuiltinLspRuntime` has been renamed to `RubyLsp::RuboCop::RuntimeAdapter`. This change follows the Adapter pattern (GoF) and reflects a class design that considers architectural principles.

Currently, there is no change log, as this corresponds to a refactoring of the internal structure.

Follow-up to https://github.com/rubocop/rubocop/pull/13628 and https://github.com/rubocop/rubocop/pull/12679

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
