### PR TITLE
Fix an error for `Style/ComparableBetween` when comparing the value with itself

### DIFF
--- a/changelog/fix_comparable_between_self_comapre.md
+++ b/changelog/fix_comparable_between_self_comapre.md
@@ -1,0 +1,1 @@
+* [#14134](https://github.com/rubocop/rubocop/pull/14134): Fix an error for `Style/ComparableBetween` when comparing the value with itself. ([@earlopain][])

--- a/lib/rubocop/cop/style/comparable_between.rb
+++ b/lib/rubocop/cop/style/comparable_between.rb
@@ -61,8 +61,8 @@ module RuboCop
 
         def register_offense(node, min_and_value, max_and_value)
           value = (min_and_value & max_and_value).first
-          min = min_and_value.find { _1 != value }
-          max = max_and_value.find { _1 != value }
+          min = min_and_value.find { _1 != value } || value
+          max = max_and_value.find { _1 != value } || value
 
           prefer = "#{value.source}.between?(#{min.source}, #{max.source})"
           add_offense(node, message: format(MSG, prefer: prefer)) do |corrector|

--- a/spec/rubocop/cop/style/comparable_between_spec.rb
+++ b/spec/rubocop/cop/style/comparable_between_spec.rb
@@ -34,6 +34,28 @@ RSpec.describe RuboCop::Cop::Style::ComparableBetween, :config do
     RUBY
   end
 
+  it 'registers an offense when comparing with itself as the min value' do
+    expect_offense(<<~RUBY)
+      x >= x and x <= max
+      ^^^^^^^^^^^^^^^^^^^ Prefer `x.between?(x, max)` over logical comparison.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.between?(x, max)
+    RUBY
+  end
+
+  it 'registers an offense when comparing with itself as both the min and max value' do
+    expect_offense(<<~RUBY)
+      x >= x and x <= x
+      ^^^^^^^^^^^^^^^^^ Prefer `x.between?(x, x)` over logical comparison.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.between?(x, x)
+    RUBY
+  end
+
   it 'does not register an offense when logical comparison excludes max value' do
     expect_no_offenses(<<~RUBY)
       x >= min && x < max


### PR DESCRIPTION
The code doesn't make much sense, but currently it errors since both entries in the array get rejected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
