### PR TITLE
Fix incorrect autocorrections for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_sole_nested_conditional_incorrect_autocorrections_20250320230831.md
+++ b/changelog/fix_sole_nested_conditional_incorrect_autocorrections_20250320230831.md
@@ -1,0 +1,1 @@
+* [#14012](https://github.com/rubocop/rubocop/pull/14012): Fix incorrect autocorrections for `Style/SoleNestedConditional`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -96,11 +96,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, node, if_branch)
-          if node.condition.or_type? || node.condition.assignment?
-            corrector.wrap(node.condition, '(', ')')
-          end
-
-          if outer_condition_modify_form?(node, if_branch)
+          if node.modifier_form?
             autocorrect_outer_condition_modify_form(corrector, node, if_branch)
           else
             autocorrect_outer_condition_basic(corrector, node, if_branch)
@@ -108,74 +104,48 @@ module RuboCop
         end
 
         def autocorrect_outer_condition_basic(corrector, node, if_branch)
-          correct_from_unless_to_if(corrector, node) if node.unless?
+          correct_node(corrector, node)
 
-          outer_condition = node.condition
-          correct_outer_condition(corrector, outer_condition)
-
-          and_operator = if_branch.unless? ? ' && !' : ' && '
           if if_branch.modifier_form?
-            correct_for_guard_condition_style(corrector, outer_condition, if_branch, and_operator)
+            correct_for_guard_condition_style(corrector, node, if_branch)
           else
-            correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
+            correct_for_basic_condition_style(corrector, node, if_branch)
             correct_for_comment(corrector, node, if_branch)
           end
         end
 
-        def autocorrect_outer_condition_modify_form(corrector, node, if_branch)
-          correct_from_unless_to_if(corrector, if_branch, is_modify_form: true) if if_branch.unless?
-          correct_for_outer_condition_modify_form_style(corrector, node, if_branch)
+        def correct_node(corrector, node)
+          corrector.replace(node.loc.keyword, 'if') if node.unless?
+          corrector.replace(node.condition, chainable_condition(node))
         end
 
-        def correct_from_unless_to_if(corrector, node, is_modify_form: false)
-          corrector.replace(node.loc.keyword, 'if')
+        def correct_for_guard_condition_style(corrector, node, if_branch)
+          corrector.insert_after(node.condition, " && #{chainable_condition(if_branch)}")
 
-          insert_bang(corrector, node, is_modify_form)
-        end
-
-        def correct_for_guard_condition_style(corrector, outer_condition, if_branch, and_operator)
-          condition = if_branch.condition
-          corrector.insert_after(outer_condition, "#{and_operator}#{replace_condition(condition)}")
-
-          range = range_between(if_branch.loc.keyword.begin_pos, condition.source_range.end_pos)
+          range = range_between(
+            if_branch.loc.keyword.begin_pos, if_branch.condition.source_range.end_pos
+          )
           corrector.remove(range_with_surrounding_space(range, newlines: false))
-          corrector.remove(if_branch.loc.keyword)
         end
 
-        def correct_for_basic_condition_style(corrector, node, if_branch, and_operator)
+        def correct_for_basic_condition_style(corrector, node, if_branch)
           range = range_between(
             node.condition.source_range.end_pos, if_branch.condition.source_range.begin_pos
           )
-          corrector.replace(range, and_operator)
+          corrector.replace(range, ' && ')
+
+          corrector.replace(if_branch.condition, chainable_condition(if_branch))
+
           corrector.remove(range_by_whole_lines(node.loc.end, include_final_newline: true))
-
-          wrap_condition(corrector, if_branch.condition)
         end
 
-        def wrap_condition(corrector, condition)
-          # Handle `send` and `block` nodes that need to be wrapped in parens
-          # FIXME: autocorrection prevents syntax errors by wrapping the entire node in parens,
-          #        but wrapping the argument list would be a more ergonomic correction.
-          node_to_check = condition&.any_block_type? ? condition.send_node : condition
-          return unless wrap_condition?(node_to_check)
+        def autocorrect_outer_condition_modify_form(corrector, node, if_branch)
+          correct_node(corrector, if_branch)
 
-          if condition.call_type?
-            source = parenthesized_method_arguments(condition)
+          corrector.insert_before(if_branch.condition, "#{chainable_condition(node)} && ")
 
-            corrector.replace(condition, source)
-          else
-            corrector.wrap(condition, '(', ')')
-          end
-        end
-
-        def correct_for_outer_condition_modify_form_style(corrector, node, if_branch)
-          condition = if_branch.condition
-          corrector.insert_before(condition,
-                                  "#{'!' if node.unless?}#{replace_condition(node.condition)} && ")
-
-          corrector.remove(node.condition)
-          corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
-          corrector.replace(if_branch.loc.keyword, 'if')
+          range = range_between(node.loc.keyword.begin_pos, node.condition.source_range.end_pos)
+          corrector.remove(range_with_surrounding_space(range, newlines: false))
         end
 
         def correct_for_comment(corrector, node, if_branch)
@@ -187,61 +157,36 @@ module RuboCop
           corrector.insert_before(node.loc.keyword, comment_text) unless comments.empty?
         end
 
-        def correct_outer_condition(corrector, condition)
-          return unless require_parentheses?(condition)
+        def chainable_condition(node)
+          wrapped_condition = add_parentheses_if_needed(node.condition)
 
-          end_pos = condition.loc.selector.end_pos
-          begin_pos = condition.first_argument.source_range.begin_pos
-          return if end_pos > begin_pos
+          return wrapped_condition if node.if?
 
-          range = range_between(end_pos, begin_pos)
-          corrector.remove(range)
-          corrector.insert_after(range, '(')
-          corrector.insert_after(condition.last_argument, ')')
+          node.condition.and_type? ? "!(#{wrapped_condition})" : "!#{wrapped_condition}"
         end
 
-        def insert_bang(corrector, node, is_modify_form)
-          condition = node.condition
+        def add_parentheses_if_needed(condition)
+          # Handle `send` and `block` nodes that need to be wrapped in parens
+          # FIXME: autocorrection prevents syntax errors by wrapping the entire node in parens,
+          #        but wrapping the argument list would be a more ergonomic correction.
+          node_to_check = condition&.any_block_type? ? condition.send_node : condition
+          return condition.source unless add_parentheses?(node_to_check)
 
-          if (condition.send_type? && condition.comparison_method? && !condition.parenthesized?) ||
-             (is_modify_form && wrap_condition?(condition))
-            corrector.wrap(node.condition, '!(', ')')
-          elsif condition.and_type?
-            insert_bang_for_and(corrector, node)
-          else
-            corrector.insert_before(condition, '!')
-          end
-        end
-
-        def insert_bang_for_and(corrector, node)
-          lhs, rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring
-
-          if lhs.and_type?
-            insert_bang_for_and(corrector, lhs)
-            corrector.insert_before(rhs, '!') if rhs
-          else
-            corrector.insert_before(lhs, '!')
-            corrector.insert_before(rhs, '!')
-          end
-        end
-
-        def require_parentheses?(condition)
-          condition.call_type? && !condition.arguments.empty? && !condition.parenthesized? &&
-            !condition.comparison_method?
-        end
-
-        def wrap_condition?(node)
-          node.operator_keyword? || (node.call_type? && node.arguments.any? && !node.parenthesized?)
-        end
-
-        def replace_condition(condition)
-          return condition.source unless wrap_condition?(condition)
-
-          if condition.call_type? && !condition.comparison_method?
+          if parenthesize_method?(condition)
             parenthesized_method_arguments(condition)
           else
             "(#{condition.source})"
           end
+        end
+
+        def parenthesize_method?(node)
+          node.call_type? && node.arguments.any? && !node.parenthesized? &&
+            !node.comparison_method? && !node.operator_method?
+        end
+
+        def add_parentheses?(node)
+          node.assignment? || (node.operator_keyword? && !node.and_type?) ||
+            (node.call_type? && node.arguments.any? && !node.parenthesized?)
         end
 
         def parenthesized_method_arguments(node)
@@ -253,10 +198,6 @@ module RuboCop
 
         def allow_modifier?
           cop_config['AllowModifier']
-        end
-
-        def outer_condition_modify_form?(node, if_branch)
-          node.condition.source_range.begin_pos > if_branch.condition.source_range.begin_pos
         end
       end
     end


### PR DESCRIPTION
Fixes wrong autocorrections for this cop.

Two types of wrong autocorrections have been fixed, they're listed in sections below. While fixing all this, I noticed some duplication of coupled logic and things that could be simplified, so I took the opportunity to refactor the cop. Let me know if I changed too much, I could try splitting this into multiple PRs.

## Unless with &&

https://github.com/rubocop/rubocop/pull/10647 introduced logic to autocorrect `unless` with `&&`, e.g. this:

```ruby
unless foo && bar
  5 if baz
end
```
is autocorrected to:
```ruby
if !foo && !bar && baz
  5
end
```

`unless foo && bar` is not equivalent to `if !foo && !bar`; the correct form is `if !(foo && bar)` (or `!foo || !bar` if we follow [De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws)). A simple example showing incorrectness:
```ruby
foo = true
bar = false

5 unless foo && bar
# => 5

5 if !foo && !bar
# => nil
```

This PR fixes autocorrection to:
```ruby
if !(foo && bar) && baz
  5
end
```

## Conditions with operators

Previously, code such as (simplified production examples, single `&` is intentional):
```ruby
if foo & bar
  5 if baz
end

if foo
  5 if bar & baz
end
```
would get autocorrected to (modifier form for simplicity):
```ruby
5 if foo &(bar) && baz

5 if foo && bar &(baz)
```
which is invalid syntax.

This PR fixes autocorrection to:
```ruby
5 if (foo & bar) && baz

5 if foo && (bar & baz)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
