### PR TITLE
Ignore permission errors when searching for gemspec files

### DIFF
--- a/changelog/fix_ignore_permission_errors_searching_for_gemspecs.md
+++ b/changelog/fix_ignore_permission_errors_searching_for_gemspecs.md
@@ -1,0 +1,1 @@
+* [#14030](https://github.com/rubocop/rubocop/pull/14030) Ignore permission errors when searching for gemspec files ([@joshheinrichs-shopify][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -102,7 +102,11 @@ module RuboCop
           @config.traverse_directories_upwards(@config.base_dir_for_path_parameters) do |dir|
             # NOTE: Can't use `dir.glob` because of JRuby 9.4.8.0 incompatibility:
             # https://github.com/jruby/jruby/issues/8358
-            candidates = Pathname.glob("#{dir}/*.gemspec")
+            candidates = begin
+              Pathname.glob("#{dir}/*.gemspec")
+            rescue Errno::EACCES, Errno::EPERM
+              []
+            end
             # Bundler will use a gemspec whatever the filename is, as long as its the only one in
             # the folder.
             break candidates.first if candidates.one?

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -665,5 +665,14 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
         end
       end
     end
+
+    context 'when gemspec file is not visible' do
+      [Errno::EPERM, Errno::EACCES].each do |error_class|
+        it "handles #{error_class} errors gracefully" do
+          expect(Pathname).to receive(:glob).and_raise(error_class).at_least(1).times
+          expect(target_ruby.version).to eq default_version
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm attempting to run rubocop (and other test tools) in an environment constrained by sandbox-exec[1] to improve reproducibility. In this sandboxed environment, tools only have access to a read-only copy of the project dirctory, a fake writeable home directory, and a writeable temp directory. When attempting to run rubocop in this setup, it fails to due permission errors while attempting to search for gemspec files in parent directories outside the sandbox. In this scenario I think it's reasonable to treat hidden gemspecs the same as gemspecs that don't exist.

[1] https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
