### PR TITLE
Fix wrong autocorrect for `Lint/EmptyConditionalBody` when assigning to a variable with single branch

### DIFF
--- a/changelog/fix_autocorrect_empty_cond_single_branch.md
+++ b/changelog/fix_autocorrect_empty_cond_single_branch.md
@@ -1,0 +1,1 @@
+* [#13912](https://github.com/rubocop/rubocop/pull/13912): Fix wrong autocorrect for `Lint/EmptyConditionalBody` when assigning to a variable with only a single branch. ([@earlopain][])

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -416,6 +416,26 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
+  it 'does not autocorrect when there is only one branch with assignment' do
+    expect_offense(<<~RUBY)
+      x = if foo
+          ^^^^^^ Avoid `if` branches without a body.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not autocorrect when there is only one branch after `||`' do
+    expect_offense(<<~RUBY)
+      x || if foo
+           ^^^^^^ Avoid `if` branches without a body.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
   context '>= Ruby 3.1', :ruby31 do
     it 'registers an offense for multi-line value omission in `unless`' do
       expect_offense(<<~RUBY)
@@ -426,6 +446,8 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
             condition || other_condition
           end
       RUBY
+
+      expect_no_corrections
     end
   end
 


### PR DESCRIPTION
This currently produces wrong syntax:
```rb
var = if nil; end
# =>
var =
```

I chose not to offer autocorrect in such cases. But you could also:
* Remove the variable as well
* Assign nil to it

Not doing anything seems safest. There are others that will produce invalid syntax now, for example `x > if nil; end` but that is already a runtime error and not trivial to correctly handle. I'd leave this one for if somebody actually complains.

Found with https://github.com/rubocop/rubocop/pull/13183

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
