### PR TITLE
Fix wrong autocorrection for `Style/MapIntoArray`

### DIFF
--- a/changelog/fix_wrong_autocorrect_for_style_map_into_array.md
+++ b/changelog/fix_wrong_autocorrect_for_style_map_into_array.md
@@ -1,0 +1,1 @@
+* [#14068](https://github.com/rubocop/rubocop/pull/14068): Fix wrong autocorrection for `Style/MapIntoArray` when using `push` or `append` with hash argument without braces. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -212,9 +212,11 @@ module RuboCop
         end
 
         def correct_push_node(corrector, push_node)
+          arg_node = push_node.first_argument
           range = push_node.source_range
-          arg_range = push_node.first_argument.source_range
+          arg_range = arg_node.source_range
 
+          corrector.wrap(arg_node, '{ ', ' }') if arg_node.hash_type? && !arg_node.braces?
           corrector.remove(range_between(range.begin_pos, arg_range.begin_pos))
           corrector.remove(range_between(arg_range.end_pos, range.end_pos))
         end

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `each` with `push` with hash argument without braces to build an array' do
+    expect_offense(<<~RUBY)
+      dest = []
+      src.each { |e| dest.push(e: 2) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dest = src.map { |e| { e: 2 } }
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `each` with `push` with hash argument with braces to build an array' do
+    expect_offense(<<~RUBY)
+      dest = []
+      src.each { |e| dest.push({ e: 2 }) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dest = src.map { |e| { e: 2 } }
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `each` with `append` to build an array' do
     expect_offense(<<~RUBY)
       dest = []
@@ -34,6 +58,30 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
 
     expect_correction(<<~RUBY)
       dest = src.map { |e| e * 2 }
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `each` with `append` with hash argument without braces to build an array' do
+    expect_offense(<<~RUBY)
+      dest = []
+      src.each { |e| dest.append(e: 2) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dest = src.map { |e| { e: 2 } }
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `each` with `append` with hash argument with braces to build an array' do
+    expect_offense(<<~RUBY)
+      dest = []
+      src.each { |e| dest.append({ e: 2 }) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `map` instead of `each` to map elements into an array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dest = src.map { |e| { e: 2 } }
     RUBY
   end
 


### PR DESCRIPTION
Fixes wrong autocorrection for this cop when using `Array#push` or `Array#append` with a hash argument without braces. Previously, this:
```ruby
dest = []
src.each { |e| dest.push(e: 2) }
```
would get autocorrected to:
```ruby
dest = src.map { |e| e: 2 }
```
which is invalid syntax. Now it gets autocorrected to:
```ruby
dest = src.map { |e| { e: 2 } }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
