### PR TITLE
Make `SuggestExtensions` aware of plugin extensions

### DIFF
--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -97,7 +97,13 @@ module RuboCop
         end
 
         def loaded_extensions
-          @config_store.for_pwd.loaded_features.to_a
+          rubocop_config = @config_store.for_pwd
+
+          plugin_names = rubocop_config.loaded_plugins.map do |plugin|
+            plugin.about.name
+          end
+
+          plugin_names + rubocop_config.loaded_features.to_a
         end
 
         def installed_and_not_loaded_extensions


### PR DESCRIPTION
This PR updates `SuggestExtensions` to properly handle plugin extensions.

For example, when changing the plugin specification for `rubocop-rake` from `require` to `plugins`:

```diff
 inherit_from: .rubocop_todo.yml

-require:
-  - rubocop/cop/internal_affairs
+plugins:
+  - rubocop-internal_affairs
   - rubocop-rake
+
+require:
   - rubocop-rspec

 AllCops:
```

Currently, `rubocop-rake` is unexpectedly displayed as part of `SuggestExtensions`:

```console
$ bundle exec rubocop
(snip)

The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-rake

You can opt out of this message by adding the following to your config
(see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

Ideally, when a plugin is specified under `plugins`, it should not be displayed by `SuggestExtensions`, just like when it is specified under `require`.

Since this is a follow-up to the unreleased #13792, there is no changelog entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
