### PR TITLE
[Fix #13844] Fix an error for `Style/RedundantFormat`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_format.md
+++ b/changelog/fix_an_error_for_style_redundant_format.md
@@ -1,0 +1,1 @@
+* [#13844](https://github.com/rubocop/rubocop/issues/13844): Fix an error for `Style/RedundantFormat` when a template argument is used without keyword arguments. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -113,7 +113,7 @@ module RuboCop
         end
 
         def find_argument(sequence, arguments, hash)
-          if sequence.annotated? || sequence.template?
+          if hash && (sequence.annotated? || sequence.template?)
             find_hash_value_node(hash, sequence.name.to_sym).first
           elsif sequence.arg_number
             arguments[sequence.arg_number.to_i - 1]

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -308,6 +308,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
               #{method}('%{foo}', foo: foo)
             RUBY
           end
+
+          it 'does not register an offense when not given keyword arguments' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%{foo}', foo)
+            RUBY
+          end
         end
 
         context 'with an interpolated format string' do


### PR DESCRIPTION
This PR fixes an error for `Style/RedundantFormat` when a template argument is used without keyword arguments.

Fixes #13844.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
