### PR TITLE
[Fix #14041] Fix an error when using ERB templated config YAML with server mode

### DIFF
--- a/changelog/fix_an_error_when_using_erb_templated_yaml_config.md
+++ b/changelog/fix_an_error_when_using_erb_templated_yaml_config.md
@@ -1,0 +1,1 @@
+* [#14041](https://github.com/rubocop/rubocop/issues/14041): Fix an error when using ERB templated config YAML with server mode. ([@koic][])

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -379,6 +379,25 @@ RSpec.describe RuboCop::Server::Cache do
           it { expect(restart_key).to eq(hexdigest) }
         end
       end
+
+      context 'when ERB pre-processing of the configuration file', :isolated_environment do
+        context 'when `CacheRootDirectory` configure value is set' do
+          it 'does not raise an error' do
+            create_file('.rubocop.yml', <<~YAML)
+              AllCops:
+                CacheRootDirectory: '/tmp/cache-root-directory'
+              Style/Encoding:
+                Enabled: <%= 1 == 1 %>
+                Exclude:
+                <% Dir['*.rb'].sort.each do |name| %>
+                  - <%= name %>
+                <% end %>
+            YAML
+
+            expect { restart_key }.not_to raise_error
+          end
+        end
+      end
     end
 
     describe '.pid_running?', :isolated_environment do


### PR DESCRIPTION
This PR fixes an error when using ERB templated config YAML with server mode.

Fixes #14041

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
