### PR TITLE
Introduce EnforcedStyleForMultiline "diff_comma"

### DIFF
--- a/changelog/new_introduce_enforced_style_for_multiline_diff_comma_20250208163732.md
+++ b/changelog/new_introduce_enforced_style_for_multiline_diff_comma_20250208163732.md
@@ -1,0 +1,1 @@
+* [#9935](https://github.com/rubocop/rubocop/issues/9935): Introduce EnforcedStyleForMultiline "diff_comma". ([@flavorjones][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5688,14 +5688,17 @@ Style/TrailingCommaInArrayLiteral:
   StyleGuide: '#no-trailing-array-commas'
   Enabled: true
   VersionAdded: '0.53'
-  # If `comma`, the cop requires a comma after the last item in an array,
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty, multiline array literals.
+  # If `comma`, the cop requires a comma after the last item in an array, but only when each item is
+  # on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all non-empty, multiline
+  # array literals.
+  # If `diff_comma`, the cop requires a comma after the last item of all non-empty, multiline array
+  # literals, but only when that last item immediately precedes a newline.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
+    - diff_comma
     - no_comma
 
 Style/TrailingCommaInBlockArgs:
@@ -5707,14 +5710,17 @@ Style/TrailingCommaInBlockArgs:
 Style/TrailingCommaInHashLiteral:
   Description: 'Checks for trailing comma in hash literals.'
   Enabled: true
-  # If `comma`, the cop requires a comma after the last item in a hash,
-  # but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty, multiline hash literals.
+  # If `comma`, the cop requires a comma after the last item in a hash, but only when each item is
+  # on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all non-empty, multiline
+  # hash literals.
+  # If `diff_comma`, the cop requires a comma after the last item of all non-empty, multiline hash
+  # literals, but only when that last item immediately precedes a newline.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
+    - diff_comma
     - no_comma
   VersionAdded: '0.53'
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -4,6 +4,7 @@ module RuboCop
   module Cop
     # Common methods shared by Style/TrailingCommaInArguments,
     # Style/TrailingCommaInArrayLiteral and Style/TrailingCommaInHashLiteral
+    # rubocop:disable Metrics/ModuleLength
     module TrailingComma
       include ConfigurableEnforcedStyle
       include RangeHelp
@@ -57,6 +58,8 @@ module RuboCop
           ', unless each item is on its own line'
         when :consistent_comma
           ', unless items are split onto multiple lines'
+        when :diff_comma
+          ', unless that item immediately precedes a newline'
         else
           ''
         end
@@ -68,6 +71,8 @@ module RuboCop
           multiline?(node) && no_elements_on_same_line?(node)
         when :consistent_comma
           multiline?(node) && !method_name_and_arguments_on_same_line?(node)
+        when :diff_comma
+          multiline?(node) && last_item_precedes_newline?(node)
         else
           false
         end
@@ -128,6 +133,12 @@ module RuboCop
 
       def on_same_line?(range1, range2)
         range1.last_line == range2.line
+      end
+
+      def last_item_precedes_newline?(node)
+        after_last_item =
+          range_between(node.children.last.source_range.end_pos, node.loc.end.begin_pos)
+        after_last_item.source =~ /\A,?\s*\n/
       end
 
       def avoid_comma(kind, comma_begin_pos, extra_info)
@@ -205,5 +216,6 @@ module RuboCop
         false
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -6,12 +6,13 @@ module RuboCop
       # Checks for trailing comma in array literals.
       # The configuration options are:
       #
-      # * `consistent_comma`: Requires a comma after the
-      # last item of all non-empty, multiline array literals.
-      # * `comma`: Requires a comma after last item in an array,
-      # but only when each item is on its own line.
-      # * `no_comma`: Does not require a comma after the
-      # last item in an array
+      # * `consistent_comma`: Requires a comma after the last item of all non-empty, multiline array
+      # literals.
+      # * `comma`: Requires a comma after the last item in an array, but only when each item is on
+      # its own line.
+      # * `diff_comma`: Requires a comma after the last item in an array, but only when that item is
+      # followed by an immediate newline.
+      # * `no_comma`: Does not require a comma after the last item in an array
       #
       # @example EnforcedStyleForMultiline: consistent_comma
       #   # bad
@@ -36,6 +37,14 @@ module RuboCop
       #     1,
       #     2,
       #   ]
+      #
+      #   # bad
+      #   a = [1, 2,
+      #        3, 4]
+      #
+      #   # good
+      #   a = [1, 2,
+      #        3, 4,]
       #
       # @example EnforcedStyleForMultiline: comma
       #   # bad
@@ -71,6 +80,38 @@ module RuboCop
       #     1,
       #     2,
       #   ]
+      #
+      # @example EnforcedStyleForMultiline: diff_comma
+      #   # bad
+      #   a = [1, 2,]
+      #
+      #   # good
+      #   a = [1, 2]
+      #
+      #   # good
+      #   a = [
+      #     1, 2,
+      #     3,
+      #   ]
+      #
+      #   # good
+      #   a = [
+      #     1, 2, 3,
+      #   ]
+      #
+      #   # good
+      #   a = [
+      #     1,
+      #     2,
+      #   ]
+      #
+      #   # bad
+      #   a = [1, 2,
+      #        3, 4,]
+      #
+      #   # good
+      #   a = [1, 2,
+      #        3, 4]
       #
       # @example EnforcedStyleForMultiline: no_comma (default)
       #   # bad

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -6,12 +6,13 @@ module RuboCop
       # Checks for trailing comma in hash literals.
       # The configuration options are:
       #
-      # * `consistent_comma`: Requires a comma after the
-      # last item of all non-empty, multiline hash literals.
-      # * `comma`: Requires a comma after the last item in a hash,
-      # but only when each item is on its own line.
-      # * `no_comma`: Does not require a comma after the
-      # last item in a hash
+      # * `consistent_comma`: Requires a comma after the last item of all non-empty, multiline hash
+      # literals.
+      # * `comma`: Requires a comma after the last item in a hash, but only when each item is on its
+      # own line.
+      # * `diff_comma`: Requires a comma after the last item in a hash, but only when that item is
+      # followed by an immediate newline.
+      # * `no_comma`: Does not require a comma after the last item in a hash
       #
       # @example EnforcedStyleForMultiline: consistent_comma
       #
@@ -37,6 +38,14 @@ module RuboCop
       #     foo: 1,
       #     bar: 2,
       #   }
+      #
+      #   # bad
+      #   a = { foo: 1, bar: 2,
+      #         baz: 3, qux: 4 }
+      #
+      #   # good
+      #   a = { foo: 1, bar: 2,
+      #         baz: 3, qux: 4, }
       #
       # @example EnforcedStyleForMultiline: comma
       #
@@ -73,6 +82,39 @@ module RuboCop
       #     foo: 1,
       #     bar: 2,
       #   }
+      #
+      # @example EnforcedStyleForMultiline: diff_comma
+      #
+      #   # bad
+      #   a = { foo: 1, bar: 2, }
+      #
+      #   # good
+      #   a = { foo: 1, bar: 2 }
+      #
+      #   # good
+      #   a = {
+      #     foo: 1, bar: 2,
+      #     qux: 3,
+      #   }
+      #
+      #   # good
+      #   a = {
+      #     foo: 1, bar: 2, qux: 3,
+      #   }
+      #
+      #   # good
+      #   a = {
+      #     foo: 1,
+      #     bar: 2,
+      #   }
+      #
+      #   # bad
+      #   a = { foo: 1, bar: 2,
+      #         baz: 3, qux: 4, }
+      #
+      #   # good
+      #   a = { foo: 1, bar: 2,
+      #         baz: 3, qux: 4 }
       #
       # @example EnforcedStyleForMultiline: no_comma (default)
       #

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
       include_examples 'single line lists', ', unless each item is on its own line'
     end
 
+    context 'when EnforcedStyleForMultiline is diff_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'diff_comma' } }
+
+      include_examples 'single line lists', ', unless that item immediately precedes a newline'
+    end
+
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
@@ -193,6 +199,98 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
       end
     end
 
+    context 'when EnforcedStyleForMultiline is diff_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'diff_comma' } }
+
+      context 'when closing bracket is on same line as last value' do
+        it 'accepts no trailing comma' do
+          expect_no_offenses(<<~RUBY)
+            VALUES = [
+                       1001,
+                       2020,
+                       3333]
+          RUBY
+        end
+      end
+
+      it 'accepts two values on the same line' do
+        expect_no_offenses(<<~RUBY)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        RUBY
+      end
+
+      it 'registers an offense for literal with two of the values ' \
+         'on the same line and no trailing comma' do
+        expect_offense(<<~RUBY)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                     ^^^^ Put a comma after the last item of a multiline array.
+                   ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        RUBY
+      end
+
+      it 'accepts trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333,
+                   ]
+        RUBY
+      end
+
+      it 'registers an offense for a trailing comma on same line as closing bracket' do
+        expect_offense(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333,]
+                        ^ Avoid comma after the last item of an array, unless that item immediately precedes a newline.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333]
+        RUBY
+      end
+
+      it 'accepts a multiline word array' do
+        expect_no_offenses(<<~RUBY)
+          ingredients = %w(
+            sausage
+            anchovies
+            olives
+          )
+        RUBY
+      end
+
+      it 'accepts a multiline array with a single item and trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          foo = [
+            1,
+          ]
+        RUBY
+      end
+
+      it 'accepts a multiline array with items on a single line and trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          foo = [
+            1, 2,
+          ]
+        RUBY
+      end
+    end
+
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
@@ -248,6 +346,21 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
                     2020,
                     3333,
                    ]
+        RUBY
+      end
+
+      it 'registers an offense for no trailing comma on same line as closing bracket' do
+        expect_offense(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333]
+                    ^^^^ Put a comma after the last item of a multiline array.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333,]
         RUBY
       end
 

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
       include_examples 'single line lists', ', unless each item is on its own line'
     end
 
+    context 'when EnforcedStyleForMultiline is diff_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'diff_comma' } }
+
+      include_examples 'single line lists', ', unless that item immediately precedes a newline'
+    end
+
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
@@ -174,6 +180,89 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
       end
     end
 
+    context 'when EnforcedStyleForMultiline is diff_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'diff_comma' } }
+
+      context 'when closing bracket is on same line as last value' do
+        it 'accepts a literal with no trailing comma' do
+          expect_no_offenses(<<~RUBY)
+            VALUES = {
+                       a: "b",
+                       b: "c",
+                       d: "e"}
+          RUBY
+        end
+      end
+
+      it 'registers an offense for no trailing comma' do
+        expect_offense(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+                  ^^^^^^^ Put a comma after the last item of a multiline hash.
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+          }
+        RUBY
+      end
+
+      it 'accepts trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          MAP = {
+                  a: 1001,
+                  b: 2020,
+                  c: 3333,
+                }
+        RUBY
+      end
+
+      it 'registers an offense for a trailing comma on same line as closing brace' do
+        expect_offense(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333, }
+                         ^ Avoid comma after the last item of a hash, unless that item immediately precedes a newline.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333 }
+        RUBY
+      end
+
+      it 'accepts trailing comma after a heredoc' do
+        expect_no_offenses(<<~RUBY)
+          route(help: {
+            'auth' => <<-HELP.chomp,
+          ...
+          HELP
+          })
+        RUBY
+      end
+
+      it 'accepts a multiline hash with a single pair and trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          bar = {
+            a: 123,
+          }
+        RUBY
+      end
+
+      it 'accepts a multiline hash with pairs on a single line and trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          bar = {
+            a: 1001, b: 2020,
+          }
+        RUBY
+      end
+    end
+
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
@@ -220,6 +309,21 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
                   b: 2020,
                   c: 3333,
                 }
+        RUBY
+      end
+
+      it 'registers an offense for no trailing comma on same line as closing brace' do
+        expect_offense(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333 }
+                  ^^^^^^^ Put a comma after the last item of a multiline hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333, }
         RUBY
       end
 


### PR DESCRIPTION
Introduce EnforcedStyleForMultiline "diff_comma".

[Fix #9935]

A new "diff_comma" enforced style for `Style::TrailingCommaInArrayLiteral`
and `Style::TrailingCommaInHashLiteral` that omits the trailing comma unless
the final item of the hash/array literal is at the end of line.

This style behaves similarly to "consistent_comma" with the exception of this case:

```ruby
# consistent_comma behavior
## bad
a = { foo: 1, bar: 2,
      baz: 3, qux: 4 }

## good
a = { foo: 1, bar: 2,
      baz: 3, qux: 4, }

# diff_comma behavior
## bad
a = { foo: 1, bar: 2,
      baz: 3, qux: 4, }

## good
a = { foo: 1, bar: 2,
      baz: 3, qux: 4 }
```

In #9935 it was discussed whether this should be the behavior of
"consistent_comma" but some concerns were raised about whether this
was expected behavior or not, or whether the change would be
disruptive.

This style convention results in "clean diffs" where adding an item to
the hash/array literal results in a diff like:

```patch
 {
   foo: 123,
+  bar: 456,
 }
```

without the downside of unnecessary "consistent_comma" commas like
this when placing a closing bracket on the same line as the final
argument:

```
 { foo: 123,
   bar: 456, }
           ^ like this one
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
