### PR TITLE
Enable reusable Prism parse result for Ruby LSP add-on

### DIFF
--- a/changelog/new_enable_reusable_prism_parse_results_for_ruby_lsp_addon.md
+++ b/changelog/new_enable_reusable_prism_parse_results_for_ruby_lsp_addon.md
@@ -1,0 +1,1 @@
+* [#13899](https://github.com/rubocop/rubocop/pull/13899): Enable reusable Prism parse result for Ruby LSP add-on. ([@koic][])

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -30,7 +30,7 @@ module RuboCop
         @layout_mode = false
       end
 
-      def format(path, text, command:)
+      def format(path, text, command:, prism_result: nil)
         safe_autocorrect = if command
                              command == 'rubocop.formatAutocorrects'
                            else
@@ -40,15 +40,15 @@ module RuboCop
         formatting_options = { autocorrect: true, safe_autocorrect: safe_autocorrect }
         formatting_options[:only] = config_only_options if @lint_mode || @layout_mode
 
-        @runner.run(path, text, formatting_options)
+        @runner.run(path, text, formatting_options, prism_result: prism_result)
         @runner.formatted_source
       end
 
-      def offenses(path, text, document_encoding = nil)
+      def offenses(path, text, document_encoding = nil, prism_result: nil)
         diagnostic_options = {}
         diagnostic_options[:only] = config_only_options if @lint_mode || @layout_mode
 
-        @runner.run(path, text, diagnostic_options)
+        @runner.run(path, text, diagnostic_options, prism_result: prism_result)
         @runner.offenses.map do |offense|
           Diagnostic.new(
             document_encoding, offense, path, @cop_registry[offense.cop_name]&.first

--- a/lib/rubocop/lsp/stdin_runner.rb
+++ b/lib/rubocop/lsp/stdin_runner.rb
@@ -41,9 +41,11 @@ module RuboCop
       end
 
       # rubocop:disable Metrics/MethodLength
-      def run(path, contents, options)
+      def run(path, contents, options, prism_result: nil)
         @options = options.merge(DEFAULT_RUBOCOP_OPTIONS)
         @options[:stdin] = contents
+
+        @prism_result = prism_result
 
         @offenses = []
         @warnings = []

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -489,7 +489,11 @@ module RuboCop
 
       processed_source = if @options[:stdin]
                            ProcessedSource.new(
-                             @options[:stdin], ruby_version, file, parser_engine: parser_engine
+                             @options[:stdin],
+                             ruby_version,
+                             file,
+                             parser_engine: parser_engine,
+                             prism_result: @prism_result
                            )
                          else
                            begin

--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -16,11 +16,21 @@ module RubyLsp
       end
 
       def run_diagnostic(uri, document)
-        @runtime.offenses(uri_to_path(uri), document.source, document.encoding)
+        @runtime.offenses(
+          uri_to_path(uri),
+          document.source,
+          document.encoding,
+          prism_result: prism_result(document)
+        )
       end
 
       def run_formatting(uri, document)
-        @runtime.format(uri_to_path(uri), document.source, command: 'rubocop.formatAutocorrects')
+        @runtime.format(
+          uri_to_path(uri),
+          document.source,
+          command: 'rubocop.formatAutocorrects',
+          prism_result: prism_result(document)
+        )
       end
 
       def run_range_formatting(_uri, _partial_source, _base_indentation)
@@ -41,6 +51,14 @@ module RubyLsp
         else
           uri.to_s.delete_prefix('file://')
         end
+      end
+
+      def prism_result(document)
+        prism_result = document.parse_result
+
+        # NOTE: `prism_result` must be `Prism::ParseLexResult` compatible object.
+        # This is for compatibility parsed result unsupported.
+        prism_result.is_a?(Prism::ParseLexResult) ? prism_result : nil
       end
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/ruby-lsp/pull/1849

This feature utilizes https://github.com/ruby/prism/pull/3478 and https://github.com/rubocop/rubocop-ast/pull/359 to implement https://github.com/Shopify/ruby-lsp/pull/1849.

As described in https://github.com/rubocop/rubocop-ast/pull/359, it speeds up the processing around `Prism::Translation::Parser` via `ProcessedSource` by 1.3x when using the Ruby LSP add-on.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
