### PR TITLE
Fix a false positive for `Style/TrivialAccessors` with `instance_eval` and numblocks

### DIFF
--- a/changelog/fix_false_positive_trivial_accessor_numblock.md
+++ b/changelog/fix_false_positive_trivial_accessor_numblock.md
@@ -1,0 +1,1 @@
+* [#13896](https://github.com/rubocop/rubocop/pull/13896): Fix a false positive for `Style/TrivialAccessors` with `instance_eval` and numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -113,7 +113,7 @@ module RuboCop
         private
 
         def in_module_or_instance_eval?(node)
-          node.each_ancestor(:block, :class, :sclass, :module).each do |pnode|
+          node.each_ancestor(:any_block, :class, :sclass, :module).each do |pnode|
             case pnode.type
             when :class, :sclass
               return false

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -317,6 +317,19 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
     RUBY
   end
 
+  it 'accepts writer nested within an instance_eval numblock call' do
+    expect_no_offenses(<<~RUBY)
+      something.instance_eval do
+        _1
+        begin
+          def bar=(bar)
+            @bar = bar
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'accepts reader nested within an instance_eval call' do
     expect_no_offenses(<<~RUBY)
       something.instance_eval do


### PR DESCRIPTION
The first yielded argument for `instance_eval` is the object itself

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
