### PR TITLE
[Fix #14131] Fix false positives for `Style/ArgumentsForwarding`

### DIFF
--- a/changelog/fix_false_positives_for_style_arguments_forwarding_cop.md
+++ b/changelog/fix_false_positives_for_style_arguments_forwarding_cop.md
@@ -1,0 +1,1 @@
+* [#14131](https://github.com/rubocop/rubocop/issues/14131): Fix false positives for `Style/ArgumentsForwarding` when using anonymous block argument forwarding to a method with a block. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -479,6 +479,9 @@ module RuboCop
           end
 
           def ruby_32_only_anonymous_forwarding?
+            # A block argument and an anonymous block argument are never passed together.
+            return false if @send_node.each_ancestor(:any_block).any?
+
             def_all_anonymous_args?(@def_node) && send_all_anonymous_args?(@send_node)
           end
 

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -1165,6 +1165,36 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'does not register an offense when using anonymous block argument forwarding to a method with a block', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, **, &)
+          with_block(*, **) do
+            bar(baz(*, **, &))
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using anonymous block argument forwarding to a method with a numbered block', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, **, &)
+          with_block(*, **) do
+            bar(baz(*, **, &), _1)
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using anonymous block argument forwarding to a method with an `it` block', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*, **, &)
+          with_block(*, **) do
+            bar(baz(*, **, &), it)
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense when using block arg forwarding with no forwarding arguments' do
       expect_offense(<<~RUBY)
         def before_transition(options = {}, &block)


### PR DESCRIPTION
This PR fixes false positives for `Style/ArgumentsForwarding` when using anonymous block argument forwarding to a method with a block.

Fixes #14131.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
