### PR TITLE
[Fix #13766] Fix false positives for `Style/InverseMethods`

### DIFF
--- a/changelog/fix_false_positive_for_style_inverse_methods.md
+++ b/changelog/fix_false_positive_for_style_inverse_methods.md
@@ -1,0 +1,1 @@
+* [#13766](https://github.com/rubocop/rubocop/issues/13766): Fix false positives for `Style/InverseMethods` when using `any?` or `none?` with safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -33,14 +33,9 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     RUBY
   end
 
-  it 'registers an offense for safe navigation calling !.none? with a symbol proc' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for safe navigation calling !.none? with a symbol proc' do
+    expect_no_offenses(<<~RUBY)
       !foo&.none?(&:even?)
-      ^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.any?(&:even?)
     RUBY
   end
 
@@ -55,14 +50,9 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     RUBY
   end
 
-  it 'registers an offense for safe navigation calling !.none? with a block' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for safe navigation calling !.none? with a block' do
+    expect_no_offenses(<<~RUBY)
       !foo&.none? { |f| f.even? }
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.any? { |f| f.even? }
     RUBY
   end
 
@@ -90,14 +80,9 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     RUBY
   end
 
-  it 'registers an offense for safe navigation calling !.any? inside parens' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for safe navigation calling !.any? inside parens' do
+    expect_no_offenses(<<~RUBY)
       !(foo&.any? &:working?)
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use `none?` instead of inverting `any?`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      foo&.none? &:working?
     RUBY
   end
 
@@ -168,17 +153,17 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     odd?: :even?,
     blank?: :present?,
     exclude?: :include? }.each do |method, inverse|
-      it "registers an offense for !foo.#{method}" do
-        expect_offense(<<~RUBY, method: method)
-          !foo.%{method}
-          ^^^^^^{method} Use `#{inverse}` instead of inverting `#{method}`.
-        RUBY
+    it "registers an offense for !foo.#{method}" do
+      expect_offense(<<~RUBY, method: method)
+        !foo.%{method}
+        ^^^^^^{method} Use `#{inverse}` instead of inverting `#{method}`.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          foo.#{inverse}
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        foo.#{inverse}
+      RUBY
     end
+  end
 
   { :== => :!=,
     :!= => :==,
@@ -207,6 +192,18 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
         foo #{inverse} bar
       RUBY
     end
+  end
+
+  it 'allows using `any?` method with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.any?(&:odd)
+    RUBY
+  end
+
+  it 'allows using `none?` method with safe navigation operator' do
+    expect_no_offenses(<<~RUBY)
+      !nullable&.none?(&:odd)
+    RUBY
   end
 
   it 'allows comparing for relational comparison operator (`<`) with safe navigation operator' do


### PR DESCRIPTION
This PR fixes false positives for `Style/InverseMethods` when using `any?` or `none?` with safe navigation operator.
Additionally, some specs for the existing incorrect behavior has been updated.

Fixes #13766.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
