### PR TITLE
Remove duplicate security issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/rubocop/rubocop/security
-    about: Privately report a security vulnerability.
   - name: GitHub Discussions
     url: https://github.com/rubocop/rubocop/discussions
     about: For anything else.


### PR DESCRIPTION
Followup to https://github.com/rubocop/rubocop/pull/13998

I though it was not present because `config.yml` was added, but it just wasn't there in my fork because
private security reporting is disabled there

Looks like this right now:
![grafik](https://github.com/user-attachments/assets/00c32b76-39a1-40eb-b59a-f9d96f495feb)
