### PR TITLE
Allow merging of configured arrays and non-arrays

### DIFF
--- a/changelog/change_allow_merging_of_configured_arrays_and_non_arrays_20250222010203.md
+++ b/changelog/change_allow_merging_of_configured_arrays_and_non_arrays_20250222010203.md
@@ -1,0 +1,1 @@
+* [#13892](https://github.com/rubocop/rubocop/pull/13892): Allow merging of configured arrays and non-arrays. ([@sambostock][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -123,7 +123,7 @@ module RuboCop
         elsif merge_hashes?(base_hash, derived_hash, key)
           result[key] = merge(base_hash[key], derived_hash[key], **opts)
         elsif should_union?(derived_hash, base_hash, opts[:inherit_mode], key)
-          result[key] = base_hash[key] | derived_hash[key]
+          result[key] = Array(base_hash[key]) | Array(derived_hash[key])
         elsif opts[:debug]
           warn_on_duplicate_setting(base_hash, derived_hash, key, **opts)
         end
@@ -205,7 +205,7 @@ module RuboCop
     end
 
     def should_union?(derived_hash, base_hash, root_mode, key)
-      return false unless base_hash[key].is_a?(Array)
+      return false unless base_hash[key].is_a?(Array) || derived_hash[key].is_a?(Array)
 
       derived_mode = derived_hash['inherit_mode']
       return false if should_override?(derived_mode, key)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -712,6 +712,9 @@ RSpec.describe RuboCop::ConfigLoader do
               - foo.rb
             Include:
               - bar.rb
+            InheritedArraySpecifiedString:
+              - 'string in array'
+            InheritedStringSpecifiedArray: 'bare string'
         YAML
         create_file(file_path, <<~YAML)
           inherit_from:
@@ -723,12 +726,17 @@ RSpec.describe RuboCop::ConfigLoader do
                 - AllowedIdentifiers
                 - Exclude
                 - Include
+                - InheritedStringSpecifiedArray
+                - InheritedArraySpecifiedString
             AllowedIdentifiers:
               - iso2
             Exclude:
               - test.rb
             Include:
               - another_test.rb
+            InheritedArraySpecifiedString: 'bare string'
+            InheritedStringSpecifiedArray:
+              - 'string in array'
         YAML
       end
 
@@ -739,6 +747,14 @@ RSpec.describe RuboCop::ConfigLoader do
         expect(examples_configuration['Include']).to contain_exactly('bar.rb', 'another_test.rb')
         expect(examples_configuration['AllowedIdentifiers'])
           .to match_array(%w[capture3 iso8601 rfc1123_date rfc2822 rfc3339 rfc822 iso2 x86_64])
+        expect(examples_configuration['InheritedArraySpecifiedString']).to contain_exactly(
+          'bare string',
+          'string in array'
+        )
+        expect(examples_configuration['InheritedStringSpecifiedArray']).to contain_exactly(
+          'bare string',
+          'string in array'
+        )
       end
     end
 


### PR DESCRIPTION
_See https://github.com/rubocop/rubocop/pull/13884#issuecomment-2675874658 for context._

Previously, merging would only be performed if the base value was an `Array`. If the derived value was an `Array`, but the base value was not, an overwrite would be performed.

For example, many cops specify a single `Reference` directly as a `String`. However, as `Reference` uses `Array(value)` behind the scenes, and accepts either a `String` or an `Array` of strings, a consumer may decide to add additional references.

    # config/default.yml
    Security/JSONLoad:
      Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'

    # .rubocop.yml
    Security/JSONLoad:
      Reference:
        - https://example.com#another-reason-to-use-json-parse-instead-of-load

Unfortunately, this would overwrite the original, even if configured to merge..

By looking at both the base and derived values to check for the presence of an `Array`, we can detect that a merge may be appropriate, and by wrapping both values in `Array(...)`, we can allow the merge to succeed, resulting in the intended config combination:

    Security/JSONLoad:
      Reference:
        - https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load
        - https://example.com#another-reason-to-use-json-parse-instead-of-load

It remains the responsibility of the config validation phase and individual cops to ensure arrays are rejected where they are unexpected.

This change technically makes it possible to extend array configurations by providing a bare string, although the intention is to support the reverse (specifically for the `Reference` use case).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
