### PR TITLE
Fix writing generics type of rbs-inline annotation for nested class in `Style/CommentedKeyword`

### DIFF
--- a/changelog/fix_fix_writing_generics_type_of_rbs_inline_annotation_20250226233214.md
+++ b/changelog/fix_fix_writing_generics_type_of_rbs_inline_annotation_20250226233214.md
@@ -1,0 +1,1 @@
+* [#13915](https://github.com/rubocop/rubocop/pull/13915): Fix writing generics type of rbs-inline annotation for nested class in `Style/CommentedKeyword`. ([@dak2][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         REGEXP = /(?<keyword>\S+).*#/.freeze
 
-        SUBCLASS_DEFINITION = /\A\s*class\s+\w+\s*<\s*\w+/.freeze
+        SUBCLASS_DEFINITION = /\A\s*class\s+(\w|::)+\s*<\s*(\w|::)+/.freeze
         METHOD_DEFINITION = /\A\s*def\s/.freeze
 
         def on_new_investigation

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -241,6 +241,14 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
     expect_no_offenses(<<~RUBY)
       class X < Y #[String]
       end
+      class A < B::C #[String]
+      end
+      class A < B::C::D #[String]
+      end
+      class A::B < C #[String]
+      end
+      class A::B::C < D #[String]
+      end
     RUBY
   end
 
@@ -261,6 +269,18 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
       class X < Y #String ]
                   ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
       end
+      class A < B::C #String]
+                     ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class A < B::C::D #String]
+                        ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class A::B < C #String]
+                     ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
+      class A::B::C < D #String]
+                        ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+      end
     RUBY
 
     expect_correction(<<~RUBY)
@@ -278,6 +298,18 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
       end
       #String ]
       class X < Y
+      end
+      #String]
+      class A < B::C
+      end
+      #String]
+      class A < B::C::D
+      end
+      #String]
+      class A::B < C
+      end
+      #String]
+      class A::B::C < D
       end
     RUBY
   end


### PR DESCRIPTION
[RBS::Inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.

I made rules for generics type below pull request, but nested classes were not supported.

Follow https://github.com/rubocop/rubocop/pull/13476

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
