### PR TITLE
Extension plugin is loaded automatically with `require 'rubocop/rspec/support'`

### DIFF
--- a/changelog/change_plugin_is_loaded_automatically_with_rubocop_rspec_support.md
+++ b/changelog/change_plugin_is_loaded_automatically_with_rubocop_rspec_support.md
@@ -1,0 +1,1 @@
+* [#13839](https://github.com/rubocop/rubocop/pull/13839): Extension plugin is loaded automatically with `require 'rubocop/rspec/support'. ([@koic][])

--- a/docs/modules/ROOT/pages/plugin_migration_guide.adoc
+++ b/docs/modules/ROOT/pages/plugin_migration_guide.adoc
@@ -121,10 +121,3 @@ And use `require_relative` for the plugin class file instead of the above.
 ----
 require_relative 'rubocop/performance/plugin'
 ----
-
-In non-runtime environments like `spec/spec_helper.rb`, replace `require_relative 'rubocop/performance/plugin'` with `RuboCop::ConfigLoader.inject_defaults!`.
-
-[source,ruby]
-----
-RuboCop::ConfigLoader.inject_defaults!("#{__dir__}/../config/default.yml")
-----

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -163,6 +163,10 @@ module RuboCop
         end
       end
 
+      # This API is primarily intended for testing and documenting plugins.
+      # When testing a plugin using `rubocop/rspec/support`, the plugin is loaded automatically,
+      # so this API is usually not needed. It is intended to be used only when implementing tests
+      # that do not use `rubocop/rspec/support`.
       # rubocop:disable Metrics/MethodLength
       def inject_defaults!(config_yml_path)
         if Pathname(config_yml_path).directory?

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -13,6 +13,13 @@ module CopHelper
   let(:parser_engine) { ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym }
   let(:rails_version) { false }
 
+  before(:all) do
+    plugins = Gem.loaded_specs.filter_map do |feature_name, feature_specification|
+      feature_name if feature_specification.metadata['default_lint_roller_plugin']
+    end
+    RuboCop::Plugin.integrate_plugins(RuboCop::Config.new, plugins)
+  end
+
   def inspect_source(source, file = nil)
     RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
     RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}


### PR DESCRIPTION
With this change, extension plugins that use `require 'rubocop/rspec/support'` for testing no longer need to include the following code in `spec/spec_helper.rb`.

```ruby
project_root = Pathname.new(__dir__).join('..')
RuboCop::ConfigLoader.inject_defaults!(project_root.join('config', 'default.yml'))
RuboCop::ConfigObsoletion.files << project_root.join('config', 'obsoletion.yml')
```

https://github.com/rubocop/rubocop-rails/blob/0e23cab4232cde7b1a74bafc758d19784576c527/spec/spec_helper.rb#L8-L10

In other words, extension plugins using RSpec can remove code related to `Inject`.

Accordingly, the purpose of `RuboCop::ConfigLoader.inject_defaults!` will be clarified and documented. When testing a plugin using `rubocop/rspec/support`, the plugin is loaded automatically, so this API is usually not needed. It is intended to be used only when implementing tests that do not use `rubocop/rspec/support`.
It may become unnecessary as a public API in the future, but it is being retained for now as a precaution.

Follow-up https://github.com/rubocop/rubocop/pull/13792

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
