### PR TITLE
[Fix #13621] Add `ForbiddenIdentifiers` config to `Naming/MethodName` cop

### DIFF
--- a/changelog/change_add_forbidden_config_to_method_name_20250227140441.md
+++ b/changelog/change_add_forbidden_config_to_method_name_20250227140441.md
@@ -1,0 +1,1 @@
+* [#13621](https://github.com/rubocop/rubocop/issues/13621): Add `ForbiddenIdentifiers` and `ForbiddenPatterns` config options to `Naming/MethodName` cop. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2995,6 +2995,7 @@ Naming/MethodName:
   StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '<<next>>'
   EnforcedStyle: snake_case
   SupportedStyles:
     - snake_case
@@ -3006,6 +3007,10 @@ Naming/MethodName:
   #     - '\A\s*onSelectionCleared\s*'
   #
   AllowedPatterns: []
+  ForbiddenIdentifiers:
+    - __id__
+    - __send__
+  ForbiddenPatterns: []
 
 Naming/MethodParameterName:
   Description: >-

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -75,6 +75,8 @@ require_relative 'rubocop/cop/mixin/allowed_identifiers'
 require_relative 'rubocop/cop/mixin/allowed_methods'
 require_relative 'rubocop/cop/mixin/allowed_pattern'
 require_relative 'rubocop/cop/mixin/allowed_receivers'
+require_relative 'rubocop/cop/mixin/forbidden_identifiers'
+require_relative 'rubocop/cop/mixin/forbidden_pattern'
 require_relative 'rubocop/cop/mixin/auto_corrector' # rubocop:todo Naming/InclusiveLanguage
 require_relative 'rubocop/cop/mixin/check_assignment'
 require_relative 'rubocop/cop/mixin/check_line_breakable'

--- a/lib/rubocop/cop/mixin/forbidden_identifiers.rb
+++ b/lib/rubocop/cop/mixin/forbidden_identifiers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This module encapsulates the ability to forbid certain identifiers in a cop.
+    module ForbiddenIdentifiers
+      SIGILS = '@$' # if a variable starts with a sigil it will be removed
+
+      def forbidden_identifier?(name)
+        name = name.to_s.delete(SIGILS)
+
+        forbidden_identifiers.any? && forbidden_identifiers.include?(name)
+      end
+
+      def forbidden_identifiers
+        cop_config.fetch('ForbiddenIdentifiers', [])
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/forbidden_pattern.rb
+++ b/lib/rubocop/cop/mixin/forbidden_pattern.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This module encapsulates the ability to forbid certain patterns in a cop.
+    module ForbiddenPattern
+      def forbidden_pattern?(name)
+        forbidden_patterns.any? { |pattern| Regexp.new(pattern).match?(name) }
+      end
+
+      def forbidden_patterns
+        cop_config.fetch('ForbiddenPatterns', [])
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -6,14 +6,31 @@ module RuboCop
       # Makes sure that all methods use the configured style,
       # snake_case or camelCase, for their names.
       #
-      # This cop has `AllowedPatterns` configuration option.
-      #
-      #   Naming/MethodName:
-      #     AllowedPatterns:
-      #       - '\AonSelectionBulkChange\z'
-      #       - '\AonSelectionCleared\z'
-      #
       # Method names matching patterns are always allowed.
+      #
+      # The cop can be configured with `AllowedPatterns` to allow certain regexp patterns:
+      #
+      # [source,yaml]
+      # ----
+      # Naming/MethodName:
+      #   AllowedPatterns:
+      #     - '\AonSelectionBulkChange\z'
+      #     - '\AonSelectionCleared\z'
+      # ----
+      #
+      # As well, you can also forbid specific method names or regexp patterns
+      # using `ForbiddenIdentifiers` or `ForbiddenPatterns`:
+      #
+      # [source,yaml]
+      # ----
+      # Naming/MethodName:
+      #   ForbiddenIdentifiers:
+      #     - 'def'
+      #     - 'super'
+      #   ForbiddenPatterns:
+      #     - '_v1\z'
+      #     - '_gen1\z'
+      # ----
       #
       # @example EnforcedStyle: snake_case (default)
       #   # bad
@@ -28,12 +45,26 @@ module RuboCop
       #
       #   # good
       #   def fooBar; end
+      #
+      # @example ForbiddenIdentifiers: ['def', 'super']
+      #   # bad
+      #   def def; end
+      #   def super; end
+      #
+      # @example ForbiddenPatterns: ['_v1\z', '_gen1\z']
+      #   # bad
+      #   def release_v1; end
+      #   def api_gen1; end
+      #
       class MethodName < Base
         include ConfigurableNaming
         include AllowedPattern
         include RangeHelp
+        include ForbiddenIdentifiers
+        include ForbiddenPattern
 
         MSG = 'Use %<style>s for method names.'
+        MSG_FORBIDDEN = '`%<identifier>s` is forbidden, use another method name instead.'
 
         # @!method sym_name(node)
         def_node_matcher :sym_name, '(sym $_name)'
@@ -48,18 +79,43 @@ module RuboCop
             name = attr_name(name_item)
             next if !name || matches_allowed_pattern?(name)
 
-            check_name(node, name, range_position(node))
+            if forbidden_name?(name.to_s)
+              register_forbidden_name(node)
+            else
+              check_name(node, name, range_position(node))
+            end
           end
         end
 
         def on_def(node)
           return if node.operator_method? || matches_allowed_pattern?(node.method_name)
 
-          check_name(node, node.method_name, node.loc.name)
+          if forbidden_name?(node.method_name.to_s)
+            register_forbidden_name(node)
+          else
+            check_name(node, node.method_name, node.loc.name)
+          end
         end
         alias on_defs on_def
 
         private
+
+        def forbidden_name?(name)
+          forbidden_identifier?(name) || forbidden_pattern?(name)
+        end
+
+        def register_forbidden_name(node)
+          if node.type?(:def, :defs)
+            name_node = node.loc.name
+            method_name = node.method_name
+          else
+            attrs = node.attribute_accessor?
+            name_node = attrs.last.last
+            method_name = attr_name(name_node)
+          end
+          message = format(MSG_FORBIDDEN, identifier: method_name)
+          add_offense(name_node, message: message)
+        end
 
         def attr_name(name_item)
           sym_name(name_item) || str_name(name_item)

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -53,6 +53,8 @@ module RuboCop
         include AllowedIdentifiers
         include ConfigurableNaming
         include AllowedPattern
+        include ForbiddenIdentifiers
+        include ForbiddenPattern
 
         MSG = 'Use %<style>s for variable names.'
         MSG_FORBIDDEN = '`%<identifier>s` is forbidden, use another name instead.'
@@ -92,27 +94,12 @@ module RuboCop
 
         private
 
+        def forbidden_name?(name)
+          forbidden_identifier?(name) || forbidden_pattern?(name)
+        end
+
         def message(style)
           format(MSG, style: style)
-        end
-
-        def forbidden_identifiers
-          cop_config.fetch('ForbiddenIdentifiers', [])
-        end
-
-        def forbidden_patterns
-          cop_config.fetch('ForbiddenPatterns', [])
-        end
-
-        def matches_forbidden_pattern?(name)
-          forbidden_patterns.any? { |pattern| Regexp.new(pattern).match?(name) }
-        end
-
-        def forbidden_name?(name)
-          name = name.to_s.delete(SIGILS)
-
-          (forbidden_identifiers.any? && forbidden_identifiers.include?(name)) ||
-            (forbidden_patterns.any? && matches_forbidden_pattern?(name))
         end
 
         def register_forbidden_name(node)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -623,8 +623,9 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         todo_contents = File.read('.rubocop_todo.yml').lines[8..].join
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
-          # Configuration parameters: AllowedPatterns.
+          # Configuration parameters: AllowedPatterns, ForbiddenIdentifiers, ForbiddenPatterns.
           # SupportedStyles: snake_case, camelCase
+          # ForbiddenIdentifiers: __id__, __send__
           Naming/MethodName:
             EnforcedStyle: camelCase
 
@@ -1664,6 +1665,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(File.readlines('.rubocop_todo.yml')[10..].join)
           .to eq(<<~YAML)
             # SupportedStyles: snake_case, camelCase
+            # ForbiddenIdentifiers: __id__, __send__
             Naming/MethodName:
               Exclude:
                 - 'bad.rb'

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -192,6 +192,120 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     end
   end
 
+  shared_examples 'forbidden identifiers' do |identifier|
+    context 'when ForbiddenIdentifiers is set' do
+      let(:cop_config) { super().merge('ForbiddenIdentifiers' => [identifier]) }
+
+      context 'for multi-line method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def %{identifier}
+                ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+              true
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for single-line method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def %{identifier}; true; end
+                ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for class method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def self.%{identifier}
+                     ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for singleton method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def foo.%{identifier}
+                    ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for attr methods' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            attr_reader :#{identifier}
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            attr_writer :#{identifier}
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            attr_accessor :#{identifier}
+                          ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+    end
+  end
+
+  shared_examples 'forbidden patterns' do |pattern, identifier|
+    context 'when ForbiddenIdentifiers is set' do
+      let(:cop_config) { super().merge('ForbiddenPatterns' => [pattern]) }
+
+      context 'for multi-line method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def %{identifier}
+                ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+              true
+            end
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for single-line method definition' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            def %{identifier}; true; end
+                ^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for attr methods' do
+        it 'registers an offense when method with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            attr_reader :#{identifier}
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            attr_writer :#{identifier}
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+            attr_accessor :#{identifier}
+                          ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+    end
+  end
+
   context 'when configured for snake_case' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
@@ -264,6 +378,8 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'never accepted',  'snake_case'
     include_examples 'always accepted', 'snake_case'
     include_examples 'multiple attr methods', 'snake_case'
+    include_examples 'forbidden identifiers', 'super'
+    include_examples 'forbidden patterns', '_v1\z', 'api_v1'
   end
 
   context 'when configured for camelCase' do
@@ -340,6 +456,8 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'always accepted', 'camelCase'
     include_examples 'never accepted',  'camelCase'
     include_examples 'multiple attr methods', 'camelCase'
+    include_examples 'forbidden identifiers', 'super'
+    include_examples 'forbidden patterns', '_gen\d+\z', 'user_gen1'
   end
 
   it 'accepts for non-ascii characters' do


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13621

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/