### PR TITLE
Update `InternalAffairs/ExampleDescription` to handle `expect_no_corrections` with "registers an offense and corrects" description

### DIFF
--- a/lib/rubocop/cop/internal_affairs/example_description.rb
+++ b/lib/rubocop/cop/internal_affairs/example_description.rb
@@ -50,10 +50,12 @@ module RuboCop
         }.freeze
 
         EXPECT_NO_CORRECTIONS_DESCRIPTION_MAPPING = {
-          /\A(auto[- ]?)?correct/ => 'does not correct'
+          /\A(auto[- ]?)?corrects?/ => 'does not correct',
+          /\band (auto[- ]?)?corrects/ => 'but does not correct'
         }.freeze
 
         EXPECT_CORRECTION_DESCRIPTION_MAPPING = {
+          /\bbut (does not|doesn't) (auto[- ]?)?correct/ => 'and autocorrects',
           /\b(does not|doesn't) (auto[- ]?)?correct/ => 'autocorrects'
         }.freeze
 

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -203,6 +203,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
           expect_correction('code', source: 'new code')
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it 'autocorrects' do
+          expect_correction('code', source: 'new code')
+        end
+      RUBY
     end
 
     context 'in conjunction with expect_offense' do
@@ -214,6 +220,13 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
             expect_correction('code')
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          it 'registers an offense and autocorrects' do
+            expect_offense('code')
+            expect_correction('code')
+          end
+        RUBY
       end
 
       context 'when the description is invalid for both methods' do
@@ -221,6 +234,13 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
           expect_offense(<<~RUBY)
             it 'does not register an offense and does not autocorrect' do
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_offense`.
+              expect_offense('code')
+              expect_correction('code')
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            it 'registers an offense and autocorrects' do
               expect_offense('code')
               expect_correction('code')
             end
@@ -238,6 +258,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
           expect_no_corrections
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it 'does not correct' do
+          expect_no_corrections
+        end
+      RUBY
     end
 
     context 'in conjunction with expect_offense' do
@@ -249,7 +275,44 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
             expect_no_corrections
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          it 'does not correct' do
+            expect_offense('code')
+            expect_no_corrections
+          end
+        RUBY
       end
+    end
+
+    it 'registers an offense with a "registers an offense and corrects" description' do
+      expect_offense(<<~RUBY)
+        it 'registers an offense and corrects' do
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
+          expect_no_corrections
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'registers an offense but does not correct' do
+          expect_no_corrections
+        end
+      RUBY
+    end
+
+    it 'registers an offense with a "registers an offense and autocorrects" description' do
+      expect_offense(<<~RUBY)
+        it 'registers an offense and autocorrects' do
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description does not match use of `expect_no_corrections`.
+          expect_no_corrections
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'registers an offense but does not correct' do
+          expect_no_corrections
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/deprecated_constants_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_constants_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedConstants, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when using deprecated methods that have no alternative' do
+  it 'registers an offense when using deprecated methods that have no alternative' do
     expect_offense(<<~RUBY)
       Have::No::Alternative
       ^^^^^^^^^^^^^^^^^^^^^ Do not use `Have::No::Alternative`, deprecated since Ruby 2.4.

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::EnsureReturn, :config do
-  it 'registers an offense and corrects for return in ensure' do
+  it 'registers an offense but does not correct for return in ensure' do
     expect_offense(<<~RUBY)
       begin
         something
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn, :config do
     expect_no_corrections
   end
 
-  it 'registers an offense and corrects for return with argument in ensure' do
+  it 'registers an offense but does not correct for return with argument in ensure' do
     expect_offense(<<~RUBY)
       begin
         foo

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Lint::UnifiedInteger, :config do
     context 'target ruby version < 2.4', :ruby23, unsupported_on: :prism do
       context "when #{klass}" do
         context 'without any decorations' do
-          it 'registers an offense and autocorrects' do
+          it 'registers an offense but does not correct' do
             expect_offense(<<~RUBY, klass: klass)
               1.is_a?(%{klass})
                       ^{klass} Use `Integer` instead of `#{klass}`.

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects with 1.times with method chain' do
+  it 'registers an offense but does not correct with 1.times with method chain' do
     expect_offense(<<~RUBY)
       1.times.reverse_each do
       ^^^^^^^ Useless call to `1.times` detected.

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           RUBY
         end
 
-        it 'registers an offense and autocorrects when not all methods are defined in class' do
+        it 'registers an offense but does not correct when not all methods are defined in class' do
           expect_offense(<<~RUBY, access_modifier: access_modifier)
             module Foo
               def bar; end

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects for === when the receiver is a regexp' do
+    it 'registers an offense but does not correct for === when the receiver is a regexp' do
       expect_offense(<<~RUBY)
         /OMG/ === var
               ^^^ Avoid the use of the case equality operator `===`.
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects for === when the receiver is self.klass' do
+    it 'registers an offense but does not correct for === when the receiver is self.klass' do
       expect_offense(<<~RUBY)
         self.klass === var
                    ^^^ Avoid the use of the case equality operator `===`.

--- a/spec/rubocop/cop/style/comparable_clamp_spec.rb
+++ b/spec/rubocop/cop/style/comparable_clamp_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe RuboCop::Cop::Style::ComparableClamp, :config do
       expect_no_corrections
     end
 
-    it 'registers and corrects an offense when using `[[low, high].min].max`' do
+    it 'registers but does not correct an offense when using `[[low, high].min].max`' do
       expect_offense(<<~RUBY)
         [low, [x, high].min].max
         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Comparable#clamp` instead.
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::Style::ComparableClamp, :config do
       expect_no_corrections
     end
 
-    it 'registers and corrects an offense when using `[low, [high, x].min].max`' do
+    it 'registers but does not correct an offense when using `[low, [high, x].min].max`' do
       expect_offense(<<~RUBY)
         [low, [high, x].min].max
         ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Comparable#clamp` instead.

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -772,7 +772,7 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
       end
 
       context 'with a ternary' do
-        it 'registers an offense and corrects' do
+        it 'registers an offense but does not correct' do
           expect_offense(<<~RUBY)
             x = foo ? bar : bar
                       ^^^ Move `bar` out of the conditional.


### PR DESCRIPTION
Also added `expect_correction`s to the tests where it was missing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
