### PR TITLE
Fix false positive for format specification with non-numeric precision

### DIFF
--- a/changelog/fix_fix_false_positive_for_format_specifier_with_20250210140055.md
+++ b/changelog/fix_fix_false_positive_for_format_specifier_with_20250210140055.md
@@ -1,0 +1,1 @@
+* [#13817](https://github.com/rubocop/rubocop/pull/13817): Fix false positive for format specifier with non-numeric precision. ([@dvandersluis][])

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -11,7 +11,7 @@ module RuboCop
         NUMBER_ARG    = /\*#{DIGIT_DOLLAR}?/.freeze
         NUMBER        = /\d+|#{NUMBER_ARG}|#{INTERPOLATION}/.freeze
         WIDTH         = /(?<width>#{NUMBER})/.freeze
-        PRECISION     = /\.(?<precision>#{NUMBER})/.freeze
+        PRECISION     = /\.(?<precision>#{NUMBER}?)/.freeze
         TYPE          = /(?<type>[bBdiouxXeEfgGaAcps])/.freeze
         NAME          = /<(?<name>\w+)>/.freeze
         TEMPLATE_NAME = /(?<!#)\{(?<name>\w+)\}/.freeze

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -249,6 +249,10 @@ RSpec.describe RuboCop::Cop::Lint::FormatParameterMismatch, :config do
     expect_no_offenses('format("%d%d", *test)')
   end
 
+  it 'does not register an offense for precision with no number' do
+    expect_no_offenses('format("%.d", 0)')
+  end
+
   context 'on format with %{} interpolations' do
     context 'and 1 argument' do
       it 'does not register an offense' do


### PR DESCRIPTION
Ruby's documentation lists `'%.d'` as a valid format specification (https://ruby-doc.org/3.4.1/format_specifications_rdoc.html#label-Precision+Specifier), but it is not handled by `RuboCop::Cop::Utils::FormatString`. It isn't explicitly mentioned in the Ruby 2.7 documentation, but it is valid there as well:

```
[1] pry(main)> RUBY_VERSION
=> "2.7.8"
[2] pry(main)> sprintf('%.d', 0)
=> ""
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
