### PR TITLE
[Fix #13849] Fix an error for `Lint/UselessConstantScoping`

### DIFF
--- a/changelog/fix_an_error_lint_useless_constant_scoping.md
+++ b/changelog/fix_an_error_lint_useless_constant_scoping.md
@@ -1,0 +1,1 @@
+* [#13849](https://github.com/rubocop/rubocop/issues/13849): Fix an error for `Lint/UselessConstantScoping` when multiple assigning to constants after `private` access modifier. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -56,8 +56,12 @@ module RuboCop
         private
 
         def after_private_modifier?(left_siblings)
-          left_siblings.compact.select(&:send_type?).any? do |node|
-            node.command?(:private) && node.arguments.none?
+          access_modifier_candidates = left_siblings.compact.select do |left_sibling|
+            left_sibling.respond_to?(:send_type?) && left_sibling.send_type?
+          end
+
+          access_modifier_candidates.any? do |candidate|
+            candidate.command?(:private) && candidate.arguments.none?
           end
         end
 

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
     RUBY
   end
 
+  it 'registers an offense when multiple assigning to constants after `private` access modifier' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+        FOO = BAR = 42
+        ^^^^^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using constant' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
This PR fixes an error for `Lint/UselessConstantScoping` hen multiple assigning to constants after `private` access modifier.

Fixes #13849.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
