### PR TITLE
Prevent `version_spec` from leaking `ConfigLoader.default_configuration` changes

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -80,6 +80,21 @@ RSpec.shared_context 'maintain registry' do
   end
 end
 
+RSpec.shared_context 'maintain default configuration' do
+  around(:each) do |example|
+    # Make a copy of the current configuration that will not change when source hash changes
+    default_configuration = RuboCop::ConfigLoader.default_configuration
+    config = RuboCop::Config.create(
+      default_configuration.to_h.clone,
+      default_configuration.loaded_path
+    )
+
+    example.run
+
+    RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
+  end
+end
+
 # This context assumes nothing and defines `cop`, among others.
 RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
   ### Meant to be overridden at will

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   config.include_context 'isolated bundler', :isolated_bundler
   config.include_context 'lsp', :lsp
   config.include_context 'maintain registry', :restore_registry
+  config.include_context 'maintain default configuration', :restore_configuration
   config.include_context 'ruby 2.0', :ruby20
   config.include_context 'ruby 2.1', :ruby21
   config.include_context 'ruby 2.2', :ruby22

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Version do
     end
   end
 
-  describe '.extension_versions', :isolated_environment, :restore_registry do
+  describe '.extension_versions', :isolated_environment, :restore_configuration, :restore_registry do
     subject(:extension_versions) { described_class.extension_versions(env) }
 
     let(:env) { instance_double(RuboCop::CLI::Environment, config_store: config_store) }


### PR DESCRIPTION
When a plugin is loaded in a test, it overrides `ConfigLoader.default_configuration` and does not revert it since it is a global cache. This allows for the state to be maintained when given as new spec metadata.

Fixes #13870.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
