### PR TITLE
Fix undefined method Logger when processing watched file notifications

### DIFF
--- a/changelog/fix_fix_undefined_method_logger_when_processing_20250212102241.md
+++ b/changelog/fix_fix_undefined_method_logger_when_processing_20250212102241.md
@@ -1,0 +1,1 @@
+* [#13822](https://github.com/rubocop/rubocop/pull/13822): Fix undefined method Logger when processing watched file notifications. ([@vinistock][])

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -66,7 +66,7 @@ module RubyLsp
 
         @runtime_adapter = RuntimeAdapter.new
 
-        ::RuboCop::LSP::Logger(<<~MESSAGE, prefix: '[RuboCop]')
+        ::RuboCop::LSP::Logger.log(<<~MESSAGE, prefix: '[RuboCop]')
           Re-initialized RuboCop LSP addon #{::RuboCop::Version::STRING} due to .rubocop.yml file change.
         MESSAGE
       end

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -117,6 +117,29 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
     end
   end
 
+  describe 'workspace/didChangeWatchedFiles' do
+    it 'creates new runtime adapter' do
+      with_server(source, '.rubocop.yml') do |server, uri|
+        addon = RubyLsp::Addon.addons.find { |a| a.name == 'RuboCop' }
+        expect(addon).to be_an_instance_of(RubyLsp::RuboCop::Addon)
+        original_runtime_adapter = addon.instance_variable_get(:@runtime_adapter)
+
+        server.process_message(
+          method: 'workspace/didChangeWatchedFiles',
+          params: {
+            changes: [{
+              uri: uri.to_s,
+              type: RubyLsp::Constant::FileChangeType::CHANGED
+            }]
+          }
+        )
+
+        new_runtime_adapter = addon.instance_variable_get(:@runtime_adapter)
+        expect(new_runtime_adapter).not_to eq original_runtime_adapter
+      end
+    end
+  end
+
   private
 
   # Lifted from here, because we need to override the formatter to RuboCop in the spec helper:


### PR DESCRIPTION
The code for handling watched file notifications was crashing every time because it was trying to invoke `Logger()`, which is a module not a method. The actual method is `Logger.log`.

I added a test to verify that the runtime adapter is properly reloaded whenever the config file is updated.

Note: I did not use an RSpec's subject block for this test because we need to verify things _inside_ the `with_server` block, while add-ons are still loaded and activated (the method unloads them at the end). The watched files notification doesn't return a response (because it's an LSP notification and not a request) and so this is the only way to verify what's happening.

Please let me know if you want to include this in the changelog.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
