### PR TITLE
[Fix #13867] Fix an error for plugins when not running RuboCop through Bundler

### DIFF
--- a/changelog/fix_error_plugin_no_bundler.md
+++ b/changelog/fix_error_plugin_no_bundler.md
@@ -1,0 +1,1 @@
+* [#13867](https://github.com/rubocop/rubocop/issues/13867): Fix an error for plugins when not running RuboCop through Bundler. ([@earlopain][])

--- a/lib/rubocop/plugin.rb
+++ b/lib/rubocop/plugin.rb
@@ -22,6 +22,9 @@ module RuboCop
       def plugin_capable?(feature_name)
         return true if BUILTIN_INTERNAL_PLUGINS.key?(feature_name)
         return true if feature_name == OBSOLETE_INTERNAL_AFFAIRS_PLUGIN_NAME
+
+        # When not using Bundler. Makes the spec available in loaded_specs but does not require it.
+        Gem.try_activate(feature_name)
         return false unless (gem = Gem.loaded_specs[feature_name])
 
         !!gem.metadata['default_lint_roller_plugin']

--- a/spec/rubocop/plugin_spec.rb
+++ b/spec/rubocop/plugin_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe RuboCop::Plugin do
 
       it { is_expected.to be(false) }
     end
+
+    context 'when the plugin is not yet activated' do
+      let(:feature) { 'rubocop-rspec' }
+
+      around do |example|
+        prev_loaded_spec = Gem.loaded_specs[feature]
+        Gem.loaded_specs[feature] = nil
+        example.call
+        Gem.loaded_specs[feature] = prev_loaded_spec
+      end
+
+      it { is_expected.to be(true) }
+    end
   end
 
   describe '.integrate_plugins' do


### PR DESCRIPTION
Because `Gem.loaded_specs` doesn't contain the gems yet at that point. The automatic injection of the config was removed, so no config is made available at all.

I don't particularly like the fix or test since it is somewhat close to bundler internals but I don't see a different solution. `try_activate` has been around in this form since at least the last 15 years


Initially I tried using `load` but that does not work since the gem is not activated. I've manually tested that this fixes the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
