### PR TITLE
Fix incorrect plugin exception name

### DIFF
--- a/lib/rubocop/plugin/not_supported_error.rb
+++ b/lib/rubocop/plugin/not_supported_error.rb
@@ -1,26 +1,28 @@
 # frozen_string_literal: true
 
 module RuboCop
-  # An exception raised when a plugin is not supported by the RuboCop engine.
-  # @api private
-  class NotSupportedError < Error
-    def initialize(unsupported_plugins)
-      super
+  module Plugin
+    # An exception raised when a plugin is not supported by the RuboCop engine.
+    # @api private
+    class NotSupportedError < Error
+      def initialize(unsupported_plugins)
+        super
 
-      @unsupported_plugins = unsupported_plugins
-    end
+        @unsupported_plugins = unsupported_plugins
+      end
 
-    def message
-      if @unsupported_plugins.one?
-        about_plugin = @unsupported_plugins.first.about
+      def message
+        if @unsupported_plugins.one?
+          about = @unsupported_plugins.first.about
 
-        "#{about_plugin.name} #{about_plugin.version} is not a plugin supported by RuboCop engine."
-      else
-        unsupported_plugin_names = @unsupported_plugins.map do |plugin|
-          "#{plugin.about.name} #{plugin.about.version}"
-        end.join(', ')
+          "#{about.name} #{about.version} is not a plugin supported by RuboCop engine."
+        else
+          unsupported_plugin_names = @unsupported_plugins.map do |plugin|
+            "#{plugin.about.name} #{plugin.about.version}"
+          end.join(', ')
 
-        "#{unsupported_plugin_names} are not plugins supported by RuboCop engine."
+          "#{unsupported_plugin_names} are not plugins supported by RuboCop engine."
+        end
       end
     end
   end

--- a/spec/rubocop/plugin/configuration_integrator_spec.rb
+++ b/spec/rubocop/plugin/configuration_integrator_spec.rb
@@ -63,5 +63,23 @@ RSpec.describe RuboCop::Plugin::ConfigurationIntegrator do
         expect(exclude[1]).to end_with('.erb')
       end
     end
+
+    context 'when using a plugin with an unsupported RuboCop engine' do
+      let(:rubocop_config) do
+        RuboCop::Config.new
+      end
+      let(:unsupported_plugin) do
+        Class.new(LintRoller::Plugin) do
+          def supported?(context)
+            context.engine == :not_rubocop
+          end
+        end
+      end
+      let(:plugins) { [unsupported_plugin.new] }
+
+      it 'raises `RuboCop::Plugin::NotSupportedError`' do
+        expect { integrated_config }.to raise_error(RuboCop::Plugin::NotSupportedError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR corrects the plugin exception name from
`RuboCop::NotSupportedError` to `RuboCop::Plugin::NotSupportedError`.

This resolves the following unexpected issue:

```console
     NameError:
       uninitialized constant RuboCop::Plugin::NotSupportedError
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
