### PR TITLE
Allow writing RBS::Inline annotation `#:` after end keyword in `Style/CommentedKeyword`

### DIFF
--- a/changelog/fix_allow_writing_rbs_inline_annotation__after_end_20250408193945.md
+++ b/changelog/fix_allow_writing_rbs_inline_annotation__after_end_20250408193945.md
@@ -1,0 +1,1 @@
+* [#14080](https://github.com/rubocop/rubocop/pull/14080): Allow writing RBS::Inline annotation `#:` after end keyword in `Style/CommentedKeyword`. ([@dak2][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -58,7 +58,7 @@ module RuboCop
         REGEXP = /(?<keyword>\S+).*#/.freeze
 
         SUBCLASS_DEFINITION = /\A\s*class\s+(\w|::)+\s*<\s*(\w|::)+/.freeze
-        METHOD_DEFINITION = /\A\s*def\s/.freeze
+        METHOD_OR_END_DEFINITIONS = /\A\s*(def\s|end)/.freeze
 
         STEEP_REGEXP = /#\ssteep:ignore(\s|\z)/.freeze
 
@@ -102,7 +102,7 @@ module RuboCop
           case line
           when SUBCLASS_DEFINITION
             comment.text.start_with?(/#\[.+\]/)
-          when METHOD_DEFINITION
+          when METHOD_OR_END_DEFINITIONS
             comment.text.start_with?('#:')
           else
             false

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -237,120 +237,159 @@ RSpec.describe RuboCop::Cop::Style::CommentedKeyword, :config do
     RUBY
   end
 
-  it 'does not register an offense for RBS::Inline generics annotation' do
-    expect_no_offenses(<<~RUBY)
-      class X < Y #[String]
-      end
-      class A < B::C #[String]
-      end
-      class A < B::C::D #[String]
-      end
-      class A::B < C #[String]
-      end
-      class A::B::C < D #[String]
-      end
-    RUBY
-  end
-
-  it 'registers an offense and corrects for RBS::Inline non generics annotation' do
-    expect_offense(<<~RUBY)
-      class X #[String]
-              ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class X < Y #[String
-                  ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class X < Y #String]
-                  ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class X < Y # String]
-                  ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class X < Y #String ]
-                  ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class A < B::C #String]
-                     ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class A < B::C::D #String]
-                        ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class A::B < C #String]
-                     ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-      class A::B::C < D #String]
-                        ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      #[String]
-      class X
-      end
-      #[String
-      class X < Y
-      end
-      #String]
-      class X < Y
-      end
-      # String]
-      class X < Y
-      end
-      #String ]
-      class X < Y
-      end
-      #String]
-      class A < B::C
-      end
-      #String]
-      class A < B::C::D
-      end
-      #String]
-      class A::B < C
-      end
-      #String]
-      class A::B::C < D
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for RBS::Inline annotation for method definition' do
-    expect_no_offenses(<<~RUBY)
-      def x #: String
-      end
-
-      class Y
-        def y #: String
+  context 'when RBS::Inline annotation is used' do
+    it 'does not register an offense for RBS::Inline generics annotation' do
+      expect_no_offenses(<<~RUBY)
+        class X < Y #[String]
         end
-      end
-    RUBY
-  end
+        class A < B::C #[String]
+        end
+        class A < B::C::D #[String]
+        end
+        class A::B < C #[String]
+        end
+        class A::B::C < D #[String]
+        end
+      RUBY
+    end
 
-  it 'registers an offense and corrects for RBS::Inline annotation for non method definition' do
-    expect_offense(<<~RUBY)
-      class X #: String
-              ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
-      end #: String
-          ^^^^^^^^^ Do not place comments on the same line as the `end` keyword.
-      module Y #: String
-               ^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
-      end
-      begin #: String
-            ^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
-      end
-    RUBY
+    it 'registers an offense and corrects for RBS::Inline non generics annotation' do
+      expect_offense(<<~RUBY)
+        class X #[String]
+                ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class X < Y #[String
+                    ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class X < Y #String]
+                    ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class X < Y # String]
+                    ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class X < Y #String ]
+                    ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class A < B::C #String]
+                       ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class A < B::C::D #String]
+                          ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class A::B < C #String]
+                       ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        class A::B::C < D #String]
+                          ^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      #: String
-      class X
-      end
-      #: String
-      module Y
-      end
-      #: String
-      begin
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        #[String]
+        class X
+        end
+        #[String
+        class X < Y
+        end
+        #String]
+        class X < Y
+        end
+        # String]
+        class X < Y
+        end
+        #String ]
+        class X < Y
+        end
+        #String]
+        class A < B::C
+        end
+        #String]
+        class A < B::C::D
+        end
+        #String]
+        class A::B < C
+        end
+        #String]
+        class A::B::C < D
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation for method definition' do
+      expect_no_offenses(<<~RUBY)
+        def x #: String
+        end
+
+        class Y
+          def y #: String
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects for RBS::Inline annotation for non method definition' do
+      expect_offense(<<~RUBY)
+        class X #: String
+                ^^^^^^^^^ Do not place comments on the same line as the `class` keyword.
+        end
+        module Y #: String
+                 ^^^^^^^^^ Do not place comments on the same line as the `module` keyword.
+        end
+        begin #: String
+              ^^^^^^^^^ Do not place comments on the same line as the `begin` keyword.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #: String
+        class X
+        end
+        #: String
+        module Y
+        end
+        #: String
+        begin
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation `#:` for `end` keyword of method' do
+      expect_no_offenses(<<~RUBY)
+        def x
+        end #: String
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation `#:` for `end` keyword of block' do
+      expect_no_offenses(<<~RUBY)
+        def x
+          doubled_nums = [1, 2, 3].map do |num|
+            num * 2
+          end #: Array[Integer]
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation `#:` for `end` keyword of class' do
+      expect_no_offenses(<<~RUBY)
+        class X
+        end #: String
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation `#:` for `end` keyword of module' do
+      expect_no_offenses(<<~RUBY)
+        module X
+        end #: String
+      RUBY
+    end
+
+    it 'does not register an offense for RBS::Inline annotation `#:` for `end` keyword of begin' do
+      expect_no_offenses(<<~RUBY)
+        begin
+        end #: String
+      RUBY
+    end
   end
 
   context 'when Steep annotation is used' do


### PR DESCRIPTION
[RBS::Inline](https://github.com/soutaro/rbs-inline) is a utility to embed RBS type declarations into Ruby code as comments.
    
We can write type declarations as `#:` after end keyword, especially when assigning variables.
    
ref. https://github.com/soutaro/steep/blob/bfa83623798279cb36f9c627fb68824e22ab9293/lib/steep/source.rb#L304
    
So I fixed the rule to allow writing RBS::Inline annotations `#:` after the end keyword.
    
In strictly, it is correct to write it only after the end keyword in a block of variable assignments.
    
However, in the context of the end keyword, except for variable assignments and method definitions, Steep does not check type or outputs an error if it is not the correct type.
Also, RBS::Inline does not generate rbs from `#:` after the end keyword except in a block of variable assignments.
    
So I have no motivation to write `#:` after end keyword except at variable assignment, so to avoid implementation complexity, I implemented allow writing `#:` after end keyword without restriction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
