### PR TITLE
[Fix #13900] Fix infinite loop between `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundBlockBody` with `EnforcedStyle: no_empty_lines`

### DIFF
--- a/changelog/fix_fix_infinite_loop_between_20250225100033.md
+++ b/changelog/fix_fix_infinite_loop_between_20250225100033.md
@@ -1,0 +1,1 @@
+* [#13900](https://github.com/rubocop/rubocop/issues/13900): Fix infinite loop between `Layout/EmptyLinesAroundAccessModifier` and `Layout/EmptyLinesAroundBlockBody` with `EnforcedStyle: no_empty_lines`. ([@dvandersluis][])

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -341,6 +341,149 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           .bar
         RUBY
       end
+
+      context 'inside an implicit `begin` node' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            foo
+            %{access_modifier}
+            ^{access_modifier} Keep a blank line before and after `%{access_modifier}`.
+            bar
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo
+
+            #{access_modifier}
+
+            bar
+          RUBY
+        end
+      end
+
+      context 'when `Layout/EmptyLinesAroundBlockBody` is configured with `EnforcedStyle: no_empty_lines`' do
+        let(:other_cops) do
+          { 'Layout/EmptyLinesAroundBlockBody' => { 'EnforcedStyle' => 'no_empty_lines' } }
+        end
+
+        context 'access modifier is the only child of the block' do
+          it 'registers an offense but does not correct' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line after `%{access_modifier}`.
+              end
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'access modifier is the first child of the block' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line after `%{access_modifier}`.
+                foo
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Module.new do
+                #{access_modifier}
+
+                foo
+              end
+            RUBY
+          end
+        end
+
+        context 'access modifier is the last child of the block' do
+          it 'registers an offense and partially corrects' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                foo
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line before and after `%{access_modifier}`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Module.new do
+                foo
+
+                #{access_modifier}
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'when `Layout/EmptyLinesAroundBlockBody` is configured with `EnforcedStyle: empty_lines`' do
+        let(:other_cops) do
+          { 'Layout/EmptyLinesAroundBlockBody' => { 'EnforcedStyle' => 'empty_lines' } }
+        end
+
+        context 'access modifier is the only child of the block' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line after `%{access_modifier}`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Module.new do
+                #{access_modifier}
+
+              end
+            RUBY
+          end
+        end
+
+        context 'access modifier is the first child of the block' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line after `%{access_modifier}`.
+                foo
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Module.new do
+                #{access_modifier}
+
+                foo
+              end
+            RUBY
+          end
+        end
+
+        context 'access modifier is the last child of the block' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY, access_modifier: access_modifier)
+              Module.new do
+                foo
+                %{access_modifier}
+                ^{access_modifier} Keep a blank line before and after `%{access_modifier}`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              Module.new do
+                foo
+
+                #{access_modifier}
+
+              end
+            RUBY
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes infinite loop when  `Layout/EmptyLinesAroundAccessModifier` is configured with `EnforcedStyle: around` and `Layout/EmptyLinesAroundBlockBlody` with `EnforcedStyle: no_empty_lines`, and there is an access modifier with no following code at the beginning or end of a block.

eg.:
```ruby
block do
  def foo
  end

  private
end
```

Previously the two cops would repeatedly add and remove a line after `private`.

Fixes #13900.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
