### PR TITLE
[Fix #8099] Fix infinite loop between `Layout/SpaceAroundOperators` and `Layout/HashAlignment` with `EnforcedHashRocketStyle` being an array containing `table`

### DIFF
--- a/changelog/fix_fix_infinite_loop_between_20250313153235.md
+++ b/changelog/fix_fix_infinite_loop_between_20250313153235.md
@@ -1,0 +1,1 @@
+* [#8099](https://github.com/rubocop/rubocop/issues/8099): Fix infinite loop between `Layout/SpaceAroundOperators` and `Layout/HashAlignment` with `EnforcedHashRocketStyle` being an array containing `table`. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -260,7 +260,10 @@ module RuboCop
         end
 
         def hash_table_style?
-          align_hash_cop_config && align_hash_cop_config['EnforcedHashRocketStyle'] == 'table'
+          return false unless align_hash_cop_config
+
+          enforced_styles = Array(align_hash_cop_config['EnforcedHashRocketStyle'])
+          enforced_styles.include?('table')
         end
 
         def space_around_exponent_operator?

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -559,6 +559,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
           RUBY
         end
       end
+
+      context 'and Layout/HashAlignment:EnforcedHashRocketStyle is key, table' do
+        let(:hash_style) { %w[key table] }
+
+        it 'registers an offense and corrects a hash rocket without spaces' do
+          expect_offense(<<~RUBY)
+            { 1=>2, a: b }
+               ^^ Surrounding space missing for operator `=>`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            { 1 => 2, a: b }
+          RUBY
+        end
+      end
     end
 
     context 'when a hash literal is on multiple lines' do
@@ -585,6 +600,19 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
 
       context 'and Layout/HashAlignment:EnforcedHashRocketStyle is table' do
         let(:hash_style) { 'table' }
+
+        it "doesn't register an offense for a hash rocket without spaces" do
+          expect_no_offenses(<<~RUBY)
+            {
+              1=>2,
+              a: b
+            }
+          RUBY
+        end
+      end
+
+      context 'and Layout/HashAlignment:EnforcedHashRocketStyle is key, table' do
+        let(:hash_style) { %w[key table] }
 
         it "doesn't register an offense for a hash rocket without spaces" do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Although `Layout/SpaceAroundOperators` already had a carve-out for dealing with `table` hash style, `Layout/HashAlignment` allows multiple values for `EnforcedHashRocketStyle`, which was not handled, thus leading to an infinite loop.

Fixes #8099.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
