### PR TITLE
[Fix #13965] Update `Lint/RedundantCopDisableDirective` to register an offense when cop names are given with improper casing

### DIFF
--- a/changelog/fix_update_lint_redundant_cop_disable_directive_to_20250310151635.md
+++ b/changelog/fix_update_lint_redundant_cop_disable_directive_to_20250310151635.md
@@ -1,0 +1,1 @@
+* [#13965](https://github.com/rubocop/rubocop/issues/13965): Update `Lint/RedundantCopDisableDirective` to register an offense when cop names are given with improper casing. ([@dvandersluis][])

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -12,7 +12,7 @@ module RuboCop
     # @api private
     LINT_SYNTAX_COP = "#{LINT_DEPARTMENT}/Syntax"
     # @api private
-    COP_NAME_PATTERN = '([A-Z]\w+/)*(?:[A-Z]\w+)'
+    COP_NAME_PATTERN = '([A-Za-z]\w+/)*(?:[A-Za-z]\w+)'
     # @api private
     COP_NAMES_PATTERN = "(?:#{COP_NAME_PATTERN} , )*#{COP_NAME_PATTERN}"
     # @api private

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -266,6 +266,28 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
               RUBY
             end
+
+            context 'when the department starts with a lowercase letter' do
+              it 'registers an offense' do
+                expect_offense(<<~RUBY)
+                  # rubocop:disable lint/SelfAssignment
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `lint/SelfAssignment` (did you mean `Lint/SelfAssignment`?).
+                RUBY
+
+                expect_correction('')
+              end
+            end
+
+            context 'when the cop starts with a lowercase letter' do
+              it 'registers an offense' do
+                expect_offense(<<~RUBY)
+                  # rubocop:disable Lint/selfAssignment
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Lint/selfAssignment` (did you mean `Lint/SelfAssignment`?).
+                RUBY
+
+                expect_correction('')
+              end
+            end
           end
 
           context 'all cops' do


### PR DESCRIPTION
This change allows the cop to report offenses for disabled cops with incorrect letter casing. The disable is redundant because cop names are case-sensitive, but the offense will point out the proper cop name.

Fixes #13965.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
