### PR TITLE
Allow writing Steep annotation on the same line as `def`, `end`, `begin`, `class` and `module` in `Style/CommentedKeyword`

### DIFF
--- a/changelog/new_allow_writing_steep_annotaion_to_method_definition.md
+++ b/changelog/new_allow_writing_steep_annotaion_to_method_definition.md
@@ -1,0 +1,1 @@
+* [#13943](https://github.com/rubocop/rubocop/pull/13943): Allow writing steep annotation to method definition for `Style/CommentedKeyword`. ([@dak2][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -9,8 +9,8 @@ module RuboCop
       # These keywords are: `class`, `module`, `def`, `begin`, `end`.
       #
       # Note that some comments
-      # (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`)
-      # and RBS::Inline annotation comments are allowed.
+      # (`:nodoc:`, `:yields:`, `rubocop:disable` and `rubocop:todo`),
+      # RBS::Inline annotation, and Steep annotation (`steep:ignore`) are allowed.
       #
       # Autocorrection removes comments from `end` keyword and keeps comments
       # for `class`, `module`, `def` and `begin` above the keyword.
@@ -60,6 +60,8 @@ module RuboCop
         SUBCLASS_DEFINITION = /\A\s*class\s+(\w|::)+\s*<\s*(\w|::)+/.freeze
         METHOD_DEFINITION = /\A\s*def\s/.freeze
 
+        STEEP_REGEXP = /#\ssteep:ignore(\s|\z)/.freeze
+
         def on_new_investigation
           processed_source.comments.each do |comment|
             next unless offensive?(comment) && (match = source_line(comment).match(REGEXP))
@@ -86,6 +88,7 @@ module RuboCop
         def offensive?(comment)
           line = source_line(comment)
           return false if rbs_inline_annotation?(line, comment)
+          return false if steep_annotation?(comment)
 
           KEYWORD_REGEXES.any? { |r| r.match?(line) } &&
             ALLOWED_COMMENT_REGEXES.none? { |r| r.match?(line) }
@@ -104,6 +107,10 @@ module RuboCop
           else
             false
           end
+        end
+
+        def steep_annotation?(comment)
+          comment.text.match?(STEEP_REGEXP)
         end
       end
     end

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -352,4 +352,203 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
       end
     RUBY
   end
+
+  context 'when Steep annotation is used' do
+    it 'does not register an offense for `steep:ignore` annotation on the same line as `def`' do
+      expect_no_offenses(<<~RUBY)
+        def x # steep:ignore
+        end
+
+        def x # steep:ignore MethodBodyTypeMismatch
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `steep:ignore` annotation on the same line as `end`' do
+      expect_no_offenses(<<~RUBY)
+        def x
+        end # steep:ignore
+
+        def x
+        end # steep:ignore MethodBodyTypeMismatch
+      RUBY
+    end
+
+    it 'does not register an offense for `steep:ignore` annotation on the same line as `begin`' do
+      expect_no_offenses(<<~RUBY)
+        begin # steep:ignore
+        end
+
+        begin # steep:ignore NoMethod
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `steep:ignore` annotation on the same line as `class`' do
+      expect_no_offenses(<<~RUBY)
+        class X # steep:ignore
+        end
+
+        class X # steep:ignore UnknownConstant
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `steep:ignore` annotation on the same line as `module`' do
+      expect_no_offenses(<<~RUBY)
+        module X # steep:ignore
+        end
+
+        module X # steep:ignore UnknownConstant
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for non `steep:ignore` annotation on the same line as `def' do
+      expect_offense(<<~RUBY)
+        def x # steep
+              ^^^^^^^ Do not place comments on the same line as the `def` keyword.
+        end
+
+        def x #steep:ignore
+              ^^^^^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
+        end
+
+        def x # steep:ignoreMethodBodyTypeMismatch
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not place comments on the same line as the `def` keyword.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # steep
+        def x
+        end
+
+        #steep:ignore
+        def x
+        end
+
+        # steep:ignoreMethodBodyTypeMismatch
+        def x
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for non `steep:ignore` annotation on the same line as `end' do
+      expect_offense(<<~RUBY)
+        def x
+        end # steep
+            ^^^^^^^ Do not place comments on the same line as the `end` keyword.
+
+        def x
+        end #steep:ignore
+            ^^^^^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
+
+        def x
+        end # steep:ignoreMethodBodyTypeMismatch
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def x
+        end
+
+        def x
+        end
+
+        def x
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for non `steep:ignore` annotation on the same line as `begin' do
+      expect_offense(<<~RUBY)
+        begin # steep
+              ^^^^^^^ Do not place comments on the same line as the `begin` keyword.
+        end
+
+        begin #steep:ignore
+              ^^^^^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
+        end
+
+        begin # steep:ignoreUnknownConstant
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # steep
+        begin
+        end
+
+        #steep:ignore
+        begin
+        end
+
+        # steep:ignoreUnknownConstant
+        begin
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for non `steep:ignore` annotation on the same line as `class' do
+      expect_offense(<<~RUBY)
+        class X # steep
+                ^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+
+        class X #steep:ignore
+                ^^^^^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+
+        class X # steep:ignoreUnknownConstant
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # steep
+        class X
+        end
+
+        #steep:ignore
+        class X
+        end
+
+        # steep:ignoreUnknownConstant
+        class X
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for non `steep:ignore` annotation on the same line as `module' do
+      expect_offense(<<~RUBY)
+        module X # steep
+                 ^^^^^^^ Do not place comments on the same line as the `module` keyword.
+        end
+
+        module X #steep:ignore
+                 ^^^^^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
+        end
+
+        module X # steep:ignoreUnknownConstant
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # steep
+        module X
+        end
+
+        #steep:ignore
+        module X
+        end
+
+        # steep:ignoreUnknownConstant
+        module X
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
[Steep](https://github.com/soutaro/steep) is a type checker for Ruby.

Under certain circumstances, if the programmer writes `steep:ignore`, Steep will not do any type checking.

In particular, `steep:ignore` can be written on the same line as `def`, `end`, `begin`, `class` and `module` , but it is rejected by the `Style/CommentedKeyword` rules.

Another way to do this is to add options, but once an option is added, it is difficult to remove it, so the default rule written.

Also, it is unlikely that you would write `steep:ignore` if you were not using steep, so I defined it as a default rule.

refs: https://github.com/soutaro/steep/wiki/Release-Note-1.7#ignore-diagnostics-by-steepignore-comment

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
