### PR TITLE
[Fix #13885] Update `Style/HashExcept` and `Style/HashSlice` to not register an offense if selecting over the hash value

### DIFF
--- a/changelog/fix_update_style_hash_except_and_style_hash_slice_to_20250224092807.md
+++ b/changelog/fix_update_style_hash_except_and_style_hash_slice_to_20250224092807.md
@@ -1,0 +1,1 @@
+* [#13885](https://github.com/rubocop/rubocop/issues/13885): Update `Style/HashExcept` and `Style/HashSlice` to not register an offense if selecting over the hash value. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/hash_slice_spec.rb
+++ b/spec/rubocop/cop/style/hash_slice_spec.rb
@@ -1,6 +1,126 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
+  shared_examples_for 'include?' do
+    context 'using `include?`' do
+      it 'does not register an offense when using `select` and calling `!include?` method with symbol array' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| !%i[foo bar].include?(k) }
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `reject` and calling `!include?` method with symbol array' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `filter` and calling `include?` method with symbol array' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.filter { |k, v| [:foo, :bar].include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic symbol array' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| %I[\#{foo} bar].include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:"\#{foo}", :bar)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.slice(:"\#{foo}", :bar)
+        RUBY
+      end
+
+      it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic string array' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| %W[\#{foo} bar].include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice("\#{foo}", 'bar')` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.slice("\#{foo}", 'bar')
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` and calling `!include?` method with variable' do
+        expect_no_offenses(<<~RUBY)
+          array = %i[foo bar]
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` and calling `!include?` method with method call' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
+        RUBY
+      end
+
+      it 'registers an offense when using `select` and `include?`' do
+        expect_offense(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| [:bar].include?(k) }
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:bar)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.slice(:bar)
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` and calling `!include?` method with symbol array and second block value' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| ![1, 2].include?(v) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` and calling `include?` method on a key' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| k.include?('oo') }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` and calling `!include?` method on a key' do
+        expect_no_offenses(<<~RUBY)
+          {foo: 1, bar: 2, baz: 3}.select { |k, v| !k.include?('oo') }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` with an inclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa..:bbb).include?(k) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` with an exclusive range receiver' do
+        expect_no_offenses(<<~RUBY)
+          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa...:bbb).include?(k) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` called on the key block variable' do
+        expect_no_offenses(<<~RUBY)
+          hash.select { |k, v| k.include?('foo') }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `include?` called on the value block variable' do
+        expect_no_offenses(<<~RUBY)
+          hash.select { |k, v| v.include?(k) }
+        RUBY
+      end
+    end
+  end
+
   context 'Ruby 2.5 or higher', :ruby25 do
     it 'registers and corrects an offense when using `select` and comparing with `lvar == :sym`' do
       expect_offense(<<~RUBY)
@@ -90,6 +210,8 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
       RUBY
     end
 
+    it_behaves_like 'include?'
+
     context 'using `in?`' do
       it 'does not register offenses when using `select` and calling `key.in?` method with symbol array' do
         expect_no_offenses(<<~RUBY)
@@ -108,99 +230,10 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
           {foo: 1, bar: 2, baz: 3}.select { |k, v| %i[foo bar].in?(k) }
         RUBY
       end
-    end
 
-    context 'using `include?`' do
-      it 'does not register an offense when using `select` and calling `!include?` method with symbol array' do
+      it 'does not register an offense when using `select` with `include?` called on the value block variable' do
         expect_no_offenses(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| !%i[foo bar].include?(k) }
-        RUBY
-      end
-
-      it 'registers and corrects an offense when using `reject` and calling `!include?` method with symbol array' do
-        expect_offense(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
-        RUBY
-      end
-
-      it 'registers and corrects an offense when using `filter` and calling `include?` method with symbol array' do
-        expect_offense(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.filter { |k, v| [:foo, :bar].include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
-        RUBY
-      end
-
-      it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic symbol array' do
-        expect_offense(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| %I[\#{foo} bar].include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:"\#{foo}", :bar)` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.slice(:"\#{foo}", :bar)
-        RUBY
-      end
-
-      it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic string array' do
-        expect_offense(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| %W[\#{foo} bar].include?(k) }
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice("\#{foo}", 'bar')` instead.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.slice("\#{foo}", 'bar')
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` and calling `!include?` method with variable' do
-        expect_no_offenses(<<~RUBY)
-          array = [:foo, :bar]
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` and calling `!include?` method with method call' do
-        expect_no_offenses(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` and calling `!include?` method with symbol array and second block value' do
-        expect_no_offenses(<<~RUBY)
-          {foo: 1, bar: 2, baz: 3}.select { |k, v| ![1, 2].include?(v) }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` and calling `include?` method on a key' do
-        expect_no_offenses(<<~RUBY)
-          { 'foo' => 1, 'bar' => 2, 'baz' => 3 }.select { |k, v| k.include?('oo') }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` and calling `!include?` method on a key' do
-        expect_no_offenses(<<~RUBY)
-          { 'foo' => 1, 'bar' => 2, 'baz' => 3 }.select { |k, v| !k.include?('oo') }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` with `include?` with an inclusive range receiver' do
-        expect_no_offenses(<<~RUBY)
-          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa..:bbb).include?(k) }
-        RUBY
-      end
-
-      it 'does not register an offense when using `select` with `include?` with an exclusive range receiver' do
-        expect_no_offenses(<<~RUBY)
-          { foo: 1, bar: 2, baz: 3 }.select{ |k, v| (:baa...:bbb).include?(k) }
+          hash.select { |k, v| k.in?(v) }
         RUBY
       end
     end
@@ -227,6 +260,12 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
       it 'does not register an offense when using `select` and calling `!exclude?` method on a key' do
         expect_no_offenses(<<~RUBY)
           {foo: 1, bar: 2, baz: 3}.select { |k, v| !k.exclude?('oo') }
+        RUBY
+      end
+
+      it 'does not register an offense when using `select` with `!exclude?` called on the value block variable' do
+        expect_no_offenses(<<~RUBY)
+          hash.select { |k, v| !v.exclude?(k) }
         RUBY
       end
     end
@@ -370,6 +409,8 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
         RUBY
       end
 
+      it_behaves_like 'include?'
+
       context 'using `in?`' do
         it 'registers and corrects an offense when using `select` and calling `key.in?` method with symbol array' do
           expect_offense(<<~RUBY)
@@ -490,92 +531,28 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
             { foo: 1, bar: 2, baz: 3 }.select{ |k, v| k.in?(:baa...:bbb) }
           RUBY
         end
-      end
 
-      context 'using `include?`' do
-        it 'does not register an offense when using `select` and calling `!include?` method with symbol array' do
+        it 'does not register an offense when using `select` with `in?` called on the key block variable' do
           expect_no_offenses(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| !%i[foo bar].include?(k) }
+            hash.select { |k, v| 'foo'.in?(k) }
           RUBY
         end
 
-        it 'registers and corrects an offense when using `reject` and calling `!include?` method with symbol array' do
-          expect_offense(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.reject { |k, v| !%i[foo bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
-          RUBY
-        end
-
-        it 'registers and corrects an offense when using `filter` and calling `include?` method with symbol array' do
-          expect_offense(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.filter { |k, v| [:foo, :bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:foo, :bar)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.slice(:foo, :bar)
-          RUBY
-        end
-
-        it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic symbol array' do
-          expect_offense(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| %I[\#{foo} bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:"\#{foo}", :bar)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.slice(:"\#{foo}", :bar)
-          RUBY
-        end
-
-        it 'registers and corrects an offense when using `select` and calling `include?` method with dynamic string array' do
-          expect_offense(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| %W[\#{foo} bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice("\#{foo}", 'bar')` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.slice("\#{foo}", 'bar')
-          RUBY
-        end
-
-        it 'does not register an offense when using `select` and calling `!include?` method with variable' do
+        it 'does not register an offense when using `select` with `in?` called on the value block variable' do
           expect_no_offenses(<<~RUBY)
-            array = %i[foo bar]
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
+            hash.select { |k, v| k.in?(v) }
           RUBY
         end
 
-        it 'does not register an offense when using `select` and calling `!include?` method with method call' do
+        it 'does not register an offense when using `reject` with `!in?` called on the key block variable' do
           expect_no_offenses(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| !array.include?(k) }
+            hash.reject { |k, v| !'foo'.in?(k) }
           RUBY
         end
 
-        it 'registers an offense when using `select` and `include?`' do
-          expect_offense(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| [:bar].include?(k) }
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice(:bar)` instead.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.slice(:bar)
-          RUBY
-        end
-
-        it 'does not register an offense when using `select` and calling `include?` method on a key' do
+        it 'does not register an offense when using `reject` with `!in?` called on the value block variable' do
           expect_no_offenses(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| k.include?('oo') }
-          RUBY
-        end
-
-        it 'does not register an offense when using `select` and calling `!include?` method on a key' do
-          expect_no_offenses(<<~RUBY)
-            {foo: 1, bar: 2, baz: 3}.select { |k, v| !k.include?('oo') }
+            hash.reject { |k, v| !k.in?(v) }
           RUBY
         end
       end
@@ -692,6 +669,30 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
         it 'does not register an offense when using `select` and calling `!exclude?` method on a key' do
           expect_no_offenses(<<~RUBY)
             {foo: 1, bar: 2, baz: 3}.select { |k, v| !k.exclude?('oo') }
+          RUBY
+        end
+
+        it 'does not register an offense when using `select` with `!exclude?` called on the key block variable' do
+          expect_no_offenses(<<~RUBY)
+            hash.select { |k, v| !k.exclude?('foo') }
+          RUBY
+        end
+
+        it 'does not register an offense when using `select` with `!exclude?` called on the value block variable' do
+          expect_no_offenses(<<~RUBY)
+            hash.select { |k, v| !v.exclude?(k) }
+          RUBY
+        end
+
+        it 'does not register an offense when using `reject` with `exclude?` called on the key block variable' do
+          expect_no_offenses(<<~RUBY)
+            hash.reject { |k, v| k.exclude?('foo') }
+          RUBY
+        end
+
+        it 'does not register an offense when using `reject` with `exclude?` called on the value block variable' do
+          expect_no_offenses(<<~RUBY)
+            hash.reject { |k, v| v.exclude?(k) }
           RUBY
         end
       end


### PR DESCRIPTION
Update `Style/HashExcept` and `Style/HashSlice` to be able to handle when the value being called with `include?`, `exclude?` or `in?` is the hash value block argument (in which case, it cannot be replaced with `slice` or `except`).

eg:
```ruby
hash.select { |k, v| v.include?(k) }
```

Fixes #13885.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
