### PR TITLE
Bump `rubocop-rspec` development dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -373,3 +373,6 @@ Gemspec/DependencyVersion:
 
 Style/RequireOrder:
   Enabled: true
+
+RSpec/IncludeExamples:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.25.0'
 gem 'rubocop-rake', '~> 0.7.0'
-gem 'rubocop-rspec', '~> 3.5.0'
+gem 'rubocop-rspec', '~> 3.6.0'
 # Ruby LSP supports Ruby 3.0+.
 gem 'ruby-lsp', '~> 0.23', platform: :mri if RUBY_VERSION >= '3.0'
 gem 'simplecov', '~> 0.20'


### PR DESCRIPTION
Currently `lint-without-bundler` CI step fails because it uses latest `rubocop-rspec` gem version and there's a [new cop](https://github.com/rubocop/rubocop-rspec/pull/2066) which leads to ~600 offenses in the code base.

I briefly saw https://github.com/rubocop/rubocop/pull/14033 and it looks like we have no intention to forbid using `include_examples`. Let me know if I'm wrong.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
