### PR TITLE
Make `Lint/RedundantTypeConversion` aware of redundant `to_d`

### DIFF
--- a/changelog/change_make_lint_redundant_type_conversion_aware_of_redundant_to_d.md
+++ b/changelog/change_make_lint_redundant_type_conversion_aware_of_redundant_to_d.md
@@ -1,0 +1,1 @@
+* [#13967](https://github.com/rubocop/rubocop/pull/13967): Make `Lint/RedundantTypeConversion` aware of redundant `to_d`. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -3,13 +3,13 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for redundant uses of `to_s`, `to_sym`, `to_i`, `to_f`, `to_r`, `to_c`,
+      # Checks for redundant uses of `to_s`, `to_sym`, `to_i`, `to_f`, `to_d`, `to_r`, `to_c`,
       # `to_a`, `to_h`, and `to_set`.
       #
       # When one of these methods is called on an object of the same type, that object
       # is returned, making the call unnecessary. The cop detects conversion methods called
       # on object literals, class constructors, class `[]` methods, and the `Kernel` methods
-      # `String()`, `Integer()`, `Float()`, `Rational()`, `Complex()` and `Array()`.
+      # `String()`, `Integer()`, `Float()`, BigDecimal(), `Rational()`, `Complex()`, and `Array()`.
       #
       # Specifically, these cases are detected for each conversion method:
       #
@@ -98,6 +98,7 @@ module RuboCop
           to_s: 'string_constructor?',
           to_i: 'integer_constructor?',
           to_f: 'float_constructor?',
+          to_d: 'bigdecimal_constructor?',
           to_r: 'rational_constructor?',
           to_c: 'complex_constructor?',
           to_a: 'array_constructor?',
@@ -110,7 +111,7 @@ module RuboCop
         TYPED_METHODS = { to_s: %i[inspect] }.freeze
 
         CONVERSION_METHODS = Set[*LITERAL_NODE_TYPES.keys].freeze
-        RESTRICT_ON_SEND = CONVERSION_METHODS
+        RESTRICT_ON_SEND = CONVERSION_METHODS + [:to_d]
 
         private_constant :LITERAL_NODE_TYPES, :CONSTRUCTOR_MAPPING
 
@@ -135,6 +136,11 @@ module RuboCop
         # @!method float_constructor?(node)
         def_node_matcher :float_constructor?, <<~PATTERN
           #type_constructor?(:Float)
+        PATTERN
+
+        # @!method bigdecimal_constructor?(node)
+        def_node_matcher :bigdecimal_constructor?, <<~PATTERN
+          #type_constructor?(:BigDecimal)
         PATTERN
 
         # @!method rational_constructor?(node)

--- a/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
@@ -248,6 +248,18 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'accepted', 'Float("number", exception: false).to_f'
   end
 
+  describe '`to_d`' do
+    it_behaves_like 'conversion', :to_d
+
+    it_behaves_like 'offense', :to_d, 'BigDecimal(42)'
+    it_behaves_like 'offense', :to_d, 'Kernel::BigDecimal(42)'
+    it_behaves_like 'offense', :to_d, '::Kernel::BigDecimal(42)'
+    it_behaves_like 'offense', :to_d, 'BigDecimal("number", exception: true)'
+
+    it_behaves_like 'accepted', 'BigDecimal("number", exception: false).to_d'
+    it_behaves_like 'accepted', 'BigDecimal(obj, n, exception: false).to_d'
+  end
+
   describe '`to_r`' do
     it_behaves_like 'conversion', :to_r
 


### PR DESCRIPTION
This PR makes `Lint/RedundantTypeConversion` aware of redundant `to_d`.

```ruby
require 'bigdecimal/util'

BigDecimal(42).to_d == BigDecimal(42) # => true
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
