### PR TITLE
[Fix #12672] Fix false positives for `Lint/FormatParameterMismatch` when the width value is interpolated

### DIFF
--- a/changelog/fix_fix_false_positives_for_20250210112523.md
+++ b/changelog/fix_fix_false_positives_for_20250210112523.md
@@ -1,0 +1,1 @@
+* [#12672](https://github.com/rubocop/rubocop/issues/12672): Fix false positives for `Lint/FormatParameterMismatch` when the width value is interpolated. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -7,7 +7,7 @@ module RuboCop
       # expected fields for format/sprintf/#% and what is actually
       # passed as arguments.
       #
-      # In addition it checks whether different formats are used in the same
+      # In addition, it checks whether different formats are used in the same
       # format string. Do not mix numbered, unnumbered, and named formats in
       # the same format string.
       #

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -6,14 +6,15 @@ module RuboCop
       # Parses {Kernel#sprintf} format strings.
       class FormatString
         DIGIT_DOLLAR  = /(\d+)\$/.freeze
+        INTERPOLATION = /#\{.*?\}/.freeze
         FLAG          = /[ #0+-]|#{DIGIT_DOLLAR}/.freeze
         NUMBER_ARG    = /\*#{DIGIT_DOLLAR}?/.freeze
-        NUMBER        = /\d+|#{NUMBER_ARG}/.freeze
+        NUMBER        = /\d+|#{NUMBER_ARG}|#{INTERPOLATION}/.freeze
         WIDTH         = /(?<width>#{NUMBER})/.freeze
         PRECISION     = /\.(?<precision>#{NUMBER})/.freeze
         TYPE          = /(?<type>[bBdiouxXeEfgGaAcps])/.freeze
         NAME          = /<(?<name>\w+)>/.freeze
-        TEMPLATE_NAME = /\{(?<name>\w+)\}/.freeze
+        TEMPLATE_NAME = /(?<!#)\{(?<name>\w+)\}/.freeze
 
         SEQUENCE = /
             % (?<type>%)

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -343,6 +343,18 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
     it 'does not register an offense for String#% when only interpolated string' do
       expect_no_offenses('"#{foo}" % [1, 2]')
     end
+
+    it 'does not register an offense when an interpolated width' do
+      expect_no_offenses(<<~'RUBY')
+        format("%#{padding}s: %s", prefix, message)
+      RUBY
+    end
+
+    it 'does not register an offense with a negative interpolated width' do
+      expect_no_offenses(<<~'RUBY')
+        sprintf("| %-#{key_offset}s | %-#{val_offset}s |", key, value)
+      RUBY
+    end
   end
 
   context 'with interpolated string in argument' do


### PR DESCRIPTION
Previously the following cases were false positives due to the interpolated widths:

```ruby
format("%#{padding}s: %s", prefix, message)
sprintf("| %-#{key_offset}s | %-#{val_offset}s |", key, value)
```

This changes the regular expression to not consider text to be a template name (`%{name}`) if it begins with a `#`. It also extends the `NUMBER` regexp to allow for interpolation.

Fixes #12672.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
