### PR TITLE
[Fix #12692] Fix `Style/AccessorGrouping` with constants

### DIFF
--- a/changelog/fix_fix_style_accessor_grouping_with_constants_20250225172211.md
+++ b/changelog/fix_fix_style_accessor_grouping_with_constants_20250225172211.md
@@ -1,0 +1,1 @@
+* [#12692](https://github.com/rubocop/rubocop/issues/12692): Fix `Style/AccessorGrouping` with constants. ([@tejasbubane][])

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -291,6 +291,50 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         end
       RUBY
     end
+
+    context 'when constant is used in accessor' do
+      it 'registers and corrects an offense considering ordering of constant' do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_reader :one
+            ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+            OTHER_ATTRS = %i[two three].freeze
+
+            attr_reader(*OTHER_ATTRS)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            OTHER_ATTRS = %i[two three].freeze
+
+            attr_reader :one, *OTHER_ATTRS
+          end
+        RUBY
+      end
+
+      it 'registers and corrects when there is no attr_reader after constant' do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_reader :one
+            ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+            attr_reader :bar
+            ^^^^^^^^^^^^^^^^ Group together all `attr_reader` attributes.
+
+            OTHER_ATTRS = %i[two three].freeze
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            attr_reader :one, :bar
+
+            OTHER_ATTRS = %i[two three].freeze
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is separated' do


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/12692

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
