### PR TITLE
Allow free-form issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/rubocop/rubocop/security
+    about: Privately report a security vulnerability.
+  - name: GitHub Discussions
+    url: https://github.com/rubocop/rubocop/discussions
+    about: For anything else.

--- a/.github/ISSUE_TEMPLATE/freeform.md
+++ b/.github/ISSUE_TEMPLATE/freeform.md
@@ -1,0 +1,4 @@
+---
+name: Miscellaneous
+about: For things that aren't quite feature requests or bugs but still relate to the issue tracker.
+---


### PR DESCRIPTION
Feature request and bugs automatically add labels but not all types of reports should get these, like doc issues for example.

Also add a link to GH discussions.

Looks like this https://github.com/Earlopain/rubocop/issues/new/choose
![grafik](https://github.com/user-attachments/assets/0d465c80-5c01-44dd-bfb0-c43963683c31)
