### PR TITLE
[Fix #13876] Don't consider `pp` for `Lint/RedundantRequireStatement`

### DIFF
--- a/changelog/fix_redundant_require_pp.md
+++ b/changelog/fix_redundant_require_pp.md
@@ -1,0 +1,1 @@
+* [#13876](https://github.com/rubocop/rubocop/issues/13876): Don't consider `require 'pp'` to be redundant for `Lint/RedundantRequireStatement`. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2259,9 +2259,8 @@ Lint/RedundantRegexpQuantifiers:
 Lint/RedundantRequireStatement:
   Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
-  SafeAutoCorrect: false
   VersionAdded: '0.76'
-  VersionChanged: '1.57'
+  VersionChanged: '<<next>>'
 
 Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -96,18 +96,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
     end
   end
 
-  context 'target ruby version <= 2.4', :ruby24, unsupported_on: :prism do
-    it 'does not register an offense when using requiring `pp`' do
-      expect_no_offenses(<<~RUBY)
-        require 'pp'
-
-        pp foo
-      RUBY
-    end
-  end
-
   context 'target ruby version >= 2.5', :ruby25 do
-    it 'registers an offense and corrects when using requiring `pp` or already redundant features' do
+    it 'registers an offense and corrects when requiring redundant features' do
       expect_offense(<<~RUBY)
         require 'enumerator'
         ^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
@@ -117,8 +107,6 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
         ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'thread'
         ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-        require 'pp'
-        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'uri'
       RUBY
 
@@ -127,62 +115,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
       RUBY
     end
 
-    context 'when requiring `pp`' do
-      it 'does not register an offense when using `PP.pp`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
+    it 'registers no offense when requiring "pp"' do
+      expect_no_offenses(<<~RUBY)
+        require 'pp'
 
-          PP.pp
-        RUBY
-      end
-
-      it 'does not register an offense when using `::PP.pp`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          ::PP.pp
-        RUBY
-      end
-
-      it 'does not register an offense when using `pretty_inspect`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          foo.pretty_inspect
-        RUBY
-      end
-
-      it 'does not register an offense when using `pretty_print`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          foo.pretty_print(pp_instance)
-        RUBY
-      end
-
-      it 'does not register an offense when using `pretty_print_cycle`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          foo.pretty_print_cycle(pp_instance)
-        RUBY
-      end
-
-      it 'does not register an offense when using `pretty_print_inspect`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          foo.pretty_print_inspect
-        RUBY
-      end
-
-      it 'does not register an offense when using `pretty_print_instance_variables`' do
-        expect_no_offenses(<<~RUBY)
-          require 'pp'
-
-          foo.pretty_print_instance_variables
-        RUBY
-      end
+        # Imagine this code to be in a different file than the require.
+        foo.pretty_inspect
+      RUBY
     end
   end
 
@@ -205,8 +144,6 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
         ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'thread'
         ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-        require 'pp'
-        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'ruby2_keywords'
         ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'uri'
@@ -237,8 +174,6 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
         ^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'thread'
         ^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
-        require 'pp'
-        ^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'ruby2_keywords'
         ^^^^^^^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
         require 'fiber'


### PR DESCRIPTION
Fix #13876

Only the `pp` method is available. Requiring it brings in a bunch of other stuff, like the `PP` constant or a few `pretty_` methods.

There's code to handle this but it only works when those methods are exclusivly used in the file it is required in, which I don't think is a very realistic expectation.

All the other requires are truly redundant, this one looks out of place (especially for `Lint`)

Can we just remove it?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
