### PR TITLE
[Fix #14120] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#14120](https://github.com/rubocop/rubocop/issues/14120): Fix false positives for `Style/RedundantParentheses` when parens around unparenthesized method call as the second argument of a parenthesized method call. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -180,11 +180,18 @@ module RuboCop
         # @!method interpolation?(node)
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
-        def argument_of_parenthesized_method_call?(node)
-          return false if node.children.first.basic_conditional?
-          return false unless (parent = node.parent)
+        def argument_of_parenthesized_method_call?(begin_node)
+          node = begin_node.children.first
+          return false if node.basic_conditional? || method_call_parentheses_required?(node)
+          return false unless (parent = begin_node.parent)
 
-          parent.call_type? && parent.parenthesized? && parent.receiver != node
+          parent.call_type? && parent.parenthesized? && parent.receiver != begin_node
+        end
+
+        def method_call_parentheses_required?(node)
+          return false unless node.call_type?
+
+          (node.receiver.nil? || node.loc.dot) && node.arguments.any?
         end
 
         def allow_in_multiline_conditions?

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -282,6 +282,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'does not register an offense for parens around unparenthesized method call as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (y arg))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around unparenthesized safe navigation method call as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (y&.z arg))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around unparenthesized operator dot method call as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (y.+ arg))
+    RUBY
+  end
+
+  it 'does not register an offense for parens around unparenthesized operator safe navigation method call as the second argument of a parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      x(1, (y&.+ arg))
+    RUBY
+  end
+
   it 'registers an offense for parens around an expression method argument of a parenthesized method call' do
     expect_offense(<<~RUBY)
       x.y((z + w))


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when parens around unparenthesized method call as the second argument of a parenthesized method call.

Fixes #14120.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
