### PR TITLE
Fix false negative for `Style/RedundantSelfAssignment` when the method receives a block

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_self_assignment.md
+++ b/changelog/fix_false_negative_for_style_redundant_self_assignment.md
@@ -1,0 +1,1 @@
+* [#13902](https://github.com/rubocop/rubocop/pull/13902): Fix false negative for `Style/RedundantSelfAssignment` when the method receives a block. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -58,7 +58,7 @@ module RuboCop
         # rubocop:disable Metrics/AbcSize
         def on_lvasgn(node)
           return unless (rhs = node.rhs)
-          return unless rhs.call_type? && method_returning_self?(rhs.method_name)
+          return unless rhs.type?(:any_block, :call) && method_returning_self?(rhs.method_name)
           return unless (receiver = rhs.receiver)
 
           receiver_type = ASSIGNMENT_TYPE_TO_RECEIVER_TYPE[node.type]

--- a/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_assignment_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelfAssignment, :config do
         foo&.concat(ary)
       RUBY
     end
+
+    it 'registers an offense and corrects when the rhs receives a block' do
+      expect_offense(<<~RUBY)
+        foo = foo.delete_if { true }
+            ^ Redundant self assignment detected. Method `delete_if` modifies its receiver in place.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.delete_if { true }
+      RUBY
+    end
   end
 
   it 'does not register an offense when lhs and receiver are different' do


### PR DESCRIPTION
Add support for the case where the rhs method receives a block, e.g.:

```ruby
# bad
foo = foo.map! { |n| n * 2 }

# good
foo.map! { |n| n * 2 }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
