### PR TITLE
[Fix #13986] Add support for `Array#intersection` to `Style/ArrayIntersect`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -359,7 +359,6 @@ InternalAffairs/OnSendWithoutOnCSend:
     - 'lib/rubocop/cop/lint/it_without_arguments_in_block.rb'
     - 'lib/rubocop/cop/lint/safe_navigation_chain.rb'
     - 'lib/rubocop/cop/lint/useless_times.rb'
-    - 'lib/rubocop/cop/style/array_intersect.rb'
     - 'lib/rubocop/cop/style/colon_method_call.rb'
     - 'lib/rubocop/cop/style/numeric_predicate.rb'
     - 'lib/rubocop/cop/style/single_argument_dig.rb'

--- a/changelog/change_add_support_for_array_intersection_to_20250314093853.md
+++ b/changelog/change_add_support_for_array_intersection_to_20250314093853.md
@@ -1,0 +1,1 @@
+* [#13986](https://github.com/rubocop/rubocop/issues/13986): Add support for `Array#intersection` to `Style/ArrayIntersect`. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -73,6 +73,64 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
       RUBY
     end
 
+    context 'with Array#intersection' do
+      it 'registers an offense for `a.intersection(b).any?`' do
+        expect_offense(<<~RUBY)
+          a.intersection(b).any?
+          ^^^^^^^^^^^^^^^^^^^^^^ Use `a.intersect?(b)` instead of `a.intersection(b).any?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a.intersect?(b)
+        RUBY
+      end
+
+      it 'registers an offense for `a.intersection(b).none?`' do
+        expect_offense(<<~RUBY)
+          a.intersection(b).none?
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `!a.intersect?(b)` instead of `a.intersection(b).none?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !a.intersect?(b)
+        RUBY
+      end
+
+      it 'registers an offense for `a.intersection(b).empty?`' do
+        expect_offense(<<~RUBY)
+          a.intersection(b).empty?
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use `!a.intersect?(b)` instead of `a.intersection(b).empty?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !a.intersect?(b)
+        RUBY
+      end
+
+      it 'registers an offense when using safe navigation' do
+        expect_offense(<<~RUBY)
+          a&.intersection(b)&.any?
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use `a&.intersect?(b)` instead of `a&.intersection(b)&.any?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.intersect?(b)
+        RUBY
+      end
+
+      it 'does not register an offense for `array.intersection` with no arguments' do
+        expect_no_offenses(<<~RUBY)
+          array1.intersection.any?
+        RUBY
+      end
+
+      it 'does not register an offense for `array.intersection` with multiple arguments' do
+        expect_no_offenses(<<~RUBY)
+          array1.intersection(array2, array3).any?
+        RUBY
+      end
+    end
+
     context 'when `AllCops/ActiveSupportExtensionsEnabled: true`' do
       let(:config) do
         RuboCop::Config.new('AllCops' => {
@@ -100,6 +158,28 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
 
         expect_correction(<<~RUBY)
           !conditions.pluck("type").intersect?(%w[customer_country ip_country])
+        RUBY
+      end
+
+      it 'registers an offense for `a.intersection(b).present?`' do
+        expect_offense(<<~RUBY)
+          a.intersection(b).present?
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `a.intersect?(b)` instead of `a.intersection(b).present?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a.intersect?(b)
+        RUBY
+      end
+
+      it 'registers an offense for `a.intersection(b).blank?`' do
+        expect_offense(<<~RUBY)
+          a.intersection(b).blank?
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use `!a.intersect?(b)` instead of `a.intersection(b).blank?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !a.intersect?(b)
         RUBY
       end
 


### PR DESCRIPTION
Adds support for `Array#intersection` to `Style/ArrayIntersect`. 

Since [`Array#intersection`](https://ruby-doc.org/2.7.8/Array.html#method-i-intersection) allows for more variation than `Array#&` (ie. it can have zero or multiple arguments), the cop only considers it if given exactly 1 argument.

Fixes #13986.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
