### PR TITLE
[Fix #14082] Mark `Style/ComparableBetween` unsafe for autocorrect

### DIFF
--- a/changelog/change_mark_style_comparable_between_unsafe_for_20250409182216.md
+++ b/changelog/change_mark_style_comparable_between_unsafe_for_20250409182216.md
@@ -1,0 +1,1 @@
+* [#14082](https://github.com/rubocop/rubocop/issues/14082): Mark `Style/ComparableBetween` unsafe for autocorrect. ([@tejasbubane][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3702,7 +3702,9 @@ Style/CommentedKeyword:
 Style/ComparableBetween:
   Description: 'Enforces the use of `Comparable#between?` instead of logical comparison.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.74'
+  VersionChanged: '<<next>>'
   StyleGuide: '#ranges-or-between'
 
 Style/ComparableClamp:

--- a/lib/rubocop/cop/style/comparable_between.rb
+++ b/lib/rubocop/cop/style/comparable_between.rb
@@ -9,6 +9,11 @@ module RuboCop
       # although the difference generally isn't observable. If you require maximum
       # performance, consider using logical comparison.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because there is no guarantee that
+      #   `x` responds to `.between?` when autocorrecting
+      #   `x >= min && x <= max` to `x.between?(min, max)`
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
Closes #14082.

This PR marks unsafe autocorrect for `Style/ComparableBetween` because there is no guarantee that the variable `x` responds to `between?` when autocorrecting `x >= min && x <= max` to `x.between?(min, max)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
