### PR TITLE
Allow `RuboCop::ConfigLoader.inject_defaults!` to accept `Pathname` instances

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -181,7 +181,7 @@ module RuboCop
           path = File.join(project_root, 'config', 'default.yml')
           config = load_file(path)
         else
-          hash = ConfigLoader.load_yaml_configuration(config_yml_path)
+          hash = ConfigLoader.load_yaml_configuration(config_yml_path.to_s)
           config = Config.new(hash, config_yml_path).tap(&:make_excludes_absolute)
         end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1956,6 +1956,26 @@ RSpec.describe RuboCop::ConfigLoader do
     end
   end
 
+  describe '.inject_defaults!', :isolated_environment do
+    subject(:rubocop_config) { described_class.inject_defaults!(config_path) }
+
+    before do
+      create_empty_file('default.yml')
+    end
+
+    context 'when config path is a string' do
+      let(:config_path) { 'default.yml' }
+
+      it { expect { rubocop_config }.not_to raise_error }
+    end
+
+    context 'when config path is a `Pathname` object' do
+      let(:config_path) { Pathname('default.yml') }
+
+      it { expect { rubocop_config }.not_to raise_error }
+    end
+  end
+
   describe 'configuration for CharacterLiteral', :isolated_environment do
     let(:dir_path) { 'test/blargh' }
 


### PR DESCRIPTION
When using `Pathname` instance as an argument for `RuboCop::ConfigLoader.inject_defaults!`:

```ruby
project_root = Pathname.new(__dir__).join('..')
RuboCop::ConfigLoader.inject_defaults!(project_root.join('config', 'default.yml'))
```

The following error occurs:

```console
An error occurred while loading spec_helper.
Failure/Error: RuboCop::ConfigLoader.inject_defaults!(project_root.join('config', 'default.yml'))

NoMethodError:
  undefined method `start_with?' for #<Pathname:0x00007f91f62406c8>
# /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/path_util.rb:46:in `smart_path'
# /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/config_loader.rb:249:in `check_duplication'
# /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/config_loader.rb:82:in `load_yaml_configuration'
# /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/config_loader.rb:184:in `inject_defaults!'
# ./spec/spec_helper.rb:7:in `<top (required)>'
```

Investigating this error requires knowledge of RuboCop's internal implementation, which makes it difficult for users to troubleshoot. The simplest solution is to restore support for `Pathname` instance, maintaining the previous (private API period) behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
