### PR TITLE
[Fix #13950] Obsoletion cache can be broken

### DIFF
--- a/changelog/fix_obsoletion_cache_broken.md
+++ b/changelog/fix_obsoletion_cache_broken.md
@@ -1,0 +1,1 @@
+* [#13950](https://github.com/rubocop/rubocop/pull/13950): Fix sporadic errors about `rubocop-rails` or `rubocop-performance` extraction, even if they are already part of the Gemfile. ([@earlopain][])

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -50,7 +50,7 @@ module RuboCop
     # Default rules for obsoletions are in config/obsoletion.yml
     # Additional rules files can be added with `RuboCop::ConfigObsoletion.files << filename`
     def load_rules # rubocop:disable Metrics/AbcSize
-      rules = LOAD_RULES_CACHE[self.class.files] ||=
+      rules = LOAD_RULES_CACHE[self.class.files.hash] ||=
         self.class.files.each_with_object({}) do |filename, hash|
           hash.merge!(YAML.safe_load(File.read(filename)) || {}) do |_key, first, second|
             case first


### PR DESCRIPTION
Fix #13950

The `LOAD_RULES_CACHE` uses a _shared_ array, which can cause the index to become damaged. So, although the array has been modified, stale data is returned, causing the extension to ignore that is was loaded from a gem.

No tests for this one because I have no idea how and it would be incredibly specific anyways.

rehashing seems to be occasionally be performed by ruby, this demonstrates the problem:

```rb
array = []
hash = {}

hash[array] = "ok"

pp hash[array] # => "ok"

array << "added"

pp hash[array] # => nil

# Ruby does this sometimes
hash.rehash

pp hash[array] # => "ok"

```

Also see https://docs.ruby-lang.org/en/master/Hash.html#class-Hash-label-Modifying+an+Active+Hash+Key

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
