### PR TITLE
Fix `end pattern with unmatched parenthesis: / (RegexpError)` on Ruby 3.2.0

### DIFF
--- a/changelog/fix_fix_end_pattern_with_unmatched_parenthesis__20250228103004.md
+++ b/changelog/fix_fix_end_pattern_with_unmatched_parenthesis__20250228103004.md
@@ -1,0 +1,1 @@
+* [#13928](https://github.com/rubocop/rubocop/issues/13928): Fix `end pattern with unmatched parenthesis: / (RegexpError)` on Ruby 3.2.0. ([@dvandersluis][])

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -5,8 +5,11 @@ module RuboCop
     module Utils
       # Parses {Kernel#sprintf} format strings.
       class FormatString
+        # Escaping the `#` in `INTERPOLATION` and `TEMPLATE_NAME` is necessary to
+        # avoid a bug in Ruby 3.2.0
+        # See: https://bugs.ruby-lang.org/issues/19379
         DIGIT_DOLLAR  = /(?<arg_number>\d+)\$/.freeze
-        INTERPOLATION = /#\{.*?\}/.freeze
+        INTERPOLATION = /\#\{.*?\}/.freeze
         FLAG          = /[ #0+-]|#{DIGIT_DOLLAR}/.freeze
         NUMBER_ARG    = /\*#{DIGIT_DOLLAR}?/.freeze
         NUMBER        = /\d+|#{NUMBER_ARG}|#{INTERPOLATION}/.freeze
@@ -14,7 +17,7 @@ module RuboCop
         PRECISION     = /\.(?<precision>#{NUMBER}?)/.freeze
         TYPE          = /(?<type>[bBdiouxXeEfgGaAcps])/.freeze
         NAME          = /<(?<name>\w+)>/.freeze
-        TEMPLATE_NAME = /(?<!#)\{(?<name>\w+)\}/.freeze
+        TEMPLATE_NAME = /(?<!\#)\{(?<name>\w+)\}/.freeze
 
         SEQUENCE = /
             % (?<type>%)


### PR DESCRIPTION
The https://bugs.ruby-lang.org/issues/19379 bug seems to apply when using `(?-x:#...)` inside a regexp with the `x` extended mode option. Escaping the `#`s seems to fix it.

Fixes #13928.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
