### PR TITLE
Fix false negative for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#14092](https://github.com/rubocop/rubocop/pull/14092): Fix false negative for `Style/RedundantParentheses` when using some operator methods with a parenthesized argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -98,7 +98,7 @@ module RuboCop
           return false unless node.type?(:send, :super, :yield)
 
           node.arguments.one? && !node.parenthesized? &&
-            !node.arithmetic_operation? && node.first_argument.begin_type?
+            !node.operator_method? && node.first_argument.begin_type?
         end
 
         def multiline_control_flow_statements?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -975,6 +975,74 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('if x; y else (1)end')
   end
 
+  context 'when a parenthesized literal is used in a comparison' do
+    it 'registers an offense for `==`' do
+      expect_offense(<<~RUBY)
+        x == (42)
+             ^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x == 42
+      RUBY
+    end
+
+    it 'registers an offense for `>`' do
+      expect_offense(<<~RUBY)
+        x > (42)
+            ^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x > 42
+      RUBY
+    end
+
+    it 'registers an offense for `>=`' do
+      expect_offense(<<~RUBY)
+        x >= (42)
+             ^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x >= 42
+      RUBY
+    end
+
+    it 'registers an offense for `<`' do
+      expect_offense(<<~RUBY)
+        x < (42)
+            ^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x < 42
+      RUBY
+    end
+
+    it 'registers an offense for `<=`' do
+      expect_offense(<<~RUBY)
+        x <= (42)
+             ^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x <= 42
+      RUBY
+    end
+  end
+
+  it 'registers an offense for a parenthesized literal in a `=~` comparison' do
+    expect_offense(<<~RUBY)
+      x =~ (/regexp/)
+           ^^^^^^^^^^ Don't use parentheses around a literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x =~ /regexp/
+    RUBY
+  end
+
   context 'when the first argument in a method call begins with a hash literal' do
     it 'accepts parentheses if the argument list is not parenthesized' do
       expect_no_offenses('x ({ y: 1 }), z')


### PR DESCRIPTION
This PR fixes false negative for `Style/RedundantParentheses` when using some operator methods with a parenthesized argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
