### PR TITLE
Document `Style/GlobalStdStream` Ractor benefits

### DIFF
--- a/lib/rubocop/cop/style/global_std_stream.rb
+++ b/lib/rubocop/cop/style/global_std_stream.rb
@@ -8,6 +8,9 @@ module RuboCop
       # reassign (possibly to redirect some stream) constants in Ruby, you'll get
       # an interpreter warning if you do so.
       #
+      # Additionally, `$stdout/$stderr/$stdin` can safely be accessed in a Ractor because they
+      # are ractor-local, while `STDOUT/STDERR/STDIN` will raise `Ractor::IsolationError`.
+      #
       # @safety
       #   Autocorrection is unsafe because `STDOUT` and `$stdout` may point to different
       #   objects, for example.


### PR DESCRIPTION
`Ractor.new { STDOUT }` raises, `Ractor.new { $stdout }` doesn't.

Also see https://docs.ruby-lang.org/en/3.4/ractor_md.html#label-Global+variables