### PR TITLE
Fix `Style/ConditionalAssignment` cop error on `dstr` node in branch

### DIFF
--- a/changelog/fix_style_conditional_assignment_cop_error_on_dynamic_string_node_in_branch_20250329232641.md
+++ b/changelog/fix_style_conditional_assignment_cop_error_on_dynamic_string_node_in_branch_20250329232641.md
@@ -1,0 +1,1 @@
+* [#14057](https://github.com/rubocop/rubocop/pull/14057): Fix `Style/ConditionalAssignment` cop error on dynamic string node in branch. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -436,9 +436,11 @@ module RuboCop
       # Helper module to provide common methods to ConditionalAssignment
       # correctors
       module ConditionalCorrectorHelper
+        # rubocop:disable Metrics/AbcSize
         def remove_whitespace_in_branches(corrector, branch, condition, column)
           branch.each_node do |child|
             next if child.source_range.nil?
+            next if child.parent.dstr_type?
 
             white_space = white_space_range(child, column)
             corrector.remove(white_space) if white_space.source.strip.empty?
@@ -450,6 +452,7 @@ module RuboCop
             corrector.remove_preceding(loc, loc.column - column)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         def white_space_range(node, column)
           expression = node.source_range


### PR DESCRIPTION
Without this patch, new examples fail with this error:

```bash
RuboCop::Cop::Style::ConditionalAssignment SingleLineConditionsOnly false behaves like with `dstr` node in branch registers an offense for heredoc inside branch
     Failure/Error: Parser::Source::Range.new(expression.source_buffer, begin_pos, expression.begin_pos)

     ArgumentError:
       Parser::Source::Range: end_pos must not be less than begin_pos
     Shared Example Group: "with `dstr` node in branch" called from ./spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb:1092
     # ./lib/rubocop/cop/style/conditional_assignment.rb:461:in `new'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:461:in `white_space_range'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:445:in `block in remove_whitespace_in_branches'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:441:in `remove_whitespace_in_branches'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:597:in `move_branch_inside_condition'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:579:in `block in move_assignment_inside_condition'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:578:in `each'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:578:in `move_assignment_inside_condition'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:346:in `move_assignment_inside_condition'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:378:in `autocorrect'
     # ./lib/rubocop/cop/style/conditional_assignment.rb:296:in `block in check_assignment_to_condition'
```

To be precise, only heredoc-related examples fail; string interpolation examples were applying autocorrection incorrectly.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
