### PR TITLE
Fix an error for `Style/RedundantFormat`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_format_cop.md
+++ b/changelog/fix_an_error_for_style_redundant_format_cop.md
@@ -1,0 +1,1 @@
+* [#13857](https://github.com/rubocop/rubocop/pull/13857): Fix an error for `Style/RedundantFormat` when numeric placeholders is used in the template argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -160,7 +160,7 @@ module RuboCop
         end
 
         def numeric?(argument)
-          argument.type?(:numeric, :str) ||
+          argument&.type?(:numeric, :str) ||
             rational_number?(argument) ||
             complex_number?(argument)
         end

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -314,6 +314,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
               #{method}('%{foo}', foo)
             RUBY
           end
+
+          it 'does not register an offense when given numeric placeholders in the template argument' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%<placeholder>d, %<placeholder>f', placeholder)
+            RUBY
+          end
         end
 
         context 'with an interpolated format string' do


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/13844#issuecomment-2662583728.

This PR fixes an error for `Style/RedundantFormat` when numeric placeholders is used in the template argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
