### PR TITLE
[Fix #13880] Fix `Style/RedundantFormat` when given double-splatted arguments

### DIFF
--- a/changelog/fix_fix_style_redundant_format_when_given_20250220122052.md
+++ b/changelog/fix_fix_style_redundant_format_when_given_20250220122052.md
@@ -1,0 +1,1 @@
+* [#13880](https://github.com/rubocop/rubocop/issues/13880): Fix `Style/RedundantFormat` when given double-splatted arguments. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -72,6 +72,14 @@ module RuboCop
           (pair (sym %1) $_)
         PATTERN
 
+        # @!method splatted_arguments?(node, name)
+        def_node_matcher :splatted_arguments?, <<~PATTERN
+          (send _ %RESTRICT_ON_SEND <{
+            splat
+            (hash <kwsplat ...>)
+          } ...>)
+        PATTERN
+
         def on_send(node)
           format_without_additional_args?(node) do |value|
             replacement = value.source
@@ -98,7 +106,7 @@ module RuboCop
           arguments = node.arguments[1..]
 
           return unless string && arguments.any?
-          return if arguments.any?(&:splat_type?)
+          return if splatted_arguments?(node)
 
           register_all_fields_literal(node, string, arguments)
         end

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -18,7 +18,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
 
       it 'does not register an offense when called with a splat' do
         expect_no_offenses(<<~RUBY)
-          #{method}(*args)
+          #{method}('%s', *args)
+        RUBY
+      end
+
+      it 'does not register an offense when called with a double splat' do
+        expect_no_offenses(<<~RUBY)
+          #{method}('%s', **args)
+        RUBY
+      end
+
+      it 'does not register an offense when called with a double splat with annotations' do
+        expect_no_offenses(<<~RUBY)
+          #{method}('%<username>s', **args)
         RUBY
       end
 


### PR DESCRIPTION
Update `Style/RedundantFormat` to handle double splatted arguments.

Fixes #13880.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
