### PR TITLE
Fix handling of long heredoc lines with SplitStrings enabled

### DIFF
--- a/changelog/fix_handling_of_long_heredoc_lines_with_splitstrings_enabled_20250322032415.md
+++ b/changelog/fix_handling_of_long_heredoc_lines_with_splitstrings_enabled_20250322032415.md
@@ -1,0 +1,1 @@
+* [#14021](https://github.com/rubocop/rubocop/pull/14021): Fix handling of long heredoc lines with SplitStrings enabled. ([@mauro-oto][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -371,7 +371,9 @@ module RuboCop
 
         def string_delimiter(node)
           delimiter = node.loc.begin
-          delimiter ||= node.parent.loc.begin if node.parent&.dstr_type?
+          if node.parent&.dstr_type? && node.parent.loc.respond_to?(:begin)
+            delimiter ||= node.parent.loc.begin
+          end
           delimiter = delimiter&.source
 
           delimiter if %w[' "].include?(delimiter)


### PR DESCRIPTION
This fixes a problem we've been seeing related to heredocs and the `SplitStrings` configuration. Whenever we run Rubocop locally or in CI after enabling that setting, we see the following on many files with heredocs in them:

```
An error occurred while Layout/LineLength cop was inspecting /Users/mauro-oto/Projects/foo/spec/support/bar.rb:2:7.
undefined method `begin' for an instance of Parser::Source::Map::Heredoc
/Users/mauro-oto/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-1.74.0/lib/rubocop/cop/layout/line_length.rb:373:in `string_delimiter'
/Users/mauro-oto/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-1.74.0/lib/rubocop/cop/layout/line_length.rb:148:in `check_for_breakable_str'
/Users/mauro-oto/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-1.74.0/lib/rubocop/cop/layout/line_length.rb:80:in `on_str'
...

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Layout/LineLength cop was inspecting /Users/mauro-oto/Projects/foo/spec/support/bar.rb:2:7.
configuration from /Users/mauro-oto/Projects/foo/.rubocop.yml
Errors are usually caused by RuboCop bugs.
Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.74.0 (using Parser 3.3.7.2, rubocop-ast 1.41.0, analyzing as Ruby 3.3, running on ruby 3.3.6) [arm64-darwin24]
```

Not all files are affected though, but the minimal reproduction I could find is this, with more than one string interpolation:
```
<<~MESSAGE
  #{'hello' * 1} #{'world' * 1}
MESSAGE
```

However, even though I can reproduce in my local project and fix it with the change here, I can't seem to get to fail in this project's test suite through the test I'm adding here. Any suggestions around that are welcome!

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
