### PR TITLE
[Fix 13676] Fix explicitly provided hidden directories to be searchable

### DIFF
--- a/changelog/fix_allow_rubocop_to_inspect_hidden_directories_if_they_are_explicitly_provided_20250416113008.md
+++ b/changelog/fix_allow_rubocop_to_inspect_hidden_directories_if_they_are_explicitly_provided_20250416113008.md
@@ -1,0 +1,1 @@
+* [#13676](https://github.com/rubocop/rubocop/issues/13676): Allow RuboCop to inspect hidden directories if they are explicitly provided. ([@viralpraxis][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -46,7 +46,11 @@ module RuboCop
       hidden_files = all_files.select { |file| file.include?(HIDDEN_PATH_SUBSTRING) }.sort
       base_dir_config = @config_store.for(base_dir)
 
-      target_files = all_files.select { |file| to_inspect?(file, hidden_files, base_dir_config) }
+      target_files = if base_dir.include?(HIDDEN_PATH_SUBSTRING)
+                       all_files.select { |file| ruby_file?(file) }
+                     else
+                       all_files.select { |file| to_inspect?(file, hidden_files, base_dir_config) }
+                     end
 
       target_files.sort_by!(&order)
     end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -665,6 +665,26 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when provided directory contains hidden segments' do
+      let(:base_dir) { File.expand_path('.hidden') }
+
+      it 'picks relevant files within provided directory' do
+        expect(found_basenames).to match_array(%w[ruby4.rb])
+      end
+
+      context 'with nested hidden directory' do
+        before do
+          create_empty_file('.hidden/.nested-hidden/ruby5.rb')
+          create_file('.hidden/shebang-ruby', '#! /usr/bin/env ruby')
+          create_file('.hidden/shebang-zsh', '#! /usr/bin/env zsh')
+        end
+
+        it 'picks relevant files within provided directory' do
+          expect(found_basenames).to match_array(%w[ruby4.rb ruby5.rb shebang-ruby])
+        end
+      end
+    end
+
     context 'w/ --fail-fast option' do
       let(:options) { { force_exclusion: force_exclusion, debug: debug, fail_fast: true } }
 


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/13676

If provided directory path contains hidden segments (e.g. `rubocop ~/.local/share`), include all ruby files in the result of `TargetFinder#target_files_in_dir`.

This approach also finds files within nested hidden directories, i.e. given this structure

```
/.hidden
  ruby-1.rb
  /.hidden-2
    ruby-2.rb
```

running `target_files_in_dir("/.hidden")` will yield both `ruby-1.rb` and `ruby-2.rb`. I'm not sure if that's what we expect here (could someone comment on that please?)

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
