### PR TITLE
[Fix #13045] Support autocorrect for `Lint/EmptyFile`

### DIFF
--- a/changelog/fix_support_autocorrect_for_lint_empty_file.md
+++ b/changelog/fix_support_autocorrect_for_lint_empty_file.md
@@ -1,0 +1,1 @@
+* [#13045](https://github.com/rubocop/rubocop/issues/13045): Support autocorrect for `Lint/EmptyFile`. ([@zopolis4][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -185,13 +185,12 @@ module RuboCop
       end
 
       # Adds an offense that has no particular location.
-      # No correction can be applied to global offenses
-      def add_global_offense(message = nil, severity: nil)
+      def add_global_offense(message = nil, severity: nil, &block)
         severity = find_severity(nil, severity)
         message = find_message(nil, message)
         range = Offense::NO_LOCATION
-        status = enabled_line?(range.line) ? :unsupported : :disabled
-        current_offenses << Offense.new(severity, range, message, name, status)
+        status, corrector = enabled_line?(range.line) ? correct(range, &block) : :disabled
+        current_offenses << Offense.new(severity, range, message, name, status, corrector)
       end
 
       # Adds an offense on the specified range (or node with an expression)

--- a/lib/rubocop/cop/lint/empty_file.rb
+++ b/lib/rubocop/cop/lint/empty_file.rb
@@ -21,13 +21,23 @@ module RuboCop
       #   # File consisting only of comments
       #
       class EmptyFile < Base
+        extend AutoCorrector
+
         MSG = 'Empty file detected.'
 
         def on_new_investigation
-          add_global_offense(MSG) if offending?
+          return unless offending?
+
+          add_global_offense(MSG) do
+            autocorrect if autocorrect_requested?
+          end
         end
 
         private
+
+        def autocorrect
+          FileUtils.rm_f(processed_source.file_path)
+        end
 
         def offending?
           empty_file? || (!cop_config['AllowComments'] && contains_only_comments?)

--- a/spec/rubocop/cop/lint/empty_file_spec.rb
+++ b/spec/rubocop/cop/lint/empty_file_spec.rb
@@ -3,26 +3,35 @@
 RSpec.describe RuboCop::Cop::Lint::EmptyFile, :config do
   let(:commissioner) { RuboCop::Cop::Commissioner.new([cop]) }
   let(:offenses) { commissioner.investigate(processed_source).offenses }
-  let(:cop_config) { { 'AllowComments' => true } }
-  let(:source) { '' }
+  let(:file) { Tempfile.new('') }
+  let(:filename) { file.path.split('/').last }
 
-  it 'registers an offense when the file is empty' do
-    expect(offenses.size).to eq(1)
-    offense = offenses.first
-    expect(offense.message).to eq('Empty file detected.')
-    expect(offense.severity).to eq(:warning)
-  end
+  context 'when AllowComments is true' do
+    let(:cop_config) { { 'AllowComments' => true } }
+    let(:source) { '' }
 
-  it 'does not register an offense when the file contains code' do
-    expect_no_offenses(<<~RUBY)
-      foo.bar
-    RUBY
-  end
+    it 'registers an offense when the file is empty' do
+      File.write(file.path, source)
 
-  it 'does not register an offense when the file contains comments' do
-    expect_no_offenses(<<~RUBY)
-      # comment
-    RUBY
+      expect_offense(<<~RUBY, file)
+        ^{} Empty file detected.
+      RUBY
+
+      expect_no_corrections
+      expect(File).not_to exist(file.path)
+    end
+
+    it 'does not register an offense when the file contains code' do
+      expect_no_offenses(<<~RUBY)
+        foo.bar
+      RUBY
+    end
+
+    it 'does not register an offense when the file contains comments' do
+      expect_no_offenses(<<~RUBY)
+        # comment
+      RUBY
+    end
   end
 
   context 'when AllowComments is false' do
@@ -30,7 +39,15 @@ RSpec.describe RuboCop::Cop::Lint::EmptyFile, :config do
     let(:source) { '# comment' }
 
     it 'registers an offense when the file contains comments' do
-      expect(offenses.size).to eq(1)
+      File.write(file.path, source)
+
+      expect_offense(<<~RUBY, file)
+        # comment
+        ^{} Empty file detected.
+      RUBY
+
+      expect_no_corrections
+      expect(File).not_to exist(file.path)
     end
   end
 end


### PR DESCRIPTION
This fixes #13045, or at least it would if I hadn't forgotten to comment that it wasn't stale before it got automatically closed.

This PR adds autocorrect support to `add_global_offense`, and extends `Lint/EmptyFile` to use it. 

I also looked through all the other usages of `add_global_offense`, and concluded that none of them are suitable for autocorrection. 

I'm not sure whether `Lint/ScriptPermission` should technically be a global offense and just wasn't made one because that would mean no autocorrection?

-----------------
Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
