### PR TITLE
Improve documentation for `Lint/RaiseException`

### DIFF
--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -3,15 +3,18 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for `raise` or `fail` statements which are
-      # raising `Exception` class.
+      # Checks for `raise` or `fail` statements which raise `Exception` or
+      # `Exception.new`. Use `StandardError` or a specific exception class instead.
       #
-      # You can specify a module name that will be an implicit namespace
-      # using `AllowedImplicitNamespaces` option. The cop cause a false positive
-      # for namespaced `Exception` when a namespace is omitted. This option can
-      # prevent the false positive by specifying a namespace to be omitted for
-      # `Exception`. Alternatively, make `Exception` a fully qualified class
-      # name with an explicit namespace.
+      # If you have defined your own namespaced `Exception` class, it is possible
+      # to configure the cop to allow it by setting `AllowedImplicitNamespaces` to
+      # an array with the names of the namespaces to allow. By default, this is set to
+      # `['Gem']`, which allows `Gem::Exception` to be raised without an explicit namespace.
+      # If not allowed, a false positive may be registered if `raise Exception` is called
+      # within the namespace.
+      #
+      # Alternatively, use a fully qualified name with `raise`/`fail`
+      # (eg. `raise Namespace::Exception`).
       #
       # @safety
       #   This cop is unsafe because it will change the exception class being
@@ -20,15 +23,31 @@ module RuboCop
       # @example
       #   # bad
       #   raise Exception, 'Error message here'
+      #   raise Exception.new('Error message here')
       #
       #   # good
       #   raise StandardError, 'Error message here'
+      #   raise MyError.new, 'Error message here'
       #
-      # @example AllowedImplicitNamespaces: ['Gem']
+      # @example AllowedImplicitNamespaces: ['Gem'] (default)
+      #   # bad - `Foo` is not an allowed implicit namespace
+      #   module Foo
+      #     def self.foo
+      #       raise Exception # This is qualified to `Foo::Exception`.
+      #     end
+      #   end
+      #
       #   # good
       #   module Gem
       #     def self.foo
-      #       raise Exception # This exception means `Gem::Exception`.
+      #       raise Exception # This is qualified to `Gem::Exception`.
+      #     end
+      #   end
+      #
+      #   # good
+      #   module Foo
+      #     def self.foo
+      #       raise Foo::Exception
       #     end
       #   end
       class RaiseException < Base


### PR DESCRIPTION
Slightly rewrite documentation for `Lint/RaiseException` to improve clarity, and add additional examples.