### PR TITLE
Fix a false negative for `Style/RedundantFreeze` when calling methods that produce frozen objects with numblocks

### DIFF
--- a/changelog/fix_false_positive_redundant_freeze_numblock.md
+++ b/changelog/fix_false_positive_redundant_freeze_numblock.md
@@ -1,0 +1,1 @@
+* [#13935](https://github.com/rubocop/rubocop/pull/13935): Fix a false negative for `Style/RedundantFreeze` when calling methods that produce frozen objects with numblocks. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -60,7 +60,7 @@ module RuboCop
             (begin (send !{(str _) array} {:+ :- :* :** :/ :%} {float int}))
             (begin (send _ {:== :=== :!= :<= :>= :< :>} _))
             (send _ {:count :length :size} ...)
-            (block (send _ {:count :length :size} ...) ...)
+            (any_block (send _ {:count :length :size} ...) ...)
           }
         PATTERN
       end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   it_behaves_like 'immutable objects', "('a' > 'b')"
   it_behaves_like 'immutable objects', '(a > b)'
   it_behaves_like 'immutable objects', '[1, 2, 3].size'
+  it_behaves_like 'immutable objects', '[1, 2, 3].count { |x| bar?(x) }'
+  it_behaves_like 'immutable objects', '[1, 2, 3].count { bar?(_1) }'
 
   shared_examples 'mutable objects' do |o|
     it "allows #{o} with freeze" do


### PR DESCRIPTION


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
