### PR TITLE
[Fix #13611] Enable `Lint/CircularArgumentReference` on Ruby 3.4

### DIFF
--- a/changelog/change_enable_circ_arg_reference.md
+++ b/changelog/change_enable_circ_arg_reference.md
@@ -1,0 +1,1 @@
+* [#13611](https://github.com/rubocop/rubocop/issues/13611): Enable `Lint/CircularArgumentReference` on Ruby 3.4. ([@earlopain][])

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -6,9 +6,8 @@ module RuboCop
       # Checks for circular argument references in optional keyword
       # arguments and optional ordinal arguments.
       #
-      # This cop mirrors a warning produced by MRI since 2.2.
-      #
-      # NOTE: This syntax is no longer valid on Ruby 2.7 or higher.
+      # NOTE: This syntax was made invalid on Ruby 2.7 - Ruby 3.3 but is allowed
+      # again since Ruby 3.4.
       #
       # @example
       #
@@ -40,8 +39,6 @@ module RuboCop
         extend TargetRubyVersion
 
         MSG = 'Circular argument reference - `%<arg_name>s`.'
-
-        maximum_target_ruby_version 2.6
 
         def on_kwoptarg(node)
           check_for_circular_argument_references(*node)

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Run test with Ruby 2.6 because this cop cannot handle invalid syntax in Ruby 2.7+.
-RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby26, unsupported_on: :prism do # rubocop:disable Layout/LineLength
+# Run test with Ruby 3.4 because this cop cannot handle invalid syntax between Ruby 2.7 and 3.3.
+RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby34, unsupported_on: :parser do # rubocop:disable Layout/LineLength
   describe 'circular argument references in ordinal arguments' do
     context 'when the method contains a circular argument reference' do
       it 'registers an offense' do


### PR DESCRIPTION
Closes #13611

It is allowed syntax again, without a warning. Conceptually it is very close to `Lint/SelfAssignment`, so I would say it makes sense to just enable this again.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
