### PR TITLE
[Fix #13866] Tweak the offense message of `Style/RedundantFormat`

### DIFF
--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY, method: method)
             %{method}('foo')
-            ^{method}^^^^^^^ Redundant `%{method}` can be removed.
+            ^{method}^^^^^^^ Use `'foo'` directly instead of `%{method}`.
           RUBY
 
           expect_correction(<<~RUBY)
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it 'registers an offense when the argument is an interpolated string' do
           expect_offense(<<~'RUBY', method: method)
             %{method}("#{foo}")
-            ^{method}^^^^^^^^^^ Redundant `%{method}` can be removed.
+            ^{method}^^^^^^^^^^ Use `"#{foo}"` directly instead of `%{method}`.
           RUBY
 
           expect_correction(<<~'RUBY')
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it 'registers an offense when called with `Kernel`' do
           expect_offense(<<~RUBY, method: method)
             Kernel.%{method}('foo')
-            ^^^^^^^^{method}^^^^^^^ Redundant `%{method}` can be removed.
+            ^^^^^^^^{method}^^^^^^^ Use `'foo'` directly instead of `%{method}`.
           RUBY
 
           expect_correction(<<~RUBY)
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it 'registers an offense when called with `::Kernel`' do
           expect_offense(<<~RUBY, method: method)
             ::Kernel.%{method}('foo')
-            ^^^^^^^^^^{method}^^^^^^^ Redundant `%{method}` can be removed.
+            ^^^^^^^^^^{method}^^^^^^^ Use `'foo'` directly instead of `%{method}`.
           RUBY
 
           expect_correction(<<~RUBY)
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
 
             expect_offense(<<~RUBY, **options)
               %{method}(%{start_delim}%{specifier}%{end_delim}, %{value})
-              ^{method}^^{start_delim}^{specifier}^{end_delim}^^^{value}^ Redundant `%{method}` can be removed.
+              ^{method}^^{start_delim}^{specifier}^{end_delim}^^^{value}^ Use `#{result}` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY, method: method)
               %{method}('%2$s %1$s', 'world', 'hello')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `'hello world'` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY, method: method)
               %{method}('%*d', 5, 14)
-              ^{method}^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^ Use `'   14'` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects with multiple `*`s' do
             expect_offense(<<~RUBY, method: method)
               %{method}('$%0*.*f', 5, 2, 0.5)
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^ Use `'$00.50'` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY, method: method)
               #{method}('%<foo>s %<bar>s', foo: 'foo', bar: 'bar')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `'foo bar'` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -265,7 +265,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects with interpolated strings' do
             expect_offense(<<~'RUBY', method: method)
               %{method}('%<foo>s %<bar>s', foo: "#{foo}", bar: 'bar')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `"#{foo} bar"` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~'RUBY')
@@ -284,7 +284,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY, method: method)
               #{method}('%{foo}s %{bar}s', foo: 'foo', bar: 'bar')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `'foos bars'` directly instead of `#{method}`.
             RUBY
 
             expect_correction(<<~RUBY)
@@ -295,7 +295,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects with interpolated strings' do
             expect_offense(<<~'RUBY', method: method)
               %{method}('%{foo}s %{bar}s', foo: "#{foo}", bar: 'bar')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `"#{foo}s bars"` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~'RUBY')
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY, method: method)
               %{method}('%s %s', 'foo', 'bar')
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^ Redundant `%{method}` can be removed.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^ Use `'foo bar'` directly instead of `%{method}`.
             RUBY
 
             expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR tweaks the offense message of `Style/RedundantFormat`. Including the result of calls like `format('%10s', 'beepboop')` in the message helps users understand the cop's role in identifying cases where a string literal can be used instead.

Fixes #13866.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
