### PR TITLE
Fix unexpected removal of plugin configuration value

### DIFF
--- a/lib/rubocop/plugin/configuration_integrator.rb
+++ b/lib/rubocop/plugin/configuration_integrator.rb
@@ -41,7 +41,6 @@ module RuboCop
           raise Plugin::NotSupportedError, unsupported_plugins
         end
 
-        # rubocop:disable Metrics/MethodLength
         def combine_rubocop_configs(default_config, runner_context, plugins)
           fake_out_rubocop_default_configuration(default_config) do |fake_config|
             all_cop_keys_configured_by_plugins = []
@@ -57,15 +56,11 @@ module RuboCop
                 combined_config['AllCops'], plugin_config['AllCops'],
                 all_cop_keys_configured_by_plugins
               )
-              delete_already_configured_keys!(
-                combined_config.keys, plugin_config, dont_delete_keys: ['AllCops']
-              )
 
               ConfigLoader.merge_with_default(plugin_config, plugin_config_path)
             end
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def merge_plugin_config_into_all_cops!(rubocop_config, plugin_config)
           rubocop_config['AllCops'].merge!(plugin_config['AllCops'])
@@ -135,14 +130,6 @@ module RuboCop
           end
 
           [combined_all_cops, combined_configured_keys]
-        end
-
-        def delete_already_configured_keys!(configured_keys, next_config, dont_delete_keys: [])
-          duplicate_keys = configured_keys & Array(next_config&.keys)
-
-          (duplicate_keys - dont_delete_keys).each do |key|
-            next_config.delete(key)
-          end
         end
 
         def resolver

--- a/spec/rubocop/plugin/configuration_integrator_spec.rb
+++ b/spec/rubocop/plugin/configuration_integrator_spec.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require 'lint_roller'
+
 RSpec.describe RuboCop::Plugin::ConfigurationIntegrator do
   describe '.integrate_plugins_into_rubocop_config' do
-    before { described_class.integrate_plugins_into_rubocop_config(rubocop_config, plugins) }
+    subject(:integrated_config) do
+      described_class.integrate_plugins_into_rubocop_config(rubocop_config, plugins)
+    end
 
-    let(:rubocop_config) { RuboCop::Config.new }
-
-    context 'when using plugin' do
+    context 'when using internal plugin' do
+      let(:rubocop_config) { RuboCop::Config.new }
       let(:plugins) { RuboCop::Plugin::Loader.load(['rubocop/cop/internal_affairs']) }
 
       it 'integrates base cops' do
@@ -16,9 +19,48 @@ RSpec.describe RuboCop::Plugin::ConfigurationIntegrator do
       end
 
       it 'integrates plugin cops' do
-        expect(rubocop_config.to_h['InternalAffairs/CopDescription']).to eq(
+        expect(integrated_config.to_h['InternalAffairs/CopDescription']).to eq(
           { 'Include' => ['lib/rubocop/cop/**/*.rb'] }
         )
+      end
+    end
+
+    context 'when using a plugin' do
+      let(:rubocop_config) do
+        RuboCop::Config.new('Style/FrozenStringLiteralComment' => { 'Exclude' => %w[**/*.arb] })
+      end
+      let(:fake_plugin) do
+        Class.new(LintRoller::Plugin) do
+          def rules(_context)
+            LintRoller::Rules.new(
+              type: :object,
+              config_format: :rubocop,
+              value: {
+                'inherit_mode' => {
+                  'merge' => ['Exclude']
+                },
+                'Style/FrozenStringLiteralComment' => {
+                  'Exclude' => %w[**/*.erb]
+                }
+              }
+            )
+          end
+        end
+      end
+      let(:plugins) { [fake_plugin.new] }
+      let(:exclude) { integrated_config.to_h['Style/FrozenStringLiteralComment']['Exclude'] }
+
+      after do
+        default_configuration = RuboCop::ConfigLoader.default_configuration
+        default_configuration.delete('inherit_mode')
+
+        RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, default_configuration)
+      end
+
+      it 'integrates `Exclude` values from plugin cops into the configuration' do
+        expect(exclude.count).to eq 2
+        expect(exclude[0]).to end_with('.arb')
+        expect(exclude[1]).to end_with('.erb')
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue where plugin configuration keys were unexpectedly removed.

It resolves a problem where changes to a plugin's configuration for the same key as RuboCop's default configuration would result in the plugin's configuration being deleted. A regression test has been added to prevent this issue from recurring.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
