### PR TITLE
[Fix #14129] Fix false positives for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_style_arguments_forwarding.md
+++ b/changelog/fix_false_positives_for_style_arguments_forwarding.md
@@ -1,0 +1,1 @@
+* [#14129](https://github.com/rubocop/rubocop/issues/14129): Fix false positives for `Style/ArgumentsForwarding` when using default positional arg, keyword arg, and block arg in Ruby 3.1. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -146,7 +146,7 @@ module RuboCop
         minimum_target_ruby_version 2.7
 
         FORWARDING_LVAR_TYPES = %i[splat kwsplat block_pass].freeze
-        ADDITIONAL_ARG_TYPES = %i[lvar arg].freeze
+        ADDITIONAL_ARG_TYPES = %i[lvar arg optarg].freeze
 
         FORWARDING_MSG = 'Use shorthand syntax `...` for arguments forwarding.'
         ARGS_MSG = 'Use anonymous positional arguments forwarding (`*`).'

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -181,6 +181,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense when using default positional arg, keyword arg, and block arg', :ruby31, unsupported_on: :prism do
+      expect_offense(<<~RUBY)
+        def foo(arg = {}, **kwargs, &block)
+                          ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(arg, **kwargs, &block)
+                   ^^^^^^^^^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(arg = {}, ...)
+          bar(arg, ...)
+        end
+      RUBY
+    end
+
     it 'registers an offense when using block arg', :ruby31 do
       expect_offense(<<~RUBY)
         def foo(&block)


### PR DESCRIPTION
This PR fixes false positives for `Style/ArgumentsForwarding` when using default positional arg, keyword arg, and block arg in Ruby 3.1.

Fixes #14129.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
