### PR TITLE
Update `Lint/RedundantTypeConversion` to not register an offense when given a constructor with `exception: false`

### DIFF
--- a/changelog/change_update_lint_redundant_type_conversion_to_not_20250221105353.md
+++ b/changelog/change_update_lint_redundant_type_conversion_to_not_20250221105353.md
@@ -1,0 +1,1 @@
+* [#13890](https://github.com/rubocop/rubocop/pull/13890): Update `Lint/RedundantTypeConversion` to not register an offense when given a constructor with `exception: false`. ([@dvandersluis][])

--- a/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
@@ -221,8 +221,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
 
     it_behaves_like 'offense', :to_i, '42'
     it_behaves_like 'offense', :to_i, 'Integer(42)'
+    it_behaves_like 'offense', :to_i, 'Integer("42", 5)'
     it_behaves_like 'offense', :to_i, 'Kernel::Integer(42)'
     it_behaves_like 'offense', :to_i, '::Kernel::Integer(42)'
+    it_behaves_like 'offense', :to_i, 'Integer("number", exception: true)'
+
+    it_behaves_like 'accepted', 'Integer("number", exception: false).to_i'
+    it_behaves_like 'accepted', 'Integer(obj, base, exception: false).to_i'
 
     it 'does not register an offense with `inspect.to_i`' do
       expect_no_offenses(<<~RUBY)
@@ -238,6 +243,9 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'offense', :to_f, 'Float(42)'
     it_behaves_like 'offense', :to_f, 'Kernel::Float(42)'
     it_behaves_like 'offense', :to_f, '::Kernel::Float(42)'
+    it_behaves_like 'offense', :to_f, 'Float("number", exception: true)'
+
+    it_behaves_like 'accepted', 'Float("number", exception: false).to_f'
   end
 
   describe '`to_r`' do
@@ -245,8 +253,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
 
     it_behaves_like 'offense', :to_r, '5r'
     it_behaves_like 'offense', :to_r, 'Rational(42)'
+    it_behaves_like 'offense', :to_r, 'Rational(3, 8)'
     it_behaves_like 'offense', :to_r, 'Kernel::Rational(42)'
     it_behaves_like 'offense', :to_r, '::Kernel::Rational(42)'
+    it_behaves_like 'offense', :to_r, 'Rational("number", exception: true)'
+
+    it_behaves_like 'accepted', 'Rational("number", exception: false).to_r'
+    it_behaves_like 'accepted', 'Rational(x, y, exception: false).to_r'
   end
 
   describe '`to_c`' do
@@ -255,8 +268,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'offense', :to_c, '5i'
     it_behaves_like 'offense', :to_c, '5ri'
     it_behaves_like 'offense', :to_c, 'Complex(42)'
+    it_behaves_like 'offense', :to_c, 'Complex(5, 3)'
     it_behaves_like 'offense', :to_c, 'Kernel::Complex(42)'
     it_behaves_like 'offense', :to_c, '::Kernel::Complex(42)'
+    it_behaves_like 'offense', :to_c, 'Complex("number", exception: true)'
+
+    it_behaves_like 'accepted', 'Complex("number", exception: false).to_c'
+    it_behaves_like 'accepted', 'Complex(real, imag, exception: false).to_c'
   end
 
   describe '`to_a`' do


### PR DESCRIPTION
Allows code such as the following to not register `Lint/RedundantTypeConversion` offenses, as the result could be `nil`:

```ruby
Integer("number", exception: false).to_i
```

Follows https://github.com/rubocop/rubocop/pull/13702#issuecomment-2661555711.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
