### PR TITLE
Make `Lint/RedundantTypeConversion` register an offense for `to_json.to_s`

### DIFF
--- a/changelog/new_lint_redundant_type_conversion_to_json_to_s.md
+++ b/changelog/new_lint_redundant_type_conversion_to_json_to_s.md
@@ -1,0 +1,1 @@
+* [#14065](https://github.com/rubocop/rubocop/pull/14065): Update `Lint/RedundantTypeConversion` to register an offense for `to_json.to_s`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -27,7 +27,8 @@ module RuboCop
       # In all cases, chaining one same `to_*` conversion methods listed above is redundant.
       #
       # The cop can also register an offense for chaining conversion methods on methods that are
-      # expected to return a specific type regardless of receiver (eg. `foo.inspect.to_s`).
+      # expected to return a specific type regardless of receiver (eg. `foo.inspect.to_s` and
+      # `foo.to_json.to_s`).
       #
       # @example
       #   # bad
@@ -69,10 +70,12 @@ module RuboCop
       #   foo.to_s
       #
       #   # bad - chaining a conversion to a method that is expected to return the same type
-      #   inspect.to_s
+      #   foo.inspect.to_s
+      #   foo.to_json.to_s
       #
       #   # good
-      #   inspect
+      #   foo.inspect
+      #   foo.to_json
       #
       class RedundantTypeConversion < Base
         extend AutoCorrector
@@ -108,7 +111,7 @@ module RuboCop
 
         # Methods that already are expected to return a given type, which makes a further
         # conversion redundant.
-        TYPED_METHODS = { to_s: %i[inspect] }.freeze
+        TYPED_METHODS = { to_s: %i[inspect to_json] }.freeze
 
         CONVERSION_METHODS = Set[*LITERAL_NODE_TYPES.keys].freeze
         RESTRICT_ON_SEND = CONVERSION_METHODS + [:to_d]

--- a/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'offense', :to_s, %('string'), '.bar'
 
     it_behaves_like 'chained typed method', :to_s, 'inspect'
+    it_behaves_like 'chained typed method', :to_s, 'to_json'
 
     it 'registers an offense and corrects with a heredoc' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
[`#to_json`](https://github.com/ruby/json?tab=readme-ov-file#casting-non-native-types) returns a JSON _string_ representation of the given object, so following it by a `.to_s` call is redundant. Here are [search results](https://github.com/search?q=%22.to_json.to_s%22%20language%3Aruby&type=code) for would-be offenses (2.1k at the time of writing).

This PR makes `Lint/RedundantTypeConversion` cop register code like:
```ruby
foo.to_json.to_s
```
as an offense, and autocorrect it to:
```ruby
foo.to_json
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
