### PR TITLE
[Fix #13933] Fix wrong autocorrect for `Style/KeywordParametersOrder` with comments

### DIFF
--- a/changelog/fix_wrong_autocorrect_keyword_param_order_comments.md
+++ b/changelog/fix_wrong_autocorrect_keyword_param_order_comments.md
@@ -1,0 +1,1 @@
+* [#13933](https://github.com/rubocop/rubocop/issues/13933): Fix wrong autocorrect for `Style/KeywordParametersOrder` when the arguments are on multiple lines and contain comments. ([@earlopain][])

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -156,12 +156,6 @@ module RuboCop
 
           overridden_kwargs
         end
-
-        def arguments_range(node)
-          arguments = node.arguments
-
-          range_between(arguments.first.source_range.begin_pos, arguments.last.source_range.end_pos)
-        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -34,6 +34,18 @@ module RuboCop
         range_between(node.loc.begin.end_pos, node.loc.end.begin_pos)
       end
 
+      # A range containing the first to the last argument
+      # of a method call or method definition.
+      # def foo(a, b:)
+      #         ^^^^^
+      # bar(1, 2, 3, &blk)
+      #     ^^^^^^^^^^^^^
+      # baz { |x, y:, z:| }
+      #        ^^^^^^^^^
+      def arguments_range(node)
+        node.first_argument.source_range.join(node.last_argument.source_range)
+      end
+
       def range_between(start_pos, end_pos)
         Parser::Source::Range.new(processed_source.buffer, start_pos, end_pos)
       end

--- a/lib/rubocop/cop/style/expand_path_arguments.rb
+++ b/lib/rubocop/cop/style/expand_path_arguments.rb
@@ -137,11 +137,11 @@ module RuboCop
 
           case depth(stripped_current_path)
           when 0
-            range = arguments_range(current_path)
+            range = arguments_range(current_path.parent)
 
             corrector.replace(range, '__FILE__')
           when 1
-            range = arguments_range(current_path)
+            range = arguments_range(current_path.parent)
 
             corrector.replace(range, '__dir__')
           else
@@ -184,11 +184,6 @@ module RuboCop
 
           corrector.remove(node.loc.dot)
           corrector.remove(node.loc.selector)
-        end
-
-        def arguments_range(node)
-          range_between(node.parent.first_argument.source_range.begin_pos,
-                        node.parent.last_argument.source_range.end_pos)
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -50,7 +50,7 @@ module RuboCop
             corrector.remove(range_by_whole_lines(arguments.loc.end, include_final_newline: true))
           end
 
-          arguments_range = arguments_range(node)
+          arguments_range = range_with_surrounding_space(arguments_range(node), side: :left)
           # If the method name isn't on the same line as def, move it directly after def
           if arguments_range.first_line != opening_line(node)
             corrector.remove(node.loc.name)
@@ -64,14 +64,6 @@ module RuboCop
 
         def last_line_source_of_arguments(arguments)
           processed_source[arguments.last_line - 1].strip
-        end
-
-        def arguments_range(node)
-          range = range_between(
-            node.first_argument.source_range.begin_pos, node.last_argument.source_range.end_pos
-          )
-
-          range_with_surrounding_space(range, side: :left)
         end
 
         def opening_line(node)

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -230,12 +230,6 @@ module RuboCop
             !condition.comparison_method?
         end
 
-        def arguments_range(node)
-          range_between(
-            node.first_argument.source_range.begin_pos, node.last_argument.source_range.end_pos
-          )
-        end
-
         def wrap_condition?(node)
           node.operator_keyword? || (node.call_type? && node.arguments.any? && !node.parenthesized?)
         end

--- a/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
+++ b/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
@@ -93,6 +93,18 @@ RSpec.describe RuboCop::Cop::Style::KeywordParametersOrder, :config do
     RUBY
   end
 
+  it 'registers an offense but does not autocorrect when the argument range contains comments' do
+    expect_offense(<<~RUBY)
+      def foo(optional: 123,
+              ^^^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+          # Some explanation
+          required:)
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
   it 'does not register an offense when there are no `kwoptarg`s before `kwarg`s' do
     expect_no_offenses(<<~RUBY)
       def m(arg, required:, optional: 1)


### PR DESCRIPTION
Fix #13933

There is nothing sensible to do here, except to not offer autocorrect at all. I think.

The first commit extracts a method to get the arguments range into `RangeHelp` since it already exists a few times and I was about to add another one.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
