### PR TITLE
Prevent a false-positive in UselessAssignment

### DIFF
--- a/changelog/fix_useless_assignment_false_positive.md
+++ b/changelog/fix_useless_assignment_false_positive.md
@@ -1,0 +1,1 @@
+* [#13992](https://github.com/rubocop/rubocop/pull/13992): Fix `Lint/UselessAssignment` false positive when a variable is assigned inside a block in an `if`/`else`. ([@jamie][])

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -941,6 +941,40 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
   end
 
   context "when there's an unreferenced assignment in top level if branch " \
+          'also assigned and referenced in the paired else branch in a block' \
+          'while the variable is referenced after the if/else' do
+    it 'allows' do
+      expect_no_offenses(<<~RUBY)
+        if cond
+          output = []
+        else
+          output = []
+          1.times { |value| output = [value] }
+        end
+
+        output
+      RUBY
+    end
+  end
+
+  context "when there's an unreferenced assignment in top level if branch " \
+          'also assigned and referenced in the paired else branch in a numblock' \
+          'while the variable is referenced after the if/else' do
+    it 'allows' do
+      expect_no_offenses(<<~RUBY)
+        if cond
+          output = []
+        else
+          output = []
+          1.times { output = [_1] }
+        end
+
+        output
+      RUBY
+    end
+  end
+
+  context "when there's an unreferenced assignment in top level if branch " \
           'while the variable is referenced in the paired else branch' do
     it 'registers an offense for the assignment in the if branch' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Addresses https://github.com/rubocop/rubocop/issues/13990

Lint/UselessAssignment has a false positive on the provided code, where setting a variable in both halves of an if/else and then reassigning inside a block in the else would flag the assignment in the if as useless, despite the variable also being used after the if/else.

Spec extracted and simplified from some production code, cop changes authored by Cursor/Claude Sonnet. I'm not super familiar with the cop backend matchers, so this might be possible to simplify.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
