### PR TITLE
[Fix #14051] Fix incorrect autocorrect for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_condition.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#14051](https://github.com/rubocop/rubocop/issues/14051): Fix incorrect autocorrect for `Style/RedundantCondition` when true is used as the true branch and the condition takes arguments. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -230,6 +230,14 @@ module RuboCop
           node.type?(:kwsplat, :forwarded_kwrestarg)
         end
 
+        def wrap_arguments_with_parens(condition)
+          method = condition.source_range.begin.join(condition.loc.selector.end)
+          arguments = condition.first_argument.source_range.begin.join(condition.source_range.end)
+
+          "#{method.source}(#{arguments.source})"
+        end
+
+        # rubocop:disable Metrics/AbcSize
         def if_source(if_branch, arithmetic_operation)
           if branches_have_method?(if_branch.parent) && if_branch.parenthesized?
             if_branch.source.delete_suffix(')')
@@ -238,11 +246,15 @@ module RuboCop
 
             "#{if_branch.receiver.source} #{if_branch.method_name} (#{argument_source}"
           elsif if_branch.true_type?
-            if_branch.parent.condition.source
+            condition = if_branch.parent.condition
+            return condition.source if condition.arguments.empty?
+
+            wrap_arguments_with_parens(condition)
           else
             if_branch.source
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         def else_source(else_branch, arithmetic_operation) # rubocop:disable Metrics/AbcSize
           if arithmetic_operation

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -663,6 +663,36 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and autocorrects when true is used as the true branch and the condition takes arguments' do
+        expect_offense(<<~RUBY)
+          if foo? arg
+          ^^^^^^^^^^^ Use double pipes `||` instead.
+            true
+          else
+            bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo?(arg) || bar
+        RUBY
+      end
+
+      it 'registers an offense and autocorrects when true is used as the true branch and the condition takes arguments with safe navigation' do
+        expect_offense(<<~RUBY)
+          if obj&.foo? arg
+          ^^^^^^^^^^^^^^^^ Use double pipes `||` instead.
+            true
+          else
+            bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          obj&.foo?(arg) || bar
+        RUBY
+      end
+
       it 'does not register an offense when false is used as the else branch and the condition is not a predicate method' do
         expect_no_offenses(<<~RUBY)
           if !a[:key]


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Style/RedundantCondition` when true is used as the true branch and the condition takes arguments.

Fixes #14051.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
