### PR TITLE
Fix incorrect disabling of departments when inheriting configuration

### DIFF
--- a/changelog/fix_disabling_of_departments_when_inheriting_configuration.md
+++ b/changelog/fix_disabling_of_departments_when_inheriting_configuration.md
@@ -1,0 +1,1 @@
+* [#13942](https://github.com/rubocop/rubocop/pull/13942): Fix incorrect disabling of departments when inheriting configuration. ([@koic][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -63,7 +63,6 @@ module RuboCop
         loaded_features = resolver.resolve_requires(path, hash)
         add_loaded_features(loaded_features)
 
-        resolver.override_department_setting_for_cops({}, hash)
         resolver.resolve_inheritance_from_gems(hash)
         resolver.resolve_inheritance(path, hash, file, debug?)
         hash.delete('inherit_from')

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -804,6 +804,12 @@ RSpec.describe RuboCop::ConfigLoader do
         it "handles EnabledByDefault: #{enabled_by_default}, " \
            "DisabledByDefault: #{disabled_by_default} with disabled #{custom_dept_to_disable}" do
           create_file('grandparent_rubocop.yml', <<~YAML)
+            Layout:
+              Enabled: false
+
+            Layout/EndOfLine:
+              Enabled: true
+
             Naming/FileName:
               Enabled: pending
 
@@ -841,6 +847,12 @@ RSpec.describe RuboCop::ConfigLoader do
               EnabledByDefault: #{enabled_by_default}
               DisabledByDefault: #{disabled_by_default}
 
+            Layout:
+              Enabled: false
+
+            Layout/LineLength:
+              Enabled: true
+
             Style:
               Enabled: false
 
@@ -869,6 +881,15 @@ RSpec.describe RuboCop::ConfigLoader do
             expect { enabled?('Foo/Bar/Baz') }.to raise_error(RuboCop::ValidationError, message)
             next
           end
+
+          # Department disabled in grandparent config.
+          expect(enabled?('Layout/DotPosition')).to be(false)
+
+          # Enabled in grandparent config, disabled in user config.
+          expect(enabled?('Layout/EndOfLine')).to be(false)
+
+          # Department disabled in grandparent config, cop enabled in user config.
+          expect(enabled?('Layout/LineLength')).to be(true)
 
           # Department disabled in parent config, cop enabled in child.
           expect(enabled?('Metrics/MethodLength')).to be(true)


### PR DESCRIPTION
This fixes an issue where departments that were disabled in `rubocop-i18n` were unexpectedly enabled, even when they were also disabled in the user configuration.

Since `override_department_setting_for_cops` is processed in `resolve_inheritance`, unnecessary calls were being made. This caused `'override_department'` to be unexpectedly set for cop's `Enabled`.
It seems that part of the configuration processing changes introduced with plugin support was missed.

Fixes https://github.com/rubocop/rubocop-i18n/issues/66.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
