### PR TITLE
[Fix #13909] Fix false positive with `Layout/ClosingParenthesisIndentation` when first parameter is a hash

### DIFF
--- a/changelog/fix_fix_false_positive_with_20250226171903.md
+++ b/changelog/fix_fix_false_positive_with_20250226171903.md
@@ -1,0 +1,1 @@
+* [#13909](https://github.com/rubocop/rubocop/issues/13909): Fix false positive with `Layout/ClosingParenthesisIndentation` when first parameter is a hash. ([@tejasbubane][])

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -155,10 +155,10 @@ module RuboCop
         end
 
         def all_elements_aligned?(elements)
-          elements.flat_map do |e|
-            if e.hash_type?
-              e.each_child_node.map { |child| child.loc.column }
-            else
+          if elements.first.hash_type?
+            elements.first.each_child_node.map { |child| child.loc.column }
+          else
+            elements.flat_map do |e|
               e.loc.column
             end
           end.uniq.count == 1

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -114,6 +114,15 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation, :config do
                        )
         RUBY
       end
+
+      it 'does not register offense for aligned parens when first parameter is a hash' do
+        expect_no_offenses(<<~RUBY)
+          some_method({ foo: 1, bar: 2 },
+            x: 1,
+            y: 2
+          )
+        RUBY
+      end
     end
 
     context 'without arguments' do


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13909

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/