### PR TITLE
Fix plugin docs missing YAML colon

### DIFF
--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -31,7 +31,7 @@ The following is an example of a plugin that is not published as a gem:
 [source,yaml]
 ----
 plugins:
-  - rubocop-extension
+  - rubocop-extension:
       require_path: path/to/extension/plugin
       plugin_class_name: RuboCop::Extension::Plugin
 ----


### PR DESCRIPTION
Seems like a colon is missing.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
[1]: https://chris.beams.io/posts/git-commit/
