### PR TITLE
Fix wrong autocorrect for `Style/RescueModifier` when mllhs and the right-hand-side is not a bracketed array

### DIFF
--- a/changelog/fix_wrong_autocorrect_rescue_modifier_mlhs.md
+++ b/changelog/fix_wrong_autocorrect_rescue_modifier_mlhs.md
@@ -1,0 +1,1 @@
+* [#13948](https://github.com/rubocop/rubocop/pull/13948): Fix wrong autocorrect for `Style/RescueModifier` when using parallel assignment and the right-hand-side is not a bracketed array. ([@earlopain][])

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -67,11 +67,13 @@ module RuboCop
           node.parent && parentheses?(node.parent)
         end
 
+        # rubocop:disable Metrics/AbcSize
         def correct_rescue_block(corrector, node, parenthesized)
           operation = node.body
 
           node_indentation, node_offset = indentation_and_offset(node, parenthesized)
 
+          corrector.wrap(operation, '[', ']') if operation.array_type? && !operation.bracketed?
           corrector.remove(range_between(operation.source_range.end_pos, node.source_range.end_pos))
           corrector.insert_before(operation, "begin\n#{node_indentation}")
           corrector.insert_after(heredoc_end(operation) || operation, <<~RESCUE_CLAUSE.chop)
@@ -81,6 +83,7 @@ module RuboCop
             #{node_offset}end
           RESCUE_CLAUSE
         end
+        # rubocop:enable Metrics/AbcSize
 
         def indentation_and_offset(node, parenthesized)
           node_indentation = indentation(node)

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -103,12 +103,28 @@ RSpec.describe RuboCop::Cop::Style::RescueModifier, :config do
       a, b = 1, 2 rescue nil
       ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
     RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        a, b = 1, 2
+      rescue
+        nil
+      end
+    RUBY
   end
 
   it 'registers an offense for modifier rescue around parallel assignment', :ruby27 do
     expect_offense(<<~RUBY)
       a, b = 1, 2 rescue nil
              ^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a, b = begin
+               [1, 2]
+             rescue
+               nil
+             end
     RUBY
   end
 


### PR DESCRIPTION
It previously put the statement as is (`1, 2`), but that is not valid syntax on its own.

Found with https://github.com/rubocop/rubocop/pull/13183

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
