### PR TITLE
Support `it` block parameter in `Metrics` cops

### DIFF
--- a/changelog/new_support_itblock_in_metrics_cops.md
+++ b/changelog/new_support_itblock_in_metrics_cops.md
@@ -1,0 +1,1 @@
+* [#14018](https://github.com/rubocop/rubocop/pull/14018): Support `it` block parameter in `Metrics` cops. ([@koic][])

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -57,6 +57,7 @@ module RuboCop
           check_code_length(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -63,6 +63,7 @@ module RuboCop
           check_code_length(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -145,7 +145,7 @@ module RuboCop
 
           def extract_body(node)
             case node.type
-            when :class, :module, :sclass, :block, :numblock, :def, :defs
+            when :class, :module, :sclass, :block, :numblock, :itblock, :def, :defs
               node.body
             when :casgn
               extract_body(node.expression)

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -30,6 +30,7 @@ module RuboCop
       end
 
       alias on_numblock on_block
+      alias on_itblock on_block
 
       private
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.38.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.41.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       end
     end
 
+    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      it 'registers an offense for a `define_method` with itblock' do
+        expect_offense(<<~RUBY)
+          define_method :method_name do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+            x = it
+          end
+        RUBY
+      end
+    end
+
     it 'treats safe navigation method calls like regular method calls + a condition' do
       expect_offense(<<~RUBY)
         def method_name

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -137,6 +137,52 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     end
   end
 
+  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+    it 'rejects a block with more than 5 lines' do
+      expect_offense(<<~RUBY)
+        something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
+          a = it
+          a = it
+          a = it
+        end
+      RUBY
+    end
+
+    it 'reports the correct beginning and end lines' do
+      offenses = expect_offense(<<~RUBY)
+        something do
+        ^^^^^^^^^^^^ Block has too many lines. [3/2]
+          a = it
+          a = it
+          a = it
+        end
+      RUBY
+      offense = offenses.first
+      expect(offense.location.last_line).to eq(5)
+    end
+
+    it 'accepts a block with less than 3 lines' do
+      expect_no_offenses(<<~RUBY)
+        something do
+          a = it
+          a = it
+        end
+      RUBY
+    end
+
+    it 'does not count blank lines' do
+      expect_no_offenses(<<~RUBY)
+        something do
+          a = it
+
+
+          a = it
+        end
+      RUBY
+    end
+  end
+
   it 'accepts a block with multiline receiver and less than 3 lines of body' do
     expect_no_offenses(<<~RUBY)
       [

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -313,6 +313,36 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
         end
       end
     end
+
+    context 'when `it` parameter', :ruby34, unsupported_on: :parser do
+      context 'nested multiline block' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if a
+              if b
+                [1, 2].each do
+                ^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+                  puts it
+                end
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'nested inline block' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            if a
+              if b
+                [1, 2].each { puts it }
+                ^^^^^^^^^^^^^^^^^^^^^^^ Avoid more than 2 levels of block nesting.
+              end
+            end
+          RUBY
+        end
+      end
+    end
   end
 
   context 'when CountModifierForms is false' do

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -457,4 +457,83 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
       end
     end
   end
+
+  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+    context 'when inspecting a class defined with Class.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = Class.new do
+                ^^^^^^^^^^^^ Class has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+    end
+
+    context 'when inspecting a class defined with ::Class.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = ::Class.new do
+                ^^^^^^^^^^^^^^ Class has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+    end
+
+    context 'when inspecting a class defined with Struct.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = Struct.new(:foo, :bar) do
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Class has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when inspecting or equals (`||=`) for constant' do
+        expect_offense(<<~RUBY)
+          Foo ||= Struct.new(:foo, :bar) do
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Class has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when multiple assignments to constants' do
+        # `Bar` is always nil, but syntax is valid.
+        expect_offense(<<~RUBY)
+          Foo, Bar = Struct.new(:foo, :bar) do
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^ Class has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -105,6 +105,24 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     end
   end
 
+  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+    context 'when method is defined with `define_method`' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          define_method(:m) do
+          ^^^^^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'when method is a class method' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
@@ -325,6 +343,19 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
           end
         RUBY
       end
+
+      it 'accepts dynamically defined matching method name with an itblock', :ruby34, unsupported_on: :parser do
+        expect_no_offenses(<<~RUBY)
+          define_method(:foo) do
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
+          end
+        RUBY
+      end
     end
 
     context 'AllowedPatterns is enabled' do
@@ -365,6 +396,19 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
             a = _4
             a = _5
             a = _6
+          end
+        RUBY
+      end
+
+      it 'accepts dynamically defined matching method name with an itblock', :ruby34, unsupported_on: :parser do
+        expect_no_offenses(<<~RUBY)
+          define_method(:user_name) do
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
+            a = it
           end
         RUBY
       end

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -345,4 +345,38 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
       end
     end
   end
+
+  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+    context 'when inspecting a class defined with Module.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = Module.new do
+          ^^^ Module has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+    end
+
+    context 'when inspecting a class defined with ::Module.new' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          Foo = ::Module.new do
+          ^^^ Module has too many lines. [6/5]
+            a(it)
+            b(it)
+            c(it)
+            d(it)
+            e(it)
+            f(it)
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 end


### PR DESCRIPTION
This PR supports `it` block parameter in `Metrics` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
