### PR TITLE
Prevent redundant plugin loading

### DIFF
--- a/changelog/fix_prevent_redundant_plugin_loading.md
+++ b/changelog/fix_prevent_redundant_plugin_loading.md
@@ -1,0 +1,1 @@
+* [#13981](https://github.com/rubocop/rubocop/pull/13981): Prevent redundant plugin loading when a duplicate plugin is specified in an inherited config. ([@koic][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -9,7 +9,8 @@ module RuboCop
   # @api private
   class ConfigLoaderResolver # rubocop:disable Metrics/ClassLength
     def resolve_plugins(rubocop_config, plugins)
-      return if (plugins = Array(plugins)).empty?
+      plugins = Array(plugins) - ConfigLoader.loaded_plugins.map { |plugin| plugin.about.name }
+      return if plugins.empty?
 
       Plugin.integrate_plugins(rubocop_config, plugins)
     end

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -104,6 +104,48 @@ RSpec.describe RuboCop::Version do
       end
     end
 
+    context 'when plugins are specified' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          plugins:
+            - rubocop-performance
+            - rubocop-rspec
+        YAML
+      end
+
+      it 'returns the extensions' do
+        expect(extension_versions).to contain_exactly(
+          /- rubocop-performance \d+\.\d+\.\d+/,
+          /- rubocop-rspec \d+\.\d+\.\d+/
+        )
+      end
+    end
+
+    context 'when a duplicate plugin is specified in an inherited config' do
+      before do
+        create_file('base.yml', <<~YAML)
+          plugins:
+            - rubocop-performance
+        YAML
+
+        create_file('.rubocop.yml', <<~YAML)
+          inherit_from:
+            - base.yml
+
+          plugins:
+            - rubocop-performance
+            - rubocop-rspec
+        YAML
+      end
+
+      it 'returns each extension exactly once' do
+        expect(extension_versions).to contain_exactly(
+          /- rubocop-performance \d+\.\d+\.\d+/,
+          /- rubocop-rspec \d+\.\d+\.\d+/
+        )
+      end
+    end
+
     context 'with an invalid cop in config' do
       before do
         create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
This PR prevents redundant plugin loading when a duplicate plugin is specified in an inherited config.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
