### PR TITLE
Tweak the offense message for `Style/ExponentialNotation`

### DIFF
--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -60,8 +60,8 @@ module RuboCop
       class ExponentialNotation < Base
         include ConfigurableEnforcedStyle
         MESSAGES = {
-          scientific: 'Use a mantissa in [1, 10[.',
-          engineering: 'Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.',
+          scientific: 'Use a mantissa >= 1 and < 10.',
+          engineering: 'Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.',
           integral: 'Use an integer as mantissa, without trailing zero.'
         }.freeze
 

--- a/spec/rubocop/cop/style/exponential_notation_spec.rb
+++ b/spec/rubocop/cop/style/exponential_notation_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe RuboCop::Cop::Style::ExponentialNotation, :config do
     it 'registers an offense for mantissa equal to 10' do
       expect_offense(<<~RUBY)
         10e6
-        ^^^^ Use a mantissa in [1, 10[.
+        ^^^^ Use a mantissa >= 1 and < 10.
       RUBY
     end
 
     it 'registers an offense for mantissa greater than 10' do
       expect_offense(<<~RUBY)
         12.34e3
-        ^^^^^^^ Use a mantissa in [1, 10[.
+        ^^^^^^^ Use a mantissa >= 1 and < 10.
       RUBY
     end
 
     it 'registers an offense for mantissa smaller than 1' do
       expect_offense(<<~RUBY)
         0.314e1
-        ^^^^^^^ Use a mantissa in [1, 10[.
+        ^^^^^^^ Use a mantissa >= 1 and < 10.
       RUBY
     end
 
@@ -56,35 +56,35 @@ RSpec.describe RuboCop::Cop::Style::ExponentialNotation, :config do
     it 'registers an offense for exponent equal to 4' do
       expect_offense(<<~RUBY)
         10e4
-        ^^^^ Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.
+        ^^^^ Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.
       RUBY
     end
 
     it 'registers an offense for exponent equal to -2' do
       expect_offense(<<~RUBY)
         12.3e-2
-        ^^^^^^^ Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.
+        ^^^^^^^ Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.
       RUBY
     end
 
     it 'registers an offense for mantissa smaller than 0.1' do
       expect_offense(<<~RUBY)
         0.09e9
-        ^^^^^^ Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.
+        ^^^^^^ Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.
       RUBY
     end
 
     it 'registers an offense for a mantissa greater than -0.1' do
       expect_offense(<<~RUBY)
         -0.09e3
-        ^^^^^^^ Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.
+        ^^^^^^^ Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.
       RUBY
     end
 
     it 'registers an offense for mantissa smaller than -1000' do
       expect_offense(<<~RUBY)
         -1012.34e6
-        ^^^^^^^^^^ Use an exponent divisible by 3 and a mantissa in [0.1, 1000[.
+        ^^^^^^^^^^ Use an exponent divisible by 3 and a mantissa >= 0.1 and < 1000.
       RUBY
     end
 


### PR DESCRIPTION
The current offense message uses the potentially obscure `[1, 10[` form for an exclusive range. Using a ruby exclusive range is clearer for ruby developers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
