### PR TITLE
Update `Style/RedundantFormat` to register an offense for `format` arguments that can be easily inlined

### DIFF
--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -3,8 +3,14 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for calls to `Kernel#format` or `Kernel#sprintf` with only a single
-      # string argument, that can be replaced by the string itself.
+      # Checks for calls to `Kernel#format` or `Kernel#sprintf` that are redundant.
+      #
+      # Calling `format` with only a single string argument is redundant, as it can be
+      # replaced by the string itself.
+      #
+      # Also looks for `format` calls where the arguments are literals that can be
+      # inlined into a string easily. This applies to the `%s`, `%d`, `%i`, `%u`, and
+      # `%f` format specifiers.
       #
       # @example
       #
@@ -15,25 +21,200 @@ module RuboCop
       #   # good
       #   'the quick brown fox jumps over the lazy dog.'
       #
+      #   # bad
+      #   format('%s %s', 'foo', 'bar')
+      #   sprintf('%s %s', 'foo', 'bar')
+      #
+      #   # good
+      #   'foo bar'
+      #
       class RedundantFormat < Base
         extend AutoCorrector
 
         MSG = 'Redundant `%<method_name>s` can be removed.'
 
         RESTRICT_ON_SEND = %i[format sprintf].to_set.freeze
+        ACCEPTABLE_LITERAL_TYPES = %i[str dstr sym dsym numeric boolean nil].freeze
 
         # @!method format_without_additional_args?(node)
         def_node_matcher :format_without_additional_args?, <<~PATTERN
-          (send {(const {nil? cbase} :Kernel) nil?} $%RESTRICT_ON_SEND ${str dstr})
+          (send {(const {nil? cbase} :Kernel) nil?} %RESTRICT_ON_SEND ${str dstr})
+        PATTERN
+
+        # @!method rational_number?(node)
+        def_node_matcher :rational_number?, <<~PATTERN
+          {rational (send int :/ rational) (begin rational) (begin (send int :/ rational))}
+        PATTERN
+
+        # @!method complex_number?(node)
+        def_node_matcher :complex_number?, <<~PATTERN
+          {complex (send int :+ complex) (begin complex) (begin (send int :+ complex))}
+        PATTERN
+
+        # @!method find_hash_value_node(node, name)
+        def_node_search  :find_hash_value_node, <<~PATTERN
+          (pair (sym %1) $_)
         PATTERN
 
         def on_send(node)
-          format_without_additional_args?(node) do |method_name, value|
-            message = format(MSG, method_name: method_name)
-            add_offense(node, message: message) do |corrector|
+          format_without_additional_args?(node) do |value|
+            add_offense(node, message: message(node)) do |corrector|
               corrector.replace(node, value.source)
             end
+            return
           end
+
+          detect_unnecessary_fields(node)
+        end
+
+        private
+
+        def message(node)
+          format(MSG, method_name: node.method_name)
+        end
+
+        def detect_unnecessary_fields(node)
+          return unless node.first_argument&.str_type?
+
+          string = node.first_argument.value
+          arguments = node.arguments[1..]
+
+          return unless string && arguments.any?
+          return if arguments.any?(&:splat_type?)
+
+          register_all_fields_literal(node, string, arguments)
+        end
+
+        def register_all_fields_literal(node, string, arguments)
+          return unless all_fields_literal?(string, arguments.dup)
+
+          add_offense(node, message: message(node)) do |corrector|
+            replacement = format(string, *argument_values(arguments))
+            corrector.replace(node, quote(replacement, node))
+          end
+        end
+
+        def all_fields_literal?(string, arguments)
+          count = 0
+          sequences = RuboCop::Cop::Utils::FormatString.new(string).format_sequences
+          return false unless sequences.any?
+
+          sequences.each do |sequence|
+            next if sequence.percent?
+
+            hash = arguments.detect(&:hash_type?)
+            argument = find_argument(sequence, arguments, hash)
+            next unless matching_argument?(sequence, argument)
+
+            count += 1
+          end
+
+          sequences.size == count
+        end
+
+        def find_argument(sequence, arguments, hash)
+          if sequence.annotated? || sequence.template?
+            find_hash_value_node(hash, sequence.name.to_sym).first
+          elsif sequence.arg_number
+            arguments[sequence.arg_number.to_i - 1]
+          else
+            # If the specifier contains `*`, the following arguments will be used
+            # to specify the width and can be ignored.
+            (sequence.arity - 1).times { arguments.shift }
+            arguments.shift
+          end
+        end
+
+        def matching_argument?(sequence, argument)
+          # Template specifiers don't give a type, any acceptable literal type is ok.
+          return argument.type?(*ACCEPTABLE_LITERAL_TYPES) if sequence.template?
+
+          # An argument matches a specifier if it can be easily converted
+          # to that type.
+          case sequence.type
+          when 's'
+            argument.type?(*ACCEPTABLE_LITERAL_TYPES)
+          when 'd', 'i', 'u'
+            integer?(argument)
+          when 'f'
+            float?(argument)
+          else
+            false
+          end
+        end
+
+        def numeric?(argument)
+          argument.type?(:numeric, :str) ||
+            rational_number?(argument) ||
+            complex_number?(argument)
+        end
+
+        def integer?(argument)
+          numeric?(argument) && Integer(argument_value(argument), exception: false)
+        end
+
+        def float?(argument)
+          numeric?(argument) && Float(argument_value(argument), exception: false)
+        end
+
+        # Add correct quotes to the formatted string, preferring retaining the existing
+        # quotes if possible.
+        def quote(string, node)
+          str_node = node.first_argument
+          start_delimiter = str_node.loc.begin.source
+          end_delimiter = str_node.loc.end.source
+
+          # If there is any interpolation, the delimiters need to be changed potentially
+          if node.each_descendant(:dstr, :dsym).any?
+            case start_delimiter
+            when "'"
+              start_delimiter = end_delimiter = '"'
+            when /\A%q(.)/
+              start_delimiter = "%Q#{Regexp.last_match[1]}"
+            end
+          end
+
+          "#{start_delimiter}#{string}#{end_delimiter}"
+        end
+
+        def argument_values(arguments)
+          arguments.map { |argument| argument_value(argument) }
+        end
+
+        def argument_value(argument)
+          argument = argument.children.first if argument.begin_type?
+
+          if argument.dsym_type?
+            dsym_value(argument)
+          elsif argument.hash_type?
+            hash_value(argument)
+          elsif rational_number?(argument)
+            rational_value(argument)
+          elsif complex_number?(argument)
+            complex_value(argument)
+          elsif argument.respond_to?(:value)
+            argument.value
+          else
+            argument.source
+          end
+        end
+
+        def dsym_value(dsym_node)
+          dsym_node.children.first.source
+        end
+
+        def hash_value(hash_node)
+          hash_node.each_pair.with_object({}) do |pair, hash|
+            hash[pair.key.value] = argument_value(pair.value)
+          end
+        end
+
+        def rational_value(rational_node)
+          rational_node.source.to_r
+        end
+
+        def complex_value(complex_node)
+          Complex(complex_node.source)
         end
       end
     end

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Utils
       # Parses {Kernel#sprintf} format strings.
       class FormatString
-        DIGIT_DOLLAR  = /(\d+)\$/.freeze
+        DIGIT_DOLLAR  = /(?<arg_number>\d+)\$/.freeze
         INTERPOLATION = /#\{.*?\}/.freeze
         FLAG          = /[ #0+-]|#{DIGIT_DOLLAR}/.freeze
         NUMBER_ARG    = /\*#{DIGIT_DOLLAR}?/.freeze
@@ -42,7 +42,7 @@ module RuboCop
         #
         # @see https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-format
         class FormatSequence
-          attr_reader :begin_pos, :end_pos, :flags, :width, :precision, :name, :type
+          attr_reader :begin_pos, :end_pos, :flags, :width, :precision, :name, :type, :arg_number
 
           def initialize(match)
             @source = match[0]
@@ -53,6 +53,7 @@ module RuboCop
             @precision = match[:precision]
             @name = match[:name]
             @type = match[:type]
+            @arg_number = match[:arg_number]
           end
 
           def percent?


### PR DESCRIPTION
Follows https://github.com/rubocop/rubocop/pull/13793#issuecomment-2638914275

Adds `Style/RedundantFormat` offenses when all format specifiers in the format string are given literal values that can be easily replaced. This applies to `%s`, `%d`, `%i`, `%u`, and `%f` with a variety of argument types (see tests for examples). This does not include things like `%x`, `%e`, `%g`, etc., which format numeric values in specific ways (as hexadecimal, scientific notation, etc.), as those are not straightforward and will make changing the code harder after inlining the value. 

I did not add a changelog entry since #13793 is not released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
