### PR TITLE
Fix a false negative for `Lint/UselessConstantScoping` for constants defined in `class << self`

### DIFF
--- a/changelog/fix_false_negative_useless_constant_scoping_sclass.md
+++ b/changelog/fix_false_negative_useless_constant_scoping_sclass.md
@@ -1,0 +1,1 @@
+* [#13947](https://github.com/rubocop/rubocop/pull/13947): Fix a false negative for `Lint/UselessConstantScoping` for constants defined in `class << self`. ([@earlopain][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -38,7 +38,6 @@ module RuboCop
         PATTERN
 
         def on_casgn(node)
-          return if node.each_ancestor(:sclass).any?
           return unless after_private_modifier?(node.left_siblings)
           return if private_constantize?(node.right_siblings, node.name)
 

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -54,12 +54,25 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
     RUBY
   end
 
-  it 'does not register an offense when using constant after `private` access modifier in `class << self`' do
+  it 'registers an offense when using constant after `private` access modifier in `class << self`' do
+    expect_offense(<<~RUBY)
+      class Foo
+        class << self
+          private
+          CONST = 42
+          ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using constant after `private` access modifier in `class << self` with `private_constant`' do
     expect_no_offenses(<<~RUBY)
       class Foo
         class << self
           private
           CONST = 42
+          private_constant :CONST
         end
       end
     RUBY


### PR DESCRIPTION
Followup to https://github.com/rubocop/rubocop/commit/d83d67b7847d12e6c31c06cf2847b28997f669b2
Also see https://github.com/rubocop/rubocop/pull/13831#issuecomment-2697843782

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
