### PR TITLE
[Fix #13818] Fix false positives for `Lint/Void`

### DIFF
--- a/changelog/fix_false_positive_for_lint_void.md
+++ b/changelog/fix_false_positive_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#13818](https://github.com/rubocop/rubocop/issues/13818): Fix false positives for `Lint/Void` when using operator method call without argument. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -125,9 +125,14 @@ module RuboCop
           check_nonmutating(expr)
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_void_op(node, &block)
           node = node.children.first while node.begin_type?
           return unless node.call_type? && OPERATORS.include?(node.method_name)
+          if !UNARY_OPERATORS.include?(node.method_name) && node.loc.dot && node.arguments.none?
+            return
+          end
+
           return if block && yield(node)
 
           add_offense(node.loc.selector,
@@ -135,6 +140,7 @@ module RuboCop
             autocorrect_void_op(corrector, node)
           end
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def check_var(node)
           return unless node.variable? || node.const_type?

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       expect_no_offenses("a #{op} b")
     end
 
+    it "accepts void op #{op} method call without arguments unless it is on the last line" do
+      expect_no_offenses(<<~RUBY)
+        a.#{op}
+        something
+      RUBY
+    end
+
+    it "accepts void op #{op} safe navigation method call without arguments unless it is on the last line" do
+      expect_no_offenses(<<~RUBY)
+        a&.#{op}
+        something
+      RUBY
+    end
+
     it "registers an offense for parenthesized void op #{op} if not on last line" do
       expect_offense(<<~RUBY, op: op)
         (a %{op} b)


### PR DESCRIPTION
This PR fixes false positives for `Lint/Void` when using operator method call without argument.

To maintain the safety of the cop, it makes sense to ignore corner cases like #13818.

Fixes #13818.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
