### PR TITLE
Add note about frozen string literals handling for `Style/EmptyLiteral`

### DIFF
--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -6,6 +6,10 @@ module RuboCop
       # Checks for the use of a method, the result of which
       # would be a literal, like an empty array, hash, or string.
       #
+      # NOTE: When frozen string literals are enabled, `String.new`
+      # isn't corrected to an empty string since the former is
+      # mutable and the latter would be frozen.
+      #
       # @example
       #   # bad
       #   a = Array.new


### PR DESCRIPTION
The cop won't register `String.new` as an offense when frozen string literals are enabled, but this info is currently missing from cop documentation (I had to look up the code when enabling this cop on a project to verify what would autocorrect do). This PR adds the missing info. 