### PR TITLE
Fix `Lint/LiteralAsCondition` autocorrect when a literal is the condition of an elsif followed by an else.

### DIFF
--- a/changelog/fix_lint_literal_as_condition_for_if_elsif_else.md
+++ b/changelog/fix_lint_literal_as_condition_for_if_elsif_else.md
@@ -1,0 +1,1 @@
+* [#14133](https://github.com/rubocop/rubocop/pull/14133): Fix `Lint/LiteralAsCondition` autocorrect when a literal is the condition of an elsif followed by an else. ([@zopolis4][])

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -15,6 +15,61 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    it "registers an offense for truthy literal #{lit} in if-else" do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        else
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        top
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in if-elsif" do
+      expect_offense(<<~RUBY, lit: lit)
+        if condition
+          top
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          top
+        else
+          foo
+        end
+      RUBY
+    end
+
+    it "registers an offense for truthy literal #{lit} in if-elsif-else" do
+      expect_offense(<<~RUBY, lit: lit)
+        if condition
+          top
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          foo
+        else
+          bar
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          top
+        else
+          foo
+        end
+      RUBY
+    end
+
     it "registers an offense for truthy literal #{lit} in modifier if" do
       expect_offense(<<~RUBY, lit: lit)
         top if %{lit}
@@ -428,6 +483,27 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       expect_correction(<<~RUBY)
         if condition
           foo
+        end
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in if-elsif-else" do
+      expect_offense(<<~RUBY, lit: lit)
+        if condition
+          top
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          foo
+        else
+          bar
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          top
+        else
+          bar
         end
       RUBY
     end


### PR DESCRIPTION
Found while looking through #12840 to see what I had already implemented and what was left to do.

Initially I was surprised that this hadn't been reported yet, but I presume its because `Lint/LiteralAsCondition` as a cop doesn't get triggered that often, so an incorrect autocorrect for a specific case simply may not have occured yet. (Or, as in some observed cases, it may have been that the broken autocorrect was noticed and then worked around via a manual fix, and then not reported as an issue).

`correct_if_node` is getting a bit unwieldy, and would benefit from a refactor, which I'll do in another PR once i'm confident that all the functionality is there.

In any event, this PR fixes the broken autocorrect when a literal is the condition of an elsif:
```ruby
# bad
if bar
  "a"
elsif true
  "b"
else
  "c"
end

# broken autocorrect
if bar
  "a"
"b"
end

# good (and what this pr fixes the autocorrect to)
if bar
  "a"
else
  "b"
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
