### PR TITLE
Fix `Style/RedundantLineContinuation` cop error on multiline assignment

### DIFF
--- a/changelog/fix_style_redundant_line_continuation_cop_error_on_multiline_assignment_20250408235451.md
+++ b/changelog/fix_style_redundant_line_continuation_cop_error_on_multiline_assignment_20250408235451.md
@@ -1,0 +1,1 @@
+* [#14084](https://github.com/rubocop/rubocop/pull/14084): Fix `Style/RedundantLineContinuation` cop error on multiline assignment with line continuation. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -181,9 +181,7 @@ module RuboCop
           ARGUMENT_TYPES.include?(next_token.type)
         end
 
-        # rubocop:disable Metrics/AbcSize
         def argument_newline?(node)
-          node = node.to_a.last if node.assignment?
           return false if node.parenthesized_call?
 
           node = node.children.first if node.root? && node.begin_type?
@@ -196,7 +194,6 @@ module RuboCop
             node.loc.selector.line != node.first_argument.loc.line
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def find_node_for_line(last_line)
           processed_source.ast.each_node do |node|

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -1011,4 +1011,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
       end
     RUBY
   end
+
+  it 'registers an offense for multiline assignment with a line continuation' do
+    expect_offense(<<~'RUBY')
+      a, b, \
+            ^ Redundant line continuation.
+        c = [1, 2, 3]
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a, b,#{trailing_whitespace}
+        c = [1, 2, 3]
+    RUBY
+  end
 end


### PR DESCRIPTION
```bash
$ cat /tmp/ruby.rb
a, b, \
 c = [1, 2, 3]
```

```bash
bundle exec rubocop /tmp/ruby.rb --only Style/RedundantLineContinuation -d

For /tmp: An error occurred while Style/RedundantLineContinuation cop was inspecting /tmp/ruby.rb.
undefined method `parenthesized_call?' for an instance of Symbol
lib/rubocop/cop/style/redundant_line_continuation.rb:187:in `argument_newline?'
lib/rubocop/cop/style/redundant_line_continuation.rb:143:in `redundant_line_continuation?'
lib/rubocop/cop/style/redundant_line_continuation.rb:91:in `block in on_new_investigation'
lib/rubocop/cop/mixin/match_range.rb:14:in `block in each_match_range'
lib/rubocop/cop/mixin/match_range.rb:14:in `scan'
lib/rubocop/cop/mixin/match_range.rb:14:in `each_match_range'
lib/rubocop/cop/style/redundant_line_continuation.rb:89:in `on_new_investigation'
```

The `node = node.to_a.last if node.assignment?` expression was added in https://github.com/rubocop/rubocop/pull/12678, but ATM there are no tests hitting that line. Perhaps that was unintentional? Otherwise, why should assignments be treated differently?

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
