### PR TITLE
[Fix #14053] Fix incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
@@ -1,0 +1,1 @@
+* [#14053](https://github.com/rubocop/rubocop/issues/14053): Fix incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` cipher constant argument is not `cbc`. ([@koic][])

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -134,7 +134,7 @@ module RuboCop
           if NO_ARG_ALGORITHM.include?(algorithm_parts.first.upcase) && no_arguments
             "'#{algorithm_parts.first}'"
           else
-            mode = 'cbc' unless size_and_mode == ['cbc']
+            mode = 'cbc' if size_and_mode.empty?
 
             "'#{(algorithm_parts + size_and_mode + [mode]).compact.take(3).join('-')}'"
           end

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
+  it 'registers an offense with cipher constant and `ecb` argument and corrects' do
+    expect_offense(<<~RUBY)
+      OpenSSL::Cipher::BF.new('ecb')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('bf-ecb')` instead of `OpenSSL::Cipher::BF.new('ecb')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      OpenSSL::Cipher.new('bf-ecb')
+    RUBY
+  end
+
   it 'registers an offense with AES + blocksize constant and mode argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::AES128.new(:GCM)


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` cipher constant argument is not `cbc`.

Fixes #14053.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
