### PR TITLE
Fix linked pr in changelog entry for "Extension plugin is loaded automatically with require 'rubocop/rspec/support'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,7 +208,7 @@
 
 ### Changes
 
-* [#13839](https://github.com/rubocop/rubocop/pull/13839): Extension plugin is loaded automatically with `require 'rubocop/rspec/support'. ([@koic][])
+* [#13840](https://github.com/rubocop/rubocop/pull/13840): Extension plugin is loaded automatically with `require 'rubocop/rspec/support'. ([@koic][])
 
 ## 1.72.0 (2025-02-14)
 

--- a/relnotes/v1.72.1.md
+++ b/relnotes/v1.72.1.md
@@ -5,6 +5,6 @@
 
 ### Changes
 
-* [#13839](https://github.com/rubocop/rubocop/pull/13839): Extension plugin is loaded automatically with `require 'rubocop/rspec/support'. ([@koic][])
+* [#13840](https://github.com/rubocop/rubocop/pull/13840): Extension plugin is loaded automatically with `require 'rubocop/rspec/support'. ([@koic][])
 
 [@koic]: https://github.com/koic


### PR DESCRIPTION
Noticed this while looking through the changelog to find the oldest version needed to have as a minimum requirement for proper plugin support.

maybe there should be a check somewhere that no two changelog entries refer to the same pull request/issue number, or possibly something that only lets a PR add the pr number it is created by or the issue it is linked to fixing

I didn't write an entry in the changelog for this because I presume it doesn't need one?
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
