### PR TITLE
Consistently use `shared_examples` in specs

### DIFF
--- a/spec/rubocop/cop/annotation_comment_spec.rb
+++ b/spec/rubocop/cop/annotation_comment_spec.rb
@@ -55,13 +55,13 @@ RSpec.describe RuboCop::Cop::AnnotationComment do
   describe '#correct?' do
     subject { annotation.correct?(colon: colon) }
 
-    shared_examples_for 'correct' do |text|
+    shared_examples 'correct' do |text|
       let(:text) { text }
 
       it { is_expected.to be_truthy }
     end
 
-    shared_examples_for 'incorrect' do |text|
+    shared_examples 'incorrect' do |text|
       let(:text) { text }
 
       it { is_expected.to be_falsey }

--- a/spec/rubocop/cop/bundler/gem_filename_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_filename_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Bundler::GemFilename, :config do
-  shared_examples_for 'invalid gem file' do |message|
+  shared_examples 'invalid gem file' do |message|
     it 'registers an offense' do
       offenses = _investigate(cop, processed_source)
 
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Bundler::GemFilename, :config do
     end
   end
 
-  shared_examples_for 'valid gem file' do
+  shared_examples 'valid gem file' do
     it 'does not register an offense' do
       offenses = _investigate(cop, processed_source)
 

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
       end
 
       context 'method calls' do
-        shared_examples_for 'common behavior' do
+        shared_examples 'common behavior' do
           it 'does not register an offense for a non-chained method call' do
             expect_no_offenses(<<~RUBY)
               a#{operator}b

--- a/spec/rubocop/cop/lint/duplicate_branch_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_branch_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
-  shared_examples_for 'literal if allowed' do |type, value|
+  shared_examples 'literal if allowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'allows branches to be duplicated' do
         expect_no_offenses(<<~RUBY)
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal if disallowed' do |type, value|
+  shared_examples 'literal if disallowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal case allowed' do |type, value|
+  shared_examples 'literal case allowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'allows branches to be duplicated' do
         expect_no_offenses(<<~RUBY)
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal case disallowed' do |type, value|
+  shared_examples 'literal case disallowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'registers an offense' do
         expect_offense(<<~RUBY, value: value)
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal case-match allowed' do |type, value|
+  shared_examples 'literal case-match allowed' do |type, value|
     context "when returning a #{type} in multiple branches", :ruby27 do
       it 'allows branches to be duplicated' do
         expect_no_offenses(<<~RUBY)
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal case-match disallowed' do |type, value|
+  shared_examples 'literal case-match disallowed' do |type, value|
     context "when returning a #{type} in multiple branches", :ruby27 do
       it 'registers an offense' do
         expect_offense(<<~RUBY, value: value)
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal rescue allowed' do |type, value|
+  shared_examples 'literal rescue allowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'allows branches to be duplicated' do
         expect_no_offenses(<<~RUBY)
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateBranch, :config do
     end
   end
 
-  shared_examples_for 'literal rescue disallowed' do |type, value|
+  shared_examples 'literal rescue disallowed' do |type, value|
     context "when returning a #{type} in multiple branches" do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/hash_except_spec.rb
+++ b/spec/rubocop/cop/style/hash_except_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashExcept, :config do
-  shared_examples_for 'include?' do
+  shared_examples 'include?' do
     context 'using `include?`' do
       it 'does not register an offense when using `reject` and calling `!include?` method with symbol array' do
         expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/hash_fetch_chain_spec.rb
+++ b/spec/rubocop/cop/style/hash_fetch_chain_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Style::HashFetchChain, :config do
   context 'ruby >= 2.3' do
     context 'with chained `fetch` methods' do
-      shared_examples_for 'fetch chain' do |argument|
+      shared_examples 'fetch chain' do |argument|
         context "when the 2nd argument is `#{argument}`" do
           it 'does not register an offense when not chained' do
             expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/hash_slice_spec.rb
+++ b/spec/rubocop/cop/style/hash_slice_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
-  shared_examples_for 'include?' do
+  shared_examples 'include?' do
     context 'using `include?`' do
       it 'does not register an offense when using `select` and calling `!include?` method with symbol array' do
         expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Style::InfiniteLoop, :config do
     RUBY
   end
 
-  shared_examples_for 'autocorrector' do |keyword, lit|
+  shared_examples 'autocorrector' do |keyword, lit|
     it "autocorrects single line modifier #{keyword}" do
       expect_offense(<<~RUBY, keyword: keyword, lit: lit)
         something += 1 %{keyword} %{lit} # comment

--- a/spec/rubocop/cop/style/quoted_symbols_spec.rb
+++ b/spec/rubocop/cop/style/quoted_symbols_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
-  shared_examples_for 'enforce single quotes' do
+  shared_examples 'enforce single quotes' do
     it 'accepts unquoted symbols' do
       expect_no_offenses(<<~RUBY)
         :a
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::Style::QuotedSymbols, :config do
     end
   end
 
-  shared_examples_for 'enforce double quotes' do
+  shared_examples 'enforce double quotes' do
     it 'accepts unquoted symbols' do
       expect_no_offenses(<<~RUBY)
         :a

--- a/spec/support/alignment_examples.rb
+++ b/spec/support/alignment_examples.rb
@@ -2,7 +2,7 @@
 
 # `cop` and `source` must be declared with #let.
 
-RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
+RSpec.shared_examples 'misaligned' do |annotated_source, used_style|
   config_to_allow_offenses = if used_style
                                { 'EnforcedStyleAlignWith' => used_style.to_s }
                              else
@@ -29,7 +29,7 @@ RSpec.shared_examples_for 'misaligned' do |annotated_source, used_style|
   end
 end
 
-RSpec.shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
+RSpec.shared_examples 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub("\n", ' <newline>')
   it "accepts matching #{name} ... end" do

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
+RSpec.shared_examples 'empty_lines_around_class_or_module_body' do |type|
   context 'when EnforcedStyle is empty_lines_special' do
     let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_special' } }
 

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'multiline literal brace layout' do
+RSpec.shared_examples 'multiline literal brace layout' do
   include MultilineLiteralBraceHelper
 
   let(:prefix) { '' } # A prefix before the opening brace.

--- a/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_method_argument_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'multiline literal brace layout method argument' do
+RSpec.shared_examples 'multiline literal brace layout method argument' do
   include MultilineLiteralBraceHelper
 
   context 'when arguments to a method' do

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'multiline literal brace layout trailing comma' do
+RSpec.shared_examples 'multiline literal brace layout trailing comma' do
   let(:prefix) { '' } # A prefix before the opening brace.
   let(:suffix) { '' } # A suffix for the line after the closing brace.
   let(:a) { 'a' } # The first element.


### PR DESCRIPTION
Consistently use `shared_examples` in specs over `shared_examples_for`.

Follows https://github.com/rubocop/rubocop/pull/14033#issuecomment-2751974004.

