### PR TITLE
Remove no longer needed workaround for `regexp_parser` bug

### DIFF
--- a/lib/rubocop/ext/regexp_node.rb
+++ b/lib/rubocop/ext/regexp_node.rb
@@ -43,7 +43,6 @@ module RuboCop
       def named_capturing?(exp, event, named)
         event == :enter &&
           named == exp.respond_to?(:name) &&
-          !exp.text.start_with?('(?<=') &&
           exp.respond_to?(:capturing?) &&
           exp.capturing?
       end


### PR DESCRIPTION
This code was added in https://github.com/rubocop/rubocop/commit/075d4d5d7597c2b179a90f76a2a9fc886465ecb9 but actually works around a bug in `regexp_parser` that was fixed in 2.9.3 with https://github.com/ammar/regexp_parser/pull/94

It's now the minimum supported version so the workaround can just be removed

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
