### PR TITLE
Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14110](https://github.com/rubocop/rubocop/pull/14110): Fix false positives for `Style/RedundantParentheses` when parens around basic conditional as the second argument of a parenthesized method call. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -181,6 +181,7 @@ module RuboCop
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
         def argument_of_parenthesized_method_call?(node)
+          return false if node.children.first.basic_conditional?
           return false unless (parent = node.parent)
 
           parent.call_type? && parent.parenthesized? && parent.receiver != node

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -258,6 +258,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'does not register an offense for parens around `if` as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (2 if y?))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around `unless` as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (2 unless y?))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around `while` as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (2 while y?))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around `until` as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (2 until y?))
+    RUBY
+  end
+
   it 'registers an offense for parens around an expression method argument of a parenthesized method call' do
     expect_offense(<<~RUBY)
       x.y((z + w))


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14067#issuecomment-2820741234 The fix in #14093 had been overlooked.

This PR fixes false positives for `Style/RedundantParentheses` when parens around basic conditional as the second argument of a parenthesized method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
