### PR TITLE
[Fix #13990] Fix a false positive for Lint/UselessAssignment when a variable is reassigned in a different branch

### DIFF
--- a/changelog/fix_lint_useless_assignment_different_branch.md
+++ b/changelog/fix_lint_useless_assignment_different_branch.md
@@ -1,0 +1,1 @@
+* [#13990](https://github.com/rubocop/rubocop/issues/13990): Fix a false positive for `Lint/UselessAssignment` when a variable is reassigned in a different branch. ([@eugeneius][])

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -6,8 +6,6 @@ module RuboCop
       # A Variable represents existence of a local variable.
       # This holds a variable declaration node and some states of the variable.
       class Variable
-        extend NodePattern::Macros
-
         VARIABLE_DECLARATION_TYPES = (VARIABLE_ASSIGNMENT_TYPES + ARGUMENT_DECLARATION_TYPES).freeze
 
         attr_reader :name, :declaration_node, :scope, :assignments, :references, :captured_by_block
@@ -40,13 +38,10 @@ module RuboCop
 
         def mark_last_as_reassigned!(assignment)
           return if captured_by_block?
-          return if candidate_condition?(assignment.node.parent)
+          return unless assignment.branch == @assignments.last&.branch
 
           @assignments.last&.reassigned!
         end
-
-        # @!method candidate_condition?(node)
-        def_node_matcher :candidate_condition?, '[{if case case_match when}]'
 
         def referenced?
           !@references.empty?

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -551,6 +551,45 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is reassigned in another branch before a block' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          if baz
+            foo = 1
+          else
+            foo = 2
+            bar {
+              foo = 3
+            }
+          end
+
+          foo
+        end
+      RUBY
+    end
+  end
+
+  context 'when a variable is reassigned in another case branch before a block' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          case baz
+          when 1
+            foo = 1
+          else
+            foo = 2
+            bar {
+              foo = 3
+            }
+          end
+
+          foo
+        end
+      RUBY
+    end
+  end
+
   context 'when assigning in branch' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/13990.

Fixes another false positive introduced in https://github.com/rubocop/rubocop/pull/13389, by making the check added in https://github.com/rubocop/rubocop/pull/13409 stricter. Instead of trying to detect conditionals by inspecting the type of the parent node, we can limit the check to reassignments in the same branch.

Correctly handling reassignments across branches would require tracking them differently: an assignment is only useless if it's reassigned in _all_ child branches.

This is a simpler alternative to https://github.com/rubocop/rubocop/pull/13992.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/