### PR TITLE
Remove unnecessary `possible_dsl?` in `Lint/DuplicateMethods`

### DIFF
--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -461,6 +461,24 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense for same method name defined in different blocks' do
+      expect_no_offenses(<<~RUBY)
+        #{opening_line}
+          dsl_like('foo') do
+            def some_method
+              implement 1
+            end
+          end
+
+          dsl_like('bar') do
+            def some_method
+              implement 2
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   include_examples('in scope', 'class', 'class A')


### PR DESCRIPTION
This methods seems to not do much anymore nowadays. All tests continue to pass if it is removed, so simply remove it.

I added a test which I think this method was supposed to cover to make extra sure

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
