### PR TITLE
[Fix #13861] Fix `ArgumentError` related to two deprecated `AllowedPattern` APIs

### DIFF
--- a/changelog/fix_an_error_for_two_deprecated_allowed_pattern_apis.md
+++ b/changelog/fix_an_error_for_two_deprecated_allowed_pattern_apis.md
@@ -1,0 +1,1 @@
+* [#13861](https://github.com/rubocop/rubocop/issues/13861): Fix `ArgumentError` related to two deprecated `AllowedPattern` APIs. ([@koic][])

--- a/lib/rubocop/cop/mixin/allowed_pattern.rb
+++ b/lib/rubocop/cop/mixin/allowed_pattern.rb
@@ -18,12 +18,12 @@ module RuboCop
       end
 
       # @deprecated Use allowed_line? instead
-      def ignored_line?
+      def ignored_line?(line)
         warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `ignored_line?` is deprecated. Use `allowed_line?` instead.
         WARNING
 
-        allowed_line?
+        allowed_line?(line)
       end
 
       def matches_allowed_pattern?(line)
@@ -31,12 +31,12 @@ module RuboCop
       end
 
       # @deprecated Use matches_allowed_pattern? instead
-      def matches_ignored_pattern?
+      def matches_ignored_pattern?(line)
         warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `matches_ignored_pattern?` is deprecated. Use `matches_allowed_pattern?` instead.
         WARNING
 
-        matches_allowed_pattern?
+        matches_allowed_pattern?(line)
       end
 
       def allowed_patterns


### PR DESCRIPTION
This PR fixes `ArgumentError` related to two deprecated `AllowedPattern` APIs.

This bug was introduced in https://github.com/rubocop/rubocop/pull/13032, where arguments passed to methods using `alias` were not expanded properly.

Fixes #13861.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
