### PR TITLE
Add `AllowConsecutiveConditionals` setting to `Style/Next` to allow consecutive conditional statements

### DIFF
--- a/changelog/change_style_next_to_support_consecutive_conditionals.md
+++ b/changelog/change_style_next_to_support_consecutive_conditionals.md
@@ -1,0 +1,1 @@
+* [#14029](https://github.com/rubocop/rubocop/pull/14029): Add `AllowConsecutiveConditionals` setting to `Style/Next` to allow consecutive conditional statements. ([@vlad-pisanov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4804,7 +4804,7 @@ Style/Next:
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.22'
-  VersionChanged: '0.35'
+  VersionChanged: '<<next>>'
   # With `always` all conditions at the end of an iteration needs to be
   # replaced by next - with `skip_modifier_ifs` the modifier if like this one
   # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
@@ -4812,6 +4812,7 @@ Style/Next:
   # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
   # needs to have to trigger this cop
   MinBodyLength: 3
+  AllowConsecutiveConditionals: false
   SupportedStyles:
     - skip_modifier_ifs
     - always

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -694,4 +694,52 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
         .to raise_error('MinBodyLength needs to be a positive integer!')
     end
   end
+
+  context 'AllowConsecutiveConditionals: false' do
+    let(:cop_config) { { 'AllowConsecutiveConditionals' => false, 'MinBodyLength' => 1 } }
+
+    it 'registers an offense and corrects when another conditional statements is at the same depth' do
+      expect_offense(<<~RUBY)
+        [].each do
+          if foo?
+            work
+          end
+
+          if bar?
+          ^^^^^^^ Use `next` to skip iteration.
+            work
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [].each do
+          if foo?
+            work
+          end
+
+          next unless bar?
+          work
+        end
+      RUBY
+    end
+  end
+
+  context 'AllowConsecutiveConditionals: true' do
+    let(:cop_config) { { 'AllowConsecutiveConditionals' => true, 'MinBodyLength' => 1 } }
+
+    it 'does not register an offense when other conditional statements are at the same depth' do
+      expect_no_offenses(<<~RUBY)
+        [].each do
+          if foo?
+            work
+          end
+
+          if bar?
+            work
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Add `AllowConsecutiveConditionals` setting to `Style/Next` (default: `false`) to mimic the behavior of `Style/GuardClause`.

Enabling this setting allows you to write:

```ruby
values.each do |val|
   if val == 1
     bar
   end

   if val == 2
     baz
   end
end
```

instead of the asymmetrical:
```ruby
values.each do |val|
   if val == 1
     bar
   end

   next unless val == 2
   baz
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
