### PR TITLE
hash_syntax.rb docs: Clarify you're allowed to mix syntaxes

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -76,6 +76,9 @@ module RuboCop
       #   # good
       #   {foo:, bar:}
       #
+      #   # good - allowed to mix syntaxes
+      #   {foo:, bar: baz}
+      #
       # @example EnforcedShorthandSyntax: never
       #
       #   # bad


### PR DESCRIPTION
.