### PR TITLE
Prefer `References` over `Reference` in cop config

### DIFF
--- a/changelog/change_pluralize_reference_default_configs_20250401123209.md
+++ b/changelog/change_pluralize_reference_default_configs_20250401123209.md
@@ -1,0 +1,1 @@
+* [#14064](https://github.com/rubocop/rubocop/pull/14064): Prefer `References` over `Reference` in cop configs. ([@sambostock][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -274,7 +274,8 @@ Bundler/OrderedGems:
 Gemspec/AddRuntimeDependency:
   Description: 'Prefer `add_dependency` over `add_runtime_dependency`.'
   StyleGuide: '#add_dependency_vs_add_runtime_dependency'
-  Reference: https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
+  References:
+    - https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
   Enabled: pending
   VersionAdded: '1.65'
   Include:
@@ -343,7 +344,7 @@ Gemspec/RequireMFA:
   Severity: warning
   VersionAdded: '1.23'
   VersionChanged: '1.40'
-  Reference:
+  References:
     - https://guides.rubygems.org/mfa-requirement-opt-in/
   Include:
     - '**/*.gemspec'
@@ -604,7 +605,7 @@ Layout/EmptyLineAfterMultilineCondition:
   # This is disabled, because this style is not very common in practice.
   Enabled: false
   VersionAdded: '0.90'
-  Reference:
+  References:
     - https://github.com/airbnb/ruby#multiline-if-newline
 
 Layout/EmptyLineBetweenDefs:
@@ -639,7 +640,7 @@ Layout/EmptyLinesAroundAccessModifier:
   SupportedStyles:
     - around
     - only_before
-  Reference:
+  References:
     # A reference to `EnforcedStyle: only_before`.
     - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
@@ -996,7 +997,7 @@ Layout/IndentationConsistency:
   SupportedStyles:
     - normal
     - indented_internal_methods
-  Reference:
+  References:
     # A reference to `EnforcedStyle: indented_internal_methods`.
     - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
@@ -2035,7 +2036,8 @@ Lint/InterpolationCheck:
 
 Lint/ItWithoutArgumentsInBlock:
   Description: 'Checks uses of `it` calls without arguments in block.'
-  Reference: 'https://bugs.ruby-lang.org/issues/18980'
+  References:
+    - 'https://bugs.ruby-lang.org/issues/18980'
   Enabled: pending
   VersionAdded: '1.59'
 
@@ -2673,7 +2675,7 @@ Metrics/AbcSize:
   Description: >-
                  A calculated magnitude based on number of assignments,
                  branches, and conditions.
-  Reference:
+  References:
     - http://c2.com/cgi/wiki?AbcMetric
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: true
@@ -3150,7 +3152,8 @@ Security/JSONLoad:
   Description: >-
                  Prefer usage of `JSON.parse` over `JSON.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
+  References:
+    - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '1.22'
@@ -3162,7 +3165,8 @@ Security/MarshalLoad:
   Description: >-
                  Avoid using of `Marshal.load` or `Marshal.restore` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
+  References:
+    - 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
   VersionAdded: '0.47'
 
@@ -3177,7 +3181,8 @@ Security/YAMLLoad:
   Description: >-
                  Prefer usage of `YAML.safe_load` over `YAML.load` due to potential
                  security issues. See reference for more information.
-  Reference: 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
+  References:
+    - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
   VersionAdded: '0.47'
   SafeAutoCorrect: false
@@ -3271,7 +3276,8 @@ Style/ArrayCoercion:
 
 Style/ArrayFirstLast:
   Description: 'Use `arr.first` and `arr.last` instead of `arr[0]` and `arr[-1]`.'
-  Reference: '#first-and-last'
+  References:
+    - '#first-and-last'
   Enabled: false
   VersionAdded: '1.58'
   Safe: false
@@ -4009,7 +4015,7 @@ Style/ExponentialNotation:
 Style/FetchEnvVar:
   Description: >-
                  Suggests `ENV.fetch` for the replacement of `ENV[]`.
-  Reference:
+  References:
     - https://rubystyle.guide/#hash-fetch-defaults
   Enabled: pending
   VersionAdded: '1.28'
@@ -4050,7 +4056,8 @@ Style/FileWrite:
 Style/FloatDivision:
   Description: 'For performing float division, coerce one side only.'
   StyleGuide: '#float-division'
-  Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
+  References:
+    - 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
   Enabled: true
   VersionAdded: '0.72'
   VersionChanged: '1.9'
@@ -4147,7 +4154,8 @@ Style/GlobalStdStream:
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: '#instance-vars'
-  Reference: 'https://www.zenspider.com/ruby/quickref.html'
+  References:
+    - 'https://www.zenspider.com/ruby/quickref.html'
   Enabled: true
   VersionAdded: '0.13'
   # Built-in global variables are allowed by default.
@@ -4958,7 +4966,7 @@ Style/OpenStructUse:
   Description: >-
                  Avoid using OpenStruct. As of Ruby 3.0, use is officially discouraged due to performance,
                  version compatibility, and potential security issues.
-  Reference:
+  References:
     - https://docs.ruby-lang.org/en/3.0.0/OpenStruct.html#class-OpenStruct-label-Caveats
 
   Enabled: pending
@@ -5203,7 +5211,8 @@ Style/RedundantFetchBlock:
   Description: >-
                   Use `fetch(key, value)` instead of `fetch(key) { value }`
                   when value has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or is a constant.
-  Reference: 'https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
+  References:
+    - 'https://github.com/fastruby/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code'
   Enabled: true
   Safe: false
   # If enabled, this cop will autocorrect usages of
@@ -5445,7 +5454,8 @@ Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Integer]`.
-  Reference: 'https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  References:
+    - 'https://github.com/fastruby/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
   VersionAdded: '0.30'
 
@@ -5940,7 +5950,8 @@ Style/YAMLFileRead:
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'
-  Reference: 'https://en.wikipedia.org/wiki/Yoda_conditions'
+  References:
+    - 'https://en.wikipedia.org/wiki/Yoda_conditions'
   Enabled: true
   EnforcedStyle: forbid_for_all_comparison_operators
   SupportedStyles:

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -9,16 +9,16 @@ module RuboCop
 
     # @api private
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details
-                       Enabled Reference].freeze
+                       Enabled Reference References].freeze
     # @api private
     INTERNAL_PARAMS = %w[Description StyleGuide
                          VersionAdded VersionChanged VersionRemoved
-                         Reference Safe SafeAutoCorrect].freeze
+                         Reference References Safe SafeAutoCorrect].freeze
     # @api private
     NEW_COPS_VALUES = %w[pending disable enable].freeze
 
     # @api private
-    CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect].to_set.freeze
+    CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect References].to_set.freeze
     CONFIG_CHECK_DEPARTMENTS = %w[pending override_department].freeze
     CONFIG_CHECK_AUTOCORRECTS = %w[always contextual disabled].freeze
     private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
@@ -260,8 +260,7 @@ module RuboCop
       end
     end
 
-    # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
-    def check_cop_config_value(hash, parent = nil)
+    def check_cop_config_value(hash, parent = nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       hash.each do |key, value|
         check_cop_config_value(value, key) if value.is_a?(Hash)
 
@@ -271,6 +270,8 @@ module RuboCop
           supposed_values = 'a boolean'
         elsif key == 'AutoCorrect' && !CONFIG_CHECK_AUTOCORRECTS.include?(value)
           supposed_values = '`always`, `contextual`, `disabled`, or a boolean'
+        elsif key == 'References'
+          supposed_values = 'an array of strings'
         else
           next
         end
@@ -278,7 +279,6 @@ module RuboCop
         raise ValidationError, param_error_message(parent, key, value, supposed_values)
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
     # FIXME: Handling colors in exception messages like this is ugly.
     def param_error_message(parent, key, value, supposed_values)

--- a/lib/rubocop/cop/internal_affairs/undefined_config.rb
+++ b/lib/rubocop/cop/internal_affairs/undefined_config.rb
@@ -10,7 +10,12 @@ module RuboCop
         extend FileFinder
 
         ALLOWED_CONFIGURATIONS = %w[
-          Safe SafeAutoCorrect AutoCorrect Severity StyleGuide Details Reference Include Exclude
+          Safe SafeAutoCorrect AutoCorrect
+          Severity
+          StyleGuide
+          Details
+          Reference References
+          Include Exclude
         ].freeze
         RESTRICT_ON_SEND = %i[[] fetch].freeze
         MSG = '`%<name>s` is not defined in the configuration for `%<cop>s` ' \

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -32,7 +32,7 @@ module RuboCop
       # @param [String] cop_name for specific cop name
       # @param [Hash] cop_config configs for specific cop, from config#for_cop
       # @option cop_config [String] :StyleGuide Extension of base styleguide URL
-      # @option cop_config [String] :Reference Full reference URL
+      # @option cop_config [String] :References Full reference URLs
       # @option cop_config [String] :Details
       #
       # @param [Hash, nil] options optional
@@ -100,8 +100,12 @@ module RuboCop
       end
 
       def reference_urls
-        urls = Array(cop_config['Reference'])
-        urls.nil? || urls.empty? ? nil : urls.reject(&:empty?)
+        urls = cop_config
+               .values_at('References', 'Reference') # Support legacy Reference key
+               .flat_map { Array(_1) }
+               .reject(&:empty?)
+
+        urls unless urls.empty?
       end
 
       def extra_details?

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -327,8 +327,12 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   def print_cop_with_doc(cop) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
     cop_config = config.for_cop(cop)
     non_display_keys = %w[
-      AutoCorrect Description Enabled StyleGuide Reference Safe SafeAutoCorrect VersionAdded
-      VersionChanged
+      Enabled
+      Description
+      StyleGuide
+      Reference References
+      Safe SafeAutoCorrect AutoCorrect
+      VersionAdded VersionChanged
     ]
     parameters = cop_config.reject { |k| non_display_keys.include? k }
     description = 'No documentation'

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -164,7 +164,7 @@ module RuboCop
 
       def cop_config_params(default_cfg, cfg)
         default_cfg.keys -
-          %w[Description StyleGuide Reference Enabled Exclude Safe
+          %w[Description StyleGuide Reference References Enabled Exclude Safe
              SafeAutoCorrect VersionAdded VersionChanged VersionRemoved] -
           cfg.keys
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1769,20 +1769,22 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', <<~YAML)
-        # Default config includes none of Min, Reference, or StyleGuide
+        # Default config includes none of Min, References, or StyleGuide
         Layout/AssignmentIndentation:
           Enabled: true
           Min: 10
           StyleGuide: '#assignment-indentation'
 
-        # Default config includes StyleGuide, but neither Min nor Reference
+        # Default config includes StyleGuide, but neither Min nor Reference nor References
         Layout/LineLength:
           Enabled: true
           Min: 10
           Reference:
             - 'https://example.com#layout-line-length-decision-log'
+          References:
+            - 'https://example.com#layout-line-length-decision-log'
 
-        # Default config includes Reference and StyleGuide, but not Min
+        # Default config includes References and StyleGuide, but not Min
         Style/GlobalVars:
           Enabled: true
           Min: 10

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1871,6 +1871,24 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'does not set an array to `References`' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Layout/EmptyComment:
+            References: 'https://example.com'
+        YAML
+      end
+
+      it 'gets a warning message' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          %r{supposed to be an array of strings and https://example\.com is not}
+        )
+      end
+    end
+
     context 'does not set `pending`, `disable`, or `enable` to `NewCops`' do
       before do
         create_file(configuration_path, <<~YAML)

--- a/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/undefined_config_spec.rb
@@ -23,10 +23,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UndefinedConfig, :config, :isolate
           module Test
             class Foo < Base
               def configured?
-                cop_config['Safe']
-                cop_config['SafeAutoCorrect']
-                cop_config['AutoCorrect']
-                cop_config['Severity']
+                #{described_class::ALLOWED_CONFIGURATIONS.map { "cop_config['#{_1}']" }.join("\n          ")}
               end
             end
           end

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -168,18 +168,60 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
       expect(urls).to eq(%w[http://example.org/styleguide#target_based_url])
     end
 
-    it 'returns reference url when it is specified' do
+    it 'returns multiple reference urls' do
+      config['Cop/Cop'] = {
+        'References' => ['https://example.com/some_style_guide',
+                         'https://example.com/some_other_guide',
+                         '']
+      }
+
+      expect(urls).to eq(['https://example.com/some_style_guide',
+                          'https://example.com/some_other_guide'])
+    end
+
+    it 'handles References as a string' do
+      # Config validation should prevent this, but we handle it here anyway.
+      config['Cop/Cop'] = { 'References' => 'https://example.com/some_style_guide' }
+
+      expect(urls).to eq(['https://example.com/some_style_guide'])
+    end
+
+    it 'merges "References" with "Reference" when both are specified and "Reference" is an array' do
+      config['Cop/Cop'] = {
+        'References' => ['https://example.com/some_style_guide',
+                         'https://example.com/some_other_guide'],
+        'Reference' => ['https://example.com/some_style_guide']
+      }
+
+      expect(urls).to eq(%w[https://example.com/some_style_guide
+                            https://example.com/some_other_guide
+                            https://example.com/some_style_guide])
+    end
+
+    it 'merges "References" with "Reference" when both are specified and "Reference" is a simple string' do
+      config['Cop/Cop'] = {
+        'References' => ['https://example.com/some_style_guide',
+                         'https://example.com/some_other_guide'],
+        'Reference' => 'https://example.com/some_style_guide'
+      }
+
+      expect(urls).to eq(%w[https://example.com/some_style_guide
+                            https://example.com/some_other_guide
+                            https://example.com/some_style_guide])
+    end
+
+    it 'returns reference url when it is specified via legacy "Reference" key' do
       config['Cop/Cop'] = { 'Reference' => 'https://example.com/some_style_guide' }
       expect(urls).to eq(%w[https://example.com/some_style_guide])
     end
 
-    it 'returns an empty array if the reference url is blank' do
+    it 'returns an empty array if the legacy "Reference" key is blank' do
       config['Cop/Cop'] = { 'Reference' => '' }
 
       expect(urls).to be_empty
     end
 
-    it 'returns multiple reference urls' do
+    it 'returns multiple reference urls when specified via legacy "Reference" key' do
       config['Cop/Cop'] = {
         'Reference' => ['https://example.com/some_style_guide',
                         'https://example.com/some_other_guide',
@@ -193,9 +235,11 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
     it 'returns style guide and reference url when they are specified' do
       config['Cop/Cop'] = {
         'StyleGuide' => '#target_based_url',
+        'References' => ['https://example.com/plural_reference'],
         'Reference' => 'https://example.com/some_style_guide'
       }
       expect(urls).to eq(%w[http://example.org/styleguide#target_based_url
+                            https://example.com/plural_reference
                             https://example.com/some_style_guide])
     end
   end


### PR DESCRIPTION
#13884 proposed warning `Reference` contains a `String`, as it breaks merging values across inherited configs. As per the discussion there, #13892 taught RuboCop to handle merging string and array configs, regardless of if the "parent" or "child" was the array.

What remained was the quirk that `Reference` could contain an `Array` in the first place. This PR teaches `MessageAnnotator` to prefer `References`, while continuing to support `Reference` for backwards compatibility. The default configs are updated to consistently use `References` accordingly, which now warns if it is not an `Array`.

Closes #13884

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
