### PR TITLE
[Fix #13846] Mark `Style/RedundantFormat` as unsafe autocorrect

### DIFF
--- a/changelog/change_mark_style_redundant_format_as_unsafe_autocorrect.md
+++ b/changelog/change_mark_style_redundant_format_as_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#13846](https://github.com/rubocop/rubocop/issues/13846): Mark `Style/RedundantFormat` as unsafe autocorrect. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5171,7 +5171,9 @@ Style/RedundantFilterChain:
 Style/RedundantFormat:
   Description: 'Checks for usages of `Kernel#format` or `Kernel#sprintf` with only a single argument.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.72'
+  VersionChanged: '<<next>>'
 
 Style/RedundantFreeze:
   Description: "Checks usages of Object#freeze on immutable objects."

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -12,6 +12,22 @@ module RuboCop
       # inlined into a string easily. This applies to the `%s`, `%d`, `%i`, `%u`, and
       # `%f` format specifiers.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because string object returned by
+      #   `format` and `sprintf` are never frozen. If `format('string')` is autocorrected to
+      #   `'string'`, `FrozenError` may occur when calling a destructive method like `String#<<`.
+      #   Consider using `'string'.dup` instead of `format('string')`.
+      #   Additionally, since the necessity of `dup` cannot be determined automatically,
+      #   this autocorrection is inherently unsafe.
+      #
+      #   [source,ruby]
+      #   ----
+      #   # frozen_string_literal: true
+      #
+      #   format('template').frozen? # => false
+      #   'template'.frozen?         # => true
+      #   ----
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
This PR marks `Style/RedundantFormat` as unsafe autocorrect.

Fixes #13846.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
