### PR TITLE
Correct `Style/RedundantParentheses` documentation

### DIFF
--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -13,8 +13,7 @@ module RuboCop
       #   # good
       #   x if y.z.nil?
       #
-      # rubocop:disable Metrics/ClassLength
-      class RedundantParentheses < Base
+      class RedundantParentheses < Base # rubocop:disable Metrics/ClassLength
         include Parentheses
         extend AutoCorrector
 
@@ -299,7 +298,6 @@ module RuboCop
           block.keywords? && begin_node.each_ancestor(:call).any?
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end


### PR DESCRIPTION
The `rubocop:disable Metrics/ClassLength` comment leaks in the actual documentation:
![Screenshot 2025-02-17 at 10 04 31](https://github.com/user-attachments/assets/8e5a92ba-bd77-4f66-923a-ac5c840a35a2)

https://docs.rubocop.org/rubocop/cops_style.html#styleredundantparentheses