### PR TITLE
[Fix #14111] Fix an error for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_false_positive_for_style_safe_navigation.md
+++ b/changelog/fix_false_positive_for_style_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#14111](https://github.com/rubocop/rubocop/issues/14111): Fix an error for `Style/SafeNavigation` when the RHS of `&&` is a complex `||` expression composed of `&&` conditions. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -321,7 +321,7 @@ module RuboCop
         end
 
         def matching_call_nodes?(left, right)
-          return false unless left && right
+          return false unless left && right.respond_to?(:call_type?)
 
           left.call_type? && right.call_type? && left.children == right.children
         end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1467,6 +1467,16 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     RUBY
   end
 
+  it 'does not register an offense when the RHS of `&&` is a complex `||` expression composed of `&&` conditions' do
+    expect_no_offenses(<<~RUBY)
+      foo && (
+        (foo >= 1 && foo < 2) ||
+        (foo >= 3 && foo < 4) ||
+        (foo >= 5 && foo < 6)
+      )
+    RUBY
+  end
+
   context 'respond_to?' do
     it 'allows method calls safeguarded by a respond_to check' do
       expect_no_offenses('foo.bar if foo.respond_to?(:bar)')


### PR DESCRIPTION
This PR fixes an error for `Style/SafeNavigation` when the RHS of `&&` is a complex `||` expression composed of `&&` conditions.

Fixes #14111

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
