### PR TITLE
Offend parentheses for chained && expressions in `Style/RedundantParentheses`

### DIFF
--- a/changelog/change_redundant_parentheses_for_chained_and.md
+++ b/changelog/change_redundant_parentheses_for_chained_and.md
@@ -1,0 +1,1 @@
+* [#14024](https://github.com/rubocop/rubocop/pull/14024): Change `Style/RedundantParentheses` to offend parentheses for chained `&&` expressions. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -89,8 +89,8 @@ module RuboCop
 
         def inheritance_check?(node)
           argument = node.first_argument
-          node.method?(:<) &&
-            (argument.const_type? && argument.short_name.to_s.upcase != argument.short_name.to_s)
+          node.method?(:<) && argument.const_type? &&
+            argument.short_name.to_s.upcase != argument.short_name.to_s
         end
 
         def preferred_condition(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -17,7 +17,7 @@ module RuboCop
         include Parentheses
         extend AutoCorrector
 
-        ALLOWED_NODE_TYPES = %i[and or send splat kwsplat].freeze
+        ALLOWED_NODE_TYPES = %i[or send splat kwsplat].freeze
 
         # @!method square_brackets?(node)
         def_node_matcher :square_brackets?, <<~PATTERN
@@ -162,6 +162,7 @@ module RuboCop
             return if node.semantic_operator? && begin_node.parent
             return if node.multiline? && allow_in_multiline_conditions?
             return if ALLOWED_NODE_TYPES.include?(begin_node.parent&.type)
+            return if !node.and_type? && begin_node.parent&.and_type?
             return if begin_node.parent&.if_type? && begin_node.parent.ternary?
 
             'a logical expression'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -765,6 +765,97 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers parentheses around `&&` followed by another `&&`' do
+    expect_offense(<<~RUBY)
+      (x && y) && z
+      ^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x && y && z
+    RUBY
+  end
+
+  it 'registers parentheses around `&&` preceded by another `&&`' do
+    expect_offense(<<~RUBY)
+      x && (y && z)
+           ^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x && y && z
+    RUBY
+  end
+
+  it 'registers parentheses around `&&` preceded and followed by another `&&`' do
+    expect_offense(<<~RUBY)
+      x && (y && z) && w
+           ^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x && y && z && w
+    RUBY
+  end
+
+  it 'registers parentheses around `&&` preceded by another `&&` and followed by `||`' do
+    expect_offense(<<~RUBY)
+      x && (y && z) || w
+           ^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x && y && z || w
+    RUBY
+  end
+
+  it 'registers parentheses around `&&` preceded by `||` and followed by another `&&`' do
+    expect_offense(<<~RUBY)
+      x || (y && z) && w
+           ^^^^^^^^ Don't use parentheses around a logical expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x || y && z && w
+    RUBY
+  end
+
+  it 'accepts parentheses around `&&` followed by `||`' do
+    expect_no_offenses(<<~RUBY)
+      (x && y) || z
+    RUBY
+  end
+
+  it 'accepts parentheses around `&&` preceded by `||`' do
+    expect_no_offenses(<<~RUBY)
+      x || (y && z)
+    RUBY
+  end
+
+  it 'accepts parentheses around `&&` preceded and followed by `||`' do
+    expect_no_offenses(<<~RUBY)
+      x || (y && z) || w
+    RUBY
+  end
+
+  it 'accepts parentheses around `||` followed by `&&`' do
+    expect_no_offenses(<<~RUBY)
+      (x || y) && z
+    RUBY
+  end
+
+  it 'accepts parentheses around `||` preceded by `&&`' do
+    expect_no_offenses(<<~RUBY)
+      x && (y || z)
+    RUBY
+  end
+
+  it 'accepts parentheses around `||` preceded and followed by `&&`' do
+    expect_no_offenses(<<~RUBY)
+      x && (y || z) && w
+    RUBY
+  end
+
   it 'accepts parentheses around arithmetic operator' do
     expect_no_offenses('x - (y || z)')
   end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14012#discussion_r2006625844 to see if this change is acceptable.

Offends cases such as `(x && y) && z` and autocorrects to `x && y && z` since parentheses have no bearing on expression evaluation.

I know that in some cases parentheses are redundant for the machine but not for the human since they might make the intention clearer; this cop already accepts redundant parentheses in cases such as: https://github.com/rubocop/rubocop/blob/4ac46fac606eb7e0643686bd622a532cd2f8c2d5/spec/rubocop/cop/style/redundant_parentheses_spec.rb#L805-L808

In case we don't want to change existing behavior, I'm also okay with that, but then I'd like to change this PR so it at least adds an expectation that `(x && y) && z` doesn't offend (currently, this case isn't covered). 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
