### PR TITLE
Fix false positive in RedundantCurrentDirectoryInPath cop for one-character paths

### DIFF
--- a/changelog/fix_redundant_current_directory_prefix_regexp_20250414044527.md
+++ b/changelog/fix_redundant_current_directory_prefix_regexp_20250414044527.md
@@ -1,0 +1,1 @@
+* [#14089](https://github.com/rubocop/rubocop/pull/14089): Fix redundant current directory prefix regexp. ([@sferik][])

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -20,7 +20,7 @@ module RuboCop
 
         MSG = 'Remove the redundant current directory path.'
         RESTRICT_ON_SEND = %i[require_relative].freeze
-        CURRENT_DIRECTORY_PREFIX = %r{./+}.freeze
+        CURRENT_DIRECTORY_PREFIX = %r{\./+}.freeze
         REDUNDANT_CURRENT_DIRECTORY_PREFIX = /\A#{CURRENT_DIRECTORY_PREFIX}/.freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
+++ b/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
     RUBY
   end
 
+  it 'does not register an offense when not using a one-character path in `require_relative`' do
+    expect_no_offenses(<<~RUBY)
+      require_relative 'p/t/feature'
+    RUBY
+  end
+
   it 'does not register an offense when not using a current directory path in `require_relative`' do
     expect_no_offenses(<<~RUBY)
       require_relative 'path/to/feature'


### PR DESCRIPTION
Dots (i.e. periods) in regular expressions need to be escaped, otherwise they are a wildcard for any single character.