### PR TITLE
Make the lint_roller dependency version stricter

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json', '~> 2.3')
   s.add_dependency('language_server-protocol', '>= 3.17.0')
-  s.add_dependency('lint_roller', '>= 1.1.0')
+  s.add_dependency('lint_roller', '~> 1.1.0')
   s.add_dependency('parallel', '~> 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')


### PR DESCRIPTION
Given the feedback in https://github.com/standardrb/lint_roller/issues/8, there is a possibility that the lint_roller API may change.

To prevent unexpected issues caused by API incompatibility, the runtime dependency on lint_roller will be made stricter.
Expecting semantic versioning, the patch version will be updated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
