### PR TITLE
Fix some false positives for `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: omit_parentheses` style and numblocks

### DIFF
--- a/changelog/fix_method_call_args_numblock.md
+++ b/changelog/fix_method_call_args_numblock.md
@@ -1,0 +1,1 @@
+* [#13946](https://github.com/rubocop/rubocop/pull/13946): Fix some false positives for `Style/MethodCallWithArgsParentheses` with `EnforcedStyle: omit_parentheses` style and numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -108,7 +108,7 @@ module RuboCop
           end
 
           def call_in_literals?(node)
-            parent = node.parent&.block_type? ? node.parent.parent : node.parent
+            parent = node.parent&.any_block_type? ? node.parent.parent : node.parent
             return false unless parent
 
             parent.type?(:pair, :array, :range) ||
@@ -117,7 +117,7 @@ module RuboCop
           end
 
           def call_in_logical_operators?(node)
-            parent = node.parent&.block_type? ? node.parent.parent : node.parent
+            parent = node.parent&.any_block_type? ? node.parent.parent : node.parent
             return false unless parent
 
             logical_operator?(parent) ||
@@ -153,7 +153,7 @@ module RuboCop
           end
 
           def call_in_argument_with_block?(node)
-            parent = node.parent&.block_type? && node.parent.parent
+            parent = node.parent&.any_block_type? && node.parent.parent
             return false unless parent
 
             parent.type?(:call, :super, :yield)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -839,12 +839,30 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       RUBY
     end
 
+    it 'accepts parens in array literal calls with numblocks' do
+      expect_no_offenses(<<~RUBY)
+        [
+          foo.bar.quux(:args) do
+            pass _1
+          end,
+        ]
+      RUBY
+    end
+
     it 'accepts parens in calls with logical operators' do
       expect_no_offenses('foo(a) && bar(b)')
       expect_no_offenses('foo(a) || bar(b)')
       expect_no_offenses(<<~RUBY)
         foo(a) || bar(b) do
           pass
+        end
+      RUBY
+    end
+
+    it 'accepts parens in calls with logical operator and numblock' do
+      expect_no_offenses(<<~RUBY)
+        foo(a) || bar(b) do
+          pass _1
         end
       RUBY
     end
@@ -1152,6 +1170,16 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           foo(
             bar.new(quux) do
               pass
+            end
+          )
+        RUBY
+      end
+
+      it 'accepts parens in argument calls with numblocks' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            bar.new(quux) do
+              pass _1
             end
           )
         RUBY


### PR DESCRIPTION
Some of this syntax is actually currently allowed on Ruby 3.4 with prism. See https://bugs.ruby-lang.org/issues/21168

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
