### PR TITLE
Add `Mode: conservative` configuration to `Style/FormatStringToken` to make the cop only register offenses for strings given to `printf`, `sprintf`, `format`, and `%`

### DIFF
--- a/changelog/change_add_mode_conservative_configuration_to_20250311170524.md
+++ b/changelog/change_add_mode_conservative_configuration_to_20250311170524.md
@@ -1,0 +1,1 @@
+* [#13979](https://github.com/rubocop/rubocop/pull/13979): Add `Mode: conservative` configuration to `Style/FormatStringToken` to make the cop only register offenses for strings given to `printf`, `sprintf`, `format`, and `%`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4090,8 +4090,14 @@ Style/FormatStringToken:
   # style token in a format string to be allowed when enforced style is not
   # `unannotated`.
   MaxUnannotatedPlaceholdersAllowed: 1
+  # The mode the cop operates in. Two values are allowed:
+  # * aggressive (default): all strings are considered
+  # * conservative:
+  #     only register offenses for strings given to `printf`, `sprintf`,
+  #     format` and `%` methods. Other strings are not considered.
+  Mode: aggressive
   VersionAdded: '0.49'
-  VersionChanged: '1.0'
+  VersionChanged: '<<next>>'
   AllowedMethods: []
   AllowedPatterns: []
 


### PR DESCRIPTION
Add `Mode: conservative/aggressive` configuration to `Style/FormatStringToken`. When given `conservative`, the cop will only apply to arguments of `printf`, `sprintf`, `format`, and `%`.

The `Mode` configuration is an existing pattern from `Style/StringConcatenation`. 

Follows https://github.com/rubocop/rubocop/pull/13974#issuecomment-2714675509

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
