### PR TITLE
[Fix #12851] Add `EnforcedStyleForClasses` and `EnforcedStyleForModules` configuration options to `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/change_add_enforced_style_for_classes_and_20250227100212.md
+++ b/changelog/change_add_enforced_style_for_classes_and_20250227100212.md
@@ -1,0 +1,1 @@
+* [#12851](https://github.com/rubocop/rubocop/issues/12851): Add `EnforcedStyleForClasses` and `EnforcedStyleForModules` configuration options to `Style/ClassAndModuleChildren`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3499,6 +3499,7 @@ Style/ClassAndModuleChildren:
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.19'
+  VersionChanged: '<<next>>'
   #
   # Basically there are two different styles:
   #
@@ -3514,7 +3515,21 @@ Style/ClassAndModuleChildren:
   #
   # The compact style is only forced, for classes or modules with one child.
   EnforcedStyle: nested
-  SupportedStyles:
+  SupportedStyles: &supported_styles
+    - nested
+    - compact
+  # Configure classes separately, if desired. If not set, or set to `nil`,
+  # the `EnforcedStyle` value will be used.
+  EnforcedStyleForClasses: ~
+  SupportedStylesForClasses:
+    - ~
+    - nested
+    - compact
+  # Configure modules separately, if desired. If not set, or set to `nil`,
+  # the `EnforcedStyle` value will be used.
+  EnforcedStyleForModules: ~
+  SupportedStylesForModules:
+    - ~
     - nested
     - compact
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -450,4 +450,96 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       end
     end
   end
+
+  context 'when EnforcedStyleForClasses is set' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'nested', 'EnforcedStyleForClasses' => enforced_style_for_classes }
+    end
+
+    context 'EnforcedStyleForClasses: nil' do
+      let(:enforced_style_for_classes) { nil }
+
+      it 'uses the set `EnforcedStyle` for classes' do
+        expect_offense(<<~RUBY)
+          class FooClass::BarClass
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooClass
+            class BarClass
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyleForClasses: compact' do
+      let(:enforced_style_for_classes) { 'compact' }
+
+      it 'registers an offense for classes with nested children' do
+        expect_offense(<<~RUBY)
+          class FooClass
+                ^^^^^^^^ Use compact module/class definition instead of nested style.
+            class BarClass
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass::BarClass
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when EnforcedStyleForModules is set' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'nested', 'EnforcedStyleForModules' => enforced_style_for_modules }
+    end
+
+    context 'EnforcedStyleForModules: nil' do
+      let(:enforced_style_for_modules) { nil }
+
+      it 'uses the set `EnforcedStyle` for modules' do
+        expect_offense(<<~RUBY)
+          module FooModule::BarModule
+                 ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyleForModules: compact' do
+      let(:enforced_style_for_modules) { 'compact' }
+
+      it 'registers an offense for modules with nested children' do
+        expect_offense(<<~RUBY)
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            module BarModule
+              def method_example
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule::BarModule
+            def method_example
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
These new options allow the cop to be configured separately for classes and modules. If they are not set, or set to nil, the `EnforceStyle` value will be used instead.

I chose to do this rather than splitting the cop into two, as to avoid making changes that will affect a lot of configurations. I expect most people want the same style for both, as per the [style guide](https://github.com/rubocop/ruby-style-guide#namespace-definition).

Fixes #12851.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
