### PR TITLE
[Fix #11024] Add `require` options to Style/EndlessMethod

### DIFF
--- a/changelog/new_add_require_endless_method_option_to_style_endless_method.md
+++ b/changelog/new_add_require_endless_method_option_to_style_endless_method.md
@@ -1,0 +1,1 @@
+* [#11024](https://github.com/rubocop/rubocop/issues/11024): Add `require_always` option to `Style/EndlessMethod`. ([@koic][])

--- a/changelog/new_add_require_single_line_endless_method_option_to_style_endless_method.md
+++ b/changelog/new_add_require_single_line_endless_method_option_to_style_endless_method.md
@@ -1,0 +1,1 @@
+* [#11024](https://github.com/rubocop/rubocop/issues/11024): Add `require_single_line` option to `Style/EndlessMethod`. ([@jtannas][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3922,6 +3922,7 @@ Style/EndlessMethod:
     - allow_single_line
     - allow_always
     - disallow
+    - require_always
 
 Style/EnvHome:
   Description: "Checks for consistent usage of `ENV['HOME']`."

--- a/config/default.yml
+++ b/config/default.yml
@@ -3922,6 +3922,7 @@ Style/EndlessMethod:
     - allow_single_line
     - allow_always
     - disallow
+    - require_single_line
     - require_always
 
 Style/EnvHome:

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -5,9 +5,10 @@ module RuboCop
     module Style
       # Checks for endless methods.
       #
-      # It can enforce endless method definitions whenever possible. It can also disallow multiline
-      # endless method definitions or all endless definitions.
+      # It can enforce endless method definitions whenever possible or with single line methods.
+      # It can also disallow multiline endless method definitions or all endless definitions.
       #
+      # `require_single_line` style enforces endless method definitions for single line methods.
       # `require_always` style enforces endless method definitions for single statement methods.
       #
       # Other method definition types are not considered by this cop.
@@ -17,6 +18,7 @@ module RuboCop
       # * allow_single_line (default) - only single line endless method definitions are allowed.
       # * allow_always - all endless method definitions are allowed.
       # * disallow - all endless method definitions are disallowed.
+      # * require_single_line - endless method definitions are required for single line methods.
       # * require_always - all endless method definitions are required.
       #
       # NOTE: Incorrect endless method definitions will always be
@@ -85,6 +87,27 @@ module RuboCop
       #      .baz
       #   end
       #
+      # @example EnforcedStyle: require_single_line
+      #   # bad
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # bad
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
+      #
       # @example EnforcedStyle: require_always
       #   # bad
       #   def my_method
@@ -117,6 +140,7 @@ module RuboCop
         CORRECTION_STYLES = %w[multiline single_line].freeze
         MSG = 'Avoid endless method definitions.'
         MSG_MULTI_LINE = 'Avoid endless method definitions with multiple lines.'
+        MSG_REQUIRE_SINGLE = 'Use endless method definitions for single line methods.'
         MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
         def on_def(node)
@@ -125,6 +149,8 @@ module RuboCop
             handle_allow_style(node)
           when :disallow
             handle_disallow_style(node)
+          when :require_single_line
+            handle_require_single_line_style(node)
           when :require_always
             handle_require_always_style(node)
           end
@@ -141,11 +167,26 @@ module RuboCop
           end
         end
 
+        def handle_require_single_line_style(node)
+          if node.endless? && !node.single_line?
+            add_offense(node, message: MSG_MULTI_LINE) do |corrector|
+              correct_to_multiline(corrector, node)
+            end
+          elsif !node.endless? && can_be_made_endless?(node) && node.body.single_line?
+            return if too_long_when_made_endless?(node)
+
+            add_offense(node, message: MSG_REQUIRE_SINGLE) do |corrector|
+              corrector.replace(node, endless_replacement(node))
+            end
+          end
+        end
+
         def handle_require_always_style(node)
-          return if node.endless? || !node.body || node.body.begin_type? || node.body.kwbegin_type?
+          return if node.endless? || !can_be_made_endless?(node)
+          return if too_long_when_made_endless?(node)
 
           add_offense(node, message: MSG_REQUIRE_ALWAYS) do |corrector|
-            correct_to_endless_method(corrector, node)
+            corrector.replace(node, endless_replacement(node))
           end
         end
 
@@ -165,16 +206,24 @@ module RuboCop
           corrector.replace(node, replacement)
         end
 
-        def correct_to_endless_method(corrector, node)
-          replacement = <<~RUBY.strip
+        def endless_replacement(node)
+          <<~RUBY.strip
             def #{node.method_name}#{arguments(node)} = #{node.body.source}
           RUBY
-
-          corrector.replace(node, replacement)
         end
 
         def arguments(node, missing = '')
           node.arguments.any? ? node.arguments.source : missing
+        end
+
+        def can_be_made_endless?(node)
+          node.body && !node.body.begin_type? && !node.body.kwbegin_type?
+        end
+
+        def too_long_when_made_endless?(node)
+          return false unless config.cop_enabled?('Layout/LineLength')
+
+          endless_replacement(node).length > config.for_cop('Layout/LineLength')['Max']
         end
       end
     end

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -5,8 +5,10 @@ module RuboCop
     module Style
       # Checks for endless methods.
       #
-      # It can enforce either the use of endless methods definitions
-      # for single-lined method bodies, or disallow endless methods.
+      # It can enforce endless method definitions whenever possible. It can also disallow multiline
+      # endless method definitions or all endless definitions.
+      #
+      # `require_always` style enforces endless method definitions for single statement methods.
       #
       # Other method definition types are not considered by this cop.
       #
@@ -15,36 +17,94 @@ module RuboCop
       # * allow_single_line (default) - only single line endless method definitions are allowed.
       # * allow_always - all endless method definitions are allowed.
       # * disallow - all endless method definitions are disallowed.
+      # * require_always - all endless method definitions are required.
       #
       # NOTE: Incorrect endless method definitions will always be
       # corrected to a multi-line definition.
       #
       # @example EnforcedStyle: allow_single_line (default)
-      #   # good
-      #   def my_method() = x
-      #
       #   # bad, multi-line endless method
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # good
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
       #
       # @example EnforcedStyle: allow_always
       #   # good
-      #   def my_method() = x
+      #   def my_method
+      #     x
+      #   end
       #
       #   # good
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
       #
       # @example EnforcedStyle: disallow
       #   # bad
-      #   def my_method() = x
+      #   def my_method = x
       #
       #   # bad
-      #   def my_method() = x.foo
-      #                      .bar
-      #                      .baz
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
+      #
+      #   # good
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # good
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
+      #
+      # @example EnforcedStyle: require_always
+      #   # bad
+      #   def my_method
+      #     x
+      #   end
+      #
+      #   # bad
+      #   def my_method
+      #     x.foo
+      #      .bar
+      #      .baz
+      #   end
+      #
+      #   # good
+      #   def my_method = x
+      #
+      #   # good
+      #   def my_method = x.foo
+      #                    .bar
+      #                    .baz
       #
       class EndlessMethod < Base
         include ConfigurableEnforcedStyle
@@ -57,12 +117,16 @@ module RuboCop
         CORRECTION_STYLES = %w[multiline single_line].freeze
         MSG = 'Avoid endless method definitions.'
         MSG_MULTI_LINE = 'Avoid endless method definitions with multiple lines.'
+        MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
         def on_def(node)
-          if style == :disallow
-            handle_disallow_style(node)
-          else
+          case style
+          when :allow_single_line, :allow_always
             handle_allow_style(node)
+          when :disallow
+            handle_disallow_style(node)
+          when :require_always
+            handle_require_always_style(node)
           end
         end
 
@@ -77,10 +141,40 @@ module RuboCop
           end
         end
 
+        def handle_require_always_style(node)
+          return if node.endless? || !node.body || node.body.begin_type? || node.body.kwbegin_type?
+
+          add_offense(node, message: MSG_REQUIRE_ALWAYS) do |corrector|
+            correct_to_endless_method(corrector, node)
+          end
+        end
+
         def handle_disallow_style(node)
           return unless node.endless?
 
           add_offense(node) { |corrector| correct_to_multiline(corrector, node) }
+        end
+
+        def correct_to_multiline(corrector, node)
+          replacement = <<~RUBY.strip
+            def #{node.method_name}#{arguments(node)}
+              #{node.body.source}
+            end
+          RUBY
+
+          corrector.replace(node, replacement)
+        end
+
+        def correct_to_endless_method(corrector, node)
+          replacement = <<~RUBY.strip
+            def #{node.method_name}#{arguments(node)} = #{node.body.source}
+          RUBY
+
+          corrector.replace(node, replacement)
+        end
+
+        def arguments(node, missing = '')
+          node.arguments.any? ? node.arguments.source : missing
         end
       end
     end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -8,8 +8,8 @@ module RuboCop
       #
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #
-      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line` or
-      # `allow_always`, single-line methods will be autocorrected to endless
+      # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line`, `allow_always`,
+      # or `require_always`, single-line methods will be autocorrected to endless
       # methods if there is only one statement in the body.
       #
       # @example

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -9,8 +9,8 @@ module RuboCop
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #
       # If `Style/EndlessMethod` is enabled with `EnforcedStyle: allow_single_line`, `allow_always`,
-      # or `require_always`, single-line methods will be autocorrected to endless
-      # methods if there is only one statement in the body.
+      # `require_single_line`, or `require_always`, single-line methods will be autocorrected
+      # to endless methods if there is only one statement in the body.
       #
       # @example
       #   # bad

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
+        RUBY
+      end
     end
 
     context 'EnforcedStyle: allow_single_line' do
@@ -44,6 +52,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
       it 'does not register an offense for an endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
         RUBY
       end
 
@@ -114,6 +130,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for a single line method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end
+        RUBY
+      end
+
       it 'does not register an offense for a multiline endless method' do
         expect_no_offenses(<<~RUBY)
           def my_method() = x.foo
@@ -135,6 +159,116 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           def my_method(a, b) = x.foo
                                  .bar
                                  .baz
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyle: require_always' do
+      let(:cop_config) { { 'EnforcedStyle' => 'require_always' } }
+
+      it 'does not register an offense for an endless method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method() = x
+        RUBY
+      end
+
+      it 'does not register an offense for an endless method with arguments' do
+        expect_no_offenses(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'does not register an offense for an multiline endless method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method = x.foo
+                           .bar
+                           .baz
+        RUBY
+      end
+
+      it 'does not register an offense for no statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiple statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x.foo
+            x.bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offenses for multiple statements method with `begin`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            begin
+              foo && bar
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b)
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline method' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions.
+            x.foo
+             .bar
+             .baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x.foo
+             .bar
+             .baz
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b)
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x.foo
+             .bar
+             .baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b) = x.foo
+             .bar
+             .baz
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -2,6 +2,16 @@
 
 RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
   context 'Ruby >= 3.0', :ruby30 do
+    let(:other_cops) do
+      {
+        'Layout/LineLength' => {
+          'Enabled' => line_length_enabled,
+          'Max' => 80
+        }
+      }
+    end
+    let(:line_length_enabled) { true }
+
     context 'EnforcedStyle: disallow' do
       let(:cop_config) { { 'EnforcedStyle' => 'disallow' } }
 
@@ -163,6 +173,133 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
       end
     end
 
+    context 'EnforcedStyle: require_single_line' do
+      let(:cop_config) { { 'EnforcedStyle' => 'require_single_line' } }
+
+      it 'does not register an offense for a single line endless method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method() = x
+        RUBY
+      end
+
+      it 'does not register an offense for a single line endless method with arguments' do
+        expect_no_offenses(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method' do
+        expect_offense(<<~RUBY)
+          def my_method() = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                             .bar
+                             .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method
+            x.foo
+                             .bar
+                             .baz
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for no statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiple statements method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x.foo
+            x.bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiple statements method with `begin`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            begin
+              foo && bar
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x
+        RUBY
+      end
+
+      it 'does not register an offense when the endless version excess Metrics/MaxLineLength[Max]' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            'this_string_ends_at_column_75_________________________________________'
+          end
+        RUBY
+      end
+
+      context 'when Metrics/MaxLineLength is disabled' do
+        let(:line_length_enabled) { false }
+
+        it 'registers an offense and corrects for a long single line method that is long' do
+          expect_offense(<<~RUBY)
+            def my_method
+            ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+              'this_string_ends_at_column_75_________________________________________'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def my_method = 'this_string_ends_at_column_75_________________________________________'
+          RUBY
+        end
+      end
+
+      it 'registers an offense and corrects for a single line method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b)
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b) = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method with arguments' do
+        expect_offense(<<~RUBY)
+          def my_method(a, b) = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                                 .bar
+                                 .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method(a, b)
+            x.foo
+                                 .bar
+                                 .baz
+          end
+        RUBY
+      end
+    end
+
     context 'EnforcedStyle: require_always' do
       let(:cop_config) { { 'EnforcedStyle' => 'require_always' } }
 
@@ -202,7 +339,7 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
-      it 'does not register an offenses for multiple statements method with `begin`' do
+      it 'does not register an offense for multiple statements method with `begin`' do
         expect_no_offenses(<<~RUBY)
           def my_method
             begin
@@ -253,6 +390,31 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
              .bar
              .baz
         RUBY
+      end
+
+      it 'does not register an offense when the endless version excess Metrics/MaxLineLength[Max]' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            'this_string_ends_at_column_75_________________________________________'
+          end
+        RUBY
+      end
+
+      context 'when Metrics/MaxLineLength is disabled' do
+        let(:line_length_enabled) { false }
+
+        it 'registers an offense and corrects for a long single line method that is long' do
+          expect_offense(<<~RUBY)
+            def my_method
+            ^^^^^^^^^^^^^ Use endless method definitions.
+              'this_string_ends_at_column_75_________________________________________'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def my_method = 'this_string_ends_at_column_75_________________________________________'
+          RUBY
+        end
       end
 
       it 'registers an offense and corrects for a multiline method with arguments' do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -318,6 +318,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
       it_behaves_like 'convert to endless method'
     end
 
+    context 'with `require_single_line` style' do
+      let(:endless_method_config) { { 'EnforcedStyle' => 'require_single_line' } }
+
+      it_behaves_like 'convert to endless method'
+    end
+
     context 'with `require_always` style' do
       let(:endless_method_config) { { 'EnforcedStyle' => 'require_always' } }
 

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -318,6 +318,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
       it_behaves_like 'convert to endless method'
     end
 
+    context 'with `require_always` style' do
+      let(:endless_method_config) { { 'EnforcedStyle' => 'require_always' } }
+
+      it_behaves_like 'convert to endless method'
+    end
+
     context 'prior to ruby 3.0', :ruby27, unsupported_on: :prism do
       let(:endless_method_config) { { 'EnforcedStyle' => 'allow_always' } }
 


### PR DESCRIPTION
Work on this began in PR #11064 but hasn't seen any significant activity in recent months.
Credit to @koic for doing most of the heavy lifting. I just extended it with another option

---

Fixes #11024.

This PR adds `require_always` and `require_single` options to `Style/EndlessMethod`
`require_always` by @koic requires that endless method definitions are used when possible.
`require_single_line` by @jtannas requires that single line methods be endless and forbids multiline endless methods.

```ruby
# EnforcedStyle: require_single_line
# bad

def my_method
  x
end

# bad
def my_method = x.foo
                 .bar
                 .baz

# good
def my_method = x

# good
def my_method
  x.foo
   .bar
   .baz
end

# EnforcedStyle: require_always

# bad
def my_method
  x
end

# bad
def my_method
  x.foo
   .bar
   .baz
end

# good
def my_method = x

# good
def my_method = x.foo
                 .bar
                 .baz
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/