### PR TITLE
Do not emit a warning for an actually empty file while checking if it is executable

### DIFF
--- a/changelog/fix_do_not_emit_a_warning_for_an_actually_empty_file_20250327192458.md
+++ b/changelog/fix_do_not_emit_a_warning_for_an_actually_empty_file_20250327192458.md
@@ -1,0 +1,1 @@
+* [#14048](https://github.com/rubocop/rubocop/pull/14048): Do not emit a warning for a zero-sized file while checking if it is executable. ([@viralpraxis][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -175,7 +175,7 @@ module RuboCop
     end
 
     def ruby_executable?(file)
-      return false unless File.extname(file).empty? && File.exist?(file)
+      return false if !File.extname(file).empty? || !File.exist?(file) || File.empty?(file)
 
       first_line = File.open(file, &:readline)
       /#!.*(#{ruby_interpreters(file).join('|')})/.match?(first_line)

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -639,6 +639,32 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when file is actually empty' do
+      include_context 'mock console output'
+
+      before do
+        create_file('dir1/flag', nil)
+      end
+
+      context 'and debug mode is enabled' do
+        let(:debug) { true }
+
+        it 'outputs error message' do
+          found_files
+          expect($stderr.string).to be_empty
+        end
+      end
+
+      context 'and debug mode is disabled' do
+        let(:debug) { false }
+
+        it 'outputs nothing' do
+          found_files
+          expect($stderr.string).to be_empty
+        end
+      end
+    end
+
     context 'w/ --fail-fast option' do
       let(:options) { { force_exclusion: force_exclusion, debug: debug, fail_fast: true } }
 

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 
 module FileHelper
+  # rubocop:disable Metrics/MethodLength
   def create_file(file_path, content, retain_line_terminators: false)
     file_path = File.expand_path(file_path)
 
@@ -18,6 +19,8 @@ module FileHelper
     FileUtils.mkdir_p dir_path
 
     File.open(file_path, file_mode) do |file|
+      break if content.nil?
+
       case content
       when String
         file.puts content
@@ -28,6 +31,7 @@ module FileHelper
 
     file_path
   end
+  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable InternalAffairs/CreateEmptyFile
   def create_empty_file(file_path)


### PR DESCRIPTION
main:

```console
$ touch lockfile
$ bundle exec rubocop -d
<snip>
Unprocessable file <snip>/lockfile: EOFError, end of file reached

$ bundle exec rubocop lockfile
Inspecting 1 file
W

Offenses:

lockfile:1:1: W: Lint/EmptyFile: Empty file detected.

1 file inspected, 1 offense detected
```

This seems to be inconsistent and does not make much sense to treat differently an actually empty file and e.g. a file with a single newline.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
