### PR TITLE
Fix `InternalAffairs/RedundantDescribedClassAsSubject` cop error on missing `describe`

### DIFF
--- a/changelog/fix_internal_affairs_redundant_described_class_as_subject_cop_error_20250309144628.md
+++ b/changelog/fix_internal_affairs_redundant_described_class_as_subject_cop_error_20250309144628.md
@@ -1,0 +1,1 @@
+* [#13968](https://github.com/rubocop/rubocop/pull/13968): Fix `InternalAffairs/RedundantDescribedClassAsSubject` cop error on missing `describe`. ([@viralpraxis][])

--- a/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_described_class_as_subject.rb
@@ -37,14 +37,14 @@ module RuboCop
           return if described_class_arguments.count >= 2
 
           describe = find_describe_method_node(node)
-
-          unless (exist_config = describe.last_argument.source == ':config')
-            additional_message = ' and specify `:config` in `describe`'
-          end
+          exist_config = describe && describe.last_argument.source == ':config'
+          additional_message = ' and specify `:config` in `describe`' unless exist_config
 
           message = format(MSG, additional_message: additional_message)
 
           add_offense(node, message: message) do |corrector|
+            next unless describe
+
             corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
 
             corrector.insert_after(describe.last_argument, ', :config') unless exist_config
@@ -54,7 +54,9 @@ module RuboCop
         private
 
         def find_describe_method_node(block_node)
-          block_node.ancestors.find { |node| node.block_type? && node.method?(:describe) }.send_node
+          block_node.ancestors.find do |node|
+            node.block_type? && node.method?(:describe)
+          end&.send_node
         end
       end
     end

--- a/spec/rubocop/cop/internal_affairs/redundant_described_class_as_subject_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_described_class_as_subject_spec.rb
@@ -62,4 +62,16 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantDescribedClassAsSubject, 
       end
     RUBY
   end
+
+  it 'registers an offense without `describe` DSL' do
+    expect_offense(<<~RUBY)
+      shared_context "shared cop context" do
+        subject(:cop) { described_class.new }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant `subject` and specify `:config` in `describe`.
+        let(:config) { RuboCop::Config.new }
+      end
+    RUBY
+
+    expect_no_corrections
+  end
 end


### PR DESCRIPTION
This cops raises within `shared_{context,example}` DSL (when `describe` is missing)

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
