### PR TITLE
Enable `RSpec/Dialect` to enforce `shared_examples` instead of `shared_examples_for`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,6 +161,11 @@ RSpec:
       - expect_no_offenses
       - expect_offense
 
+RSpec/Dialect:
+  Enabled: true
+  PreferredMethods:
+    shared_examples_for: shared_examples
+
 RSpec/ExampleWithoutDescription:
   EnforcedStyle: single_line_only
 


### PR DESCRIPTION
Enables `RSpec/Dialect` to enforce consistency when defining `shared_examples`.

Follows #14034, https://github.com/rubocop/rubocop-rspec/pull/2065.