### PR TITLE
Fix false negative for `Layout/MultilineMethodParameterLineBreaks` when class method definitions are used

### DIFF
--- a/changelog/fix_false_negative_for_layout_multiline_parameter_line_breaks.md
+++ b/changelog/fix_false_negative_for_layout_multiline_parameter_line_breaks.md
@@ -1,0 +1,1 @@
+* [#14028](https://github.com/rubocop/rubocop/pull/14028): Fix false negative for `Layout/MultilineMethodParameterLineBreaks` when class method definitions are used. ([@vlad-pisanov][])

--- a/lib/rubocop/cop/layout/multiline_method_parameter_line_breaks.rb
+++ b/lib/rubocop/cop/layout/multiline_method_parameter_line_breaks.rb
@@ -65,6 +65,7 @@ module RuboCop
 
           check_line_breaks(node, node.arguments, ignore_last: ignore_last_element?)
         end
+        alias on_defs on_def
 
         private
 

--- a/spec/rubocop/cop/layout/multiline_method_parameter_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_parameter_line_breaks_spec.rb
@@ -211,4 +211,39 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodParameterLineBreaks, :config
       RUBY
     end
   end
+
+  context 'when a class method definition is used' do
+    context 'when all parameters are on the same line' do
+      it 'does not add any offenses' do
+        expect_no_offenses(<<~RUBY)
+          def self.taz(
+            foo, bar
+          )
+          end
+        RUBY
+      end
+    end
+
+    context 'when not all parameters are on separate lines' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def self.taz(abc,
+          foo, bar,
+               ^^^ Each parameter in a multi-line method definition must start on a separate line.
+          baz
+          )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.taz(abc,
+          foo,#{trailing_whitespace}
+          bar,
+          baz
+          )
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make `Layout/MultilineMethodParameterLineBreaks` handle class method definitions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
