### PR TITLE
Fix false negative for `Layout/LineLength` when autocorrecting class method definitions

### DIFF
--- a/changelog/fix_false_negative_lint_line_length_autocorrect.md
+++ b/changelog/fix_false_negative_lint_line_length_autocorrect.md
@@ -1,0 +1,1 @@
+* [#14027](https://github.com/rubocop/rubocop/pull/14027): Fix false negative for `Layout/LineLength` when autocorrecting class method definitions. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -93,6 +93,7 @@ module RuboCop
         alias on_send on_potential_breakable_node
         alias on_csend on_potential_breakable_node
         alias on_def on_potential_breakable_node
+        alias on_defs on_potential_breakable_node
 
         def on_new_investigation
           return unless processed_source.raw_source.include?(';')

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -48,7 +48,7 @@ module RuboCop
 
           args = process_args(node.arguments)
           return extract_breakable_node_from_elements(node, args, max)
-        elsif node.def_type?
+        elsif node.type?(:def, :defs)
           return extract_breakable_node_from_elements(node, node.arguments, max)
         elsif node.type?(:array, :hash)
           return extract_breakable_node_from_elements(node, node.children, max)
@@ -220,7 +220,7 @@ module RuboCop
 
       # @api private
       def already_on_multiple_lines?(node)
-        return node.first_line != node.last_argument.last_line if node.def_type?
+        return node.first_line != node.last_argument.last_line if node.type?(:def, :defs)
 
         !node.single_line?
       end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1022,6 +1022,32 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       end
     end
 
+    context 'class method definition' do
+      context 'when under limit' do
+        it 'does not add any offenses' do
+          expect_no_offenses(<<~RUBY)
+            def self.foo(foo: 1, bar: "2"); end
+          RUBY
+        end
+      end
+
+      context 'when over limit' do
+        it 'adds an offense and autocorrects it' do
+          expect_offense(<<~RUBY)
+            def self.foo(abc: "100000", def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [87/40]
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def self.foo(abc: "100000",#{trailing_whitespace}
+            def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'method call' do
       context 'when under limit' do
         it 'does not add any offenses' do


### PR DESCRIPTION
Fix `Layout/LineLength` to autocorrect long class method definitions just like it autocorrects regular method definitions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
