### PR TITLE
Fix false positives for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_condition.md
+++ b/changelog/fix_false_positive_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#13938](https://github.com/rubocop/rubocop/pull/13938): Fix false positives for `Style/RedundantCondition` when a variable or a constant is used. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -182,9 +182,8 @@ module RuboCop
           return false unless node.ternary? || node.if?
 
           cond = node.condition
-          if cond.call_type? && (!cond.predicate_method? || allowed_method?(cond.method_name))
-            return false
-          end
+          return false unless cond.call_type?
+          return false if !cond.predicate_method? || allowed_method?(cond.method_name)
 
           node.if_branch&.true_type? && node.else_branch && !node.else_branch.true_type?
         end

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -571,6 +571,58 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
     end
 
     context 'when `true` as the true branch' do
+      it 'does not register an offense when true is used as the true branch and the condition is a local variable' do
+        expect_no_offenses(<<~RUBY)
+          variable = do_something
+
+          if variable
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when true is used as the true branch and the condition is an instance variable' do
+        expect_no_offenses(<<~RUBY)
+          if @variable
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when true is used as the true branch and the condition is a class variable' do
+        expect_no_offenses(<<~RUBY)
+          if @@variable
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when true is used as the true branch and the condition is a global variable' do
+        expect_no_offenses(<<~RUBY)
+          if $variable
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when true is used as the true branch and the condition is a constant' do
+        expect_no_offenses(<<~RUBY)
+          if CONST
+            true
+          else
+            a
+          end
+        RUBY
+      end
+
       it 'does not register an offense when true is used as the true branch and the condition is not a predicate method' do
         expect_no_offenses(<<~RUBY)
           if a[:key]


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantCondition` when a variable or a constant is used.

This fixes false positives that were not addressed in #13919. For example, logic that transforms `variable = 42` into `variable ? true : false` should not be detected. Since it is fundamentally impossible to determine what values a variable or constant might be assigned, they are always allowed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
