### PR TITLE
Add display flag to rubocop_todo.yml header.

### DIFF
--- a/changelog/new_add_display_flag_to_rubocop_todo_yml_header_20250221151347.md
+++ b/changelog/new_add_display_flag_to_rubocop_todo_yml_header_20250221151347.md
@@ -1,0 +1,1 @@
+* [#13891](https://github.com/rubocop/rubocop/pull/13891): Add display flag to rubocop_todo.yml header. ([@dersam][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Formatter
     # This formatter displays a YAML configuration file where all cops that
     # detected any offenses are configured to not detect the offense.
-    class DisabledConfigFormatter < BaseFormatter
+    class DisabledConfigFormatter < BaseFormatter # rubocop:disable Metrics/ClassLength
       include PathUtil
 
       HEADING = <<~COMMENTS
@@ -70,7 +70,11 @@ module RuboCop
         @options.fetch(:auto_gen_enforced_style, true)
       end
 
-      def command
+      def only_fail_level_offenses?
+        @options.fetch(:display_only_fail_level_offenses, false)
+      end
+
+      def command # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         command = 'rubocop --auto-gen-config'
 
         command += ' --auto-gen-only-exclude' if @options[:auto_gen_only_exclude]
@@ -85,6 +89,8 @@ module RuboCop
         command += ' --no-auto-gen-timestamp' unless show_timestamp?
 
         command += ' --no-auto-gen-enforced-style' unless auto_gen_enforced_style?
+
+        command += ' --display-only-fail-level-offenses' if only_fail_level_offenses?
 
         command
       end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -221,6 +221,43 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
+  context 'when display_only_fail_level_offenses option is passed' do
+    before do
+      formatter.started(['test_a.rb', 'test_b.rb'])
+      formatter.file_started('test_a.rb', options)
+      formatter.file_finished('test_a.rb', offenses)
+      formatter.file_started('test_b.rb', options)
+      formatter.file_finished('test_b.rb', [offenses.first])
+      formatter.finished(['test_a.rb', 'test_b.rb'])
+    end
+
+    let(:formatter) { described_class.new(output, display_only_fail_level_offenses: true) }
+
+    let(:expected_heading_command) do
+      'rubocop --auto-gen-config --display-only-fail-level-offenses'
+    end
+
+    let(:expected_rubocop_todo) do
+      [heading,
+       '# Offense count: 2',
+       'Test/Cop1:',
+       '  Exclude:',
+       "    - 'test_a.rb'",
+       "    - 'test_b.rb'",
+       '',
+       '# Offense count: 1',
+       'Test/Cop2:',
+       '  Exclude:',
+       "    - 'test_a.rb'",
+       ''].join("\n")
+    end
+
+    it 'displays YAML configuration disabling all cops with offenses' do
+      expect(output.string).to eq(expected_rubocop_todo)
+      expect($stdout.string).to eq("Created .rubocop_todo.yml.\n")
+    end
+  end
+
   context 'when no files are inspected' do
     before do
       formatter.started([])


### PR DESCRIPTION
When using varying severity levels, the user may not want non-failing severity cops to appear in the `.rubocop_todo.yml` file.

Adding the `--display-only-fail-level-offenses` flag to the regeneration command provided in the file header helps ensure this remains the case on large codebases with many developers. This flag will only be added when it is passed as part of the original `--auto-gen-config` call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
