### PR TITLE
Warn if `Reference` config is a `String`

### DIFF
--- a/changelog/change_warn_if_reference_config_is_a_string_20250221022539.md
+++ b/changelog/change_warn_if_reference_config_is_a_string_20250221022539.md
@@ -1,0 +1,1 @@
+* [#13884](https://github.com/rubocop/rubocop/pull/13884): Warn if `Reference` config is a `String`. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -272,7 +272,8 @@ Bundler/OrderedGems:
 Gemspec/AddRuntimeDependency:
   Description: 'Prefer `add_dependency` over `add_runtime_dependency`.'
   StyleGuide: '#add_dependency_vs_add_runtime_dependency'
-  Reference: https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
+  Reference:
+    - https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
   Enabled: pending
   VersionAdded: '1.65'
   Include:
@@ -2034,7 +2035,8 @@ Lint/InterpolationCheck:
 
 Lint/ItWithoutArgumentsInBlock:
   Description: 'Checks uses of `it` calls without arguments in block.'
-  Reference: 'https://bugs.ruby-lang.org/issues/18980'
+  Reference:
+    - 'https://bugs.ruby-lang.org/issues/18980'
   Enabled: pending
   VersionAdded: '1.59'
 
@@ -3140,7 +3142,8 @@ Security/JSONLoad:
   Description: >-
                  Prefer usage of `JSON.parse` over `JSON.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  Reference:
+    - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '1.22'
@@ -3152,7 +3155,8 @@ Security/MarshalLoad:
   Description: >-
                  Avoid using of `Marshal.load` or `Marshal.restore` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
+  Reference:
+    - 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
   VersionAdded: '0.47'
 
@@ -3167,7 +3171,8 @@ Security/YAMLLoad:
   Description: >-
                  Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
+  Reference:
+    - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false
@@ -3261,7 +3266,8 @@ Style/ArrayCoercion:
 
 Style/ArrayFirstLast:
   Description: 'Use `arr.first` and `arr.last` instead of `arr[0]` and `arr[-1]`.'
-  Reference: '#first-and-last'
+  Reference:
+    - '#first-and-last'
   Enabled: false
   VersionAdded: '1.58'
   Safe: false
@@ -4017,7 +4023,8 @@ Style/FileWrite:
 Style/FloatDivision:
   Description: 'For performing float division, coerce one side only.'
   StyleGuide: '#float-division'
-  Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
+  Reference:
+    - 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
   Enabled: true
   VersionAdded: '0.72'
   VersionChanged: '1.9'
@@ -4108,7 +4115,8 @@ Style/GlobalStdStream:
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: '#instance-vars'
-  Reference: 'https://www.zenspider.com/ruby/quickref.html'
+  Reference:
+    - 'https://www.zenspider.com/ruby/quickref.html'
   Enabled: true
   VersionAdded: '0.13'
   # Built-in global variables are allowed by default.
@@ -5144,7 +5152,8 @@ Style/RedundantFetchBlock:
   Description: >-
                   Use `fetch(key, value)` instead of `fetch(key) { value }`
                   when value has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or is a constant.
-  Reference: 'https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
+  Reference:
+    - 'https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
   Enabled: true
   Safe: false
   # If enabled, this cop will autocorrect usages of
@@ -5386,7 +5395,8 @@ Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Integer]`.
-  Reference: 'https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Reference:
+    - 'https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
   VersionAdded: '0.30'
 
@@ -5875,7 +5885,8 @@ Style/YAMLFileRead:
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'
-  Reference: 'https://en.wikipedia.org/wiki/Yoda_conditions'
+  Reference:
+    - 'https://en.wikipedia.org/wiki/Yoda_conditions'
   Enabled: true
   EnforcedStyle: forbid_for_all_comparison_operators
   SupportedStyles:

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -18,7 +18,7 @@ module RuboCop
     NEW_COPS_VALUES = %w[pending disable enable].freeze
 
     # @api private
-    CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect].to_set.freeze
+    CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect Reference].to_set.freeze
     CONFIG_CHECK_DEPARTMENTS = %w[pending override_department].freeze
     CONFIG_CHECK_AUTOCORRECTS = %w[always contextual disabled].freeze
     private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
@@ -259,7 +259,7 @@ module RuboCop
       end
     end
 
-    # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
     def check_cop_config_value(hash, parent = nil)
       hash.each do |key, value|
         check_cop_config_value(value, key) if value.is_a?(Hash)
@@ -270,6 +270,9 @@ module RuboCop
           supposed_values = 'a boolean'
         elsif key == 'AutoCorrect' && !CONFIG_CHECK_AUTOCORRECTS.include?(value)
           supposed_values = '`always`, `contextual`, `disabled`, or a boolean'
+        elsif key == 'Reference'
+          warn string_reference_warning(parent)
+          next
         else
           next
         end
@@ -277,13 +280,20 @@ module RuboCop
         raise ValidationError, param_error_message(parent, key, value, supposed_values)
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
 
     # FIXME: Handling colors in exception messages like this is ugly.
     def param_error_message(parent, key, value, supposed_values)
       "#{Rainbow('').reset}" \
         "Property #{Rainbow(key).yellow} of #{Rainbow(parent).yellow} cop " \
         "is supposed to be #{supposed_values} and #{Rainbow(value).yellow} is not."
+    end
+
+    # FIXME: Handling colors in exception messages like this is ugly.
+    def string_reference_warning(cop_name)
+      "#{Rainbow('').reset}#{Rainbow('Warning:').yellow} " \
+        "Property #{Rainbow('Reference').yellow} of #{Rainbow(cop_name).yellow} cop " \
+        'is supposed to be an array of strings. Providing a string is deprecated.'
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1808,6 +1808,24 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    it 'prints a warning if Reference is a string instead of an array' do
+      create_file('example/example1.rb', '#' * 90)
+
+      create_file('example/.rubocop.yml', <<~YAML)
+        Security/JSONLoad:
+          Reference: 'https://example.com#security-json-load'
+
+        Security/MarshalLoad:
+          Reference:
+            - 'https://example.com#security-marshal-load'
+      YAML
+
+      expect(cli.run(%w[--format simple example])).to eq(1)
+      expect($stderr.string).to eq(<<~RESULT)
+        Warning: Property Reference of Security/JSONLoad cop is supposed to be an array of strings. Providing a string is deprecated.
+      RESULT
+    end
+
     it 'works when a configuration file passed by -c specifies Exclude with regexp' do
       create_file('example/example1.rb', '#' * 90)
 


### PR DESCRIPTION
Using a simple `String` prevents consumers from appending additional references.

By using an `Array` instead, even for single strings, other configurations can extend the `Reference` list via

```yml
inherit_mode:
  merge:
  - Reference
```

Related to #13833 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
