### PR TITLE
Fix documentation formatting for `Naming/BlockForwarding` and `Style/ArgumentsForwarding`

### DIFF
--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -201,6 +201,21 @@ NOTE: Requires Ruby version 3.1
 | -
 |===
 
+In Ruby 3.1, anonymous block forwarding has been added.
+
+This cop identifies places where `do_something(&block)` can be replaced
+by `do_something(&)`.
+
+It also supports the opposite style by alternative `explicit` option.
+You can specify the block variable name for autocorrection with `BlockForwardingName`.
+The default variable name is `block`. If the name is already in use, it will not be
+autocorrected.
+
+[NOTE]
+====
+Because of a bug in Ruby 3.3.0, when a block is referenced inside of another block,
+no offense will be registered until Ruby 3.4:
+
 [source,ruby]
 ----
 def foo(&block)
@@ -208,7 +223,7 @@ def foo(&block)
   block_method { bar(&block) }
 end
 ----
---
+====
 
 [#examples-namingblockforwarding]
 === Examples

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -514,6 +514,39 @@ NOTE: Requires Ruby version 2.7
 | 1.58
 |===
 
+In Ruby 2.7, arguments forwarding has been added.
+
+This cop identifies places where `do_something(*args, &block)`
+can be replaced by `do_something(...)`.
+
+In Ruby 3.1, anonymous block forwarding has been added.
+
+This cop identifies places where `do_something(&block)` can be replaced
+by `do_something(&)`; if desired, this functionality can be disabled
+by setting `UseAnonymousForwarding: false`.
+
+In Ruby 3.2, anonymous args/kwargs forwarding has been added.
+
+This cop also identifies places where `use_args(*args)`/`use_kwargs(**kwargs)` can be
+replaced by `use_args(*)`/`use_kwargs(**)`; if desired, this functionality can be disabled
+by setting `UseAnonymousForwarding: false`.
+
+And this cop has `RedundantRestArgumentNames`, `RedundantKeywordRestArgumentNames`,
+and `RedundantBlockArgumentNames` options. This configuration is a list of redundant names
+that are sufficient for anonymizing meaningless naming.
+
+Meaningless names that are commonly used can be anonymized by default:
+e.g., `*args`, `**options`, `&block`, and so on.
+
+Names not on this list are likely to be meaningful and are allowed by default.
+
+This cop handles not only method forwarding but also forwarding to `super`.
+
+[NOTE]
+====
+Because of a bug in Ruby 3.3.0, when a block is referenced inside of another block,
+no offense will be registered until Ruby 3.4:
+
 [source,ruby]
 ----
 def foo(&block)
@@ -521,7 +554,7 @@ def foo(&block)
   block_method { bar(&block) }
 end
 ----
---
+====
 
 [#examples-styleargumentsforwarding]
 === Examples

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -14,10 +14,10 @@ module RuboCop
       # autocorrected.
       #
       # [NOTE]
-      # --
+      # ====
       # Because of a bug in Ruby 3.3.0, when a block is referenced inside of another block,
       # no offense will be registered until Ruby 3.4:
-
+      #
       # [source,ruby]
       # ----
       # def foo(&block)
@@ -25,7 +25,7 @@ module RuboCop
       #   block_method { bar(&block) }
       # end
       # ----
-      # --
+      # ====
       #
       # @example EnforcedStyle: anonymous (default)
       #

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -32,10 +32,10 @@ module RuboCop
       # This cop handles not only method forwarding but also forwarding to `super`.
       #
       # [NOTE]
-      # --
+      # ====
       # Because of a bug in Ruby 3.3.0, when a block is referenced inside of another block,
       # no offense will be registered until Ruby 3.4:
-
+      #
       # [source,ruby]
       # ----
       # def foo(&block)
@@ -43,7 +43,7 @@ module RuboCop
       #   block_method { bar(&block) }
       # end
       # ----
-      # --
+      # ====
       #
       # @example
       #   # bad


### PR DESCRIPTION
Some bad formatting slipped into `Naming/BlockForwarding` and `Style/ArgumentsForwarding` during the previous release, which broke the [public docs](https://docs.rubocop.org/rubocop/cops_style.html) (wonky formatting, chopped-off navigation, and missing cop descriptions)

![image](https://github.com/user-attachments/assets/22633f77-71ae-4730-b230-45050ae76831)

This fixes that

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
