### PR TITLE
Fix `Style/ClassAndModuleChildren` cop error on one-liner class definition

### DIFF
--- a/changelog/fix_style_class_and_module_children_cop_error_on_one_liner_class_definition_20250416225515.md
+++ b/changelog/fix_style_class_and_module_children_cop_error_on_one_liner_class_definition_20250416225515.md
@@ -1,0 +1,1 @@
+* [#14099](https://github.com/rubocop/rubocop/pull/14099): Fix `Style/ClassAndModuleChildren` cop error on one-liner class definition and nested enforced style. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -131,13 +131,19 @@ module RuboCop
             "#{node.body.children.first.const_name}"
         end
 
+        # rubocop:disable Metrics/AbcSize
         def remove_end(corrector, body)
-          remove_begin_pos = body.loc.end.begin_pos - leading_spaces(body).size
+          remove_begin_pos = if same_line?(body.loc.name, body.loc.end)
+                               body.loc.name.end_pos
+                             else
+                               body.loc.end.begin_pos - leading_spaces(body).size
+                             end
           adjustment = processed_source.raw_source[remove_begin_pos] == ';' ? 0 : 1
           range = range_between(remove_begin_pos, body.loc.end.end_pos + adjustment)
 
           corrector.remove(range)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def unindent(corrector, node)
           return unless node.body.children.last

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -367,20 +367,6 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
-    it 'registers an offense for classes with nested one-liner children' do
-      expect_offense(<<~RUBY)
-        class FooClass
-              ^^^^^^^^ Use compact module/class definition instead of nested style.
-          class BarClass; end
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        class FooClass::BarClass
-        end
-      RUBY
-    end
-
     it 'accepts class/module with single method' do
       expect_no_offenses(<<~RUBY)
         class FooClass
@@ -445,6 +431,98 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         expect_correction(<<~RUBY)
           class M::C
             def foo; 1; end
+          end
+        RUBY
+      end
+    end
+
+    context 'with one-liner class defintiion' do
+      it 'registers an offense for classes with nested one-liner children' do
+        expect_offense(<<~RUBY)
+          class FooClass
+                ^^^^^^^^ Use compact module/class definition instead of nested style.
+            class BarClass; end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass::BarClass
+          end
+        RUBY
+      end
+
+      it 'registers an offense when one-liner class definition is 3 levels deep' do
+        expect_offense(<<~RUBY)
+          class A < B
+            class C
+                  ^ Use compact module/class definition instead of nested style.
+              class D; end
+            end
+
+            class E
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A < B
+            class C::D
+            end
+
+            class E
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when one-liner class definition is 4 levels deep' do
+        expect_offense(<<~RUBY)
+          class A < B
+            class F
+              class C
+                    ^ Use compact module/class definition instead of nested style.
+                class D; end
+              end
+
+              class E
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A < B
+            class F
+              class C::D
+              end
+
+              class E
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when one-liner class definition has multitple whitespaces before the `end` token' do
+        expect_offense(<<~RUBY)
+          class A < B
+            class C
+                  ^ Use compact module/class definition instead of nested style.
+              class D;    end
+            end
+
+            class E
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A < B
+            class C::D
+            end
+
+            class E
+            end
           end
         RUBY
       end


### PR DESCRIPTION
Currently RuboCop is unable to investigate programs like this

```ruby
class A < B
  class C
    class D; end
  end

  class E
  end
end
```

Upon merging this patch, the Rails codebase will be error-free in the context of the state space traversal technique used by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
