### PR TITLE
[Fix #13916] Stop Lint/LiteralAsCondition from acting on the rhs of && statements.

### DIFF
--- a/changelog/fix_lint_literal_as_condition_autocorrecting_rhs_and_nodes.md
+++ b/changelog/fix_lint_literal_as_condition_autocorrecting_rhs_and_nodes.md
@@ -1,0 +1,1 @@
+* [#13916](https://github.com/rubocop/rubocop/issues/13916): Fix `Lint/LiteralAsCondition` acting on the right hand side of && nodes. ([@zopolis4][])


### PR DESCRIPTION
Fixes #13916.

~~This does mean some valid cases won't be caught, but for a Lint cop I presume its better to prioritize safety.~~

The right hand side of an && isn't a condition, its just executed conditionally. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
