### PR TITLE
[Fix #13941] Fix false negative from `Lint/UselessConstantScoping` for class and module definitions

### DIFF
--- a/changelog/fix_fix_false_negative_from_20250304141816.md
+++ b/changelog/fix_fix_false_negative_from_20250304141816.md
@@ -1,0 +1,1 @@
+* [#13941](https://github.com/rubocop/rubocop/issues/13941): Fix false negative from `Lint/UselessConstantScoping` for class and module definitions. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -45,15 +45,26 @@ module RuboCop
           (send nil? :private_constant $...)
         PATTERN
 
-        def on_casgn(node)
-          return if node.each_ancestor(:sclass).any?
-          return unless after_private_modifier?(node.left_siblings)
-          return if private_constantize?(node.right_siblings, node.name)
+        def on_class(node)
+          check_node(node)
+        end
+        alias on_module on_class
 
-          add_offense(node)
+        def on_casgn(node)
+          check_node(node)
         end
 
         private
+
+        def check_node(node)
+          return if node.each_ancestor(:sclass).any?
+          return unless after_private_modifier?(node.left_siblings)
+
+          name = node.type?(:class, :module) ? node.identifier : node.name
+          return if private_constantize?(node.right_siblings, name)
+
+          add_offense(node)
+        end
 
         def after_private_modifier?(left_siblings)
           access_modifier_candidates = left_siblings.compact.select do |left_sibling|

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -46,6 +46,46 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
     RUBY
   end
 
+  it 'registers an offense when defining class after `private` access modifier' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+        class Bar; end
+        ^^^^^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when defining class constant after `private` access modifier' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+        Bar = Class.new
+        ^^^^^^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when defining module after `private` access modifier' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+        module Bar; end
+        ^^^^^^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
+  it 'does not register offense when class and module are defined without access modifiers' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        class Bar; end
+        Baz = Class.new
+        module Qux; end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using constant' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13941

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/