### PR TITLE
[Fix #12669] Update autocorrection for `Lint/EmptyConditionalBody` to be safe

### DIFF
--- a/changelog/change_update_autocorrection_for_20250227114940.md
+++ b/changelog/change_update_autocorrection_for_20250227114940.md
@@ -1,0 +1,1 @@
+* [#12669](https://github.com/rubocop/rubocop/issues/12669): Update autocorrection for `Lint/EmptyConditionalBody` to be safe. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1887,10 +1887,9 @@ Lint/EmptyConditionalBody:
   Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
   Enabled: true
   AutoCorrect: contextual
-  SafeAutoCorrect: false
   AllowComments: true
   VersionAdded: '0.89'
-  VersionChanged: '1.61'
+  VersionChanged: '<<next>>'
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2285,8 +2285,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('example.rb', <<~RUBY)
         # frozen_string_literal: true
 
-        if foo and bar
-        end
+        a.foo..b.bar # Lint/AmbiguousRange offense is not safe correctable
       RUBY
       expect(cli.run(['--display-only-safe-correctable', 'example.rb'])).to eq(0)
       expect($stderr.string).to eq('')

--- a/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
+++ b/spec/rubocop/cop/lint/empty_conditional_body_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `if` and `else` body' do
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `if` and `else` body with some indentation' do
@@ -34,13 +34,10 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      def foo
-          end
-    RUBY
+    expect_no_corrections
   end
 
-  it 'registers an offense for missing `if` body with present `else` body' do
+  it 'registers an offense and corrects for missing `if` body with present `else` body' do
     expect_offense(<<~RUBY)
       class Foo
         if condition
@@ -123,13 +120,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      if condition
-        do_something1
-      elsif other_condition2
-        do_something2
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `if` and `elsif` body' do
@@ -143,11 +134,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      if other_condition2
-        do_something
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense for missing all branches of `if` and `elsif` body' do
@@ -159,7 +146,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
   it 'registers an offense for missing all branches of `if` and multiple `elsif` body' do
@@ -173,10 +160,10 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
-  it 'registers an offense for missing `if` body with `else`' do
+  it 'registers an offense and corrects for missing `if` body with `else`' do
     expect_offense(<<~RUBY)
       if condition
       ^^^^^^^^^^^^ Avoid `if` branches without a body.
@@ -192,7 +179,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
-  it 'registers an offense for missing `unless` body with `else`' do
+  it 'registers an offense and corrects for missing `unless` body with `else`' do
     expect_offense(<<~RUBY)
       unless condition
       ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
@@ -208,7 +195,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
-  it 'registers an offense for missing `if` body with conditional `else` body' do
+  it 'registers an offense and corrects for missing `if` body with conditional `else` body' do
     expect_offense(<<~RUBY)
       if condition
       ^^^^^^^^^^^^ Avoid `if` branches without a body.
@@ -224,7 +211,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
-  it 'registers an offense for missing `unless` body with conditional `else` body' do
+  it 'registers an offense and corrects for missing `unless` body with conditional `else` body' do
     expect_offense(<<~RUBY)
       unless condition
       ^^^^^^^^^^^^^^^^ Avoid `unless` branches without a body.
@@ -248,7 +235,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `if` body with `elsif`' do
@@ -262,13 +249,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      if other_condition
-        do_something
-      elsif another_condition
-        do_something_else
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `elsif` body with `end` on the same line' do
@@ -279,11 +260,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
     RUBY
 
-    expect_correction(<<~RUBY)
-      if cond_a
-        do_a
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `elsif` and `else` bodies with `end` on the same line' do
@@ -294,11 +271,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       ^^^^^^^^^^^^^ Avoid `elsif` branches without a body.
     RUBY
 
-    expect_correction(<<~RUBY)
-      if cond_a
-        do_a
-      else;end
-    RUBY
+    expect_no_corrections
   end
 
   it 'does not register an offense for missing `elsif` body with a comment' do
@@ -322,13 +295,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      if condition
-        do_something
-      else
-        # noop
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'does not register an offense for missing `elsif` body with an inline comment' do
@@ -353,13 +320,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      if foo
-        do_foo
-      elsif bar
-        do_bar
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers an offense for missing `unless` body' do
@@ -369,7 +330,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction('')
+    expect_no_corrections
   end
 
   it 'registers an offense when missing `if` body and using method call for return value' do
@@ -400,7 +361,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
   end
 
-  it 'autocorrects properly when the if is assigned to a variable' do
+  it 'registers an offense when the if is assigned to a variable' do
     expect_offense(<<~RUBY)
       x = if foo
           ^^^^^^ Avoid `if` branches without a body.
@@ -409,14 +370,10 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      x = if bar
-        5
-      end
-    RUBY
+    expect_no_corrections
   end
 
-  it 'does not autocorrect when there is only one branch with assignment' do
+  it 'registers an offense when there is only one branch with assignment' do
     expect_offense(<<~RUBY)
       x = if foo
           ^^^^^^ Avoid `if` branches without a body.
@@ -426,7 +383,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     expect_no_corrections
   end
 
-  it 'does not autocorrect when there is only one branch after `||`' do
+  it 'registers an offense when there is only one branch after `||`' do
     expect_offense(<<~RUBY)
       x || if foo
            ^^^^^^ Avoid `if` branches without a body.
@@ -434,6 +391,32 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     RUBY
 
     expect_no_corrections
+  end
+
+  it 'does not register an offense for an `if` with `nil` body' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        nil
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an `unless` with `nil` body' do
+    expect_no_offenses(<<~RUBY)
+      unless condition
+        nil
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an `elsif` with `nil` body' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        do_something
+      elsif other_condition
+        nil
+      end
+    RUBY
   end
 
   context '>= Ruby 3.1', :ruby31 do
@@ -451,7 +434,37 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
     end
   end
 
-  context 'when AllowComments is false' do
+  context 'when `AllowComments` is `true`' do
+    let(:cop_config) { { 'AllowComments' => true } }
+
+    it 'does not register an offense for missing `if` body with a comment' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          # noop
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for missing `elsif` body with a comment' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          do_something
+        elsif other_condition
+          # noop
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for missing `unless` body with a comment' do
+      expect_no_offenses(<<~RUBY)
+        unless condition
+          # noop
+        end
+      RUBY
+    end
+  end
+
+  context 'when `AllowComments` is `false`' do
     let(:cop_config) { { 'AllowComments' => false } }
 
     it 'registers an offense for missing `if` body with a comment' do
@@ -462,7 +475,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         end
       RUBY
 
-      expect_correction('')
+      expect_no_corrections
     end
 
     it 'registers an offense for missing `elsif` body with a comment' do
@@ -475,11 +488,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         end
       RUBY
 
-      expect_correction(<<~RUBY)
-        if condition
-          do_something
-        end
-      RUBY
+      expect_no_corrections
     end
 
     it 'registers an offense for missing `unless` body with a comment' do
@@ -490,7 +499,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyConditionalBody, :config do
         end
       RUBY
 
-      expect_correction('')
+      expect_no_corrections
     end
   end
 end


### PR DESCRIPTION
In #10862, autocorrection was added to remove branches that had no body. This was made unsafe in #10867, because deleting a branch introduces a behaviour change if any of the branch conditions had side effects. There have been a considerable number of bugfix PRs since, and still broken examples, such as https://github.com/rubocop/rubocop/pull/10862#pullrequestreview-1065335927.

As a `Lint` cop, it'd be better to just not correct when unsafe. The user can decide whether the branch can be removed, or an explicit `nil` can be added.

Empty branches with comments (with `AllowComments: true` configuration) are still allowed and not corrected.

Fixes #12669.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
