### PR TITLE
Support `it` block parameter in `Lint` cops

### DIFF
--- a/changelog/new_support_itblock_in_lint_cops.md
+++ b/changelog/new_support_itblock_in_lint_cops.md
@@ -1,0 +1,1 @@
+* [#14017](https://github.com/rubocop/rubocop/pull/14017): Support `it` block parameter in `Lint` cops. ([@koic][])

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -73,7 +73,7 @@ module RuboCop
       #   require 'my_debugger/start'
       class Debugger < Base
         MSG = 'Remove debugger entry point `%<source>s`.'
-        BLOCK_TYPES = %i[block numblock kwbegin].freeze
+        BLOCK_TYPES = %i[block numblock itblock kwbegin].freeze
 
         def on_send(node)
           return if assumed_usage_context?(node)
@@ -120,7 +120,7 @@ module RuboCop
           return true if assumed_argument?(node)
 
           node.each_ancestor.none? do |ancestor|
-            BLOCK_TYPES.include?(ancestor.type) || ancestor.lambda_or_proc?
+            ancestor.type?(:any_block, :kwbegin) || ancestor.lambda_or_proc?
           end
         end
 

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -53,6 +53,7 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -64,6 +65,8 @@ module RuboCop
               (args (arg _)) ...)
             (numblock
               $(call _ {:each_with_index :with_index} ...) 1 ...)
+            (itblock
+              $(call _ {:each_with_index :with_index} ...) _ ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -49,6 +49,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -59,6 +60,8 @@ module RuboCop
               $(call _ {:each_with_object :with_object} _) (args (arg _)) ...)
             (numblock
               $(call _ {:each_with_object :with_object} _) 1 ...)
+            (itblock
+              $(call _ {:each_with_object :with_object} _) _ ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/lint/unexpected_block_arity.rb
+++ b/lib/rubocop/cop/lint/unexpected_block_arity.rb
@@ -53,6 +53,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -74,6 +75,7 @@ module RuboCop
 
         def arg_count(node)
           return node.children[1] if node.numblock_type? # the maximum numbered param for the block
+          return 1 if node.itblock_type? # `it` block parameter is always one
 
           # Only `arg`, `optarg` and `mlhs` (destructuring) count as arguments that
           # can be used. Keyword arguments are not used for these methods so are

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -43,6 +43,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def after_block(node)
           @instance_eval_count -= 1 if instance_eval_block?(node)

--- a/lib/rubocop/cop/lint/unreachable_loop.rb
+++ b/lib/rubocop/cop/lint/unreachable_loop.rb
@@ -101,9 +101,8 @@ module RuboCop
           check(node) if loop_method?(node)
         end
 
-        def on_numblock(node)
-          check(node) if loop_method?(node)
-        end
+        alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -189,8 +188,9 @@ module RuboCop
 
         def preceded_by_continue_statement?(break_statement)
           break_statement.left_siblings.any? do |sibling|
-            # Numblocks have the arguments count as a number in the AST.
-            next if sibling.is_a?(Integer)
+            # Numblocks have the arguments count as a number or,
+            # itblocks have `:it` symbol in the AST.
+            next if sibling.is_a?(Integer) || sibling.is_a?(Symbol)
             next if sibling.loop_keyword? || loop_method?(sibling)
 
             sibling.each_descendant(*CONTINUE_KEYWORDS).any?

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -143,6 +143,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -86,6 +86,7 @@ module RuboCop
           check_expression(node.body)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_begin(node)
           check_begin(node)

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -54,7 +54,7 @@ module RuboCop
 
       ZERO_ARITY_SUPER_TYPE = :zsuper
 
-      TWISTED_SCOPE_TYPES = %i[block numblock class sclass defs module].freeze
+      TWISTED_SCOPE_TYPES = %i[block numblock itblock class sclass defs module].freeze
       SCOPE_TYPES = (TWISTED_SCOPE_TYPES + [:def]).freeze
 
       SEND_TYPE = :send

--- a/lib/rubocop/cop/variable_force/scope.rb
+++ b/lib/rubocop/cop/variable_force/scope.rb
@@ -46,7 +46,7 @@ module RuboCop
           else
             child_index = case node.type
                           when :module, :sclass then 1
-                          when :def, :class, :block, :numblock then 2
+                          when :def, :class, :block, :numblock, :itblock then 2
                           when :defs then 3
                           end
 

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
       end
     end
 
+    context 'without receiver and itblock', :ruby34, unsupported_on: :parser do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          some_method a { puts it }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Parenthesize the param `a { puts it }` to make sure that the block will be associated with the `a` method call.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          some_method(a { puts it })
+        RUBY
+      end
+    end
+
     context 'with receiver' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -143,6 +143,16 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect_no_offenses('return 1 if any_errors? { o = _1 }.present?')
   end
 
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'accepts = in an itblock that is called in a condition' do
+      expect_no_offenses('return 1 if any_errors? { o = inspect(it) }')
+    end
+
+    it 'accepts = in an itblock followed by method call' do
+      expect_no_offenses('return 1 if any_errors? { o = it }.present?')
+    end
+  end
+
   it 'accepts assignment in a block after ||' do
     expect_no_offenses(<<~RUBY)
       if x?(bar) || y? { z = baz }

--- a/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
+++ b/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
     RUBY
   end
 
+  it 'registers an offense for a module defined within an itblock', :ruby34, unsupported_on: :parser do
+    expect_offense(<<~RUBY)
+      describe do
+        module Foo; end
+        ^^^^^^^^^^^^^^^ Do not define constants this way within a block.
+        it
+      end
+    RUBY
+  end
+
   it 'does not register an offense for a constant with an explicit self scope' do
     expect_no_offenses(<<~RUBY)
       describe do
@@ -188,6 +198,16 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
           module Foo
           end
           _1
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a module defined within an itblock of `enums` method', :ruby34, unsupported_on: :parser do
+      expect_no_offenses(<<~RUBY)
+        enums do
+          module Foo
+          end
+          it
         end
       RUBY
     end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
+    it 'registers an offense for a `custom_debugger` call when used in `it` block', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        x.y = do_something do
+          z(it)
+          custom_debugger
+          ^^^^^^^^^^^^^^^ Remove debugger entry point `custom_debugger`.
+        end
+      RUBY
+    end
+
     it 'registers an offense for a `custom_debugger` call when used in lambda literal' do
       expect_offense(<<~RUBY)
         x.y = -> { custom_debugger }

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -148,6 +148,44 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
     end
   end
 
+  context '`Class.new` `it` block', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and does not autocorrect when no `super` call' do
+      expect_offense(<<~RUBY)
+        Class.new(Parent) do
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+          end
+
+          do_something(it)
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense for the `Class.new` without parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new do
+          def initialize
+          end
+
+          do_something(it)
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the `Class.new` with stateless parent class argument' do
+      expect_no_offenses(<<~RUBY)
+        Class.new(Object) do
+          def initialize
+          end
+
+          do_something(it)
+        end
+      RUBY
+    end
+  end
+
   context 'callbacks' do
     it 'registers no offense when module callback without `super` call' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -393,6 +393,51 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     end
   end
 
+  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+    it 'does not register offense for nested definition inside `Module.new` with itblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def self.define
+            Module.new do
+              def y
+              end
+
+              do_something(it)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register offense for nested definition inside instance_eval with itblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def x(obj)
+            obj.instance_eval do
+              @bar = it
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register offense for nested definition inside instance_exec with itblock' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def x(obj)
+            obj.instance_exec(3) do
+              @bar = it
+              def y
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when Ruby >= 3.2', :ruby32 do
     it 'does not register offense for nested definition inside `Data.define`' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe RuboCop::Cop::Lint::NonLocalExitFromIterator, :config do
           end
         RUBY
       end
+
+      it 'registers an offense for itblocks', :ruby34, unsupported_on: :parser do
+        expect_offense(<<~RUBY)
+          items.each do
+            return if baz?(it)
+            ^^^^^^ Non-local exit from iterator, [...]
+            it.update!(foobar: true)
+          end
+        RUBY
+      end
     end
 
     context 'and has multiple arguments' do

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     end
   end
 
+  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and corrects for method call with space before the parenthesis when block argument and parenthesis' do
+      expect_offense(<<~RUBY)
+        a.concat ((1..1).map { it * 10 })
+                ^ `((1..1).map { it * 10 })` interpreted as grouped expression.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.concat((1..1).map { it * 10 })
+      RUBY
+    end
+
+    it 'does not register an offense for method call with space before the parenthesis when block argument is no parenthesis' do
+      expect_no_offenses(<<~RUBY)
+        a.concat (1..1).map { it * 10 }
+      RUBY
+    end
+  end
+
   it 'does not register an offense for expression followed by an operator' do
     expect_no_offenses(<<~RUBY)
       func (x) || y

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -113,4 +113,43 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex, :config do
       expect_no_offenses('with_index { _1 }')
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for `ary.each_with_index { it }` and corrects to `ary.each`' do
+      expect_offense(<<~RUBY)
+        ary.each_with_index { it }
+            ^^^^^^^^^^^^^^^ Use `each` instead of `each_with_index`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary.each { it }
+      RUBY
+    end
+
+    it 'registers an offense for `ary&.each_with_index { it }` and corrects to `ary&.each`' do
+      expect_offense(<<~RUBY)
+        ary&.each_with_index { it }
+             ^^^^^^^^^^^^^^^ Use `each` instead of `each_with_index`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary&.each { it }
+      RUBY
+    end
+
+    it 'registers an offense when using `ary.each.with_index { it }` and corrects to `ary.each`' do
+      expect_offense(<<~RUBY)
+        ary.each.with_index { it }
+                 ^^^^^^^^^^ Remove redundant `with_index`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary.each { it }
+      RUBY
+    end
+
+    it 'accepts with_index without receiver with an itblock' do
+      expect_no_offenses('with_index { it }')
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -113,4 +113,39 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject, :config do
       RUBY
     end
   end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense and corrects when using `ary.each_with_object { it }`' do
+      expect_offense(<<~RUBY)
+        ary.each_with_object([]) { it }
+            ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary.each { it }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `ary&.each_with_object { it }`' do
+      expect_offense(<<~RUBY)
+        ary&.each_with_object([]) { it }
+             ^^^^^^^^^^^^^^^^^^^^ Use `each` instead of `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary&.each { it }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `ary.each.with_object([]) { it }`' do
+      expect_offense(<<~RUBY)
+        ary.each.with_object([]) { it }
+                 ^^^^^^^^^^^^^^^ Remove redundant `with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary.each { it }
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/return_in_void_context_spec.rb
+++ b/spec/rubocop/cop/lint/return_in_void_context_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe RuboCop::Cop::Lint::ReturnInVoidContext, :config do
       RUBY
     end
 
+    it 'registers an offense when the value is returned in an itblock', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        class A
+          def initialize
+            foo do
+              it
+              return :qux
+              ^^^^^^ Do not return a value in `initialize`.
+            end
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense when the value is returned from inside a proc' do
       expect_offense(<<~RUBY)
         class A

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -494,4 +494,20 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
   end
+
+  context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for ordinary method chain exists after ' \
+       'safe navigation method call with a block using `it` parameter' do
+      expect_offense(<<~RUBY)
+        something
+        x&.select { foo(it) }.bar
+                             ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        something
+        x&.select { foo(it) }&.bar
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -409,6 +409,19 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
         RUBY
       end
     end
+
+    context 'when assigning an `it` block parameter', :ruby34, unsupported_on: :parser do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def x(array)
+            array.each {
+              bar = it
+            }.each { |bar|
+            }
+          end
+        RUBY
+      end
+    end
   end
 
   context 'with Ractor.new' do

--- a/spec/rubocop/cop/lint/unexpected_block_arity_spec.rb
+++ b/spec/rubocop/cop/lint/unexpected_block_arity_spec.rb
@@ -172,6 +172,25 @@ RSpec.describe RuboCop::Cop::Lint::UnexpectedBlockArity, :config do
     end
   end
 
+  context 'with an itblock', :ruby34, unsupported_on: :parser do
+    context 'when given one parameter' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          values.reduce { it }
+          ^^^^^^^^^^^^^^^^^^^^ `reduce` expects at least 2 positional arguments, got 1.
+        RUBY
+      end
+    end
+
+    context 'with no receiver' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          reduce { it }
+        RUBY
+      end
+    end
+  end
+
   it 'registers multiple offenses' do
     expect_offense(<<~RUBY)
       values.reduce { |a| a }

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -588,6 +588,17 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
         RUBY
       end
 
+      it 'does not look inside inner itblocks', :ruby34, unsupported_on: :parser do
+        expect_no_offenses(<<~RUBY)
+          foo.#{method}(bar) do |acc, el|
+            values.map do
+              next el if something?
+              it
+            end
+          end
+        RUBY
+      end
+
       it 'allows break with no value' do
         expect_no_offenses(<<~RUBY)
           foo.#{method}([]) do |acc, el|

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -296,6 +296,20 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
 
+    it "accepts `#{t}` if called in `instance_eval` with itblock", :ruby34, unsupported_on: :parser do
+      expect_no_offenses <<~RUBY
+        class Dummy
+          def #{t}; end
+        end
+
+        d = Dummy.new
+        d.instance_eval do
+          #{t}
+          it
+        end
+      RUBY
+    end
+
     it "accepts `#{t}` if called in nested `instance_eval`" do
       expect_no_offenses <<~RUBY
         class Dummy

--- a/spec/rubocop/cop/lint/unreachable_loop_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_loop_spec.rb
@@ -242,6 +242,15 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
           RUBY
         end
       end
+
+      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            2.times { raise it }
+            ^^^^^^^^^^^^^^^^^^^^ This loop will have at most one iteration.
+          RUBY
+        end
+      end
     end
   end
 
@@ -321,6 +330,17 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
         [1, 2, 3].each do
         ^^^^^^^^^^^^^^^^^ This loop will have at most one iteration.
           return _1.odd? || break
+        end
+      RUBY
+    end
+  end
+
+  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    it 'registers an offense when using `return do_something(value) || break` in a loop' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3].each do
+        ^^^^^^^^^^^^^^^^^ This loop will have at most one iteration.
+          return it.odd? || break
         end
       RUBY
     end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -1058,6 +1058,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           end
         RUBY
       end
+
+      it 'registers an offense if no method is defined in `Data.define` with itblock', :ruby34, unsupported_on: :parser do
+        expect_offense(<<~RUBY, modifier: modifier)
+          Data.define do
+            %{modifier}
+            ^{modifier} Useless `#{modifier}` access modifier.
+            do_something(it)
+          end
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -173,6 +173,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
       RUBY
     end
 
+    it 'registers an offense for an itblock', :ruby34, unsupported_on: :parser do
+      expect_offense(<<~RUBY)
+        define_method(:foo) { it }
+        ruby2_keywords :foo
+        ^^^^^^^^^^^^^^^^^^^ `ruby2_keywords` is unnecessary for method `foo`.
+      RUBY
+    end
+
     it 'does not register an offense for `Proc#ruby2_keywords`' do
       expect_no_offenses(<<~RUBY)
         block = proc { |_, *args| klass.new(*args) }

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -549,6 +549,25 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers offense for nonmutating method that takes an `it` parameter block' do
+        expect_offense(<<~RUBY)
+          [1,2,3].map do
+          ^^^^^^^^^^^^^^ Method `#map` used in void context. Did you mean `#each`?
+            it.to_s
+          end
+          "done"
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1,2,3].each do
+            it.to_s
+          end
+          "done"
+        RUBY
+      end
+    end
+
     it 'registers an offense if not on last line' do
       expect_offense(<<~RUBY)
         x.sort

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 end


### PR DESCRIPTION
This PR supports `it` block parameter in `Lint` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
