### PR TITLE
Make plugin load error messages more user-friendly

### DIFF
--- a/lib/rubocop/plugin/load_error.rb
+++ b/lib/rubocop/plugin/load_error.rb
@@ -13,21 +13,12 @@ module RuboCop
 
       def message
         <<~MESSAGE
-          Failed loading plugin `#{@plugin_name}` because we couldn't determine the corresponding plugin class to instantiate.
-          First, try upgrading it. If the issue persists, please check with the developer regarding the following points.
+          Failed to load plugin `#{@plugin_name}` because the corresponding plugin class could not be determined for instantiation.
+          Try upgrading it first (e.g., `bundle update #{@plugin_name}`).
+          If `#{@plugin_name}` is not yet a plugin, use `require: #{@plugin_name}` instead of `plugins: `#{@plugin_name}` in your configuration.
 
-          RuboCop plugin class names must either be:
-
-            - If the plugin is a gem, defined in the gemspec as `default_lint_roller_plugin'
-
-              spec.metadata['default_lint_roller_plugin'] = 'MyModule::Plugin'
-
-            - Set in YAML as `plugin_class_name'; example:
-
-              plugins:
-                - incomplete:
-                    require_path: my_module/plugin
-                    plugin_class_name: "MyModule::Plugin"
+          For further assistance, check with the developer regarding the following points:
+          https://docs.rubocop.org/rubocop/plugin_migration_guide.html
         MESSAGE
       end
     end


### PR DESCRIPTION
Users who encounter plugin load errors are usually those who have misconfigured the plugin, rather than the plugin developers.

## Before

The previous error message was more geared towards plugin developers.

```console
$ bundle exec rubocop lib/rubocop.rb
Error: Failed loading plugin `rubocop-performance` because we couldn't determine the corresponding plugin class to instantiate.
First, try upgrading it. If the issue persists, please check with the developer regarding the following points.

RuboCop plugin class names must either be:

  - If the plugin is a gem, defined in the gemspec as `default_lint_roller_plugin'

    spec.metadata['default_lint_roller_plugin'] = 'MyModule::Plugin'

  - Set in YAML as `plugin_class_name'; example:

    plugins:
      - incomplete:
          require_path: my_module/plugin
          plugin_class_name: "MyModule::Plugin"
```

This error message might only confuse the user.

## After

This PR adjusts the message to guide users on the actions they should take when they see the error.

```console
$ bundle exec rubocop path/to/file.rb
Error: Failed to load plugin `rubocop-performance` because the corresponding plugin class could not be determined for instantiation.
Try upgrading it first (e.g., `bundle update rubocop-performance`).
If `rubocop-performance` is not yet a plugin, use `require: rubocop-performance` instead of `plugins: `rubocop-performance` in your configuration.

For further assistance, check with the developer regarding the following points:
https://docs.rubocop.org/rubocop/plugin_migration_guide.html
```

In most cases, this load error occurs because an extension cop doesn't support plugin system yet, `.rubocop.yml` contains `plugins: rubocop-foo`.

In this situation, the user has two options: run `bundle update`, or if that doesn't resolve the issue,
update `.rubocop.yml` to use `require: rubocop-foo` instead.

If contacting the developer is necessary, the migration guide included in this message may be helpful.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
