### PR TITLE
[Fix #13836] Fix an error for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_parentheses.md
+++ b/changelog/fix_an_error_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#13836](https://github.com/rubocop/rubocop/issues/13836): Fix an error for `Style/RedundantParentheses` when a different expression appears before a range literal. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -217,7 +217,9 @@ module RuboCop
 
         def disallowed_literal?(begin_node, node)
           if node.range_type?
-            begin_node.parent&.begin_type?
+            return false unless (parent = begin_node.parent)
+
+            parent.begin_type? && parent.children.one?
           else
             !raised_to_power_negative_numeric?(begin_node, node)
           end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -697,6 +697,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('(a...b)')
   end
 
+  it 'accepts parentheses around an irange when a different expression precedes it' do
+    expect_no_offenses(<<~RUBY)
+      do_something
+      (a..b)
+    RUBY
+  end
+
+  it 'accepts parentheses around an erange when a different expression precedes it' do
+    expect_no_offenses(<<~RUBY)
+      do_something
+      (a...b)
+    RUBY
+  end
+
   it 'accepts an irange starting is a parenthesized condition' do
     expect_no_offenses('(a || b)..c')
   end


### PR DESCRIPTION
This PR fixes an error for `Style/RedundantParentheses` when a different expression appears before a range literal.

Fixes #13836.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
