### PR TITLE
Add `EnforcedStyle: allow_single_line` as the default to `Style/ItBlockParameter`

### DIFF
--- a/changelog/change_add_allow_single_line_to_style_it_block_parameter.md
+++ b/changelog/change_add_allow_single_line_to_style_it_block_parameter.md
@@ -1,0 +1,1 @@
+* [#14066](https://github.com/rubocop/rubocop/pull/14066): Add `EnforcedStyle: allow_single_line` as the default to `Style/ItBlockParameter`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4423,12 +4423,14 @@ Style/ItAssignment:
 Style/ItBlockParameter:
   Description: 'Checks for blocks with one argument where `it` block parameter can be used.'
   Enabled: pending
-  EnforcedStyle: only_numbered_parameters
+  EnforcedStyle: allow_single_line
   SupportedStyles:
+    - allow_single_line
     - only_numbered_parameters
     - always
     - disallow
   VersionAdded: '1.75'
+  VersionChanged: '<<next>>'
 
 Style/KeywordArgumentsMerging:
   Description: >-

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -2,6 +2,74 @@
 
 RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
   context '>= Ruby 3.4', :ruby34 do
+    context 'EnforcedStyle: allow_single_line' do
+      let(:cop_config) { { 'EnforcedStyle' => 'allow_single_line' } }
+
+      it 'registers an offense when using multiline `it` parameters', unsupported_on: :parser do
+        expect_offense(<<~RUBY)
+          block do
+          ^^^^^^^^ Avoid using numbered parameters for multi-line blocks.
+            do_something(it)
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when using a single numbered parameters' do
+        expect_offense(<<~RUBY)
+          block { do_something(_1) }
+                               ^^ Use `it` block parameter.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          block { do_something(it) }
+        RUBY
+      end
+
+      it 'registers an offense when using twice a single numbered parameters' do
+        expect_offense(<<~RUBY)
+          block do
+            foo(_1)
+                ^^ Use `it` block parameter.
+            bar(_1)
+                ^^ Use `it` block parameter.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          block do
+            foo(it)
+            bar(it)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using `it` block parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(it) }
+        RUBY
+      end
+
+      it 'does not register an offense when using named block parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { |arg| do_something(arg) }
+        RUBY
+      end
+
+      it 'does not register an offense when using multiple numbered parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(_1, _2) }
+        RUBY
+      end
+
+      it 'does not register an offense when using a single numbered parameters `_2`' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(_2) }
+        RUBY
+      end
+    end
+
     context 'EnforcedStyle: only_numbered_parameters' do
       let(:cop_config) { { 'EnforcedStyle' => 'only_numbered_parameters' } }
 


### PR DESCRIPTION
This PR adds `EnforcedStyle: allow_single_line` as the default to `Style/ItBlockParameter`.

This adds the default configuration that follows `EnforcedStyle: allow_single_line (default)` of `Style/NumberedParameters` cop:
https://docs.rubocop.org/rubocop/1.75/cops_style.html#stylenumberedparameters

In RuboCop, numbered block parameters are allowed only in single-line blocks. It makes sense to apply the same default style to `it` block parameters as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
