### PR TITLE
[Doc] Tweak navigation of docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -22,8 +22,9 @@
 ** xref:cops_security.adoc[Security]
 ** xref:cops_style.adoc[Style]
 ** xref:v1_upgrade_notes.adoc[Upgrade Notes]
+* Plugins
+** xref:extensions.adoc[Plugin Configuration]
 ** xref:plugin_migration_guide.adoc[Plugin Migration Guide]
-* xref:extensions.adoc[Extensions]
 * xref:integration_with_other_tools.adoc[Integration with Other Tools]
 * xref:automated_code_review.adoc[Automated Code Review]
 * xref:development.adoc[Development]

--- a/docs/modules/ROOT/pages/extensions.adoc
+++ b/docs/modules/ROOT/pages/extensions.adoc
@@ -1,4 +1,4 @@
-= Extensions
+= Plugin Configuration
 
 :lint_roller: https://github.com/standardrb/lint_roller[lint_roller]
 


### PR DESCRIPTION
"Plugin Migration Guide" page was previously placed under the "Cop Documentation" category, but it actually belongs to plugin extension, not cop: https://docs.rubocop.org/rubocop/1.74/plugin_migration_guide.html

Therefore, a new "Plugin Documentation" category has been created, and the "Plugin Migration Guide" page has been moved under it. And, the "Extensions" page will be moved to the new category.

To ensure existing URLs remain unchanged, the original page name has been retained.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
