### PR TITLE
[Fix #14116] Make `Style/TrailingCommaInArguments` cop aware of trailing commans in `[]` method call

### DIFF
--- a/changelog/fix_make_style_trailing_comma_in_arguments_cop_aware_of_square_brackets_20250423131225.md
+++ b/changelog/fix_make_style_trailing_comma_in_arguments_cop_aware_of_square_brackets_20250423131225.md
@@ -1,0 +1,1 @@
+* [#14116](https://github.com/rubocop/rubocop/issues/14116): Make `Style/TrailingCommaInArguments` cop aware of trailing commas in `[]` method call. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -107,7 +107,7 @@ module RuboCop
       # of the argument is not considered multiline, even if the argument
       # itself might span multiple lines.
       def allowed_multiline_argument?(node)
-        elements(node).one? && !Util.begins_its_line?(node.loc.end)
+        elements(node).one? && (!node.loc.end || !Util.begins_its_line?(node.loc.end))
       end
 
       def elements(node)

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -79,8 +79,14 @@ module RuboCop
       #   # bad
       #   method(1, 2,)
       #
+      #   # bad
+      #   object[1, 2,]
+      #
       #   # good
       #   method(1, 2)
+      #
+      #   # good
+      #   object[1, 2]
       #
       #   # good
       #   method(
@@ -96,7 +102,7 @@ module RuboCop
         end
 
         def on_send(node)
-          return unless node.arguments? && node.parenthesized?
+          return unless node.arguments? && (node.parenthesized? || node.method?(:[]))
 
           check(node, node.arguments, 'parameter of %<article>s method call',
                 node.last_argument.source_range.end_pos,


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/14116

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
