### PR TITLE
Fix false negatives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negative_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14067](https://github.com/rubocop/rubocop/pull/14067): Fix false negatives for `Style/RedundantParentheses` when using parens around singleton method body. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -78,7 +78,7 @@ module RuboCop
           ancestor = node.ancestors.first
           return false unless ancestor
 
-          !ancestor.type?(:begin, :def, :any_block)
+          !ancestor.type?(:begin, :any_def, :any_block)
         end
 
         def allowed_ternary?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -583,6 +583,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for parens around singleton method body' do
+    expect_offense(<<~RUBY)
+      def self.x
+        (foo; bar)
+        ^^^^^^^^^^ Don't use parentheses around a method call.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.x
+        foo; bar
+      end
+    RUBY
+  end
+
   it 'registers an offense for parens around last expressions in method body' do
     expect_offense(<<~RUBY)
       def x


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantParentheses` when using parens around singleton method body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
