### PR TITLE
Remove `broken_on: :prism` from specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'fiddle', platform: :windows if RUBY_VERSION >= '3.4'
 gem 'irb'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
-gem 'prism', '~> 1.2'
+gem 'prism', '~> 1.4'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.24.0'

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -82,8 +82,7 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray, :config do
   end
 
   context 'with binary encoded source' do
-    # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
-    it 'adds an offense and corrects when tokens contain quotes', broken_on: :prism do
+    it 'adds an offense and corrects when tokens contain quotes' do
       expect_offense(<<~RUBY.b)
         # encoding: BINARY
 
@@ -98,8 +97,7 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray, :config do
       RUBY
     end
 
-    # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
-    it 'accepts if tokens contain no quotes', broken_on: :prism do
+    it 'accepts if tokens contain no quotes' do
       expect_no_offenses(<<~RUBY.b)
         # encoding: BINARY
 

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -46,8 +46,7 @@ RSpec.describe RuboCop::Cop::Lint::PercentSymbolArray, :config do
     end
 
     context 'with binary encoded source' do
-      # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
-      it 'registers an offense and corrects when tokens contain quotes', broken_on: :prism do
+      it 'registers an offense and corrects when tokens contain quotes' do
         expect_offense(<<~RUBY.b)
           # encoding: BINARY
 
@@ -62,8 +61,7 @@ RSpec.describe RuboCop::Cop::Lint::PercentSymbolArray, :config do
         RUBY
       end
 
-      # FIXME: This spec should work with the latest Prism and Ruby 3.4.0dev.
-      it 'accepts if tokens contain no quotes', broken_on: :prism do
+      it 'accepts if tokens contain no quotes' do
         expect_no_offenses(<<~RUBY.b)
           # encoding: BINARY
 


### PR DESCRIPTION
With the release of Prism 1.4.0, the previously broken specs are now passing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
