### PR TITLE
[Fix #14075] Fix an error for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_an_error_for_layout_empty_line_after_guard_clause_cop.md
+++ b/changelog/fix_an_error_for_layout_empty_line_after_guard_clause_cop.md
@@ -1,0 +1,1 @@
+* [#14075](https://github.com/rubocop/rubocop/issues/14075): Fix an error for `Layout/EmptyLineAfterGuardClause` when calling a method on the result of a single-line `if` with `return`. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -131,7 +131,7 @@ module RuboCop
 
         def next_sibling_parent_empty_or_else?(node)
           next_sibling = node.right_sibling
-          return true if next_sibling.nil?
+          return true unless next_sibling.is_a?(AST::Node)
 
           parent = next_sibling.parent
 

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -668,6 +668,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'does not register an offense when calling a method on the result of a single-line `if` with `return`' do
+    expect_no_offenses(<<~RUBY)
+      if cond then return end.then { 42 }
+    RUBY
+  end
+
   it 'does not register an offense when the clause ends with a semicolon but is followed by a newline' do
     expect_no_offenses(<<~RUBY)
       def foo(item)


### PR DESCRIPTION
This PR fixes an error for `Layout/EmptyLineAfterGuardClause` when calling a method on the result of a single-line `if` with `return`.

Fixes #14075.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
