### PR TITLE
[Fix #13807] Fix false negatives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negative_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#13807](https://github.com/rubocop/rubocop/issues/13807): Fix false negatives for `Style/RedundantParentheses` when chaining `[]` method calls. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -20,7 +20,7 @@ module RuboCop
         ALLOWED_NODE_TYPES = %i[and or send splat kwsplat].freeze
 
         # @!method square_brackets?(node)
-        def_node_matcher :square_brackets?, '(send {(send _recv _msg) str array hash} :[] ...)'
+        def_node_matcher :square_brackets?, '(send `{(send _recv _msg) str array hash} :[] ...)'
 
         # @!method method_node_and_args(node)
         def_node_matcher :method_node_and_args, '$(call _recv _msg $...)'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'redundant', '("x"&.to_sym)', '"x"&.to_sym', 'a method call'
   it_behaves_like 'redundant', '(x[:y])', 'x[:y]', 'a method call'
   it_behaves_like 'redundant', '("foo"[0])', '"foo"[0]', 'a method call'
+  it_behaves_like 'redundant', '(foo[0][0])', 'foo[0][0]', 'a method call'
   it_behaves_like 'redundant', '(["foo"][0])', '["foo"][0]', 'a method call'
   it_behaves_like 'redundant', '({0 => :a}[0])', '{0 => :a}[0]', 'a method call'
   it_behaves_like 'redundant', '(x; y)', 'x; y', 'a method call'
@@ -556,6 +557,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'plausible', 'x += (foo; bar)'
   it_behaves_like 'plausible', 'x + (foo; bar)'
   it_behaves_like 'plausible', 'x((foo; bar))'
+
+  it_behaves_like 'plausible', '(foo[key] & bar.baz).any?'
 
   it 'registers an offense for parens around method body' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantParentheses` when chaining `[]` method calls.

Fixes #13807

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
