### PR TITLE
Fix `Style/ClassAndModuleChildren` cop error on tab-intended compactable modules

### DIFF
--- a/changelog/fix_style_class_and_module_children_cop_error_on_tab_intended_compactable_modules_20250422154713.md
+++ b/changelog/fix_style_class_and_module_children_cop_error_on_tab_intended_compactable_modules_20250422154713.md
@@ -1,0 +1,1 @@
+* [#14114](https://github.com/rubocop/rubocop/pull/14114): Fix `Style/ClassAndModuleChildren` cop error on tab-intended compactable modules. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -149,9 +149,9 @@ module RuboCop
           return unless node.body.children.last
 
           last_child_leading_spaces = leading_spaces(node.body.children.last)
-          return if leading_spaces(node).size == last_child_leading_spaces.size
+          return if spaces_size(leading_spaces(node)) == spaces_size(last_child_leading_spaces)
 
-          column_delta = configured_indentation_width - last_child_leading_spaces.size
+          column_delta = configured_indentation_width - spaces_size(last_child_leading_spaces)
           return if column_delta.zero?
 
           AlignmentCorrector.correct(corrector, processed_source, node, column_delta)
@@ -159,6 +159,16 @@ module RuboCop
 
         def leading_spaces(node)
           node.source_range.source_line[/\A\s*/]
+        end
+
+        def spaces_size(spaces_string)
+          mapping = { "\t" => tab_indentation_width }
+          spaces_string.chars.sum { |character| mapping.fetch(character, 1) }
+        end
+
+        def tab_indentation_width
+          config.for_cop('Layout/IndentationStyle')['IndentationWidth'] ||
+            configured_indentation_width
         end
 
         def check_style(node, body, style)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -385,6 +385,25 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'registers an offense for tab-intended nested children' do
+      expect_offense(<<~RUBY)
+        module A
+               ^ Use compact module/class definition instead of nested style.
+        \tmodule B
+        \t\tmodule C
+        \t\t\tbody
+        \t\tend
+        \tend
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module A::B::C
+        \t\t\tbody
+        end
+      RUBY
+    end
+
     context 'with unindented nested nodes' do
       it 'registers an offense and autocorrects unindented class' do
         expect_offense(<<~RUBY)
@@ -433,6 +452,65 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
             def foo; 1; end
           end
         RUBY
+      end
+
+      context 'with tab-intended nested nodes' do
+        it 'registers an offense and autocorrects when 3rd-level module has unintended body' do
+          expect_offense(<<~RUBY)
+            module A
+                   ^ Use compact module/class definition instead of nested style.
+            \tmodule B
+            \t\tmodule C
+            \t\tbody
+            \t\tend
+            \tend
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module A::B::C
+            \t\tbody
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when all nested modules have the same indentation' do
+          expect_offense(<<~RUBY)
+            module A
+                   ^ Use compact module/class definition instead of nested style.
+            \tmodule B
+            \tmodule C
+            \tbody
+            \tend
+            \tend
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module A::B::C
+            \tbody
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when all nested modules have the same indentation and nested body is intended' do
+          expect_offense(<<~RUBY)
+            module A
+                   ^ Use compact module/class definition instead of nested style.
+            \tmodule B
+            \tmodule C
+            \t\tbody
+            \tend
+            \tend
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module A::B::C
+            \t\tbody
+            end
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Before these changes most of weirdly-tab-intended programms like this

```ruby
  module A
  \tmodule B
  \tmodule C
  \tbody
  \tend
  \tend
  end
```

were producing this error

```bash
Parser::ClobberingError:
       Parser::Source::TreeRewriter detected clobbering
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:48:in `autocorrect_line'
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:25:in `block in correct'
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:102:in `block in each_line'
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:101:in `each_line'
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:101:in `each_line'
     # ./lib/rubocop/cop/correctors/alignment_corrector.rb:24:in `correct'
```

This bug was found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
