### PR TITLE
Fix `Style/ConditionalAssignment` cop error on oneline if-then-else

### DIFF
--- a/changelog/fix_style_conditional_assignment_cop_error_on_one_line_if_then_else_20250408231542.md
+++ b/changelog/fix_style_conditional_assignment_cop_error_on_one_line_if_then_else_20250408231542.md
@@ -1,0 +1,1 @@
+* [#14083](https://github.com/rubocop/rubocop/pull/14083): Fix `Style/ConditionalAssignment` cop error on one-line if-then-else. ([@viralpraxis][])

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -904,6 +904,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    it 'registers an offense for assignment to an one-line if then else' do
+      expect_offense(<<~RUBY)
+        bar = if foo then 1 else 2 end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo then bar = 1 else bar = 2 end
+      RUBY
+    end
+
     it 'registers an offense for an assignment that uses if branch bodies including a block' do
       expect_offense(<<~RUBY)
         result = if condition


### PR DESCRIPTION
```bash
echo 'bar = if foo then 1 else 2 end' | bundle exec rubocop --stdin bug.rb -c <(echo "Style/ConditionalAssignment:\n EnforcedStyle: assign_inside_condition") -d
An error occurred while Style/ConditionalAssignment cop was inspecting rubocop/bug.rb:1:0.
Parser::Source::TreeRewriter detected clobbering
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter.rb:414:in `enforce_policy'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:234:in `call'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:234:in `swallow'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:98:in `with'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:120:in `place_in_hierarchy'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:107:in `do_combine'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter/action.rb:31:in `combine'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter.rb:400:in `combine'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter.rb:194:in `replace'
3.3.0/gems/parser-3.3.7.2/lib/parser/source/tree_rewriter.rb:218:in `remove'
lib/rubocop/cop/corrector.rb:54:in `remove_preceding'
lib/rubocop/cop/style/conditional_assignment.rb:452:in `block in remove_whitespace_in_branches'
lib/rubocop/cop/style/conditional_assignment.rb:449:in `each'
lib/rubocop/cop/style/conditional_assignment.rb:449:in `remove_whitespace_in_branches'
lib/rubocop/cop/style/conditional_assignment.rb:597:in `move_branch_inside_condition'
lib/rubocop/cop/style/conditional_assignment.rb:579:in `block in move_assignment_inside_condition'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
