### PR TITLE
Improve offense message for `Style/LineEndConcatenation`

### DIFF
--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -36,7 +36,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Use `\\` instead of `+` or `<<` to concatenate those strings.'
+        MSG = 'Use `\\` instead of `%<operator>s` to concatenate multiline strings.'
         CONCAT_TOKEN_TYPES = %i[tPLUS tLSHFT].freeze
         SIMPLE_STRING_TOKEN_TYPE = :tSTRING
         COMPLEX_STRING_BEGIN_TOKEN = :tSTRING_BEG
@@ -61,14 +61,20 @@ module RuboCop
           successor = tokens[index + 2]
 
           return unless eligible_token_set?(predecessor, operator, successor)
-
           return if same_line?(operator, successor)
 
           next_successor = token_after_last_string(successor, index)
-
           return unless eligible_next_successor?(next_successor)
 
-          add_offense(operator.pos) { |corrector| autocorrect(corrector, operator.pos) }
+          register_offense(operator)
+        end
+
+        def register_offense(operator)
+          message = format(MSG, operator: operator.text)
+
+          add_offense(operator.pos, message: message) do |corrector|
+            autocorrect(corrector, operator.pos)
+          end
         end
 
         def autocorrect(corrector, operator_range)

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers an offense for string concat at line end' do
     expect_offense(<<~RUBY)
       top = "test" +
-                   ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+                   ^ Use `\\` instead of `+` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers an offense for string concat with << at line end' do
     expect_offense(<<~RUBY)
       top = "test" <<
-                   ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+                   ^^ Use `\\` instead of `<<` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
     expect_offense(<<~RUBY)
       top = "test " \\
       "foo" <<
-            ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+            ^^ Use `\\` instead of `<<` to concatenate multiline strings.
       "bar"
     RUBY
 
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers an offense for dynamic string concat at line end' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" +
-                       ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^ Use `\` instead of `+` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers an offense for dynamic string concat with << at line end' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" <<
-                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -71,9 +71,9 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers multiple offenses when there are chained << methods' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" <<
-                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "top" <<
-            ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "ubertop"
     RUBY
 
@@ -87,9 +87,9 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers multiple offenses when there are chained concatenations' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" +
-                       ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^ Use `\` instead of `+` to concatenate multiline strings.
       "top" +
-            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^ Use `\` instead of `+` to concatenate multiline strings.
       "foo"
     RUBY
 
@@ -103,11 +103,11 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'registers multiple offenses when there are chained concatenations combined with << calls' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" <<
-                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "top" +
-            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^ Use `\` instead of `+` to concatenate multiline strings.
       "foo" <<
-            ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "bar"
     RUBY
 
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
       "foo" +
       %(bar) +
       "baz" +
-            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^ Use `\` instead of `+` to concatenate multiline strings.
       "qux"
     RUBY
 
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'autocorrects a + with trailing whitespace to \\' do
     expect_offense(<<~RUBY)
       top = "test" +#{trailing_whitespace}
-                   ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+                   ^ Use `\\` instead of `+` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'autocorrects a + with \\ to just \\' do
     expect_offense(<<~RUBY)
       top = "test" + \\
-                   ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+                   ^ Use `\\` instead of `+` to concatenate multiline strings.
       "top"
     RUBY
 
@@ -224,10 +224,10 @@ RSpec.describe RuboCop::Cop::Style::LineEndConcatenation, :config do
   it 'autocorrects only the lines that should be autocorrected' do
     expect_offense(<<~'RUBY')
       top = "test#{x}" <<
-                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+                       ^^ Use `\` instead of `<<` to concatenate multiline strings.
       "top" + # comment
       "foo" +
-            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+            ^ Use `\` instead of `+` to concatenate multiline strings.
       "bar" +
       %(baz) +
       "qux"


### PR DESCRIPTION
Improve the offense message for `Style/LineEndConcatenation` to refer to the actual operator being used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
