### PR TITLE
[Fix #12948] Add `ForbiddenNames` configuration to `Naming/VariableName` to specify names that are forbidden

### DIFF
--- a/changelog/change_add_forbidden_names_configuration_to_20250219104915.md
+++ b/changelog/change_add_forbidden_names_configuration_to_20250219104915.md
@@ -1,0 +1,1 @@
+* [#12948](https://github.com/rubocop/rubocop/issues/12948): Add `ForbiddenNames` configuration to `Naming/VariableName` to specify names that are forbidden. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3081,13 +3081,15 @@ Naming/VariableName:
   StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
-  VersionChanged: '1.8'
+  VersionChanged: '<<next>>'
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case
     - camelCase
   AllowedIdentifiers: []
   AllowedPatterns: []
+  ForbiddenIdentifiers: []
+  ForbiddenPatterns: []
 
 Naming/VariableNumber:
   Description: 'Use the configured style when numbering symbols, methods and variables.'

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -109,6 +109,316 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
     end
   end
 
+  shared_examples 'forbidden identifiers' do |identifier|
+    context 'when ForbiddenIdentifiers is set' do
+      let(:cop_config) { super().merge('ForbiddenIdentifiers' => [identifier]) }
+
+      context 'with `lvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            %{identifier} = true
+            ^{identifier} `%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `ivasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            @%{identifier} = true
+            ^^{identifier} `@%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `cvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            @@%{identifier} = true
+            ^^^{identifier} `@@%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `gvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            $%{identifier} = true
+            ^^{identifier} `$%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `arg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier})
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `optarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier} = false)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `restarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(*%{identifier})
+                     ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+        end
+      end
+
+      context 'with `kwarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier}:)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `kwargopt`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier}: true)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+        end
+      end
+
+      context 'with `kwrestarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(**%{identifier})
+                      ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `blockarg` in `def`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(&%{identifier})
+                     ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `blockarg` in `block`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            foo do |%{identifier}|
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      it 'does not register an offense for a method definition' do
+        expect_no_offenses(<<~RUBY)
+          def #{identifier}
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method identifier' do
+        expect_no_offenses(<<~RUBY)
+          #{identifier}()
+        RUBY
+      end
+    end
+  end
+
+  shared_examples 'forbidden patterns' do |pattern, identifier|
+    context 'when ForbiddenPatterns is set' do
+      let(:cop_config) { super().merge('ForbiddenPatterns' => [pattern]) }
+
+      context 'with `lvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            %{identifier} = true
+            ^{identifier} `%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `ivasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            @%{identifier} = true
+            ^^{identifier} `@%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `cvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            @@%{identifier} = true
+            ^^^{identifier} `@@%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `gvasgn`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            $%{identifier} = true
+            ^^{identifier} `$%{identifier}` is forbidden, use another name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `arg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier})
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `optarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier} = false)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `restarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(*%{identifier})
+                     ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+        end
+      end
+
+      context 'with `kwarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier}:)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `kwargopt`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(%{identifier}: true)
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+        end
+      end
+
+      context 'with `kwrestarg`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(**%{identifier})
+                      ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `blockarg` in `def`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo(&%{identifier})
+                     ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'with `blockarg` in `block`' do
+        it 'registers an offense when given a forbidden identifier' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            foo do |%{identifier}|
+                    ^{identifier} `%{identifier}` is forbidden, use another name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      it 'does not register an offense for a method definition' do
+        expect_no_offenses(<<~RUBY)
+          def #{identifier}
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method identifier' do
+        expect_no_offenses(<<~RUBY)
+          #{identifier}()
+        RUBY
+      end
+    end
+  end
+
   context 'when configured for snake_case' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
@@ -206,6 +516,8 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
     include_examples 'always accepted'
     include_examples 'allowed identifiers', 'firstArg'
     include_examples 'allowed patterns', 'st[A-Z]', 'firstArg'
+    include_examples 'forbidden identifiers', 'first_arg'
+    include_examples 'forbidden patterns', 'st_[a-z]', 'first_arg'
   end
 
   context 'when configured for camelCase' do
@@ -304,5 +616,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableName, :config do
     include_examples 'always accepted'
     include_examples 'allowed identifiers', 'first_arg'
     include_examples 'allowed patterns', 'st_[a-z]', 'first_arg'
+    include_examples 'forbidden identifiers', 'first_arg'
+    include_examples 'forbidden patterns', 'st_[a-z]', 'first_arg'
   end
 end


### PR DESCRIPTION
Adds `ForbiddenNames` configuration to `Naming/VariableName` to allow disallowed identifiers to be specified, following https://github.com/rubocop/rubocop/pull/13825#issuecomment-2654192113. 

This applies to local variables, instance variables, class variables, global variables, method arguments (positional, keyword, rest or block), and block arguments. This explicitly does not apply to method names, because I can see there being use cases for overriding "reserved" methods (for instance, as per the issue, in Rails it would make sense to not override request with a local variable, but you may wish to override the request method).

Fixes #12948.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
