### PR TITLE
[Fix #14137] Fix `Style/TrailingCommaInArguments` cop error if style is `comma`

### DIFF
--- a/changelog/fix_style_trailing_command_in_arguments_cop_error_on_comma_multiline_style_20250429084405.md
+++ b/changelog/fix_style_trailing_command_in_arguments_cop_error_on_comma_multiline_style_20250429084405.md
@@ -1,0 +1,1 @@
+* [#14137](https://github.com/rubocop/rubocop/issues/14137): Fix `Style/TrailingCommaInArguments` cop error if `EnforcedStyleForMultiline` is set to `comma`. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -107,7 +107,7 @@ module RuboCop
       # of the argument is not considered multiline, even if the argument
       # itself might span multiple lines.
       def allowed_multiline_argument?(node)
-        elements(node).one? && (!node.loc.end || !Util.begins_its_line?(node.loc.end))
+        elements(node).one? && !Util.begins_its_line?(node_end_location(node))
       end
 
       def elements(node)
@@ -127,8 +127,12 @@ module RuboCop
 
       def no_elements_on_same_line?(node)
         items = elements(node).map(&:source_range)
-        items << node.loc.end
+        items << node_end_location(node)
         items.each_cons(2).none? { |a, b| on_same_line?(a, b) }
+      end
+
+      def node_end_location(node)
+        node.loc.end || node.source_range.end.adjust(begin_pos: -1)
       end
 
       def on_same_line?(range1, range2)

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -3,88 +3,90 @@
 RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
   shared_examples 'single line lists' do |extra_info|
     [%w[( )], %w[[ ]]].each do |start_bracket, end_bracket|
-      it 'registers an offense for trailing comma in a method call' do
-        expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
-          some_method#{start_bracket}a, b, c, #{end_bracket}
-                      _{start_bracket}      ^ Avoid comma after the last parameter of a method call#{extra_info}.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_method#{start_bracket}a, b, c #{end_bracket}
-        RUBY
-      end
-
-      it 'registers an offense for trailing comma preceded by whitespace in a method call' do
-        expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
-          some_method#{start_bracket}a, b, c , #{end_bracket}
-                     _{start_bracket}        ^ Avoid comma after the last parameter of a method call#{extra_info}.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_method#{start_bracket}a, b, c  #{end_bracket}
-        RUBY
-      end
-
-      it 'registers an offense for trailing comma in a method call with hash parameters at the end' do
-        expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
-          some_method#{start_bracket}a, b, c: 0, d: 1, #{end_bracket}
-                     _{start_bracket}                ^ Avoid comma after the last parameter of a method call#{extra_info}.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_method#{start_bracket}a, b, c: 0, d: 1 #{end_bracket}
-        RUBY
-      end
-
-      it 'accepts method call without trailing comma' do
-        expect_no_offenses("some_method#{start_bracket}a, b, c#{end_bracket}")
-      end
-
-      it 'accepts method call without trailing comma when a line break before a method call' do
-        expect_no_offenses(<<~RUBY)
-          obj
-            .do_something#{start_bracket}:foo, :bar#{end_bracket}
-        RUBY
-      end
-
-      it 'accepts method call without trailing comma with single element hash ' \
-         'parameters at the end' do
-        expect_no_offenses("some_method#{start_bracket}a: 1#{end_bracket}")
-      end
-
-      it 'accepts method call without parameters' do
-        expect_no_offenses('some_method')
-      end
-
-      it 'accepts chained single-line method calls' do
-        expect_no_offenses(<<~RUBY)
-          target
-            .some_method#{start_bracket}a#{end_bracket}
-        RUBY
-      end
-
-      context 'when using safe navigation operator' do
+      context "with `#{start_bracket}#{end_bracket}` brackets" do
         it 'registers an offense for trailing comma in a method call' do
           expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
-            receiver&.some_method#{start_bracket}a, b, c, #{end_bracket}
-                                 _{start_bracket}       ^ Avoid comma after the last parameter of a method call#{extra_info}.
+            some_method#{start_bracket}a, b, c, #{end_bracket}
+                        _{start_bracket}      ^ Avoid comma after the last parameter of a method call#{extra_info}.
           RUBY
 
           expect_correction(<<~RUBY)
-            receiver&.some_method#{start_bracket}a, b, c #{end_bracket}
+            some_method#{start_bracket}a, b, c #{end_bracket}
           RUBY
         end
 
-        it 'registers an offense for trailing comma in a method call with hash ' \
-           'parameters at the end' do
+        it 'registers an offense for trailing comma preceded by whitespace in a method call' do
           expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
-            receiver&.some_method#{start_bracket}a, b, c: 0, d: 1, #{end_bracket}
-                                 _{start_bracket}                ^ Avoid comma after the last parameter of a method call#{extra_info}.
+            some_method#{start_bracket}a, b, c , #{end_bracket}
+                      _{start_bracket}         ^ Avoid comma after the last parameter of a method call#{extra_info}.
           RUBY
 
           expect_correction(<<~RUBY)
-            receiver&.some_method#{start_bracket}a, b, c: 0, d: 1 #{end_bracket}
+            some_method#{start_bracket}a, b, c  #{end_bracket}
           RUBY
+        end
+
+        it 'registers an offense for trailing comma in a method call with hash parameters at the end' do
+          expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+            some_method#{start_bracket}a, b, c: 0, d: 1, #{end_bracket}
+                      _{start_bracket}                 ^ Avoid comma after the last parameter of a method call#{extra_info}.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            some_method#{start_bracket}a, b, c: 0, d: 1 #{end_bracket}
+          RUBY
+        end
+
+        it 'accepts method call without trailing comma' do
+          expect_no_offenses("some_method#{start_bracket}a, b, c#{end_bracket}")
+        end
+
+        it 'accepts method call without trailing comma when a line break before a method call' do
+          expect_no_offenses(<<~RUBY)
+            obj
+              .do_something#{start_bracket}:foo, :bar#{end_bracket}
+          RUBY
+        end
+
+        it 'accepts method call without trailing comma with single element hash ' \
+           'parameters at the end' do
+          expect_no_offenses("some_method#{start_bracket}a: 1#{end_bracket}")
+        end
+
+        it 'accepts method call without parameters' do
+          expect_no_offenses('some_method')
+        end
+
+        it 'accepts chained single-line method calls' do
+          expect_no_offenses(<<~RUBY)
+            target
+              .some_method#{start_bracket}a#{end_bracket}
+          RUBY
+        end
+
+        context 'when using safe navigation operator' do
+          it 'registers an offense for trailing comma in a method call' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              receiver&.some_method#{start_bracket}a, b, c, #{end_bracket}
+                                  _{start_bracket}        ^ Avoid comma after the last parameter of a method call#{extra_info}.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              receiver&.some_method#{start_bracket}a, b, c #{end_bracket}
+            RUBY
+          end
+
+          it 'registers an offense for trailing comma in a method call with hash ' \
+             'parameters at the end' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              receiver&.some_method#{start_bracket}a, b, c: 0, d: 1, #{end_bracket}
+                                  _{start_bracket}                 ^ Avoid comma after the last parameter of a method call#{extra_info}.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              receiver&.some_method#{start_bracket}a, b, c: 0, d: 1 #{end_bracket}
+            RUBY
+          end
         end
       end
     end
@@ -161,175 +163,159 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     context 'when EnforcedStyleForMultiline is no_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }
 
-      it 'registers an offense for trailing comma in a method call with ' \
-         'hash parameters at the end' do
-        expect_offense(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,)
-                            ^ Avoid comma after the last parameter of a method call.
-        RUBY
+      [%w[( )], %w[[ ]]].each do |start_bracket, end_bracket|
+        context "with `#{start_bracket}#{end_bracket}` brackets" do
+          it 'registers an offense for trailing comma in a method call with ' \
+             'hash parameters at the end' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,#{end_bracket}
+                                ^ Avoid comma after the last parameter of a method call.
+            RUBY
 
-        expect_correction(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1)
-        RUBY
-      end
+            expect_correction(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1#{end_bracket}
+            RUBY
+          end
 
-      it 'registers an offense for trailing comma in a `[]` method call with ' \
-         'hash parameters at the end' do
-        expect_offense(<<~RUBY)
-          object[
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,]
-                            ^ Avoid comma after the last parameter of a method call.
-        RUBY
+          it 'accepts a method call with hash parameters at the end and no trailing comma' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}a,
+                          b,
+                          c: 0,
+                          d: 1
+                        #{end_bracket}
+            RUBY
+          end
 
-        expect_correction(<<~RUBY)
-          object[
-                        a,
-                        b,
-                        c: 0,
-                        d: 1]
-        RUBY
-      end
+          it 'accepts comma inside a heredoc parameter at the end' do
+            expect_no_offenses(<<~RUBY)
+              route#{start_bracket}help: {
+                'auth' => <<-HELP.chomp
+              ,
+              HELP
+              }#{end_bracket}
+            RUBY
+          end
 
-      it 'accepts a method call with hash parameters at the end and no trailing comma' do
-        expect_no_offenses(<<~RUBY)
-          some_method(a,
-                      b,
-                      c: 0,
-                      d: 1
-                     )
-        RUBY
-      end
+          it 'accepts comma inside a heredoc with comments inside' do
+            expect_no_offenses(<<~RUBY)
+              route#{start_bracket}
+                <<-HELP
+                ,
+                # some comment
+                HELP
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts comma inside a heredoc parameter at the end' do
-        expect_no_offenses(<<~RUBY)
-          route(help: {
-            'auth' => <<-HELP.chomp
-          ,
-          HELP
-          })
-        RUBY
-      end
+          it 'accepts comma inside a heredoc with method and comments inside' do
+            expect_no_offenses(<<~RUBY)
+              route#{start_bracket}
+                <<-HELP.chomp
+                ,
+                # some comment
+                HELP
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts comma inside a heredoc with comments inside' do
-        expect_no_offenses(<<~RUBY)
-          route(
-            <<-HELP
-            ,
-            # some comment
-            HELP
-          )
-        RUBY
-      end
+          it 'accepts comma inside a heredoc in brackets' do
+            expect_no_offenses(<<~RUBY)
+              expect_no_offenses(
+                expect_no_offenses(<<~SOURCE)
+                  run#{start_bracket}
+                        :foo, defaults.merge(
+                                              bar: 3)#{end_bracket}
+                SOURCE
+              )
+            RUBY
+          end
 
-      it 'accepts comma inside a heredoc with method and comments inside' do
-        expect_no_offenses(<<~RUBY)
-          route(
-            <<-HELP.chomp
-            ,
-            # some comment
-            HELP
-          )
-        RUBY
-      end
+          it 'accepts comma inside a modified heredoc parameter' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+                <<-LOREM.delete("\\n")
+                  Something with a , in it
+                LOREM
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts comma inside a heredoc in brackets' do
-        expect_no_offenses(<<~RUBY)
-          expect_no_offenses(
-            expect_no_offenses(<<~SOURCE)
-              run(
-                    :foo, defaults.merge(
-                                          bar: 3))
-            SOURCE
-          )
-        RUBY
-      end
+          it 'autocorrects unwanted comma after modified heredoc parameter' do
+            expect_offense(<<~'RUBY', start_bracket: start_bracket, end_bracket: end_bracket)
+              some_method%{start_bracket}
+                <<-LOREM.delete("\n"),
+                                     ^ Avoid comma after the last parameter of a method call.
+                  Something with a , in it
+                LOREM
+              %{end_bracket}
+            RUBY
 
-      it 'accepts comma inside a modified heredoc parameter' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-            <<-LOREM.delete("\\n")
-              Something with a , in it
-            LOREM
-          )
-        RUBY
-      end
+            expect_correction(<<~RUBY)
+              some_method#{start_bracket}
+                <<-LOREM.delete("\\n")
+                  Something with a , in it
+                LOREM
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'autocorrects unwanted comma after modified heredoc parameter' do
-        expect_offense(<<~'RUBY')
-          some_method(
-            <<-LOREM.delete("\n"),
-                                 ^ Avoid comma after the last parameter of a method call.
-              Something with a , in it
-            LOREM
-          )
-        RUBY
+          context 'when there is string interpolation inside heredoc parameter' do
+            it 'accepts comma inside a heredoc parameter' do
+              expect_no_offenses(<<~RUBY)
+                some_method#{start_bracket}
+                  <<-SQL
+                    \#{variable}.a ASC,
+                    \#{variable}.b ASC
+                  SQL
+                #{end_bracket}
+              RUBY
+            end
 
-        expect_correction(<<~'RUBY')
-          some_method(
-            <<-LOREM.delete("\n")
-              Something with a , in it
-            LOREM
-          )
-        RUBY
-      end
+            it 'accepts comma inside a heredoc parameter when on a single line' do
+              expect_no_offenses(<<~RUBY)
+                some_method#{start_bracket}
+                  bar: <<-BAR
+                    \#{variable} foo, bar
+                  BAR
+                #{end_bracket}
+              RUBY
+            end
 
-      context 'when there is string interpolation inside heredoc parameter' do
-        it 'accepts comma inside a heredoc parameter' do
-          expect_no_offenses(<<~RUBY)
-            some_method(
-              <<-SQL
-                \#{variable}.a ASC,
-                \#{variable}.b ASC
-              SQL
-            )
-          RUBY
-        end
+            it 'autocorrects unwanted comma inside string interpolation' do
+              expect_offense(<<~'RUBY')
+                some_method(
+                  bar: <<-BAR,
+                    #{other_method(a, b,)} foo, bar
+                                       ^ Avoid comma after the last parameter of a method call.
+                  BAR
+                  baz: <<-BAZ
+                    #{third_method(c, d,)} foo, bar
+                                       ^ Avoid comma after the last parameter of a method call.
+                  BAZ
+                )
+              RUBY
 
-        it 'accepts comma inside a heredoc parameter when on a single line' do
-          expect_no_offenses(<<~RUBY)
-            some_method(
-              bar: <<-BAR
-                \#{variable} foo, bar
-              BAR
-            )
-          RUBY
-        end
-
-        it 'autocorrects unwanted comma inside string interpolation' do
-          expect_offense(<<~'RUBY')
-            some_method(
-              bar: <<-BAR,
-                #{other_method(a, b,)} foo, bar
-                                   ^ Avoid comma after the last parameter of a method call.
-              BAR
-              baz: <<-BAZ
-                #{third_method(c, d,)} foo, bar
-                                   ^ Avoid comma after the last parameter of a method call.
-              BAZ
-            )
-          RUBY
-
-          expect_correction(<<~RUBY)
-            some_method(
-              bar: <<-BAR,
-                \#{other_method(a, b)} foo, bar
-              BAR
-              baz: <<-BAZ
-                \#{third_method(c, d)} foo, bar
-              BAZ
-            )
-          RUBY
+              expect_correction(<<~RUBY)
+                some_method(
+                  bar: <<-BAR,
+                    \#{other_method(a, b)} foo, bar
+                  BAR
+                  baz: <<-BAZ
+                    \#{third_method(c, d)} foo, bar
+                  BAZ
+                )
+              RUBY
+            end
+          end
         end
       end
     end
@@ -337,270 +323,278 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     context 'when EnforcedStyleForMultiline is comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'comma' } }
 
-      context 'when closing bracket is on same line as last value' do
-        it 'accepts a method call with Hash as last parameter split on multiple lines' do
-          expect_no_offenses(<<~RUBY)
-            some_method(a: "b",
-                        c: "d")
-          RUBY
+      [%w[( )], %w[[ ]]].each do |start_bracket, end_bracket|
+        context "with `#{start_bracket}#{end_bracket}` brackets" do
+          context 'when closing bracket is on same line as last value' do
+            it 'accepts a method call with Hash as last parameter split on multiple lines' do
+              expect_no_offenses(<<~RUBY)
+                some_method#{start_bracket}a: "b",
+                            c: "d"#{end_bracket}
+              RUBY
+            end
+          end
+
+          it 'registers an offense for no trailing comma in a method call with ' \
+             'hash parameters at the end' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1
+                            ^^^^ Put a comma after the last parameter of a multiline method call.
+                        #{end_bracket}
+            RUBY
+
+            expect_correction(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,
+                        #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts a method call with two parameters on the same line' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}a, b
+                        #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts trailing comma in a method call with hash parameters at the end' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,
+                        #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts missing comma after heredoc with comments' do
+            expect_no_offenses(<<~RUBY)
+              route#{start_bracket}
+                a, <<-HELP.chomp
+                ,
+                # some comment
+                HELP
+              #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts no trailing comma in a method call with a multiline ' \
+             'braceless hash at the end with more than one parameter on a line' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b: 0,
+                            c: 0, d: 1
+                        #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts a trailing comma in a method call with single line hashes' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+              { a: 0, b: 1 },
+              { a: 1, b: 0 },
+              #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts an empty hash being passed as a method argument' do
+            expect_no_offenses(<<~RUBY)
+              Foo.new#{start_bracket}{
+                      }#{end_bracket}
+            RUBY
+          end
+
+          it 'accepts a multiline call with a single argument and trailing comma' do
+            expect_no_offenses(<<~RUBY)
+              method#{start_bracket}
+                1,
+              #{end_bracket}
+            RUBY
+          end
+
+          it 'does not break when a method call is chained on the offending one' do
+            expect_no_offenses(<<~RUBY)
+              foo.bar#{start_bracket}
+                baz: 1,
+              #{end_bracket}.fetch(:qux)
+            RUBY
+          end
+
+          it 'does not break when a safe method call is chained on the offending simple one' do
+            expect_no_offenses(<<~RUBY)
+              foo
+                &.do_something#{start_bracket}:bar, :baz#{end_bracket}
+            RUBY
+          end
+
+          it 'does not break when a safe method call is chained on the offending more complex one' do
+            expect_no_offenses(<<~RUBY)
+              foo.bar#{start_bracket}
+                baz: 1,
+              #{end_bracket}&.fetch(:qux)
+            RUBY
+          end
         end
-      end
-
-      it 'registers an offense for no trailing comma in a method call with ' \
-         'hash parameters at the end' do
-        expect_offense(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1
-                        ^^^^ Put a comma after the last parameter of a multiline method call.
-                     )
-        RUBY
-
-        expect_correction(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
-        RUBY
-      end
-
-      it 'accepts a method call with two parameters on the same line' do
-        expect_no_offenses(<<~RUBY)
-          some_method(a, b
-                     )
-        RUBY
-      end
-
-      it 'accepts trailing comma in a method call with hash parameters at the end' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
-        RUBY
-      end
-
-      it 'accepts missing comma after heredoc with comments' do
-        expect_no_offenses(<<~RUBY)
-          route(
-            a, <<-HELP.chomp
-            ,
-            # some comment
-            HELP
-          )
-        RUBY
-      end
-
-      it 'accepts no trailing comma in a method call with a multiline ' \
-         'braceless hash at the end with more than one parameter on a line' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-                        a,
-                        b: 0,
-                        c: 0, d: 1
-                     )
-        RUBY
-      end
-
-      it 'accepts a trailing comma in a method call with single line hashes' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-           { a: 0, b: 1 },
-           { a: 1, b: 0 },
-          )
-        RUBY
-      end
-
-      it 'accepts an empty hash being passed as a method argument' do
-        expect_no_offenses(<<~RUBY)
-          Foo.new({
-                   })
-        RUBY
-      end
-
-      it 'accepts a multiline call with a single argument and trailing comma' do
-        expect_no_offenses(<<~RUBY)
-          method(
-            1,
-          )
-        RUBY
-      end
-
-      it 'does not break when a method call is chained on the offending one' do
-        expect_no_offenses(<<~RUBY)
-          foo.bar(
-            baz: 1,
-          ).fetch(:qux)
-        RUBY
-      end
-
-      it 'does not break when a safe method call is chained on the offending simple one' do
-        expect_no_offenses(<<~RUBY)
-          foo
-            &.do_something(:bar, :baz)
-        RUBY
-      end
-
-      it 'does not break when a safe method call is chained on the offending more complex one' do
-        expect_no_offenses(<<~RUBY)
-          foo.bar(
-            baz: 1,
-          )&.fetch(:qux)
-        RUBY
       end
     end
 
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
-      context 'when closing bracket is on same line as last value' do
-        it 'registers an offense for a method call, with a Hash as the ' \
-           'last parameter, split on multiple lines' do
-          expect_offense(<<~RUBY)
-            some_method(a: "b",
-                        c: "d")
-                        ^^^^^^ Put a comma after the last parameter of a multiline method call.
-          RUBY
+      [%w[( )], %w[[ ]]].each do |start_bracket, end_bracket|
+        context "with `#{start_bracket}#{end_bracket}` brackets" do
+          context 'when closing bracket is on same line as last value' do
+            it 'registers an offense for a method call, with a Hash as the ' \
+               'last parameter, split on multiple lines' do
+              expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+                some_method#{start_bracket}a: "b",
+                            c: "d"#{end_bracket}
+                            ^^^^^^ Put a comma after the last parameter of a multiline method call.
+              RUBY
 
-          expect_correction(<<~RUBY)
-            some_method(a: "b",
-                        c: "d",)
-          RUBY
-        end
-      end
+              expect_correction(<<~RUBY)
+                some_method#{start_bracket}a: "b",
+                            c: "d",#{end_bracket}
+              RUBY
+            end
+          end
 
-      it 'registers an offense for no trailing comma in a method call with ' \
-         'hash parameters at the end' do
-        expect_offense(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1
-                        ^^^^ Put a comma after the last parameter of a multiline method call.
-                     )
-        RUBY
+          it 'registers an offense for no trailing comma in a method call with ' \
+             'hash parameters at the end' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1
+                            ^^^^ Put a comma after the last parameter of a multiline method call.
+                        #{end_bracket}
+            RUBY
 
-        expect_correction(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
-        RUBY
-      end
+            expect_correction(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,
+                        #{end_bracket}
+            RUBY
+          end
 
-      it 'registers an offense for no trailing comma in a method call with' \
-         'two parameters on the same line' do
-        expect_offense(<<~RUBY)
-          some_method(a, b
-                         ^ Put a comma after the last parameter of a multiline method call.
-                     )
-        RUBY
+          it 'registers an offense for no trailing comma in a method call with' \
+             'two parameters on the same line' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              some_method#{start_bracket}a, b
+                             ^ Put a comma after the last parameter of a multiline method call.
+                        #{end_bracket}
+            RUBY
 
-        expect_correction(<<~RUBY)
-          some_method(a, b,
-                     )
-        RUBY
-      end
+            expect_correction(<<~RUBY)
+              some_method#{start_bracket}a, b,
+                        #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts trailing comma in a method call with hash parameters at the end' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                     )
-        RUBY
-      end
+          it 'accepts trailing comma in a method call with hash parameters at the end' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,
+                        #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts a trailing comma in a method call with a single hash parameter' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-                        a: 0,
-                        b: 1,
-                     )
-        RUBY
-      end
-
-      it 'accepts a trailing comma in a method call with ' \
-         'a single hash parameter to a receiver object' do
-        expect_no_offenses(<<~RUBY)
-          obj.some_method(
+          it 'accepts a trailing comma in a method call with a single hash parameter' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
                             a: 0,
                             b: 1,
-                         )
-        RUBY
-      end
+                        #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts a trailing comma in a method call with single line hashes' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-           { a: 0, b: 1 },
-           { a: 1, b: 0 },
-          )
-        RUBY
-      end
+          it 'accepts a trailing comma in a method call with ' \
+             'a single hash parameter to a receiver object' do
+            expect_no_offenses(<<~RUBY)
+              obj.some_method#{start_bracket}
+                                a: 0,
+                                b: 1,
+                            #{end_bracket}
+            RUBY
+          end
 
-      # this is a sad parse error
-      it 'accepts no trailing comma in a method call with a block parameter at the end' do
-        expect_no_offenses(<<~RUBY)
-          some_method(
-                        a,
-                        b,
-                        c: 0,
-                        d: 1,
-                        &block
-                     )
-        RUBY
-      end
+          it 'accepts a trailing comma in a method call with single line hashes' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+              { a: 0, b: 1 },
+              { a: 1, b: 0 },
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'autocorrects missing comma after a heredoc' do
-        expect_offense(<<~RUBY)
-          route(1, <<-HELP.chomp
-                   ^^^^^^^^^^^^^ Put a comma after the last parameter of a multiline method call.
-          ...
-          HELP
-          )
-        RUBY
+          # this is a sad parse error
+          it 'accepts no trailing comma in a method call with a block parameter at the end' do
+            expect_no_offenses(<<~RUBY)
+              some_method#{start_bracket}
+                            a,
+                            b,
+                            c: 0,
+                            d: 1,
+                            &block
+                        #{end_bracket}
+            RUBY
+          end
 
-        expect_correction(<<~RUBY)
-          route(1, <<-HELP.chomp,
-          ...
-          HELP
-          )
-        RUBY
-      end
+          it 'autocorrects missing comma after a heredoc' do
+            expect_offense(<<~RUBY, start_bracket: start_bracket, end_bracket: end_bracket)
+              route#{start_bracket}1, <<-HELP.chomp
+                       ^^^^^^^^^^^^^ Put a comma after the last parameter of a multiline method call.
+              ...
+              HELP
+              #{end_bracket}
+            RUBY
 
-      it 'accepts a multiline call with a single argument and trailing comma' do
-        expect_no_offenses(<<~RUBY)
-          method(
-            1,
-          )
-        RUBY
-      end
+            expect_correction(<<~RUBY)
+              route#{start_bracket}1, <<-HELP.chomp,
+              ...
+              HELP
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts a multiline call with arguments on a single line and trailing comma' do
-        expect_no_offenses(<<~RUBY)
-          method(
-            1, 2,
-          )
-        RUBY
-      end
+          it 'accepts a multiline call with a single argument and trailing comma' do
+            expect_no_offenses(<<~RUBY)
+              method#{start_bracket}
+                1,
+              #{end_bracket}
+            RUBY
+          end
 
-      it 'accepts a multiline call with single argument on multiple lines' do
-        expect_no_offenses(<<~RUBY)
-          method(a:
-                    "foo")
-        RUBY
+          it 'accepts a multiline call with arguments on a single line and trailing comma' do
+            expect_no_offenses(<<~RUBY)
+              method#{start_bracket}
+                1, 2,
+              #{end_bracket}
+            RUBY
+          end
+
+          it 'accepts a multiline call with single argument on multiple lines' do
+            expect_no_offenses(<<~RUBY)
+              method#{start_bracket}a:
+                        "foo"#{end_bracket}
+            RUBY
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/14137

All test cases for this cop are now tested with both `()` and `[]` brackets (if applicable).

Specs diff is quite big since I had to indent everything.

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
