### PR TITLE
[Fix #13969] Fix a false positive for `Lint/SharedMutableDefault`

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_shared_mutable_default.md
+++ b/changelog/fix_a_false_positive_for_lint_shared_mutable_default.md
@@ -1,0 +1,1 @@
+* [#13969](https://github.com/rubocop/rubocop/issues/13969): Fix a false positive for `Lint/SharedMutableDefault` when `capacity` keyword argument is used. ([@koic][])

--- a/lib/rubocop/cop/lint/shared_mutable_default.rb
+++ b/lib/rubocop/cop/lint/shared_mutable_default.rb
@@ -51,7 +51,18 @@ module RuboCop
 
         # @!method hash_initialized_with_mutable_shared_object?(node)
         def_node_matcher :hash_initialized_with_mutable_shared_object?, <<~PATTERN
-          (send (const {nil? cbase} :Hash) :new {array hash (send (const {nil? cbase} {:Array :Hash}) :new)})
+          {
+            (send (const {nil? cbase} :Hash) :new [
+              {array hash (send (const {nil? cbase} {:Array :Hash}) :new)}
+              !#capacity_keyword_argument?
+            ])
+            (send (const {nil? cbase} :Hash) :new hash #capacity_keyword_argument?)
+          }
+        PATTERN
+
+        # @!method capacity_keyword_argument?(node)
+        def_node_matcher :capacity_keyword_argument?, <<~PATTERN
+          (hash (pair (sym :capacity) _))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/lint/shared_mutable_default_spec.rb
+++ b/spec/rubocop/cop/lint/shared_mutable_default_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe RuboCop::Cop::Lint::SharedMutableDefault, :config do
     end
   end
 
+  context 'when `capacity` keyword argument is used' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        Hash.new(capacity: 42)
+      RUBY
+    end
+  end
+
   context 'when Hash is initialized with an array' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
@@ -56,6 +64,15 @@ RSpec.describe RuboCop::Cop::Lint::SharedMutableDefault, :config do
         ^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
         Hash.new(Hash.new)
         ^^^^^^^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
+      RUBY
+    end
+  end
+
+  context 'when Hash is initialized with a Hash and `capacity` keyword argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        Hash.new({}, capacity: 42)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes a false positive for `Lint/SharedMutableDefault` when `capacity` keyword argument is used.

NOTE: The `minimum_target_ruby_version: 3.4` is intentionally not specified. A false negative may occur in Ruby 3.3 or earlier, but the intent behind upgrading to Ruby 3.4 is prioritized.

Fixes #13969.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
