### PR TITLE
[Fix #13913] Fix false positives for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_condition.md
+++ b/changelog/fix_false_positives_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#13913](https://github.com/rubocop/rubocop/issues/13913): Fix false positives for `Style/RedundantCondition` when using when true is used as the true branch and the condition is not a predicate method. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5108,6 +5108,9 @@ Style/RedundantCondition:
   Description: 'Checks for unnecessary conditional expressions.'
   Enabled: true
   VersionAdded: '0.76'
+  VersionChanged: '<<next>>'
+  AllowedMethods:
+    - nonzero?
 
 Style/RedundantConditional:
   Description: "Don't return true/false from a conditional."

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -571,6 +571,16 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
     end
 
     context 'when `true` as the true branch' do
+      it 'does not register an offense when true is used as the true branch and the condition is not a predicate method' do
+        expect_no_offenses(<<~RUBY)
+          if a[:key]
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
       it 'registers an offense and autocorrects when true is used as the true branch' do
         expect_offense(<<~RUBY)
           if a.zero?
@@ -583,6 +593,31 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
 
         expect_correction(<<~RUBY)
           a.zero? || a
+        RUBY
+      end
+
+      it 'registers an offense and autocorrects when true is used as the true branch and the condition uses safe navigation' do
+        expect_offense(<<~RUBY)
+          if a&.zero?
+          ^^^^^^^^^^^ Use double pipes `||` instead.
+            true
+          else
+            a
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.zero? || a
+        RUBY
+      end
+
+      it 'does not register an offense when false is used as the else branch and the condition is not a predicate method' do
+        expect_no_offenses(<<~RUBY)
+          if !a[:key]
+            a
+          else
+            false
+          end
         RUBY
       end
 
@@ -1040,6 +1075,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
           end
         RUBY
       end
+    end
+  end
+
+  context 'when `AllowedMethods: nonzero?`' do
+    let(:cop_config) { { 'AllowedMethods' => ['nonzero?'] } }
+
+    it 'does not register an offense when using `nonzero?`' do
+      expect_no_offenses(<<~RUBY)
+        if a.nonzero?
+          true
+        else
+          false
+        end
+      RUBY
     end
   end
 end


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantCondition` when using when true is used as the true branch and condition is not predicate method.

Fixes #13913.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
