### PR TITLE
Rename `allow_named_parameter` to `only_numbered_parameters` in `Style/ItBlockParameter`

### DIFF
--- a/changelog/change_rename_allow_named_parameter_to_only_numbered_parameters.md
+++ b/changelog/change_rename_allow_named_parameter_to_only_numbered_parameters.md
@@ -1,0 +1,1 @@
+* [#14038](https://github.com/rubocop/rubocop/pull/14038): Rename `EnforcedStyle: allow_named_parameter` to `EnforcedStyle: only_numbered_parameters` in `Style/ItBlockParameter`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4423,9 +4423,9 @@ Style/ItAssignment:
 Style/ItBlockParameter:
   Description: 'Checks for blocks with one argument where `it` block parameter can be used.'
   Enabled: pending
-  EnforcedStyle: allow_named_parameter
+  EnforcedStyle: only_numbered_parameters
   SupportedStyles:
-    - allow_named_parameter
+    - only_numbered_parameters
     - always
     - disallow
   VersionAdded: '1.75'

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -7,13 +7,13 @@ module RuboCop
       #
       # It provides three `EnforcedStyle` options:
       #
-      # 1. `allow_named_parameter` (default) ... Detects only numbered block parameters.
+      # 1. `only_numbered_parameters` (default) ... Detects only numbered block parameters.
       # 2. `always` ... Always uses the `it` block parameter.
       # 3. `disallow` ... Disallows the `it` block parameter.
       #
-      # A single numbered parameter is detected when `allow_named_parameter` or `always`.
+      # A single numbered parameter is detected when `only_numbered_parameters` or `always`.
       #
-      # @example EnforcedStyle: allow_named_parameter (default)
+      # @example EnforcedStyle: only_numbered_parameters (default)
       #   # bad
       #   block { do_something(_1) }
       #

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
   context '>= Ruby 3.4', :ruby34 do
-    context 'EnforcedStyle: allow_named_parameter' do
-      let(:cop_config) { { 'EnforcedStyle' => 'allow_named_parameter' } }
+    context 'EnforcedStyle: only_numbered_parameters' do
+      let(:cop_config) { { 'EnforcedStyle' => 'only_numbered_parameters' } }
 
       it 'registers an offense when using a single numbered parameters' do
         expect_offense(<<~RUBY)
@@ -197,8 +197,8 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
   end
 
   context '<= Ruby 3.3', :ruby33 do
-    context 'EnforcedStyle: allow_named_parameter' do
-      let(:cop_config) { { 'EnforcedStyle' => 'allow_named_parameter' } }
+    context 'EnforcedStyle: only_numbered_parameters' do
+      let(:cop_config) { { 'EnforcedStyle' => 'only_numbered_parameters' } }
 
       it 'does not register an offense when using a single numbered parameters' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14026#issuecomment-2754372368.

This PR renames `EnforcedStyle: allow_named_parameter` to `EnforcedStyle: only_numbered_parameters` in `Style/ItBlockParameter`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
