### PR TITLE
[Fix #14123] Fix an error for `Lint/BooleanSymbol`

### DIFF
--- a/changelog/fix_an_error_lint_boolean_symbol.md
+++ b/changelog/fix_an_error_lint_boolean_symbol.md
@@ -1,0 +1,1 @@
+* [#14123](https://github.com/rubocop/rubocop/issues/14123): Fix an infinite loop error for `Lint/BooleanSymbol` when using the rocket hash syntax with a boolean symbol key. ([@koic][])

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -48,7 +48,7 @@ module RuboCop
         def autocorrect(corrector, node)
           boolean_literal = node.source.delete(':')
           parent = node.parent
-          if parent&.pair_type? && node.equal?(parent.children[0])
+          if parent&.pair_type? && parent.colon? && node.equal?(parent.children[0])
             corrector.remove(parent.loc.operator)
             boolean_literal = "#{node.source} =>"
           end

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe RuboCop::Cop::Lint::BooleanSymbol, :config do
     RUBY
   end
 
+  context 'when using the rocket hash syntax' do
+    it 'registers an offense when using a boolean symbol key' do
+      expect_offense(<<~RUBY)
+        { :false => 42 }
+          ^^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        { false => 42 }
+      RUBY
+    end
+  end
+
   context 'when using the new hash syntax' do
     it 'registers an offense when using `true:`' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes an infinite loop error for `Lint/BooleanSymbol` when using the rocket hash syntax with a boolean symbol key.

Fixes #14123.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
