### PR TITLE
Use the latest Ruby 3.5 parser for docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,6 @@ task documentation_syntax_check: :yard_for_generate_documentation do
   require 'parser/ruby25'
   require 'parser/ruby26'
   require 'parser/ruby27'
-  require 'parser/ruby34'
 
   ok = true
   YARD::Registry.load!
@@ -68,7 +67,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
                elsif cop == RuboCop::Cop::Lint::NumberedParameterAssignment
                  Parser::Ruby27.new(RuboCop::AST::Builder.new)
                else
-                 Parser::Ruby34.new(RuboCop::AST::Builder.new)
+                 Prism::Translation::Parser35.new(RuboCop::AST::BuilderPrism.new)
                end
       parser.diagnostics.all_errors_are_fatal = true
       parser.parse(buffer)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14025

This PR uses the latest Ruby 3.5 Prism translation parser for docs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
