### PR TITLE
Fix false negative for `Lint/ShadowingOuterLocalVariable`

### DIFF
--- a/changelog/fix_lint_shadowing_outer_local_variable_false_negative.md
+++ b/changelog/fix_lint_shadowing_outer_local_variable_false_negative.md
@@ -1,0 +1,1 @@
+* [#14036](https://github.com/rubocop/rubocop/pull/14036): Fix false negative for `Lint/ShadowingOuterLocalVariable` when block local variable is used inside a condition. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -56,10 +56,17 @@ module RuboCop
 
           outer_local_variable = variable_table.find_variable(variable.name)
           return unless outer_local_variable
+          return if variable_used_in_declaration_of_outer?(variable, outer_local_variable)
           return if same_conditions_node_different_branch?(variable, outer_local_variable)
 
           message = format(MSG, variable: variable.name)
           add_offense(variable.declaration_node, message: message)
+        end
+
+        private
+
+        def variable_used_in_declaration_of_outer?(variable, outer_local_variable)
+          variable.scope.node.each_ancestor.any?(outer_local_variable.declaration_node)
         end
 
         def same_conditions_node_different_branch?(variable, outer_local_variable)
@@ -68,7 +75,7 @@ module RuboCop
 
           outer_local_variable_node =
             find_conditional_node_from_ascendant(outer_local_variable.declaration_node)
-          return true unless outer_local_variable_node
+          return false unless outer_local_variable_node
           return false unless outer_local_variable_node.conditional?
           return true if variable_node == outer_local_variable_node
 

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -129,8 +129,8 @@ module RuboCop
           lvar_sources = node.body.each_descendant(:lvar).map(&:source)
 
           if block_arg.mlhs_type?
-            block_arg.each_descendant(:arg, :restarg).all? do |block_arg|
-              lvar_sources.none?(block_arg.source.delete_prefix('*'))
+            block_arg.each_descendant(:arg, :restarg).all? do |descendant|
+              lvar_sources.none?(descendant.source.delete_prefix('*'))
             end
           else
             lvar_sources.none?(block_arg.source.delete_prefix('*'))

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -199,6 +199,34 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when a block local variable inside an `if` has same name as an outer scope variable' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo = 1
+
+          if cond
+            bar.each do |foo|
+                         ^^^ Shadowing outer local variable - `foo`.
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block local variable has same name as method argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method(foo)
+          1.times do |foo|
+                      ^^^ Shadowing outer local variable - `foo`.
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when a block local variable has same name as an outer scope variable' \
           'with different branches of same `if` condition node' do
     it 'does not register an offense' do
@@ -317,6 +345,16 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
           foo = if condition
                   bar { |foo| baz(foo) }
                 end
+        end
+      RUBY
+    end
+  end
+
+  context 'when the same variable name as a block variable is used in return value assignment of method' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          foo = bar { |foo| baz(foo) }
         end
       RUBY
     end


### PR DESCRIPTION
Fixes a false negative for this cop when block with shadowing variable is inside a condition:
```ruby
def some_method
  foo = 1

  bar.each { |foo| } if cond
              ^^^ # Before this PR, this wouldn't be an offense
end
```

Note that currently an offense would be raised if `foo` assignment happened inside a condition:
```ruby
def some_method
  if cond
    foo = 1

    bar.each { |foo| } if cond2
                ^^^ # This is currently an offense
  end
end
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
