### PR TITLE
[Fix #13882] Fix `Style/RedundantFormat` for annotated template strings with missing hash keys

### DIFF
--- a/changelog/fix_fix_style_redundant_format_for_annotated_template_20250220164253.md
+++ b/changelog/fix_fix_style_redundant_format_for_annotated_template_20250220164253.md
@@ -1,0 +1,1 @@
+* [#13882](https://github.com/rubocop/rubocop/issues/13882): Fix `Style/RedundantFormat` for annotated template strings with missing hash keys. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -72,7 +72,7 @@ module RuboCop
           (pair (sym %1) $_)
         PATTERN
 
-        # @!method splatted_arguments?(node, name)
+        # @!method splatted_arguments?(node)
         def_node_matcher :splatted_arguments?, <<~PATTERN
           (send _ %RESTRICT_ON_SEND <{
             splat
@@ -131,7 +131,7 @@ module RuboCop
             next if sequence.percent?
 
             hash = arguments.detect(&:hash_type?)
-            argument = find_argument(sequence, arguments, hash)
+            next unless (argument = find_argument(sequence, arguments, hash))
             next unless matching_argument?(sequence, argument)
 
             count += 1
@@ -172,7 +172,7 @@ module RuboCop
         end
 
         def numeric?(argument)
-          argument&.type?(:numeric, :str) ||
+          argument.type?(:numeric, :str) ||
             rational_number?(argument) ||
             complex_number?(argument)
         end

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -290,6 +290,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
               #{method}('%<foo>s', foo: foo)
             RUBY
           end
+
+          it 'does not register an offense when there are missing hash keys' do
+            expect_no_offenses(<<~RUBY)
+              format('(%<foo>?%<bar>s:%<baz>s)', 'foobar')
+            RUBY
+          end
         end
 
         context 'with template specifiers' do


### PR DESCRIPTION
Fixes crash in `Style/RedundantFormat` when there is no hash key for a given template annotation.

Fixes #13882.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
