### PR TITLE
[Fix #13661] Make server mode detect local paths in `inherit_from` and `require`

### DIFF
--- a/changelog/new_make_server_mode_detect_local_paths_in_inherit_from_and_require.md
+++ b/changelog/new_make_server_mode_detect_local_paths_in_inherit_from_and_require.md
@@ -1,0 +1,1 @@
+* [#13661](https://github.com/rubocop/rubocop/issues/13661): Make server mode detect local paths in .rubocop.yml under `inherit_from` and `require` for automatically restart. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -57,6 +57,9 @@ RuboCop version incompatibility found, RuboCop server restarting...
 RuboCop server starting on 127.0.0.1:60665.
 ```
 
+NOTE: Detection of incompatibility changes in the local configuration also includes changes to local file paths specified by `inherit_from` and `require` in `.rubocop.yml`.
+Changes involving remote files or those considered to be searched on `$LOAD_PATH` are not detected.
+
 If you would like to start the server in the foreground, which can be useful when running within Docker, you can pass the `--no-detach` option.
 
 ```console

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -175,7 +175,7 @@ module RuboCop
       return false if inherited_file.nil? # Not inheritance resolving merge
       return false if inherited_file.start_with?('..') # Legitimate override
       return false if base_hash[key] == derived_hash[key] # Same value
-      return false if remote_file?(inherited_file) # Can't change
+      return false if PathUtil.remote_file?(inherited_file) # Can't change
 
       Gem.path.none? { |dir| inherited_file.start_with?(dir) } # Can change?
     end
@@ -243,7 +243,7 @@ module RuboCop
     end
 
     def inherited_file(path, inherit_from, file)
-      if remote_file?(inherit_from)
+      if PathUtil.remote_file?(inherit_from)
         # A remote configuration, e.g. `inherit_from: http://example.com/rubocop.yml`.
         RemoteConfig.new(inherit_from, File.dirname(path))
       elsif Pathname.new(inherit_from).absolute?
@@ -261,10 +261,6 @@ module RuboCop
         print 'Inheriting ' if ConfigLoader.debug?
         File.expand_path(inherit_from, File.dirname(path))
       end
-    end
-
-    def remote_file?(uri)
-      uri.start_with?('http://', 'https://')
     end
 
     def remote_config?(file)

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -28,6 +28,10 @@ module RuboCop
         end
     end
 
+    def remote_file?(uri)
+      uri.start_with?('http://', 'https://')
+    end
+
     SMART_PATH_CACHE = {} # rubocop:disable Style/MutableConstant
     private_constant :SMART_PATH_CACHE
 

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe RuboCop::PathUtil do
     end
   end
 
+  describe '.remote_file?' do
+    subject(:smart_path) { described_class.remote_file?(path) }
+
+    context 'when the path is an HTTP URL' do
+      let(:path) { 'http://example.com' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the path is an HTTPS URL' do
+      let(:path) { 'https://example.com' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the path is a relative path' do
+      let(:path) { './relative/path/to' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when path is an absolute path' do
+      let(:path) { '/absolute/path/to' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe '#smart_path', :isolated_environment do
     subject(:smart_path) { described_class.smart_path(path) }
 


### PR DESCRIPTION
This PR makes server mode detect local paths in .rubocop.yml under `inherit_from` and `require` for automatically restart.

Since this adds some extra processing, server mode may experience a slight performance degradation, but no significant delays are expected.
This change provides a trade-off by reducing the risk of users running with unexpected old configurations.

NOTE: Detection of incompatibility changes in the local configuration also includes changes to local file paths specified by `inherit_from` and `require` in .rubocop.yml. Changes involving remote files or those considered to be searched on `$LOAD_PATH` are not detected.

Resolves #13661 and follow-up to https://github.com/rubocop/rubocop/pull/13327#issuecomment-2411318067.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
