### PR TITLE
plugin/load_error: remove extra tick

### DIFF
--- a/lib/rubocop/plugin/load_error.rb
+++ b/lib/rubocop/plugin/load_error.rb
@@ -15,7 +15,7 @@ module RuboCop
         <<~MESSAGE
           Failed to load plugin `#{@plugin_name}` because the corresponding plugin class could not be determined for instantiation.
           Try upgrading it first (e.g., `bundle update #{@plugin_name}`).
-          If `#{@plugin_name}` is not yet a plugin, use `require: #{@plugin_name}` instead of `plugins: `#{@plugin_name}` in your configuration.
+          If `#{@plugin_name}` is not yet a plugin, use `require: #{@plugin_name}` instead of `plugins: #{@plugin_name}` in your configuration.
 
           For further assistance, check with the developer regarding the following points:
           https://docs.rubocop.org/rubocop/plugin_migration_guide.html


### PR DESCRIPTION
This PR removes an extra \` from the message printed when a plugin fails to load.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
