### PR TITLE
Fix some asciidoc formatting issues in cop documentation

### DIFF
--- a/lib/rubocop/cop/lint/useless_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_rescue.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for useless `rescue`s, which only reraise rescued exceptions.
+      # Checks for useless ``rescue``s, which only reraise rescued exceptions.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -16,16 +16,16 @@ module RuboCop
       #
       # In Ruby 3.2, anonymous args/kwargs forwarding has been added.
       #
-      # This cop also identifies places where `use_args(*args)`/`use_kwargs(**kwargs)` can be
-      # replaced by `use_args(*)`/`use_kwargs(**)`; if desired, this functionality can be disabled
-      # by setting `UseAnonymousForwarding: false`.
+      # This cop also identifies places where `+use_args(*args)+`/`+use_kwargs(**kwargs)+` can be
+      # replaced by `+use_args(*)+`/`+use_kwargs(**)+`; if desired, this functionality can be
+      # disabled by setting `UseAnonymousForwarding: false`.
       #
       # And this cop has `RedundantRestArgumentNames`, `RedundantKeywordRestArgumentNames`,
       # and `RedundantBlockArgumentNames` options. This configuration is a list of redundant names
       # that are sufficient for anonymizing meaningless naming.
       #
       # Meaningless names that are commonly used can be anonymized by default:
-      # e.g., `*args`, `**options`, `&block`, and so on.
+      # e.g., `+*args+`, `+**options+`, `&block`, and so on.
       #
       # Names not on this list are likely to be meaningful and are allowed by default.
       #

--- a/lib/rubocop/cop/style/eval_with_location.rb
+++ b/lib/rubocop/cop/style/eval_with_location.rb
@@ -4,12 +4,12 @@ module RuboCop
   module Cop
     module Style
       # Ensures that eval methods (`eval`, `instance_eval`, `class_eval`
-      # and `module_eval`) are given filename and line number values (`\_\_FILE\_\_`
-      # and `\_\_LINE\_\_`). This data is used to ensure that any errors raised
+      # and `module_eval`) are given filename and line number values (`+__FILE__+`
+      # and `+__LINE__+`). This data is used to ensure that any errors raised
       # within the evaluated code will be given the correct identification
       # in a backtrace.
       #
-      # The cop also checks that the line number given relative to `\_\_LINE\_\_` is
+      # The cop also checks that the line number given relative to `+__LINE__+` is
       # correct.
       #
       # This cop will autocorrect incorrect or missing filename and line number

--- a/lib/rubocop/cop/style/hash_transform_keys.rb
+++ b/lib/rubocop/cop/style/hash_transform_keys.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Looks for uses of `\_.each_with_object({}) {...}`,
-      # `\_.map {...}.to_h`, and `Hash[\_.map {...}]` that are actually just
+      # Looks for uses of `+_.each_with_object({}) {...}+`,
+      # `+_.map {...}.to_h+`, and `+Hash[_.map {...}]+` that are actually just
       # transforming the keys of a hash, and tries to use a simpler & faster
       # call to `transform_keys` instead.
       # It should only be enabled on Ruby version 2.5 or newer.

--- a/lib/rubocop/cop/style/hash_transform_values.rb
+++ b/lib/rubocop/cop/style/hash_transform_values.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Looks for uses of `\_.each_with_object({}) {...}`,
-      # `\_.map {...}.to_h`, and `Hash[\_.map {...}]` that are actually just
+      # Looks for uses of `+_.each_with_object({}) {...}+`,
+      # `+_.map {...}.to_h+`, and `+Hash[_.map {...}]+` that are actually just
       # transforming the values of a hash, and tries to use a simpler & faster
       # call to `transform_values` instead.
       #

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -10,7 +10,7 @@ module RuboCop
       # `nonzero?` method is allowed by default.
       # These are customizable with `AllowedMethods` option.
       #
-      # This cop targets only `if`s with a single `elsif` or `else` branch. The following
+      # This cop targets only ``if``s with a single `elsif` or `else` branch. The following
       # code will be allowed, because it has two `elsif` branches:
       #
       # [source,ruby]


### PR DESCRIPTION
Fixes various formatting issues in cop docs related to monospace formatting.

The places where double backticks have been added is [unconstrained formatting](https://docs.asciidoctor.org/asciidoc/latest/text/#unconstrained); it's required where only part of a word is formatted (e.g. \`rescue\`s -> \`\`rescue\`\`s).

Places where `\+ has been added is [literal monospace](https://docs.asciidoctor.org/asciidoc/latest/text/literal-monospace/), required to prevent e.g. bold formatting if the monospace text contains \*.

