### PR TITLE
Support `it` block parameter in `InternalAffairs` cops

### DIFF
--- a/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
+++ b/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
@@ -27,7 +27,7 @@ module RuboCop
         MSG = 'Replace `%<names>s` in node pattern union with `%<replacement>s`.'
         RESTRICT_ON_SEND = %i[def_node_matcher def_node_search].freeze
         NODE_GROUPS = {
-          any_block: %i[block numblock],
+          any_block: %i[block numblock itblock],
           argument: %i[arg optarg restarg kwarg kwoptarg kwrestarg blockarg forward_arg shadowarg],
           boolean: %i[true false],
           call: %i[send csend],

--- a/spec/rubocop/cop/internal_affairs/node_pattern_groups_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_pattern_groups_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::NodePatternGroups, :config do
     end
   end
 
-  it_behaves_like 'node group', 'any_block', %i[numblock block]
+  it_behaves_like 'node group', 'any_block', %i[itblock numblock block]
   it_behaves_like 'node group', 'argument',
                   %i[arg blockarg forward_arg kwarg kwoptarg kwrestarg optarg restarg shadowarg]
   it_behaves_like 'node group', 'boolean', %i[false true]


### PR DESCRIPTION
This PR supports `it` block parameter in `InternalAffairs` cops.

Based on my investigation, this appears to be the required `it` block parameter support for existing cops that support numbered block parameter.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
