### PR TITLE
[Fix #13856] Fix false positives for `Lint/UselessConstantScoping`

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_constant_scoping.md
+++ b/changelog/fix_false_positives_for_lint_useless_constant_scoping.md
@@ -1,0 +1,1 @@
+* [#13856](https://github.com/rubocop/rubocop/issues/13856): Fix false positives for `Lint/UselessConstantScoping` when a constant is used after `private` access modifier with arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -56,7 +56,9 @@ module RuboCop
         private
 
         def after_private_modifier?(left_siblings)
-          left_siblings.compact.select(&:send_type?).any? { |node| node.command?(:private) }
+          left_siblings.compact.select(&:send_type?).any? do |node|
+            node.command?(:private) && node.arguments.none?
+          end
         end
 
         def private_constantize?(right_siblings, const_value)

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -87,4 +87,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when using constant after `private` access modifier with arguments' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private do_something
+
+        CONST = 42
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes false positives for `Lint/UselessConstantScoping` when a constant is used after `private` access modifier with arguments.

Fixes #13856.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
