### PR TITLE
Add `AllowComments` option to cop `Style/RedundantAssignment`

### DIFF
--- a/changelog/new_add_allow_comments_option_to_style_redundant_assignment.md
+++ b/changelog/new_add_allow_comments_option_to_style_redundant_assignment.md
@@ -1,0 +1,1 @@
+* [#13911](https://github.com/rubocop/rubocop/pull/13911): Add `AllowComments` option to `Style/RedundantAssignment`. ([@lovro-bikic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5088,6 +5088,7 @@ Style/RedundantAssignment:
   Description: 'Checks for redundant assignment before returning.'
   Enabled: true
   VersionAdded: '0.87'
+  AllowComments: false
 
 Style/RedundantBegin:
   Description: "Don't use begin blocks when they are not needed."


### PR DESCRIPTION
Adds support for `AllowComments` option (default `false`) to cop `Style/RedundantAssignment`. When `AllowComments` is enabled, an offense isn't registered if there are comments between the assignment and returning lines (inclusive).

In production code, I came across this pattern a couple of times:
```ruby
def foo
  x = something
  # TODO: disabled this because of an edge case bug, see ...
  # assert_bar!(x)
  x
end
``` 
where original code doesn't cause an offense for this cop, but then part of the code between assignment and return lines is commented out which then triggers an offense. Currently, autocorrect will move the in-between comments like so:
```ruby
def foo
  something
  # TODO: disabled this because of an edge case bug, see ...
  # assert_bar!(x)
end
```
which is not desired behavior.

With the new option enabled, an offense won't be registered when there are comments between assignment and return lines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
