### PR TITLE
Clarify zero-sized file spec description

### DIFF
--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
-    context 'when file is actually empty' do
+    context 'when file is zero-sized' do
       include_context 'mock console output'
 
       before do


### PR DESCRIPTION
In https://github.com/rubocop/rubocop/pull/14048 I meant to use "zero-sized" terminology consistently since it sounds better than "actually empty".

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
