### PR TITLE
Fix a false negative for `Lint/ReturnInVoidContext` when returning out of a block

### DIFF
--- a/changelog/fix_false_negative_return_in_void_context.md
+++ b/changelog/fix_false_negative_return_in_void_context.md
@@ -1,0 +1,1 @@
+* [#13960](https://github.com/rubocop/rubocop/pull/13960): Fix a false negative for `Lint/ReturnInVoidContext` when returning out of a block. ([@earlopain][])

--- a/lib/rubocop/cop/lint/return_in_void_context.rb
+++ b/lib/rubocop/cop/lint/return_in_void_context.rb
@@ -35,21 +35,14 @@ module RuboCop
         def on_return(return_node)
           return unless return_node.descendants.any?
 
-          context_node = non_void_context(return_node)
-
-          return unless context_node&.def_type?
-          return unless context_node&.void_context?
+          def_node = return_node.each_ancestor(:def).first
+          return unless def_node&.void_context?
+          return if return_node.each_ancestor(:any_block).any?(&:lambda?)
 
           add_offense(
             return_node.loc.keyword,
-            message: format(message, method: context_node.method_name)
+            message: format(message, method: def_node.method_name)
           )
-        end
-
-        private
-
-        def non_void_context(return_node)
-          return_node.each_ancestor(:block, :def, :defs).first
         end
       end
     end

--- a/spec/rubocop/cop/lint/return_in_void_context_spec.rb
+++ b/spec/rubocop/cop/lint/return_in_void_context_spec.rb
@@ -12,6 +12,58 @@ RSpec.describe RuboCop::Cop::Lint::ReturnInVoidContext, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when the value is returned in a block' do
+      expect_offense(<<~RUBY)
+        class A
+          def initialize
+            foo do
+              return :qux
+              ^^^^^^ Do not return a value in `initialize`.
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the value is returned in a numblock' do
+      expect_offense(<<~RUBY)
+        class A
+          def initialize
+            foo do
+              _1
+              return :qux
+              ^^^^^^ Do not return a value in `initialize`.
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the value is returned from inside a proc' do
+      expect_offense(<<~RUBY)
+        class A
+          def initialize
+            proc do
+              return :qux
+              ^^^^^^ Do not return a value in `initialize`.
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers no offense when the value is returned from inside a lamdba' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          def initialize
+            lambda do
+              return :qux
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with an initialize method containing a return without a value' do
@@ -20,6 +72,18 @@ RSpec.describe RuboCop::Cop::Lint::ReturnInVoidContext, :config do
         class A
           def initialize
             return if bar?
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts when the return is in a block' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          def initialize
+            foo do
+              return if bar?
+            end
           end
         end
       RUBY


### PR DESCRIPTION
Should be block happen to be called, the return will break out of the block and attribute the return value to the method.
This has been that way since the cop was added and there were no tests for blocks.

The only expection to the rule is when returning from inside a lambda.

Additionally, I simplified the implementation. The cop looked for `sdef` but then immediatly after required that the node be simply `def`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
