### PR TITLE
[Fixes #12358] Add `does` as a forbidden prefix to `Naming/PredicateName`

### DIFF
--- a/changelog/change_add_does_as_a_forbidden_prefix_to_20250325104731.md
+++ b/changelog/change_add_does_as_a_forbidden_prefix_to_20250325104731.md
@@ -1,0 +1,1 @@
+* [#12358](https://github.com/rubocop/rubocop/issues/12358): Add `does` as a forbidden prefix to `Naming/PredicateName`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3049,17 +3049,19 @@ Naming/PredicateName:
   StyleGuide: '#bool-methods-qmark'
   Enabled: true
   VersionAdded: '0.50'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
+    - does_
   # Predicate name prefixes that should be removed.
   ForbiddenPrefixes:
     - is_
     - has_
     - have_
+    - does_
   # Predicate names which, despite having a forbidden prefix, or no `?`,
   # should still be accepted
   AllowedMethods:

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -32,7 +32,7 @@ module RuboCop
 
           # To try to avoid doing two regex checks on every string,
           # shortcut out if the string does not look like an IP address
-          return false unless could_be_ip?(contents)
+          return false unless potential_ip?(contents)
 
           ::Resolv::IPv4::Regex.match?(contents) || ::Resolv::IPv6::Regex.match?(contents)
         end
@@ -52,7 +52,7 @@ module RuboCop
           Array(allowed_addresses).map(&:downcase)
         end
 
-        def could_be_ip?(str)
+        def potential_ip?(str)
           # If the string is too long, it can't be an IP
           return false if too_long?(str)
 


### PR DESCRIPTION
No tests are added since the tests are not using the default configuration.

Fixes #12358.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
