### PR TITLE
Fix an error for `Style/HashFetchChain`

### DIFF
--- a/changelog/fix_an_error_for_style_hash_fetch_chain.md
+++ b/changelog/fix_an_error_for_style_hash_fetch_chain.md
@@ -1,0 +1,1 @@
+* [#14022](https://github.com/rubocop/rubocop/pull/14022): Fix an error for `Style/HashFetchChain` when no arguments are given to `fetch`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_fetch_chain.rb
+++ b/lib/rubocop/cop/style/hash_fetch_chain.rb
@@ -79,7 +79,7 @@ module RuboCop
 
           return false unless node.method?(:fetch)
 
-          !node.last_argument.nil_type?
+          !node.last_argument&.nil_type?
         end
 
         def inspect_chain(node)

--- a/spec/rubocop/cop/style/hash_fetch_chain_spec.rb
+++ b/spec/rubocop/cop/style/hash_fetch_chain_spec.rb
@@ -95,6 +95,14 @@ RSpec.describe RuboCop::Cop::Style::HashFetchChain, :config do
         end
       end
 
+      context 'when no arguments are given to `fetch`' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            hash.fetch
+          RUBY
+        end
+      end
+
       context 'when the 2nd argument is not `nil` or `{}`' do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/13952#issuecomment-2745256954.

This PR fixes an error for `Style/HashFetchChain` when no arguments are given to `fetch`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
