### PR TITLE
[Fix #13850] Fix false negatives for `InternalAffairs/ExampleDescription`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -90,8 +90,10 @@ module RuboCop
           description_text = string_contents(current_description)
           return unless (new_description = correct_description(description_text, description_map))
 
+          quote = current_description.dstr_type? ? '"' : "'"
+
           add_offense(current_description, message: message) do |corrector|
-            corrector.replace(current_description, "'#{new_description}'")
+            corrector.replace(current_description, "#{quote}#{new_description}#{quote}")
           end
         end
 
@@ -106,7 +108,7 @@ module RuboCop
         end
 
         def string_contents(node)
-          node.str_type? ? node.value : node.source
+          node.type?(:str, :dstr) ? node.value : node.source
         end
       end
     end

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
       RUBY
     end
 
+    it 'registers an offense when given an improper description contains string interpolation' do
+      expect_offense(<<~'RUBY')
+        it "does not register an offense #{string_interpolation}" do
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+          expect_offense('code')
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        it "registers an offense #{string_interpolation}" do
+          expect_offense('code')
+        end
+      RUBY
+    end
+
     it 'registers an offense when given an improper description with single option' do
       expect_offense(<<~RUBY)
         it 'does not register an offense', :ruby30 do
@@ -135,6 +150,21 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
 
       expect_correction(<<~RUBY)
         it 'does not register the case' do
+          expect_no_offenses('code')
+        end
+      RUBY
+    end
+
+    it 'registers an offense when given an improper description contains string interpolation for `registers`' do
+      expect_offense(<<~'RUBY')
+        it "registers an offense #{string_interpolation}" do
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_offenses`.
+          expect_no_offenses('code')
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        it "does not register an offense #{string_interpolation}" do
           expect_no_offenses('code')
         end
       RUBY


### PR DESCRIPTION
This PR fixes false negatives for `InternalAffairs/ExampleDescription` when example description contains string interpolation.

Fixes #13850.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
