### PR TITLE
Fix false positives for `Style/EndlessMethod`

### DIFF
--- a/changelog/fix_false_positives_for_style_endless_method.md
+++ b/changelog/fix_false_positives_for_style_endless_method.md
@@ -1,0 +1,1 @@
+* [#13910](https://github.com/rubocop/rubocop/pull/13910): Fix false positives for `Style/EndlessMethod` when using setter method definitions. ([@koic][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -144,6 +144,8 @@ module RuboCop
         MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
         def on_def(node)
+          return if node.assignment_method?
+
           case style
           when :allow_single_line, :allow_always
             handle_allow_style(node)

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -244,6 +244,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for a single line setter method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method=(arg)
+            arg.foo
+          end
+        RUBY
+      end
+
       it 'does not register an offense when the endless version excess Metrics/MaxLineLength[Max]' do
         expect_no_offenses(<<~RUBY)
           def my_method
@@ -389,6 +397,16 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           def my_method = x.foo
              .bar
              .baz
+        RUBY
+      end
+
+      it 'does not register an offense for a multiline setter method' do
+        expect_no_offenses(<<~RUBY)
+          def my_method=(arg)
+            x.foo
+             .bar
+             .baz
+          end
         RUBY
       end
 


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/13874#issuecomment-2684036210

This PR fixes false positives for `Style/EndlessMethod` when using assignment method definitions.

Setter methods cannot be defined as endless methods.

```console
$ ruby -vc -e "def foo=(arg) = bar"
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-darwin23]
ruby: -e:1: syntax error found (SyntaxError)
> 1 | def foo=(arg) = bar
    |     ^~~~ invalid method name; a setter method cannot be defined in an endless method definition
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
