### PR TITLE
Fix `Style/ConditionalAssignment` cop error on indexed assignment without arguments

### DIFF
--- a/changelog/fix_style_condtional_assignment_cop_error_on_indexed_assignment_without_arguments_20250418222231.md
+++ b/changelog/fix_style_condtional_assignment_cop_error_on_indexed_assignment_without_arguments_20250418222231.md
@@ -1,0 +1,1 @@
+* [#14104](https://github.com/rubocop/rubocop/pull/14104): Fix `Style/ConditionalAssignment` cop error on indexed assignment without arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -314,6 +314,7 @@ module RuboCop
 
         def assignment_node(node)
           assignment = node.send_type? ? node.last_argument : node.expression
+          return unless assignment
 
           # ignore pseudo-assignments without rhs in for nodes
           return if node.parent&.for_type?

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -777,6 +777,14 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     end
   end
 
+  shared_examples 'with indexed assignment without arguments' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        foo.[]=()
+      RUBY
+    end
+  end
+
   context 'SingleLineConditionsOnly true' do
     let(:config) do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
@@ -854,6 +862,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     it_behaves_like('multiline all assignment types allow', '<<')
 
     it_behaves_like('with `dstr` node in branch')
+    it_behaves_like('with indexed assignment without arguments')
 
     it 'allows a method call in the subject of a ternary operator' do
       expect_no_offenses('bar << foo? ? 1 : 2')
@@ -1101,6 +1110,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
 
     it_behaves_like('single line condition autocorrect')
     it_behaves_like('with `dstr` node in branch')
+    it_behaves_like('with indexed assignment without arguments')
 
     it 'corrects assignment to a multiline if else condition' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
See new test examples

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
