### PR TITLE
Support `it` block parameter in `Layout` cops

### DIFF
--- a/changelog/new_support_itblock_in_layout_cops.md
+++ b/changelog/new_support_itblock_in_layout_cops.md
@@ -1,0 +1,1 @@
+* [#14015](https://github.com/rubocop/rubocop/pull/14015): Support `it` block parameter in `Layout` cops. ([@koic][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -87,6 +87,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def style_parameter_name
           'EnforcedStyleAlignWith'

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -43,6 +43,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -92,7 +92,7 @@ module RuboCop
           case parent.type
           when :def, :defs then base_for_method_definition(parent)
           when :kwbegin then parent.loc.begin
-          when :block, :numblock
+          when :block, :numblock, :itblock
             assignment_node = assignment_node(parent)
             if same_line?(parent, assignment_node)
               assignment_node.source_range

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -277,7 +277,7 @@ module RuboCop
           case node.type
           when :def, :defs
             :method
-          when :numblock
+          when :numblock, :itblock
             :block
           else
             node.type

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -83,6 +83,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_send(node)
           return unless node.bare_access_modifier? && !node.block_literal?

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -34,6 +34,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -91,6 +91,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_class(node)
           base = node.loc.keyword

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -75,6 +75,7 @@ module RuboCop
           check_for_breakable_block(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_str(node)
           check_for_breakable_str(node)

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -69,6 +69,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -96,7 +96,7 @@ module RuboCop
         def alignment_source(node, starting_loc)
           ending_loc =
             case node.type
-            when :block, :numblock, :kwbegin
+            when :block, :numblock, :itblock, :kwbegin
               node.loc.begin
             when :def, :defs, :class, :module,
                  :lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -77,6 +77,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -103,6 +103,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.38.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.41.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -1001,4 +1001,14 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'accepts end aligned with a call chain left hand side' do
+      expect_no_offenses(<<~RUBY)
+        parser.diagnostics.consumer = lambda do
+          it << diagnostic
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -245,4 +245,40 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and corrects when multiline block `}` is not on its own line ' \
+       'and using method chain' do
+      expect_offense(<<~RUBY)
+        test {
+          it }.bar.baz
+             ^ Expression at 2, 6 should be on its own line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test {
+          it
+        }.bar.baz
+      RUBY
+    end
+
+    it 'registers an offense and corrects when multiline block `}` is not on its own line ' \
+       'and using heredoc argument' do
+      expect_offense(<<~RUBY)
+        test {
+          it.push(<<~EOS) }
+                          ^ Expression at 2, 19 should be on its own line.
+            Heredoc text.
+          EOS
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test {
+          it.push(<<~EOS)
+            Heredoc text.
+          EOS
+        }
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -597,6 +597,21 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
       RUBY
     end
 
+    it 'accepts a correctly aligned else from itblock', :ruby34, unsupported_on: :parser do
+      expect_no_offenses(<<~RUBY)
+        array_like.each do
+          it
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
     it 'accepts a correctly aligned else with assignment' do
       expect_no_offenses(<<~RUBY)
         result = array_like.each do |n|

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -728,6 +728,28 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       RUBY
     end
 
+    it 'registers offense if next to itblock', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+        foo 'second foo' do
+        ^^^^^^^^^^^^^^^^^^^ Expected 1 empty line between block definitions; found 0.
+          it
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo 'first foo' do
+          #foo body
+        end
+
+        foo 'second foo' do
+          it
+        end
+      RUBY
+    end
+
     it 'does not register offense' do
       expect_no_offenses(<<~RUBY)
         foo 'first foo' do

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -601,4 +601,37 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
       end
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    %w[private protected public module_function].each do |access_modifier|
+      it "registers an offense for missing around line before #{access_modifier}" do
+        expect_offense(<<~RUBY)
+          included do
+            it
+            #{access_modifier}
+            #{'^' * access_modifier.size} Keep a blank line before and after `#{access_modifier}`.
+            def test; end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          included do
+            it
+
+            #{access_modifier}
+
+            def test; end
+          end
+        RUBY
+      end
+
+      it "ignores #{access_modifier} with itblock argument" do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            #{access_modifier} { it }
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
         end
       end
 
+      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+        it 'registers an offense for block body ending with a blank' do
+          expect_offense(<<~RUBY)
+            some_method #{open}
+              it
+
+            ^{} Extra empty line detected at block body end.
+              #{close}
+          RUBY
+
+          expect_correction(<<~RUBY)
+            some_method #{open}
+              it
+              #{close}
+          RUBY
+        end
+      end
+
       it 'accepts block body starting with a line with spaces' do
         expect_no_offenses(<<~RUBY)
           some_method #{open}

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1629,6 +1629,26 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
       end
 
+      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+        it 'registers an offense for bad indentation of a {} body' do
+          expect_offense(<<~RUBY)
+            func {
+               it&.foo
+            ^^^ Use 2 (not 3) spaces for indentation.
+            }
+          RUBY
+        end
+
+        it 'registers an offense for bad indentation of a do-end body' do
+          expect_offense(<<~RUBY)
+            func do
+               it&.foo
+            ^^^ Use 2 (not 3) spaces for indentation.
+            end
+          RUBY
+        end
+      end
+
       # The cop uses the block end/} as the base for indentation, so if it's not
       # on its own line, all bets are off.
       it 'accepts badly indented code if block end is not on separate line' do

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1764,28 +1764,28 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
       end
 
-      context 'Ruby 2.7', :ruby27 do
+      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
         it 'adds an offense for {} block does correct it' do
           expect_offense(<<~RUBY)
-            foo.select { _1 + 4444000039123123129993912312312999199291203123123 }
+            foo.select { it + 4444000039123123129993912312312999199291203123123 }
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [69/40]
           RUBY
 
           expect_correction(<<~RUBY)
             foo.select {
-             _1 + 4444000039123123129993912312312999199291203123123 }
+             it + 4444000039123123129993912312312999199291203123123 }
           RUBY
         end
 
         it 'adds an offense for do-end block and does correct it' do
           expect_offense(<<~RUBY)
-            foo.select do _1 + 4444000039123123129993912312312999199291203123 end
+            foo.select do it + 4444000039123123129993912312312999199291203123 end
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [69/40]
           RUBY
 
           expect_correction(<<~RUBY)
             foo.select do
-             _1 + 4444000039123123129993912312312999199291203123 end
+             it + 4444000039123123129993912312312999199291203123 end
           RUBY
         end
       end

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -378,4 +378,34 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and corrects for missing newline in {} block w/o params' do
+      expect_offense(<<~RUBY)
+        test { it
+               ^^ Block body expression is on the same line as the block start.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test {#{trailing_whitespace}
+          it
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects for missing newline in do/end block with params' do
+      expect_offense(<<~RUBY)
+        test do it
+                ^^ Block body expression is on the same line as the block start.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test do#{trailing_whitespace}
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -423,6 +423,17 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
         end
       end
 
+      context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+        it 'accepts methods being aligned with method that is an argument' \
+           'when using `it` parameter' do
+          expect_no_offenses(<<~RUBY)
+            File.read('data.yml')
+                .then { YAML.safe_load it }
+                .transform_values(&:downcase)
+          RUBY
+        end
+      end
+
       it 'accepts methods being aligned with method that is an argument in assignment' do
         expect_no_offenses(<<~RUBY)
           user = authorize scope.includes(:user)
@@ -763,6 +774,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       expect_no_offenses(<<~RUBY)
         do_something.foo do
           bar(_1)
+        end.baz
+           .qux
+      RUBY
+    end
+
+    it 'accepts aligned methods in multiline `it` block chain', :ruby34, unsupported_on: :parser do
+      expect_no_offenses(<<~RUBY)
+        do_something.foo do
+          bar(it)
         end.baz
            .qux
       RUBY

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
            .join + []
         RUBY
       end
+
+      it 'accepts a method call chained onto a single line `it` block', :ruby34, unsupported_on: :parser do
+        expect_no_offenses(<<~RUBY)
+          e.select { it.cond? }
+           .join
+          a = e.select { it.cond? }
+           .join
+          e.select { it.cond? }
+           .join + []
+        RUBY
+      end
     end
 
     context 'for an expression that fits on a single line' do
@@ -743,6 +754,20 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             end.join
             e.select do
               _1.cond?
+            end.join + []
+          RUBY
+        end
+
+        it 'accepts a method call chained onto a multiline `it` block', :ruby34, unsupported_on: :parser do
+          expect_no_offenses(<<~RUBY)
+            e.select do
+              it.cond?
+            end.join
+            a = e.select do
+              it.cond?
+            end.join
+            e.select do
+              it.cond?
             end.join + []
           RUBY
         end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -642,6 +642,45 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'accepts aligned rescue in do-end `it` block in a method' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          [1, 2, 3].each do
+            it.to_s
+          rescue StandardError => _exception
+            next
+          end
+        end
+      RUBY
+    end
+
+    context 'rescue with do-end `it` block' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          def foo
+            [1, 2, 3].each do
+              it.to_s
+          rescue StandardError => _exception
+          ^^^^^^ `rescue` at 4, 0 is not aligned with `[1, 2, 3].each do` at 2, 2.
+              next
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            [1, 2, 3].each do
+              it.to_s
+            rescue StandardError => _exception
+              next
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'rescue in do-end block assigned to local variable' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
+++ b/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe RuboCop::Cop::Layout::SingleLineBlockChain, :config do
     RUBY
   end
 
+  it 'registers an offense for method call chained on the same line as a itblock', :ruby34, unsupported_on: :parser do
+    expect_offense(<<~RUBY)
+      example.select { it.cond? }.join('-')
+                                 ^^^^^ Put method call on a separate line if chained to a single line block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      example.select { it.cond? }
+      .join('-')
+    RUBY
+  end
+
   it 'registers an offense for safe navigation method call chained on the same line as a block' do
     expect_offense(<<~RUBY)
       example.select { |item| item.cond? }&.join('-')

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -81,6 +81,38 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
         RUBY
       end
     end
+
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers an offense and corrects opposite + correct style' do
+        expect_offense(<<~RUBY)
+          each{ it }
+              ^ Space missing to the left of {.
+          each { it }
+        RUBY
+
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        expect_correction(<<~RUBY)
+          each { it }
+          each { it }
+        RUBY
+      end
+
+      it 'registers an offense and corrects multiline block where the left ' \
+         'brace has no outer space' do
+        expect_offense(<<~RUBY)
+          foo.map{
+                 ^ Space missing to the left of {.
+            it.bar.to_s
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.map {
+            it.bar.to_s
+          }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is no_space' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -104,6 +104,20 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
   end
 
+  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for itblocks without inner space' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].each {it * 2}
+                        ^ Space missing inside {.
+                              ^ Space missing inside }.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3].each { it * 2 }
+      RUBY
+    end
+  end
+
   it 'accepts braces surrounded by spaces' do
     expect_no_offenses('each { puts }')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 end


### PR DESCRIPTION
This PR supports `it` block parameter in `Layout` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
