### PR TITLE
Fix `Style/SafeNavigation` with longer && chains

### DIFF
--- a/changelog/fix_style_safe_navigation_with_longer_and_chain.md
+++ b/changelog/fix_style_safe_navigation_with_longer_and_chain.md
@@ -1,0 +1,1 @@
+* [#14096](https://github.com/rubocop/rubocop/pull/14096): Fix error for `Style/SafeNavigation` with longer `&&` chain (e.g. `a && a.b && a.b.c`). ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1169,6 +1169,40 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'registers an offense for a safe navigation method call followed by a method call' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable}&.bar && %{variable}.bar.baz
+            ^{variable}^^^^^^^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar&.baz
+          RUBY
+        end
+
+        it 'registers an offense for multiple method calls with safe navigation on last call followed by a method call' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable}.bar&.baz && %{variable}.bar.baz.quux
+            ^{variable}^^^^^^^^^^^^^^{variable}^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}.bar&.baz&.quux
+          RUBY
+        end
+
+        it 'registers offenses for an object check followed by a method call followed again by another method call' do
+          expect_offense(<<~RUBY, variable: variable)
+            %{variable} && %{variable}.bar && %{variable}.bar.baz
+            _{variable}    ^{variable}^^^^^^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            ^{variable}^^^^^{variable}^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{variable}&.bar&.baz
+          RUBY
+        end
+
         it 'registers an offense for an object check followed by a method call with params' do
           expect_offense(<<~RUBY, variable: variable)
             %{variable} && %{variable}.bar(baz)


### PR DESCRIPTION
Currently, longer && chains cause overlapping offenses for `Style/SafeNavigation` cop:
```ruby
a && a.b && a.b.c
^^^^^^^^ Use safe navigation (&.)...
     ^^^^^^^^^^^^ Use safe navigation (&.)...
```
and this fails during autocorrection with `Parser::Source::TreeRewriter detected clobbering` error because the same ranges are updated.

This PR fixes the cop to prevent clobbering by autocorrecting in two passes:
```ruby
a && a.b && a.b.c
a&.b && a.b.c # after first pass
a&.b&.c # after second pass
```

As a side effect of the fix, cases such as:
```ruby
a&.b && a.b.c
```
are now also registered as cop offenses, and autocorrected to:
```ruby
a&.b&.c
```
Previously, this would only be an offense if instead of `a&.b` there was `a.b`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
