### PR TITLE
Make the language_server-protocol dependency version stricter

### DIFF
--- a/changelog/fix_make_language_server_protocol_dependency_version_stricter
+++ b/changelog/fix_make_language_server_protocol_dependency_version_stricter
@@ -1,0 +1,1 @@
+* [#13805](https://github.com/rubocop/rubocop/pull/13805): Make the language_server-protocol dependency version stricter. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -32,7 +32,9 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency('json', '~> 2.3')
-  s.add_dependency('language_server-protocol', '>= 3.17.0')
+  # NOTE: language_server-protocol gem doesn't use semantic versioning. Its versions follow x.y.z.t,
+  # where x.y.z indicates the Language Server Protocol Specification, t is an incrementing number.
+  s.add_dependency('language_server-protocol', '~> 3.17.0.2')
   s.add_dependency('lint_roller', '~> 1.1.0')
   s.add_dependency('parallel', '~> 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')


### PR DESCRIPTION
The `language_server-protocol` gem is a library that adheres to the LSP specification. Since `X.Y.Z` represents the LSP version:
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/

Only the fourth value can be updated without affecting compatibility with the LSP specification: https://github.com/mtsmfm/language_server-protocol-ruby?tab=readme-ov-file#versioning

This PR strictly defines the runtime dependency version of the `language_server-protocol` gem in advance to prevent unintended incompatibilities.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
