### PR TITLE
Use plugified RuboCop Performance (1.24) for development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,9 @@ inherit_from: .rubocop_todo.yml
 
 plugins:
   - rubocop-internal_affairs
+  - rubocop-performance
 
 require:
-  - rubocop-performance
   - rubocop-rspec
   - rubocop-rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'memory_profiler', '!= 1.0.2', platform: :mri
 gem 'prism', '~> 1.2'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-performance', '~> 1.23.0'
+gem 'rubocop-performance', '~> 1.24.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 3.4.0'
 # Ruby LSP supports Ruby 3.0+.

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -14,6 +14,8 @@ module CopHelper
   let(:rails_version) { false }
 
   before(:all) do
+    next if ENV['RUBOCOP_CORE_DEVELOPMENT']
+
     plugins = Gem.loaded_specs.filter_map do |feature_name, feature_specification|
       feature_name if feature_specification.metadata['default_lint_roller_plugin']
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,10 @@ rescue LoadError
   # Pry is not activated.
 end
 
+# NOTE: To avoid executing processes needed only for extension plugins in `rubocop/rspec/support`,
+# an environment variable is used to indicate that it is running in the RuboCop core development.
+ENV['RUBOCOP_CORE_DEVELOPMENT'] = 'true'
+
 # Require supporting files exposed for testing.
 require 'rubocop/rspec/support'
 


### PR DESCRIPTION
This commit uses plugified RuboCop Performance (1.24) for development and suppresses the following warning:

```console
$ bundle exec rubocop
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance`
instead of `require: rubocop-performance` in /Users/koic/src/github.com/rubocop/rubocop/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```

Furthermore, by skipping unnecessary processing in RuboCop's core tests, the following error is prevented.

```console
$ bundle exec rspec spec/rubocop/config_store_spec.rb:23
Run options: include {locations: {"./spec/rubocop/config_store_spec.rb" => [23]}}

Randomized with seed 950
F

Failures:

  1) RuboCop::ConfigStore.for always uses config specified in command line
     Failure/Error: @enrollment_queue = []

     FrozenError:
       can't modify frozen RuboCop::Cop::Registry: #<RuboCop::Cop::Registry:0x0000000106a92958
@registry={#<RuboCop::Cop::Badge:0x0000000124b08cc0 @department=:Migration, @department_name="Migration", @cop_name="DepartmentName",
```

This is a bug in the RuboCop core development environment introduced in https://github.com/rubocop/rubocop/pull/13840.

To determine this, `ENV['RUBOCOP_CORE_DEVELOPMENT'] = true` is set in `spec/spec_helper.rb` of RuboCop core development environment, allowing tests to check whether they are being executed from RuboCop core development environment.

But this change does not affect extension gems. So, this change does not affect third-party extensions, so there is no changelog entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
