### PR TITLE
Run Ruby 3.4 examples with prism by default

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -11,8 +11,8 @@ module CopHelper
     ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : RuboCop::TargetRuby::DEFAULT_VERSION
   end
   let(:parser_engine) do
-    # The maximum version Parser can parse is 3.4.
-    ruby_version >= 3.5 ? :parser_prism : ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym
+    # The maximum version Parser can correctly parse is 3.3.
+    ruby_version >= 3.4 ? :parser_prism : ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym
   end
   let(:rails_version) { false }
 

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -267,6 +267,5 @@ RSpec.shared_context 'ruby 3.4' do
 end
 
 RSpec.shared_context 'ruby 3.5' do
-  # Parser supports parsing Ruby <= 3.4.
-  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.5 : 3.4 }
+  let(:ruby_version) { 3.5 }
 end

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -1002,7 +1002,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'accepts end aligned with a call chain left hand side' do
       expect_no_offenses(<<~RUBY)
         parser.diagnostics.consumer = lambda do

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense and corrects when multiline block `}` is not on its own line ' \
        'and using method chain' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -597,7 +597,7 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
       RUBY
     end
 
-    it 'accepts a correctly aligned else from itblock', :ruby34, unsupported_on: :parser do
+    it 'accepts a correctly aligned else from itblock', :ruby34 do
       expect_no_offenses(<<~RUBY)
         array_like.each do
           it

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -728,7 +728,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       RUBY
     end
 
-    it 'registers offense if next to itblock', :ruby34, unsupported_on: :parser do
+    it 'registers offense if next to itblock', :ruby34 do
       expect_offense(<<~RUBY)
         foo 'first foo' do
           #foo body

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -602,7 +602,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     %w[private protected public module_function].each do |access_modifier|
       it "registers an offense for missing around line before #{access_modifier}" do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
         end
       end
 
-      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby 3.4', :ruby34 do
         it 'registers an offense for block body ending with a blank' do
           expect_offense(<<~RUBY)
             some_method #{open}

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1629,7 +1629,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
       end
 
-      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby 3.4', :ruby34 do
         it 'registers an offense for bad indentation of a {} body' do
           expect_offense(<<~RUBY)
             func {

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1826,7 +1826,7 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         end
       end
 
-      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby 3.4', :ruby34 do
         it 'adds an offense for {} block does correct it' do
           expect_offense(<<~RUBY)
             foo.select { it + 4444000039123123129993912312312999199291203123123 }

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense and corrects for missing newline in {} block w/o params' do
       expect_offense(<<~RUBY)
         test { it

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
         end
       end
 
-      context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context '>= Ruby 3.4', :ruby34 do
         it 'accepts methods being aligned with method that is an argument' \
            'when using `it` parameter' do
           expect_no_offenses(<<~RUBY)
@@ -779,7 +779,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
-    it 'accepts aligned methods in multiline `it` block chain', :ruby34, unsupported_on: :parser do
+    it 'accepts aligned methods in multiline `it` block chain', :ruby34 do
       expect_no_offenses(<<~RUBY)
         do_something.foo do
           bar(it)

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
-      it 'accepts a method call chained onto a single line `it` block', :ruby34, unsupported_on: :parser do
+      it 'accepts a method call chained onto a single line `it` block', :ruby34 do
         expect_no_offenses(<<~RUBY)
           e.select { it.cond? }
            .join
@@ -758,7 +758,7 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
           RUBY
         end
 
-        it 'accepts a method call chained onto a multiline `it` block', :ruby34, unsupported_on: :parser do
+        it 'accepts a method call chained onto a multiline `it` block', :ruby34 do
           expect_no_offenses(<<~RUBY)
             e.select do
               it.cond?

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -642,7 +642,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'accepts aligned rescue in do-end `it` block in a method' do
       expect_no_offenses(<<~RUBY)
         def foo

--- a/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
+++ b/spec/rubocop/cop/layout/single_line_block_chain_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Layout::SingleLineBlockChain, :config do
     RUBY
   end
 
-  it 'registers an offense for method call chained on the same line as a itblock', :ruby34, unsupported_on: :parser do
+  it 'registers an offense for method call chained on the same line as a itblock', :ruby34 do
     expect_offense(<<~RUBY)
       example.select { it.cond? }.join('-')
                                  ^^^^^ Put method call on a separate line if chained to a single line block.

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers an offense and corrects opposite + correct style' do
         expect_offense(<<~RUBY)
           each{ it }

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
   end
 
-  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby >= 3.4', :ruby34 do
     it 'registers an offense for itblocks without inner space' do
       expect_offense(<<~RUBY)
         [1, 2, 3].each {it * 2}

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
       end
     end
 
-    context 'without receiver and itblock', :ruby34, unsupported_on: :parser do
+    context 'without receiver and itblock', :ruby34 do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           some_method a { puts it }

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect_no_offenses('return 1 if any_errors? { o = _1 }.present?')
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'accepts = in an itblock that is called in a condition' do
       expect_no_offenses('return 1 if any_errors? { o = inspect(it) }')
     end

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Run test with Ruby 3.4 because this cop cannot handle invalid syntax between Ruby 2.7 and 3.3.
-RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby34, unsupported_on: :parser do # rubocop:disable Layout/LineLength
+RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby34 do
   describe 'circular argument references in ordinal arguments' do
     context 'when the method contains a circular argument reference' do
       it 'registers an offense' do

--- a/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
+++ b/spec/rubocop/cop/lint/constant_definition_in_block_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
     RUBY
   end
 
-  it 'registers an offense for a module defined within an itblock', :ruby34, unsupported_on: :parser do
+  it 'registers an offense for a module defined within an itblock', :ruby34 do
     expect_offense(<<~RUBY)
       describe do
         module Foo; end
@@ -202,7 +202,7 @@ RSpec.describe RuboCop::Cop::Lint::ConstantDefinitionInBlock, :config do
       RUBY
     end
 
-    it 'does not register an offense for a module defined within an itblock of `enums` method', :ruby34, unsupported_on: :parser do
+    it 'does not register an offense for a module defined within an itblock of `enums` method', :ruby34 do
       expect_no_offenses(<<~RUBY)
         enums do
           module Foo

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::Debugger, :config do
       RUBY
     end
 
-    it 'registers an offense for a `custom_debugger` call when used in `it` block', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for a `custom_debugger` call when used in `it` block', :ruby34 do
       expect_offense(<<~RUBY)
         x.y = do_something do
           z(it)

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
     end
   end
 
-  context '`Class.new` `it` block', :ruby34, unsupported_on: :parser do
+  context '`Class.new` `it` block', :ruby34 do
     it 'registers an offense and does not autocorrect when no `super` call' do
       expect_offense(<<~RUBY)
         Class.new(Parent) do

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe RuboCop::Cop::Lint::NestedMethodDefinition, :config do
     end
   end
 
-  context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby >= 3.4', :ruby34 do
     it 'does not register offense for nested definition inside `Module.new` with itblock' do
       expect_no_offenses(<<~RUBY)
         class Foo

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Lint::NonLocalExitFromIterator, :config do
         RUBY
       end
 
-      it 'registers an offense for itblocks', :ruby34, unsupported_on: :parser do
+      it 'registers an offense for itblocks', :ruby34 do
         expect_offense(<<~RUBY)
           items.each do
             return if baz?(it)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     end
   end
 
-  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+  context 'when using `it` parameter', :ruby34 do
     it 'registers an offense and corrects for method call with space before the parenthesis when block argument and parenthesis' do
       expect_offense(<<~RUBY)
         a.concat ((1..1).map { it * 10 })

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense for `ary.each_with_index { it }` and corrects to `ary.each`' do
       expect_offense(<<~RUBY)
         ary.each_with_index { it }

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense and corrects when using `ary.each_with_object { it }`' do
       expect_offense(<<~RUBY)
         ary.each_with_object([]) { it }

--- a/spec/rubocop/cop/lint/return_in_void_context_spec.rb
+++ b/spec/rubocop/cop/lint/return_in_void_context_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::ReturnInVoidContext, :config do
       RUBY
     end
 
-    it 'registers an offense when the value is returned in an itblock', :ruby34, unsupported_on: :parser do
+    it 'registers an offense when the value is returned in an itblock', :ruby34 do
       expect_offense(<<~RUBY)
         class A
           def initialize

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     end
   end
 
-  context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context '>= Ruby 3.4', :ruby34 do
     it 'registers an offense for ordinary method chain exists after ' \
        'safe navigation method call with a block using `it` parameter' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
       end
     end
 
-    context 'when assigning an `it` block parameter', :ruby34, unsupported_on: :parser do
+    context 'when assigning an `it` block parameter', :ruby34 do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           def x(array)

--- a/spec/rubocop/cop/lint/unexpected_block_arity_spec.rb
+++ b/spec/rubocop/cop/lint/unexpected_block_arity_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::Lint::UnexpectedBlockArity, :config do
     end
   end
 
-  context 'with an itblock', :ruby34, unsupported_on: :parser do
+  context 'with an itblock', :ruby34 do
     context 'when given one parameter' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
         RUBY
       end
 
-      it 'does not look inside inner itblocks', :ruby34, unsupported_on: :parser do
+      it 'does not look inside inner itblocks', :ruby34 do
         expect_no_offenses(<<~RUBY)
           foo.#{method}(bar) do |acc, el|
             values.map do

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
 
-    it "accepts `#{t}` if called in `instance_eval` with itblock", :ruby34, unsupported_on: :parser do
+    it "accepts `#{t}` if called in `instance_eval` with itblock", :ruby34 do
       expect_no_offenses <<~RUBY
         class Dummy
           def #{t}; end

--- a/spec/rubocop/cop/lint/unreachable_loop_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_loop_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
         end
       end
 
-      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby 3.4', :ruby34 do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             2.times { raise it }
@@ -335,7 +335,7 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableLoop, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense when using `return do_something(value) || break` in a loop' do
       expect_offense(<<~RUBY)
         [1, 2, 3].each do

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -1059,7 +1059,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
         RUBY
       end
 
-      it 'registers an offense if no method is defined in `Data.define` with itblock', :ruby34, unsupported_on: :parser do
+      it 'registers an offense if no method is defined in `Data.define` with itblock', :ruby34 do
         expect_offense(<<~RUBY, modifier: modifier)
           Data.define do
             %{modifier}

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       RUBY
     end
 
-    it 'registers offenses for self assignment in itblock', :ruby34, unsupported_on: :parser do
+    it 'registers offenses for self assignment in itblock', :ruby34 do
       expect_offense(<<~RUBY)
         do_something { foo += it }
                        ^^^ Useless assignment to variable - `foo`. Use `+` instead of `+=`.
@@ -2112,7 +2112,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
-  context 'using `it` block parameter', :ruby34, unsupported_on: :parser do
+  context 'using `it` block parameter', :ruby34 do
     it 'does not register an offense when the variable is used' do
       expect_no_offenses(<<~RUBY)
         var = 42

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
       RUBY
     end
 
-    it 'registers an offense for an itblock', :ruby34, unsupported_on: :parser do
+    it 'registers an offense for an itblock', :ruby34 do
       expect_offense(<<~RUBY)
         define_method(:foo) { it }
         ruby2_keywords :foo

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers offense for nonmutating method that takes an `it` parameter block' do
         expect_offense(<<~RUBY)
           [1,2,3].map do

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers an offense for a `define_method` with itblock' do
         expect_offense(<<~RUBY)
           define_method :method_name do

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     end
   end
 
-  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+  context 'when using `it` parameter', :ruby34 do
     it 'rejects a block with more than 5 lines' do
       expect_offense(<<~RUBY)
         something do

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe RuboCop::Cop::Metrics::BlockNesting, :config do
       end
     end
 
-    context 'when `it` parameter', :ruby34, unsupported_on: :parser do
+    context 'when `it` parameter', :ruby34 do
       context 'nested multiline block' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -458,7 +458,7 @@ RSpec.describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
   end
 
-  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+  context 'when using `it` parameter', :ruby34 do
     context 'when inspecting a class defined with Class.new' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     end
   end
 
-  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+  context 'when using `it` parameter', :ruby34 do
     context 'when method is defined with `define_method`' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
@@ -344,7 +344,7 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         RUBY
       end
 
-      it 'accepts dynamically defined matching method name with an itblock', :ruby34, unsupported_on: :parser do
+      it 'accepts dynamically defined matching method name with an itblock', :ruby34 do
         expect_no_offenses(<<~RUBY)
           define_method(:foo) do
             a = it
@@ -400,7 +400,7 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         RUBY
       end
 
-      it 'accepts dynamically defined matching method name with an itblock', :ruby34, unsupported_on: :parser do
+      it 'accepts dynamically defined matching method name with an itblock', :ruby34 do
         expect_no_offenses(<<~RUBY)
           define_method(:user_name) do
             a = it

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
   end
 
-  context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+  context 'when using `it` parameter', :ruby34 do
     context 'when inspecting a class defined with Module.new' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         end
       end
 
-      context 'Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby >= 3.4', :ruby34 do
         it 'accepts a multi-line itblock' do
           expect_no_offenses(<<~RUBY)
             puts [1, 2, 3].map {

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::Style::CollectionMethods, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       context "#{method} with itblock" do
         it 'registers an offense' do
           expect_offense(<<~RUBY, method: method)

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
       RUBY
     end
 
-    it 'registers an offense when looping over the same data for the third consecutive time with `it` blocks', :ruby34, unsupported_on: :parser do
+    it 'registers an offense when looping over the same data for the third consecutive time with `it` blocks', :ruby34 do
       expect_offense(<<~RUBY)
         items.each { foo(it) }
         items.each { bar(it) }

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers an offense for each without an item and uses _ as the item' do
         expect_offense(<<~RUBY)
           def func

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
       RUBY
     end
 
-    it 'reports an offense if `define_method` block body is if / unless without else', :ruby34, unsupported_on: :parser do
+    it 'reports an offense if `define_method` block body is if / unless without else', :ruby34 do
       expect_offense(<<~RUBY)
         define_method(:func) do
           if it

--- a/spec/rubocop/cop/style/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/style/hash_each_methods_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe RuboCop::Cop::Style::HashEachMethods, :config do
         end
       end
 
-      context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+      context 'Ruby 3.4', :ruby34 do
         it 'registers offense, autocorrects foo#keys.each to foo#each_key with itblock' do
           expect_offense(<<~RUBY)
             foo.keys.each { p it }

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
     context 'EnforcedStyle: disallow' do
       let(:cop_config) { { 'EnforcedStyle' => 'disallow' } }
 
-      it 'registers an offense when using `it` block parameters', unsupported_on: :parser do
+      it 'registers an offense when using `it` block parameters' do
         expect_offense(<<~RUBY)
           block { do_something(it) }
                                ^^ Avoid using `it` block parameter.
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         expect_no_corrections
       end
 
-      it 'registers an offense when using twice `it` block parameters', unsupported_on: :parser do
+      it 'registers an offense when using twice `it` block parameters' do
         expect_offense(<<~RUBY)
           block do
             foo(it)

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
       end
     end
 
-    context '>= Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context '>= Ruby 3.4', :ruby34 do
       context 'when using `it` parameter' do
         context 'with a single line lambda method call' do
           it 'registers an offense' do

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using a itblock', :ruby34, unsupported_on: :parser do
+  it 'registers an offense and corrects when using a itblock', :ruby34parser do
     expect_offense(<<~RUBY)
       dest = []
       src.each { dest << it * 2 }

--- a/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense for a chained call' do
       expect_offense(<<~RUBY)
         a do

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineBlockChain, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers an offense for a slightly more complicated case' do
         expect_offense(<<~RUBY)
           a do

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Style::Next, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it "registers an offense for #{condition} inside of downto itblock" do
         expect_offense(<<~RUBY, condition: condition)
           3.downto(1) do

--- a/spec/rubocop/cop/style/object_then_spec.rb
+++ b/spec/rubocop/cop/style/object_then_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::Style::ObjectThen, :config do
       end
     end
 
-    context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+    context 'Ruby 3.4', :ruby34 do
       it 'registers an offense for yield_self with itblock' do
         expect_offense(<<~RUBY)
           obj.yield_self { it.test }

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Style::Proc, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers an offense for a Proc.new call' do
       expect_offense(<<~RUBY)
         f = Proc.new { puts it }

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'reports an offense when assigning nested blocks which contain `begin` blocks' do
       expect_offense(<<~RUBY)
         var = do_something do

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'registers offense for self usage in itblocks' do
       expect_offense(<<~RUBY)
         %w[x y z].select do

--- a/spec/rubocop/cop/style/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/style/redundant_sort_by_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantSortBy, :config do
     end
   end
 
-  context 'Ruby 3.4', :ruby34, unsupported_on: :parser do
+  context 'Ruby 3.4', :ruby34 do
     it 'autocorrects array.sort_by { |x| x }' do
       expect_offense(<<~RUBY)
         array.sort_by { it }

--- a/spec/rubocop/cop/style/select_by_regexp_spec.rb
+++ b/spec/rubocop/cop/style/select_by_regexp_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe RuboCop::Cop::Style::SelectByRegexp, :config do
     end
   end
 
-  context 'when Ruby >= 3.4', :ruby34, unsupported_on: :parser do
+  context 'when Ruby >= 3.4', :ruby34 do
     include_examples('regexp match with `itblock`s', 'select', 'grep')
     include_examples('regexp match with `itblock`s', 'find_all', 'grep')
     include_examples('regexp match with `itblock`s', 'filter', 'grep')

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
     RUBY
   end
 
-  it 'registers an offense when using single line `do`...`end` with `it` block argument', :ruby34, unsupported_on: :parser do
+  it 'registers an offense when using single line `do`...`end` with `it` block argument', :ruby34 do
     expect_offense(<<~RUBY)
       foo do bar(it) end
       ^^^^^^^^^^^^^^^^^^ Prefer multiline `do`...`end` block.

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe RuboCop::Cop::Style::SymbolProc, :config do
     end
   end
 
-  context 'itblocks', :ruby34, unsupported_on: :parser do
+  context 'itblocks', :ruby34 do
     %w[reject select].each do |method|
       it "registers an offense when receiver is an array literal and using `#{method}` with a itblock" do
         expect_offense(<<~RUBY, method: method)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,4 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
-
-  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
-  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 end


### PR DESCRIPTION
Ref https://github.com/rubocop/rubocop/pull/14115#issuecomment-2826621725

`parser` can't correctly analyze 3.4, so it requires `broken_on: :parser` in a bunch of places.

Users don't run with `parser` on Ruby 3.4 anymore, `prism` is choosen automatically. So, there's no reason to not just do the same in tests.
