### PR TITLE
Fix `Layout/MultilineOperationIdentation` cop error on `indexasgn` node without arguments

### DIFF
--- a/changelog/fix_layout_multiline_operation_indentation_cop_error_on_indexasgn_without_arguments_20250418012616.md
+++ b/changelog/fix_layout_multiline_operation_indentation_cop_error_on_indexasgn_without_arguments_20250418012616.md
@@ -1,0 +1,1 @@
+* [#14103](https://github.com/rubocop/rubocop/pull/14103): Fix `Layout/MultilineOperationIndentation` cop error on `indexasgn` node without arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -118,7 +118,7 @@ module RuboCop
         end
 
         def right_hand_side(send_node)
-          send_node.first_argument.source_range
+          send_node.first_argument&.source_range
         end
       end
     end

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -17,6 +17,8 @@ module RuboCop
 
         lhs = left_hand_side(node.receiver)
         rhs = right_hand_side(node)
+        return unless rhs
+
         range = offending_range(node, lhs, rhs, style)
         check(range, node, lhs, rhs)
       end

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
       RUBY
     end
 
+    it 'accepts `[]=` operator without arguments', broken_on: :prism do
+      expect_no_offenses(<<~RUBY)
+        begin
+        rescue =>
+          A[]
+        end
+      RUBY
+    end
+
     it 'accepts indented operands in ordinary statement' do
       expect_no_offenses(<<~RUBY)
         a +


### PR DESCRIPTION
I believe this pattern is kinda unique since that's the only way to get this AST

```bash
$ ruby-parse --34 -e 'begin; rescue => __LINE__[]; end'
(kwbegin
  (rescue nil
    (resbody nil
      (indexasgn
        (int 1)) nil) nil))
```

and `Layout/MultilineOperationIdentation` crashes on it.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
