### PR TITLE
Fix exclusion of relative paths in plugin's `AllCops: Exclude` as expected

### DIFF
--- a/changelog/fix_all_cops_exclude_paths.md
+++ b/changelog/fix_all_cops_exclude_paths.md
@@ -1,0 +1,1 @@
+* [#13853](https://github.com/rubocop/rubocop/pull/13853): Fix exclusion of relative paths in plugin's `AllCops: Exclude` as expected. ([@koic][])

--- a/lib/rubocop/plugin/configuration_integrator.rb
+++ b/lib/rubocop/plugin/configuration_integrator.rb
@@ -57,6 +57,8 @@ module RuboCop
                 all_cop_keys_configured_by_plugins
               )
 
+              plugin_config.make_excludes_absolute
+
               ConfigLoader.merge_with_default(plugin_config, plugin_config_path)
             end
           end


### PR DESCRIPTION
When relative paths are used in a plugin's configuration file under `AllCops: Exclude`, they must be converted to absolute paths. Otherwise, the exclusion paths will not match the paths being inspected, and the files will not be excluded.

This issue was reported in https://github.com/rubocop/rubocop-rails/issues/1443. And this issue was previously reported in https://github.com/rubocop/rubocop-rails/pull/187 and is essentially a necessary process for all extension gems.

On a side note, converting to the plugin system allows us to fix such potential bugs across all extension gems in a unified manner. Of course, there is also the risk of introducing bugs uniformly...

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
