### PR TITLE
Fix comment autocorrection for Style/IfInsideElse

### DIFF
--- a/changelog/fix_style_if_inside_else_comment_autocorrect.md
+++ b/changelog/fix_style_if_inside_else_comment_autocorrect.md
@@ -1,0 +1,1 @@
+* [#14020](https://github.com/rubocop/rubocop/pull/14020): Fix comment autocorrection for `Style/IfInsideElse`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -74,6 +74,35 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     RUBY
   end
 
+  it 'catches an `if..else` nested inside an `else` with comments in both branches' do
+    expect_offense(<<~RUBY)
+      if a
+        foo
+      else
+        if b
+        ^^ Convert `if` nested inside `else` to `elsif`.
+          # this is very important
+          bar # this too
+        else
+          # this three
+          baz # this four
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a
+        foo
+      elsif b
+        # this is very important
+          bar # this too
+        else
+          # this three
+          baz # this four
+      end
+    RUBY
+  end
+
   it 'catches an if..elsif..else nested inside an else' do
     expect_offense(<<~RUBY)
       if a
@@ -114,7 +143,8 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
       elsif b
         foo
       else
-        bar if condition
+        # important info
+        bar if condition # blabla
             ^^ Convert `if` nested inside `else` to `elsif`.
       end
     RUBY
@@ -125,7 +155,8 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
       elsif b
         foo
       elsif condition
-        bar
+        # important info
+        bar # blabla
       end
     RUBY
   end


### PR DESCRIPTION
Fixes how comments are handled in autocorrection for `Style/IfInsideElse`. Previously, some of them would get deleted and some would be placed awkwardly.

Examples below are split for basic if...else form and modifier form.

## Basic form

This example:
```ruby
if foo
  bar
else
  if baz
    # one
    qux # two
  else
    # three
    quux # four
  end
end
```
would previously get autocorrected to:
```ruby
if foo
  bar
elsif baz
  qux
# one
else
  # three
  quux # four
end
```

After this PR, it's autocorrected to:
```ruby
if foo
  bar
elsif baz
  # one
  qux # two
else
  # three
  quux # four
end
```

## Modifier form

This example:
```ruby
if foo
  bar
else
  # one
  baz if qux # two
end
```
would previously get autocorrected to:
```ruby
if foo
  bar
elsif qux
  baz
end
# one
```

After this PR, it's autocorrected to:
```ruby
if foo
  bar
elsif qux
  # one
  baz # two
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
