### PR TITLE
[Fix #13617] Automatically use prism when analyzing Ruby >= 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'fiddle', platform: :windows if RUBY_VERSION >= '3.4'
 gem 'irb'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
-gem 'prism', '~> 1.4'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.24.0'

--- a/changelog/change_use_prism_ruby_3.4.md
+++ b/changelog/change_use_prism_ruby_3.4.md
@@ -1,0 +1,1 @@
+* [#13617](https://github.com/rubocop/rubocop/issues/13617): Automatically use the `prism` gem to analyze Ruby 3.4 and above. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -147,11 +147,13 @@ AllCops:
   # supported Ruby version (currently Ruby 2.7).
   TargetRubyVersion: ~
   # You can specify the parser engine. There are two options available:
+  # - `automatic`
   # - `parser_whitequark` ... https://github.com/whitequark/parser
   # - `parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)
-  # By default, `parser` is used. For the `TargetRubyVersion` value, `parser` can be specified for versions `2.0` and above.
-  # `parser_prism` can be specified for versions `3.3` and above. `parser_prism` is faster but still considered experimental.
-  ParserEngine: parser_whitequark
+  # The default `automatic` choses the best parser backend based on the `TargetRubyVersion`
+  # value. For <= 3.3 `parser_whitequark` will be used, for >= 3.4 `parser_prism`.
+  # `parser_whitequark` works with versions <= 3.3, `parser_prism` with versions >= 3.3.
+  ParserEngine: automatic
   # Determines if a notification for extension libraries should be shown when
   # rubocop is run. Keys are the name of the extension, and values are an array
   # of gems in the Gemfile that the extension is suggested for, if not already

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -35,12 +35,14 @@ The following table is the runtime support matrix.
 | 3.1 | -
 | 3.2 | -
 | 3.3 | -
-| 3.4 (experimental) | -
+| 3.4 | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.
 
-Starting from RuboCop 1.62, support for Prism's `Prism::Translation::parser` will enable analysis of Ruby 3.3+. For more details, please refer to the xref:configuration.adoc#setting-the-parser-engine[setting `ParserEngine`].
+Starting from RuboCop 1.62, support for Prism's `Prism::Translation::Parser` will enable analysis of Ruby 3.3+.
+
+Starting from RuboCop 1.XX, Prism's `Prism::Translation::Parser` is automatically chosen when analyzing Ruby 3.4+.
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[setting `TargetRubyVersion`] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -690,8 +690,7 @@ version, and will instead try to find a target Ruby version elsewhere.
 
 == Setting the parser engine
 
-NOTE: The parser engine configuration was introduced in RuboCop 1.62. This
-experimental feature has been under consideration for a while.
+NOTE: The parser engine configuration was introduced in RuboCop 1.62.
 
 RuboCop allows switching the backend parser by specifying either
 `parser_whitequark` or `parser_prism` as the value for the `ParserEngine`.
@@ -701,9 +700,9 @@ Here are the parsers used as backends for each value:
 - `ParserEngine: parser_whitequark` ... https://github.com/whitequark/parser
 - `ParserEngine: parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)
 
-By default, `parser_whitequark` is implicitly used.
+NOTE: RuboCop 1.XX, RuboCop chooses the best parser automatically so you don't need to configure it yourself.
 
-`parser_whitequark` can analyze source code from Ruby 2.0 and above:
+`parser_whitequark` can analyze source code from Ruby 2.0 until Ruby 3.3:
 
 [source,yaml]
 ----
@@ -721,21 +720,6 @@ AllCops:
 ----
 
 `parser_prism` tends to perform analysis faster than `parser_whitequark`.
-
-IMPORTANT: Since the support for Prism is experimental, it is not included in
-RuboCop's runtime dependencies.  If running RuboCop through Bundler, please add
-`gem 'prism'` to your `Gemfile`:
-
-[source,ruby]
-----
-gem 'prism'
-----
-
-There are some incompatibilities with `parser_whitequark` in `parser_prism`,
-which is the main reason why the support for it is considered experimental.
-We're working with Prism's team to address those.  You can track the outstanding
-known issues in Prism that affect RuboCop
-https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop[here].
 
 == Automatically Generated Configuration
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -291,7 +291,7 @@ module RuboCop
     end
 
     def parser_engine
-      @parser_engine ||= for_all_cops.fetch('ParserEngine', :parser_whitequark).to_sym
+      @parser_engine ||= for_all_cops.fetch('ParserEngine', :automatic).to_sym
     end
 
     def target_rails_version

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -49,17 +49,7 @@ module RuboCop
 
     # @api private
     def self.parser_version
-      config_path = ConfigFinder.find_config_path(Dir.pwd)
-      yaml = Util.silence_warnings do
-        ConfigLoader.load_yaml_configuration(config_path)
-      end
-
-      if yaml.dig('AllCops', 'ParserEngine') == 'parser_prism'
-        require 'prism'
-        "Prism #{Prism::VERSION}"
-      else
-        "Parser #{Parser::VERSION}"
-      end
+      "Parser #{Parser::VERSION}, Prism #{Prism::VERSION}"
     end
 
     # @api private


### PR DESCRIPTION
This works because of a change in `rubocop-ast` where it chooses the parser engine automatically when none (`nil`) is provided.

Requires at the very least https://github.com/rubocop/rubocop-ast/pull/370, and also some time to battletest prism 1.4.0

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
