### PR TITLE
[Fix #13794] Fix line-length breaking autoformatting for endless defs with blocks

### DIFF
--- a/changelog/fix_fix_line_length_breaking_autoformatting_with_20250303171000.md
+++ b/changelog/fix_fix_line_length_breaking_autoformatting_with_20250303171000.md
@@ -1,0 +1,1 @@
+* [#13794](https://github.com/rubocop/rubocop/issues/13794): Fix line-length breaking autoformatting for endless defs with blocks. ([@tejasbubane][])

--- a/lib/rubocop/cop/mixin/endless_method_rewriter.rb
+++ b/lib/rubocop/cop/mixin/endless_method_rewriter.rb
@@ -6,7 +6,7 @@ module RuboCop
     module EndlessMethodRewriter
       def correct_to_multiline(corrector, node)
         replacement = <<~RUBY.strip
-          def #{node.method_name}#{arguments(node)}
+          def #{method_name(node)}#{arguments(node)}
             #{node.body.source}
           end
         RUBY
@@ -15,6 +15,14 @@ module RuboCop
       end
 
       private
+
+      def method_name(node)
+        if node.receiver
+          "#{node.receiver.source}.#{node.method_name}"
+        else
+          node.method_name
+        end
+      end
 
       def arguments(node, missing = '')
         node.arguments.any? ? node.arguments.source : missing

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1022,6 +1022,61 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'Ruby >= 3.0', :ruby30 do
+      context 'endless method definition' do
+        let(:cop_config) { { 'Max' => 30 } }
+
+        context 'when under limit' do
+          it 'does not register any offense' do
+            expect_no_offenses(<<~RUBY)
+              def foo(a:, b:) = a + b
+              def foo.bar(a:, b:) = a + b
+            RUBY
+          end
+        end
+
+        context 'when over limit with block' do
+          it 'registers offense' do
+            expect_offense(<<~RUBY)
+              def citations = a_method_call[1..].map { |argument| some_method(argument) }
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [75/30]
+              def foo.citations = a_method_call[1..].map { |argument| some_method(argument) }
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [79/30]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def citations
+                a_method_call[1..].map { |argument| some_method(argument) }
+              end
+              def foo.citations
+                a_method_call[1..].map { |argument| some_method(argument) }
+              end
+            RUBY
+          end
+        end
+
+        context 'when over limit with long method name' do
+          it 'registers offense' do
+            expect_offense(<<~RUBY)
+              def citations = a_method_call_which_is_very_very_long_and_some_more(argument)
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [77/30]
+              def foo.citations = a_method_call_which_is_very_very_long_and_some_more(argument)
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [81/30]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def citations
+                a_method_call_which_is_very_very_long_and_some_more(argument)
+              end
+              def foo.citations
+                a_method_call_which_is_very_very_long_and_some_more(argument)
+              end
+            RUBY
+          end
+        end
+      end
+    end
+
     context 'method call' do
       context 'when under limit' do
         it 'does not add any offenses' do


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13794

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/