### PR TITLE
Allow `TLS1_1` and `TLS1_2` by default in `Naming/VariableNumber`

### DIFF
--- a/changelog/change_allow_tls_1_1_and_tls_1_2_in_naming_variable_number.md
+++ b/changelog/change_allow_tls_1_1_and_tls_1_2_in_naming_variable_number.md
@@ -1,0 +1,1 @@
+* [#13977](https://github.com/rubocop/rubocop/issues/13977): Allow `TLS1_1` and `TLS1_2` by default in `Naming/VariableNumber` to accommodate OpenSSL version parameter names. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3104,6 +3104,8 @@ Naming/VariableNumber:
   CheckMethodNames: true
   CheckSymbols: true
   AllowedIdentifiers:
+    - TLS1_1       # OpenSSL::SSL::TLS1_1_VERSION
+    - TLS1_2       # OpenSSL::SSL::TLS1_2_VERSION
     - capture3     # Open3.capture3
     - iso8601      # Time#iso8601
     - rfc1123_date # CGI.rfc1123_date

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -746,7 +746,9 @@ RSpec.describe RuboCop::ConfigLoader do
           .to contain_exactly('foo.rb', 'test.rb')
         expect(examples_configuration['Include']).to contain_exactly('bar.rb', 'another_test.rb')
         expect(examples_configuration['AllowedIdentifiers'])
-          .to match_array(%w[capture3 iso8601 rfc1123_date rfc2822 rfc3339 rfc822 iso2 x86_64])
+          .to match_array(
+            %w[TLS1_1 TLS1_2 capture3 iso8601 rfc1123_date rfc2822 rfc3339 rfc822 iso2 x86_64]
+          )
         expect(examples_configuration['InheritedArraySpecifiedString']).to contain_exactly(
           'bare string',
           'string in array'


### PR DESCRIPTION
This PR allows `TLS1_1` and `TLS1_2` by default in `Naming/VariableNumber`. to accommodate OpenSSL version parameter names.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
