### PR TITLE
Fix autocorrection for `Layout/LineLength` with interpolated strings when not on the first line

### DIFF
--- a/changelog/fix_fix_autocorrection_for_layout_line_length_with_20250221100644.md
+++ b/changelog/fix_fix_autocorrection_for_layout_line_length_with_20250221100644.md
@@ -1,0 +1,1 @@
+* [#13889](https://github.com/rubocop/rubocop/pull/13889): Fix autocorrection for `Layout/LineLength` with interpolated strings when not on the first line. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -209,7 +209,7 @@ module RuboCop
         # are not bisected.
         # If the string contains spaces, use them to determine a place for a clean break;
         # otherwise, the string will be broken at the line length limit.
-        def breakable_string_range(node) # rubocop:disable Metrics/AbcSize
+        def breakable_string_range(node)
           source_range = node.source_range
           relevant_substr = largest_possible_string(node)
 
@@ -221,13 +221,13 @@ module RuboCop
             adjustment = max - source_range.last_column - 3
             return if adjustment.abs > source_range.size
 
-            source_range.adjust(end_pos: max - source_range.last_column - 3)
+            source_range.adjust(end_pos: adjustment)
           end
         end
 
         def breakable_dstr_begin_position(node)
           source_range = node.source_range
-          source_range.begin_pos if source_range.begin_pos < max && source_range.end_pos >= max
+          source_range.begin_pos if source_range.column < max && source_range.last_column >= max
         end
 
         def breakable_range_by_line_index

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -797,6 +797,22 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
               end
             end
 
+            context 'when the interpolation is not on the first line' do
+              it 'registers an offense and corrects' do
+                expect_offense(<<~'RUBY')
+                  a_long_named_method_call
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#{bbbbbbbbb}"
+                                                          ^^^^^^^^^^ Line is too long. [50/40]
+                RUBY
+
+                expect_correction(<<~'RUBY')
+                  a_long_named_method_call
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                  "#{bbbbbbbbb}"
+                RUBY
+              end
+            end
+
             context 'when the entire string is interpolation' do
               it 'registers an offense but does not correct' do
                 expect_offense(<<~'RUBY')


### PR DESCRIPTION
In #13462 I added autocorrection support to `Layout/LineLength` for splitting strings. However, the way that it was calculating where to break when there was interpolation in the string was flawed (using `begin_pos` and `end_pos` to compare to `max`, rather than `column` and `last_column`). This resulted in offenses being registered but splitting not happening, as after `max` characters in the source file, no interpolation past the line length limit would register as breakable.

This fixes the calculation to use the columns on the line rather than the global position within the source.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
