### PR TITLE
Fix method name in Plugin Migration Guide

### DIFF
--- a/docs/modules/ROOT/pages/plugin_migration_guide.adoc
+++ b/docs/modules/ROOT/pages/plugin_migration_guide.adoc
@@ -102,7 +102,7 @@ Update `rubocop` to a version that supports plugins or higher.
 
 [source,ruby]
 ----
-spec.require('rubocop', '>= 1.72.0')
+spec.add_dependency('rubocop', '>= 1.72.0')
 ----
 
 === 3. Replace `Inject.defaults!` code


### PR DESCRIPTION
The `Gem::Specification#require` method is private, which causes the following error when executing the bundle command:

```
[!] There was an error while loading `rubocop-foo.gemspec`: private method 'require' called for an instance of Gem::Specification. Bundler cannot continue.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
