### PR TITLE
[Fix #13975] Fix false positives for `Style/RedundantCurrentDirectoryInPath`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_current_directory_in_path.md
+++ b/changelog/fix_false_positives_for_style_redundant_current_directory_in_path.md
@@ -1,0 +1,1 @@
+* [#13975](https://github.com/rubocop/rubocop/issues/13975): Fix false positives for `Style/RedundantCurrentDirectoryInPath` when using a complex current directory path in `require_relative`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -20,19 +20,29 @@ module RuboCop
 
         MSG = 'Remove the redundant current directory path.'
         RESTRICT_ON_SEND = %i[require_relative].freeze
-        CURRENT_DIRECTORY_PATH = './'
+        CURRENT_DIRECTORY_PREFIX = %r{./+}.freeze
+        REDUNDANT_CURRENT_DIRECTORY_PREFIX = /\A#{CURRENT_DIRECTORY_PREFIX}/.freeze
 
         def on_send(node)
           return unless (first_argument = node.first_argument)
-          return unless first_argument.str_content&.start_with?(CURRENT_DIRECTORY_PATH)
-          return unless (index = first_argument.source.index(CURRENT_DIRECTORY_PATH))
+          return unless (index = first_argument.source.index(CURRENT_DIRECTORY_PREFIX))
+          return unless (redundant_length = redundant_path_length(first_argument.str_content))
 
           begin_pos = first_argument.source_range.begin.begin_pos + index
-          range = range_between(begin_pos, begin_pos + 2)
+          end_pos = begin_pos + redundant_length
+          range = range_between(begin_pos, end_pos)
 
           add_offense(range) do |corrector|
             corrector.remove(range)
           end
+        end
+
+        private
+
+        def redundant_path_length(path)
+          return unless (match = path&.match(REDUNDANT_CURRENT_DIRECTORY_PREFIX))
+
+          match[0].length
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
+++ b/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
     RUBY
   end
 
+  it "registers an offense when using a complex current directory path in `require_relative '...'`" do
+    expect_offense(<<~RUBY)
+      require_relative './//./../path/to/feature'
+                        ^^^^ Remove the redundant current directory path.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      require_relative '../path/to/feature'
+    RUBY
+  end
+
   it 'registers an offense when using a current directory path in `require_relative %q(...)`' do
     expect_offense(<<~RUBY)
       require_relative %q(./path/to/feature)
@@ -37,6 +48,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
   it 'does not register an offense when using a parent directory path in `require_relative`' do
     expect_no_offenses(<<~RUBY)
       require_relative '../path/to/feature'
+    RUBY
+  end
+
+  it 'does not register an offense when using a path that starts with a dot in `require_relative`' do
+    expect_no_offenses(<<~RUBY)
+      require_relative '.path'
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantCurrentDirectoryInPath` when using a complex current directory path in `require_relative`.

Fixes #13975.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
