### PR TITLE
[Fix #13708] Mark `StyleKeywordArgumentsMerging` as unsafe for autocorrect

### DIFF
--- a/changelog/change_mark_style_keyword_arguments_merging_as_unsafe_20250227150403.md
+++ b/changelog/change_mark_style_keyword_arguments_merging_as_unsafe_20250227150403.md
@@ -1,0 +1,1 @@
+* [#13708](https://github.com/rubocop/rubocop/issues/13708): Mark `StyleKeywordArgumentsMerging` as unsafe for autocorrect. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4383,7 +4383,9 @@ Style/KeywordArgumentsMerging:
                  directly rather than using `merge`.
   StyleGuide: '#merging-keyword-arguments'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.68'
+  VersionChanged: '<<next>>'
 
 Style/KeywordParametersOrder:
   Description: 'Enforces that optional keyword parameters are placed at the end of the parameters list.'

--- a/lib/rubocop/cop/style/keyword_arguments_merging.rb
+++ b/lib/rubocop/cop/style/keyword_arguments_merging.rb
@@ -18,6 +18,22 @@ module RuboCop
       #   some_method(**opts, foo: true)
       #   some_method(**opts, **other_opts)
       #
+      # @safety
+      # This cop's autocorrection is unsafe because merging works differently
+      # with Rails' HashWithIndifferentAccess
+      #
+      # [source, ruby]
+      # ----
+      # def my_function_with_options(**attrs)
+      #   attrs['my_merged_option']
+      # end
+      #
+      # options = {}.with_indifferent_access
+      #
+      # my_function_with_options(**options.merge(my_merged_option: 1)) # => 1
+      #
+      # my_function_with_options(**options, my_merged_option: 1) # => nil
+      #
       class KeywordArgumentsMerging < Base
         extend AutoCorrector
 


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13708

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/