### PR TITLE
Improve `Layout/HashAlignment` documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -3643,7 +3643,7 @@ can also be configured. The options are:
 * ignore_implicit (without curly braces)
 
 Alternatively you can specify multiple allowed styles. That's done by
-passing a list of styles to EnforcedStyles.
+passing a list of styles to EnforcedHashRocketStyle and EnforcedColonStyle.
 
 [#examples-layouthashalignment]
 === Examples

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -19,7 +19,7 @@ module RuboCop
       # * ignore_implicit (without curly braces)
       #
       # Alternatively you can specify multiple allowed styles. That's done by
-      # passing a list of styles to EnforcedStyles.
+      # passing a list of styles to EnforcedHashRocketStyle and EnforcedColonStyle.
       #
       # @example EnforcedHashRocketStyle: key (default)
       #   # bad


### PR DESCRIPTION
Fix `Layout/HashAlignment` docs to refer to the actual options instead of the fictional `EnforcedStyles` option.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
