### PR TITLE
Temporarily disable windows CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -61,6 +61,8 @@ jobs:
     needs: spec-ubuntu # Don't spend CI resources on slow Windows specs if CI won't pass anyway.
     name: Spec - windows ${{ matrix.ruby }}
     runs-on: windows-latest
+    # FIXME: Temporarily disabled: https://bugs.ruby-lang.org/issues/21286
+    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +110,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows]
+        # FIXME: Temporarily removed windows: https://bugs.ruby-lang.org/issues/21286
+        os: [ubuntu]
         ruby:
           - '2.7'  # Oldest supported version
           - 'ruby' # Latest stable CRuby version


### PR DESCRIPTION
There is a bug that prevents compiling of many c extensions. Currently CI is still green because it loads from the cache but the moment a gem in the gemfile releases a new version it will fail.

It was already reported upstream: https://bugs.ruby-lang.org/issues/21286

Here is a failing run where I intentionally busted the cache: https://github.com/rubocop/rubocop/actions/runs/14707738060/job/41272016135

I noticed this when syncing my fork, where no usable cache existed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
