### PR TITLE
[Fix #13839] Fix false positives for `Lint/RedundantTypeConversion`

### DIFF
--- a/changelog/fix_false_positives_fo_lint_redundant_type_conversion.md
+++ b/changelog/fix_false_positives_fo_lint_redundant_type_conversion.md
@@ -1,0 +1,1 @@
+* [#13839](https://github.com/rubocop/rubocop/issues/13839): Fix false positives for `Lint/RedundantTypeConversion` when passing block arguments when generating a Hash or a Set. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -161,7 +161,10 @@ module RuboCop
           }
         PATTERN
 
+        # rubocop:disable Metrics/AbcSize
         def on_send(node)
+          return if hash_or_set_with_block?(node)
+
           receiver = find_receiver(node)
           return unless literal_receiver?(node, receiver) ||
                         constructor?(node, receiver) ||
@@ -174,9 +177,16 @@ module RuboCop
             corrector.remove(node.loc.dot.join(node.loc.selector))
           end
         end
+        # rubocop:enable Metrics/AbcSize
         alias on_csend on_send
 
         private
+
+        def hash_or_set_with_block?(node)
+          return false if !node.method?(:to_h) && !node.method?(:to_set)
+
+          node.parent&.any_block_type? || node.last_argument&.block_pass_type?
+        end
 
         def find_receiver(node)
           receiver = node.receiver

--- a/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
@@ -285,6 +285,10 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'offense', :to_h, '::Kernel::Hash({ foo: bar })'
     it_behaves_like 'offense', :to_h, 'Hash[foo: bar]'
     it_behaves_like 'offense', :to_h, '::Hash[foo: bar]'
+
+    it_behaves_like 'accepted', '{ key: value }.to_h { |key, value| [foo(key), bar(value)] }'
+    it_behaves_like 'accepted', '{ key: value }.to_h { [foo(_1), bar(_2)] }'
+    it_behaves_like 'accepted', '{ key: value }.to_h(&:baz)'
   end
 
   describe '`to_set`' do
@@ -294,5 +298,9 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'offense', :to_set, '::Set.new([1, 2, 3])'
     it_behaves_like 'offense', :to_set, 'Set[1, 2, 3]'
     it_behaves_like 'offense', :to_set, '::Set[1, 2, 3]'
+
+    it_behaves_like 'accepted', 'Set[1, 2, 3].to_set { |item| foo(item) }'
+    it_behaves_like 'accepted', 'Set[1, 2, 3].to_set { foo(_1) }'
+    it_behaves_like 'accepted', 'Set[1, 2, 3].to_set(&:foo)'
   end
 end


### PR DESCRIPTION
This PR fixes false positives for `Lint/RedundantTypeConversion` when passing block arguments when generating a Hash or a Set.

Fixes #13839.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
