### PR TITLE
Support `it` block parameter in `Style` cops

### DIFF
--- a/changelog/new_support_itblock_in_style_cops.md
+++ b/changelog/new_support_itblock_in_style_cops.md
@@ -1,0 +1,1 @@
+* [#14013](https://github.com/rubocop/rubocop/pull/14013): Support `it` block parameter in `Style` cops. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -208,6 +208,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -347,7 +348,7 @@ module RuboCop
         # rubocop:disable Metrics/CyclomaticComplexity
         def get_blocks(node, &block)
           case node.type
-          when :block, :numblock
+          when :block, :numblock, :itblock
             yield node
           when :send, :csend
             # When a method has an argument which is another method with a block,

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -50,6 +50,7 @@ module RuboCop
           check_method_node(node.send_node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_send(node)
           return unless implicit_block?(node)

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -80,6 +80,7 @@ module RuboCop
         # rubocop:enable Metrics/CyclomaticComplexity
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_for(node)
           return unless node.parent&.begin_type?

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -77,6 +77,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -135,6 +135,7 @@ module RuboCop
           on_def(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_if(node)
           return if accepted_form?(node)

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -74,6 +74,7 @@ module RuboCop
           check_unused_block_args(node, key, value)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         # rubocop:disable Metrics/AbcSize
         def check_unused_block_args(node, key, value)

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -106,6 +106,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -77,6 +77,7 @@ module RuboCop
           end
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -127,6 +127,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -36,6 +36,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_send(node)
           return if ignored_node?(node)

--- a/lib/rubocop/cop/style/multiline_block_chain.rb
+++ b/lib/rubocop/cop/style/multiline_block_chain.rb
@@ -44,6 +44,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -72,6 +72,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_while(node)
           check(node)

--- a/lib/rubocop/cop/style/object_then.rb
+++ b/lib/rubocop/cop/style/object_then.rb
@@ -38,6 +38,7 @@ module RuboCop
           check_method_node(node.send_node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_send(node)
           return unless node.arguments.one? && node.first_argument.block_pass_type?

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -30,6 +30,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -95,6 +95,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_kwbegin(node)
           return unless (target_node = offensive_kwbegins(node).to_a.last)

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -118,6 +118,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_if(node)
           # Allow conditional nodes to use `self` in the condition if that variable

--- a/lib/rubocop/cop/style/redundant_sort_by.rb
+++ b/lib/rubocop/cop/style/redundant_sort_by.rb
@@ -21,6 +21,7 @@ module RuboCop
 
         MSG_BLOCK = 'Use `sort` instead of `sort_by { |%<var>s| %<var>s }`.'
         MSG_NUMBLOCK = 'Use `sort` instead of `sort_by { _1 }`.'
+        MSG_ITBLOCK = 'Use `sort` instead of `sort_by { it }`.'
 
         def on_block(node)
           redundant_sort_by_block(node) do |send, var_name|
@@ -36,7 +37,17 @@ module RuboCop
           redundant_sort_by_numblock(node) do |send|
             range = sort_by_range(send, node)
 
-            add_offense(range, message: format(MSG_NUMBLOCK)) do |corrector|
+            add_offense(range, message: MSG_NUMBLOCK) do |corrector|
+              corrector.replace(range, 'sort')
+            end
+          end
+        end
+
+        def on_itblock(node)
+          redundant_sort_by_itblock(node) do |send|
+            range = sort_by_range(send, node)
+
+            add_offense(range, message: MSG_ITBLOCK) do |corrector|
               corrector.replace(range, 'sort')
             end
           end
@@ -52,6 +63,11 @@ module RuboCop
         # @!method redundant_sort_by_numblock(node)
         def_node_matcher :redundant_sort_by_numblock, <<~PATTERN
           (numblock $(call _ :sort_by) 1 (lvar :_1))
+        PATTERN
+
+        # @!method redundant_sort_by_itblock(node)
+        def_node_matcher :redundant_sort_by_itblock, <<~PATTERN
+          (itblock $(call _ :sort_by) _ (lvar :it))
         PATTERN
 
         def sort_by_range(send, node)

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -59,6 +59,7 @@ module RuboCop
           {
             (block call (args (arg $_)) ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
             (numblock call $1 ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
+            (itblock call $_ ${(send _ %REGEXP_METHODS _) match-with-lvasgn})
           }
         PATTERN
 
@@ -137,6 +138,7 @@ module RuboCop
           return unless (block_arg_name, regexp_method_send_node = regexp_match?(block_node))
 
           block_arg_name = :"_#{block_arg_name}" if block_node.numblock_type?
+
           return unless calls_lvar?(regexp_method_send_node, block_arg_name)
 
           regexp_method_send_node
@@ -150,7 +152,8 @@ module RuboCop
           return node.child_nodes.first if node.match_with_lvasgn_type?
 
           if node.receiver.lvar_type? &&
-             (block.numblock_type? || node.receiver.source == block.first_argument.source)
+             (block.type?(:numblock, :itblock) ||
+              node.receiver.source == block.first_argument.source)
             node.first_argument
           elsif node.first_argument.lvar_type?
             node.receiver

--- a/lib/rubocop/cop/style/single_line_do_end_block.rb
+++ b/lib/rubocop/cop/style/single_line_do_end_block.rb
@@ -56,11 +56,13 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
         def do_line(node)
-          if node.numblock_type? || node.arguments.children.empty? || node.send_node.lambda_literal?
+          if node.type?(:numblock, :itblock) ||
+             node.arguments.children.empty? || node.send_node.lambda_literal?
             node.loc.begin
           else
             node.arguments

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -159,6 +159,7 @@ module RuboCop
           {
             (block $#symbol_proc_receiver? $(args (arg _var)) (send (lvar _var) $_))
             (numblock $#symbol_proc_receiver? $1 (send (lvar :_1) $_))
+            (itblock $#symbol_proc_receiver? $_ (send (lvar :it) $_))
           }
         PATTERN
 
@@ -185,6 +186,7 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def destructuring_block_argument?(argument_node)
           argument_node.one? && argument_node.source.include?(',')

--- a/lib/rubocop/cop/style/top_level_method_definition.rb
+++ b/lib/rubocop/cop/style/top_level_method_definition.rb
@@ -64,6 +64,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.38.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.41.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -98,6 +98,51 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
           RUBY
         end
       end
+
+      context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+        it 'accepts a multi-line itblock' do
+          expect_no_offenses(<<~RUBY)
+            puts [1, 2, 3].map {
+              it * it
+            }, 1
+          RUBY
+        end
+
+        it 'accepts a multi-line itblock inside a nested send' do
+          expect_no_offenses(<<~RUBY)
+            puts [0] + [1,2,3].map {
+              it * it
+            }, 1
+          RUBY
+        end
+
+        it 'accepts a multi-line itblock inside a nested send when the block is the receiver' do
+          expect_no_offenses(<<~RUBY)
+            puts [1,2,3].map {
+              it * it
+            } + [0], 1
+          RUBY
+        end
+
+        it 'accepts a multi-line itblock with chained method as an argument to an operator method' do
+          expect_no_offenses(<<~RUBY)
+            foo %
+              %w[bar baz].map {
+                it.upcase
+              }.join(', ')
+          RUBY
+        end
+
+        it 'accepts a multi-line itblock with chained method as an argument to an operator method' \
+           'inside a kwarg' do
+          expect_no_offenses(<<~RUBY)
+            foo :bar, baz: 'Some text: %s' %
+                           %w[foo bar].map {
+                            it.upcase
+                           }.join(', ')
+          RUBY
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -68,6 +68,34 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context "#{method} with itblock" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            [1, 2, 3].%{method} { it + 1 }
+                      ^{method} Prefer `#{preferred_method}` over `#{method}`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            [1, 2, 3].#{preferred_method} { it + 1 }
+          RUBY
+        end
+
+        context 'with safe navigation' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, method: method)
+              [1, 2, 3]&.%{method} { it + 1 }
+                         ^{method} Prefer `#{preferred_method}` over `#{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              [1, 2, 3]&.#{preferred_method} { it + 1 }
+            RUBY
+          end
+        end
+      end
+    end
+
     context "#{method} with proc param" do
       it 'registers an offense' do
         expect_offense(<<~RUBY, method: method)

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -86,6 +86,22 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
       RUBY
     end
 
+    it 'registers an offense when looping over the same data for the third consecutive time with `it` blocks', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        items.each { foo(it) }
+        items.each { bar(it) }
+        ^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+        items.each { baz(it) }
+        ^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        items.each { foo(it)
+        bar(it)
+        baz(it) }
+      RUBY
+    end
+
     it 'registers an offense when looping over the same data as previous loop in `do`...`end` and `{`...`}` blocks' do
       expect_offense(<<~RUBY)
         items.each do |item| do_something(item) end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -463,6 +463,27 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers an offense for each without an item and uses _ as the item' do
+        expect_offense(<<~RUBY)
+          def func
+            [1, 2, 3].each do
+            ^^^^^^^^^^^^^^^^^ Prefer `for` over `each`.
+              puts it
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def func
+            for _ in [1, 2, 3] do
+              puts it
+            end
+          end
+        RUBY
+      end
+    end
+
     it 'registers an offense for correct + opposite style' do
       expect_offense(<<~RUBY)
         def func

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -112,6 +112,38 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
+    it 'reports an offense if `define_method` block body is if / unless without else', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        define_method(:func) do
+          if it
+          ^^ Use a guard clause (`return unless it`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+
+        define_method(:func) do
+          unless it
+          ^^^^^^ Use a guard clause (`return if it`) instead of wrapping the code inside a conditional expression.
+            #{body}
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        define_method(:func) do
+          return unless it
+            #{body}
+         #{trailing_whitespace}
+        end
+
+        define_method(:func) do
+          return if it
+            #{body}
+         #{trailing_whitespace}
+        end
+      RUBY
+    end
+
     it 'reports an offense if `define_singleton_method` block body is if / unless without else' do
       expect_offense(<<~RUBY)
         define_singleton_method(:func) do

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -327,6 +327,19 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
           RUBY
         end
       end
+
+      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+        it 'registers offense, autocorrects foo#keys.each to foo#each_key with itblock' do
+          expect_offense(<<~RUBY)
+            foo.keys.each { p it }
+                ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.each_key { p it }
+          RUBY
+        end
+      end
     end
 
     context 'when receiver is a hash literal' do

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34 do
+    it 'registers an offense for calling !.none? with an itblock' do
+      expect_offense(<<~RUBY)
+        !foo.none? { it.even? }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.any? { it.even? }
+      RUBY
+    end
+  end
+
   it 'registers an offense for calling !.any? inside parens' do
     expect_offense(<<~RUBY)
       !(foo.any? &:working?)

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -253,6 +253,59 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
       end
     end
 
+    context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'when using `it` parameter' do
+        context 'with a single line lambda method call' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              f = lambda { it }
+                  ^^^^^^ Use the `-> { ... }` lambda literal syntax for single line lambdas.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              f = -> { it }
+            RUBY
+          end
+        end
+
+        context 'with a multiline `->` call' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              -> {
+              ^^ Use the `lambda` method for multiline lambdas.
+                it.do_something
+              }
+            RUBY
+
+            expect_correction(<<~RUBY)
+              lambda {
+                it.do_something
+              }
+            RUBY
+          end
+        end
+
+        context 'with a multiline lambda method call' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              l = lambda do
+                it
+              end
+            RUBY
+          end
+        end
+
+        context 'with a single line lambda literal' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              lambda = -> { it }
+              lambda.(1)
+            RUBY
+          end
+        end
+      end
+    end
+
     context 'with a multiline lambda literal' do
       context 'with arguments' do
         it 'registers an offense' do

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -173,6 +173,18 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using a itblock', :ruby34, unsupported_on: :parser do
+    expect_offense(<<~RUBY)
+      dest = []
+      src.each { dest << it * 2 }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dest = src.map { it * 2 }
+    RUBY
+  end
+
   it 'registers an offense and corrects when the destination initialized multiple times' do
     expect_offense(<<~RUBY)
       dest = []

--- a/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
@@ -78,4 +78,15 @@ RSpec.describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for a chained call' do
+      expect_offense(<<~RUBY)
+        a do
+          it
+        end.c
+        ^^^^^ Avoid chaining a method call on a do...end block.
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe RuboCop::Cop::Style::MultilineBlockChain, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers an offense for a slightly more complicated case' do
+        expect_offense(<<~RUBY)
+          a do
+            it
+          end.c1.c2 do
+          ^^^^^^^^^ Avoid multi-line chains of blocks.
+            it
+          end
+        RUBY
+      end
+    end
+
     it 'registers two offenses for a chain of three blocks' do
       expect_offense(<<~RUBY)
         a do

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it "registers an offense for #{condition} inside of downto itblock" do
+        expect_offense(<<~RUBY, condition: condition)
+          3.downto(1) do
+            %{condition} it == 1
+            ^{condition}^^^^^^^^ Use `next` to skip iteration.
+              puts it
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          3.downto(1) do
+            next #{opposite} it == 1
+            puts it
+          end
+        RUBY
+      end
+    end
+
     it "registers an offense for #{condition} inside of each" do
       expect_offense(<<~RUBY, condition: condition)
         [].each do |o|

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -77,6 +77,30 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers an offense for yield_self with itblock' do
+        expect_offense(<<~RUBY)
+          obj.yield_self { it.test }
+              ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj.then { it.test }
+        RUBY
+      end
+
+      it 'registers an offense for yield_self with safe navigation and itblock' do
+        expect_offense(<<~RUBY)
+          obj&.yield_self { it.test }
+               ^^^^^^^^^^ Prefer `then` over `yield_self`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.then { it.test }
+        RUBY
+      end
+    end
+
     it 'registers an offense for yield_self with proc param' do
       expect_offense(<<~RUBY)
         obj.yield_self(&:test)

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -43,4 +43,17 @@ RSpec.describe RuboCop::Cop::Style::Proc, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for a Proc.new call' do
+      expect_offense(<<~RUBY)
+        f = Proc.new { puts it }
+            ^^^^^^^^ Use `proc` instead of `Proc.new`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f = proc { puts it }
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -570,6 +570,44 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'reports an offense when assigning nested blocks which contain `begin` blocks' do
+      expect_offense(<<~RUBY)
+        var = do_something do
+          begin
+          ^^^^^ Redundant `begin` block detected.
+            do_something do
+              begin
+              ^^^^^ Redundant `begin` block detected.
+                it
+              ensure
+                bar
+              end
+            end
+          ensure
+            baz
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = do_something do
+         #{trailing_whitespace}
+            do_something do
+             #{trailing_whitespace}
+                it
+              ensure
+                bar
+             #{trailing_whitespace}
+            end
+          ensure
+            baz
+         #{trailing_whitespace}
+        end
+      RUBY
+    end
+  end
+
   context 'when using endless method definition', :ruby30 do
     it 'registers when `begin` block has a single statement' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -184,6 +184,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers offense for self usage in itblocks' do
+      expect_offense(<<~RUBY)
+        %w[x y z].select do
+          self.axis == it
+          ^^^^ Redundant `self` detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        %w[x y z].select do
+          axis == it
+        end
+      RUBY
+    end
+  end
+
   describe 'instance methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_by_spec.rb
@@ -47,6 +47,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantSortBy, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'autocorrects array.sort_by { |x| x }' do
+      expect_offense(<<~RUBY)
+        array.sort_by { it }
+              ^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { it }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sort
+      RUBY
+    end
+
+    it 'autocorrects array&.sort_by { |x| x }' do
+      expect_offense(<<~RUBY)
+        array&.sort_by { it }
+               ^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { it }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sort
+      RUBY
+    end
+  end
+
   it 'autocorrects array.sort_by { |y| y }' do
     expect_offense(<<~RUBY)
       array.sort_by { |y| y }

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
     RUBY
   end
 
+  it 'registers an offense when using single line `do`...`end` with `it` block argument', :ruby34, unsupported_on: :parser do
+    expect_offense(<<~RUBY)
+      foo do bar(it) end
+      ^^^^^^^^^^^^^^^^^^ Prefer multiline `do`...`end` block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+       bar(it)#{' '}
+      end
+    RUBY
+  end
+
   it 'registers an offense when using single line `do`...`end` with heredoc body' do
     expect_offense(<<~RUBY)
       foo do <<~EOS end

--- a/spec/rubocop/cop/style/top_level_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/top_level_method_definition_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe RuboCop::Cop::Style::TopLevelMethodDefinition, :config do
       end
     end
 
+    context 'Ruby >= 3.4', :ruby34 do
+      it 'registers offense with inline itblock' do
+        expect_offense(<<~RUBY)
+          define_method(:foo) { puts it }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define methods at the top-level.
+        RUBY
+      end
+    end
+
     it 'registers offense for multi-line block' do
       expect_offense(<<~RUBY)
         define_method(:foo) do |x|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 end


### PR DESCRIPTION
This PR supports `it` block parameter in `Style` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
