### PR TITLE
Fix a false negatives for `Lint/NonLocalExitFromIterator` with numblocks

### DIFF
--- a/changelog/fix_false_negatives_nonlocal_exit_numblocks.md
+++ b/changelog/fix_false_negatives_nonlocal_exit_numblocks.md
@@ -1,0 +1,1 @@
+* [#13949](https://github.com/rubocop/rubocop/pull/13949): Fix a false negative for `Lint/NonLocalExitFromIterator` with numblocks. ([@earlopain][])

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -46,7 +46,7 @@ module RuboCop
         def on_return(return_node)
           return if return_value?(return_node)
 
-          return_node.each_ancestor(:block, :def, :defs) do |node|
+          return_node.each_ancestor(:any_block, :def, :defs) do |node|
             break if scoped_node?(node)
 
             # if a proc is passed to `Module#define_method` or
@@ -54,7 +54,7 @@ module RuboCop
             # non-local exit error
             break if define_method?(node.send_node)
 
-            next unless node.arguments?
+            next if node.argument_list.empty?
 
             if chained_send?(node.send_node)
               add_offense(return_node.loc.keyword)

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe RuboCop::Cop::Lint::NonLocalExitFromIterator, :config do
           end
         RUBY
       end
+
+      it 'registers an offense for numblocks' do
+        expect_offense(<<~RUBY)
+          items.each do
+            return if baz?(_1)
+            ^^^^^^ Non-local exit from iterator, [...]
+            _1.update!(foobar: true)
+          end
+        RUBY
+      end
     end
 
     context 'and has multiple arguments' do


### PR DESCRIPTION
`numblock.arguments?` always returns false for numblocks. `argument_list` is aware of other block types and includes implicit args like `_1`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
