### PR TITLE
[Fix #14070] Fix false positives for `EnforcedStyleForMultiline: diff_comma`

### DIFF
--- a/changelog/fix_false_positives_for_enforced_style_for_multiline_diff_comma.md
+++ b/changelog/fix_false_positives_for_enforced_style_for_multiline_diff_comma.md
@@ -1,0 +1,1 @@
+* [#14070](https://github.com/rubocop/rubocop/issues/14070): Fix false positives for `EnforcedStyleForMultiline: diff_comma` of `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral` when trailing comma with comment. ([@koic][])

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -136,9 +136,9 @@ module RuboCop
       end
 
       def last_item_precedes_newline?(node)
-        after_last_item =
-          range_between(node.children.last.source_range.end_pos, node.loc.end.begin_pos)
-        after_last_item.source =~ /\A,?\s*\n/
+        after_last_item = node.children.last.source_range.end.join(node.loc.end.begin)
+
+        after_last_item.source.start_with?(/,?\s*(#.*)?\n/)
       end
 
       def avoid_comma(kind, comma_begin_pos, extra_info)

--- a/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb
@@ -11,7 +11,7 @@ module RuboCop
       # * `comma`: Requires a comma after the last item in an array, but only when each item is on
       # its own line.
       # * `diff_comma`: Requires a comma after the last item in an array, but only when that item is
-      # followed by an immediate newline.
+      # followed by an immediate newline, even if there is an inline comment on the same line.
       # * `no_comma`: Does not require a comma after the last item in an array
       #
       # @example EnforcedStyleForMultiline: consistent_comma

--- a/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb
@@ -11,7 +11,7 @@ module RuboCop
       # * `comma`: Requires a comma after the last item in a hash, but only when each item is on its
       # own line.
       # * `diff_comma`: Requires a comma after the last item in a hash, but only when that item is
-      # followed by an immediate newline.
+      # followed by an immediate newline, even if there is an inline comment on the same line.
       # * `no_comma`: Does not require a comma after the last item in a hash
       #
       # @example EnforcedStyleForMultiline: consistent_comma

--- a/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_array_literal_spec.rb
@@ -249,6 +249,15 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArrayLiteral, :config do
         RUBY
       end
 
+      it 'accepts trailing comma with comment' do
+        expect_no_offenses(<<~RUBY)
+          VALUES = [1001,
+                    2020,
+                    3333, # comment
+                   ]
+        RUBY
+      end
+
       it 'registers an offense for a trailing comma on same line as closing bracket' do
         expect_offense(<<~RUBY)
           VALUES = [1001,

--- a/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_hash_literal_spec.rb
@@ -221,6 +221,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInHashLiteral, :config do
         RUBY
       end
 
+      it 'accepts trailing comma with comment' do
+        expect_no_offenses(<<~RUBY)
+          MAP = {
+                  a: 1001,
+                  b: 2020,
+                  c: 3333, # comment
+                }
+        RUBY
+      end
+
       it 'registers an offense for a trailing comma on same line as closing brace' do
         expect_offense(<<~RUBY)
           MAP = { a: 1001,


### PR DESCRIPTION
This PR fixes false positives for `EnforcedStyleForMultiline: diff_comma` of `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral` when trailing comma with comment.

Fixes #14070.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
