### PR TITLE
Offend redundant parens around method arguments for `Style/RedundantParentheses`

### DIFF
--- a/changelog/change_offend_redundant_parens_around_method_arguments.md
+++ b/changelog/change_offend_redundant_parens_around_method_arguments.md
@@ -1,0 +1,1 @@
+* [#14093](https://github.com/rubocop/rubocop/pull/14093): Register offenses for redundant parens around method arguments for `Style/RedundantParentheses`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -52,7 +52,7 @@ module RuboCop
           each_missing_enable do |cop, line_range|
             next if acceptable_range?(cop, line_range)
 
-            range = source_range(processed_source.buffer, line_range.min, (0..0))
+            range = source_range(processed_source.buffer, line_range.min, 0..0)
             comment = processed_source.comment_at_line(line_range.begin)
 
             add_offense(range, message: message(cop, comment))

--- a/lib/rubocop/formatter/pacman_formatter.rb
+++ b/lib/rubocop/formatter/pacman_formatter.rb
@@ -58,7 +58,7 @@ module RuboCop
         return pacdots(@total_files) unless @total_files > cols
         return pacdots(cols) unless (@total_files / cols).eql?(@repetitions)
 
-        pacdots((@total_files - (cols * @repetitions)))
+        pacdots(@total_files - (cols * @repetitions))
       end
 
       def pacdots(number)

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::CommentConfig do
     it 'just ignores unpaired enabling directives' do
       void_disabled_lines = disabled_lines_of_cop('Lint/Void')
       expected_part = (25..source.size).to_a
-      expect((void_disabled_lines & expected_part)).to be_empty
+      expect(void_disabled_lines & expected_part).to be_empty
     end
 
     it 'supports disabling single line with a directive at end of line' do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -225,15 +225,78 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense for parens around method arguments of a method call with an argument' do
+  it 'registers an offense for parens around a method argument of a parenthesized method call' do
     expect_offense(<<~RUBY)
       x.y((z))
-          ^^^ Don't use parentheses around a method call.
+          ^^^ Don't use parentheses around a method argument.
     RUBY
 
     expect_correction(<<~RUBY)
       x.y(z)
     RUBY
+  end
+
+  it 'registers an offense for parens around a method argument of a parenthesized method call with safe navigation' do
+    expect_offense(<<~RUBY)
+      x&.y((z))
+           ^^^ Don't use parentheses around a method argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x&.y(z)
+    RUBY
+  end
+
+  it 'registers an offense for parens around a second method argument of a parenthesized method call' do
+    expect_offense(<<~RUBY)
+      x.y(z, (w))
+             ^^^ Don't use parentheses around a method argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(z, w)
+    RUBY
+  end
+
+  it 'registers an offense for parens around an expression method argument of a parenthesized method call' do
+    expect_offense(<<~RUBY)
+      x.y((z + w))
+          ^^^^^^^ Don't use parentheses around a method argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(z + w)
+    RUBY
+  end
+
+  it 'registers an offense for parens around a range method argument of a parenthesized method call' do
+    expect_offense(<<~RUBY)
+      x.y((a..b))
+          ^^^^^^ Don't use parentheses around a method argument.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(a..b)
+    RUBY
+  end
+
+  it 'registers an offense for parens around a multiline method argument of a parenthesized method call' do
+    expect_offense(<<~RUBY)
+      x.y((foo &&
+          ^^^^^^^ Don't use parentheses around a method argument.
+        bar
+      ))
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.y(foo &&
+        bar
+      )
+    RUBY
+  end
+
+  it 'does not register an offense for parens around an array destructuring argument in method definition' do
+    expect_no_offenses('def foo((bar, baz)); end')
   end
 
   it 'registers an offense for parens around parenthesized conditional assignment' do


### PR DESCRIPTION
Currently, `Style/RedundantParentheses` will register an offense for parens around a method argument in a parenthesized method call:
```ruby
x.foo((bar))
      ^^^^^ Don't use parentheses around a method call.
```

However, an offense isn't registered with an expression argument:
```ruby
x.foo((bar + baz))
```

This PR makes the latter example an offense:
```ruby
x.foo((bar + baz))
      ^^^^^^^^^^^ Don't use parentheses around a method argument.
```

As a consequence, offense message for the first example is updated as well:
```ruby
x.foo((bar))
      ^^^^^ Don't use parentheses around a method argument.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
