### PR TITLE
Fix a false positive for `Style/DoubleNegation` when calling `define_method` with a numblock

### DIFF
--- a/changelog/fix_double_negation_numblock.md
+++ b/changelog/fix_double_negation_numblock.md
@@ -1,0 +1,1 @@
+* [#13945](https://github.com/rubocop/rubocop/pull/13945): Fix a false positive for `Style/DoubleNegation` when calling `define_method`/`define_singleton_method` with a numblock. ([@earlopain][])

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -109,7 +109,7 @@ module RuboCop
         end
 
         def define_method?(node)
-          return false unless node.block_type?
+          return false unless node.any_block_type?
 
           child = node.child_nodes.first
           return false unless child.send_type?

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -502,6 +502,15 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
       RUBY
     end
 
+    it 'does not register an offense for `!!` when return location by `define_method` with numblock' do
+      expect_no_offenses(<<~RUBY)
+        define_method :foo? do
+          do_something(_1)
+          !!qux
+        end
+      RUBY
+    end
+
     it 'does not register an offense for `!!` when return location by `define_singleton_method`' do
       expect_no_offenses(<<~RUBY)
         define_singleton_method :foo? do


### PR DESCRIPTION
Same as https://github.com/rubocop/rubocop/pull/10587

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
