### PR TITLE
[Fix #13617] Proper support for Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'fiddle', platform: :windows if RUBY_VERSION >= '3.4'
 gem 'irb'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
-gem 'prism', '~> 1.4'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.24.0'

--- a/changelog/change_prism_for_ruby_3.4.md
+++ b/changelog/change_prism_for_ruby_3.4.md
@@ -1,0 +1,1 @@
+* [#13617](https://github.com/rubocop/rubocop/issues/13617): Use the `prism` translation layer to analyze Ruby 3.4+ by default. ([@earlopain][])

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -35,15 +35,15 @@ The following table is the runtime support matrix.
 | 3.1 | -
 | 3.2 | -
 | 3.3 | -
-| 3.4 (experimental) | -
+| 3.4 | -
 | 3.5 (experimental) | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.
 
-Starting from RuboCop 1.62, support for Prism's translation layer will allow analysis of Ruby 3.3+ with the `prism` gem. For Ruby 3.5+ analysis, only the `prism` translation layer is supported, which means that you need to add the `prism gem to your Gemfile. In a future release, `prism` will become a dependency of RuboCop.
+Starting from RuboCop 1.62, support for Prism's translation layer will allow analysis of Ruby 3.3+ with the `prism` gem.
 
-For more details, please refer to the xref:configuration.adoc#setting-the-parser-engine[setting `ParserEngine`].
+Starting from RuboCop 1.75, the `prism` translation layer is used by default when analyzing Ruby 3.4+.
 
 NOTE: The compatibility xref:configuration.adoc#setting-the-target-ruby-version[setting `TargetRubyVersion`] is about code analysis (what RuboCop can analyze), not runtime (is RuboCop capable of running on some Ruby or not).
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -650,9 +650,6 @@ AllCops:
   TargetRubyVersion: 2.5
 ----
 
-NOTE: When `ParserEngine: parser_prism` is specified, `TargetRubyVersion` must
-be set to `3.3` or higher.
-
 If a `TargetRubyVersion` is not specified in your config, then RuboCop will
 check your project for a series of other files where the Ruby version may be
 specified already. The files that will be checked are (in this order):
@@ -690,8 +687,7 @@ version, and will instead try to find a target Ruby version elsewhere.
 
 == Setting the parser engine
 
-NOTE: The parser engine configuration was introduced in RuboCop 1.62. This
-experimental feature has been under consideration for a while.
+NOTE: The parser engine configuration was introduced in RuboCop 1.62. Since RuboCop 1.75, RuboCop chooses the parser engine automatically, so you don't need to configure it yourself.
 
 RuboCop allows switching the backend parser by specifying either
 `parser_whitequark` or `parser_prism` as the value for the `ParserEngine`.
@@ -701,8 +697,6 @@ Here are the parsers used as backends for each value:
 - `ParserEngine: default`
 - `ParserEngine: parser_whitequark` ... https://github.com/whitequark/parser
 - `ParserEngine: parser_prism` ... https://github.com/ruby/prism (`Prism::Translation::Parser`)
-
-NOTE: Since RuboCop 1.75, RuboCop chooses the parser engine automatically, so you don't need to configure it yourself. Currently, `parser_prism` is used for Ruby 3.5+, and `parser_whitequark` for Ruby 3.4 and below.
 
 `parser_whitequark` can analyze source code from Ruby 2.0 until Ruby 3.4:
 
@@ -722,15 +716,6 @@ AllCops:
 ----
 
 `parser_prism` tends to perform analysis faster than `parser_whitequark`.
-
-IMPORTANT: Since the support for Prism is experimental, it is not included in
-RuboCop's runtime dependencies.  If running RuboCop through Bundler, please add
-`gem 'prism'` to your `Gemfile`:
-
-[source,ruby]
-----
-gem 'prism'
-----
 
 == Automatically Generated Configuration
 

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -49,8 +49,6 @@ module RuboCop
 
     # @api private
     def self.parser_version
-      require 'prism'
-
       config_path = ConfigFinder.find_config_path(Dir.pwd)
       yaml = Util.silence_warnings do
         ConfigLoader.load_yaml_configuration(config_path)
@@ -59,8 +57,6 @@ module RuboCop
       parser_engine_text = ", #{parser_engine}" if parser_engine
 
       "Parser #{Parser::VERSION}, Prism #{Prism::VERSION}#{parser_engine_text}"
-    rescue LoadError
-      "Parser #{Parser::VERSION}"
     end
 
     # @api private

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.42.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.43.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end


### PR DESCRIPTION
> [!NOTE]  
> Requires a release for rubocop-ast, but then that will be it.

Closes #13617

Now that `rubocop-ast` uses `prism` for 3.4, all the syntax is supported and it no longer needs to me marked experimental.

As you can seen, there's not much actually happening here, mainly just doc updates. That is because this behaviour is entirely controlled in `rubocop-ast` when `ParserEngine: default` is set.

This just bumps the `rubocop-ast` requirement to always get a version where that is the case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
