### PR TITLE
Fix false alarm for config obsoletion

### DIFF
--- a/changelog/fix_false_alarm_for_extracted_cop.md
+++ b/changelog/fix_false_alarm_for_extracted_cop.md
@@ -1,0 +1,1 @@
+* [#13971](https://github.com/rubocop/rubocop/pull/13971): Fix false alarm for config obsoletion. ([@koic][])

--- a/lib/rubocop/config_obsoletion/extracted_cop.rb
+++ b/lib/rubocop/config_obsoletion/extracted_cop.rb
@@ -15,7 +15,7 @@ module RuboCop
       end
 
       def violated?
-        return false if feature_loaded?
+        return false if plugin_loaded?
 
         affected_cops.any?
       end
@@ -38,8 +38,9 @@ module RuboCop
         end
       end
 
-      def feature_loaded?
-        config.loaded_features.include?(gem)
+      def plugin_loaded?
+        # Plugins loaded via `require` are included in `loaded_features`.
+        config.loaded_plugins.include?(gem) || config.loaded_features.include?(gem)
       end
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/13950#issuecomment-2709112256

This prevents an unexpected warning that occurred because the config obsoletion was not considered in the plugin system introduced in #13792.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
