### PR TITLE
Perform initial indexing before triggering watched file notifications

### DIFF
--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -120,6 +120,10 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
   describe 'workspace/didChangeWatchedFiles' do
     it 'creates new runtime adapter' do
       with_server(source, '.rubocop.yml') do |server, uri|
+        # Ensure initial indexing is complete before trying to process did change watched file
+        # notifications
+        server.global_state.index.index_all(uris: [])
+
         addon = RubyLsp::Addon.addons.find { |a| a.name == 'RuboCop' }
         expect(addon).to be_an_instance_of(RubyLsp::RuboCop::Addon)
         original_runtime_adapter = addon.instance_variable_get(:@runtime_adapter)


### PR DESCRIPTION
Closes #14000

The Ruby LSP had a small change in how watched file notifications are processed in the latest version. Essentially, if we received notifications before the initial indexing is complete, we delay processing them.

This is important in the case of switching branches or git pulling before the initial indexing is complete. If we tried to process those notifications immediately, we could end up double indexing depending on where we're at with the initial indexing.

This change is not relevant for the actual functionality of the add-on, but it does break the test. The solution is to invoke `index_all` with an empty array of URIs to index, which does nothing other than marking the initial indexing as complete.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
