### PR TITLE
Layout/LeadingCommentSpace: allow splitting long inline RBS comment signatures

### DIFF
--- a/changelog/fix_layout_leading_comment_to_allow_rbs_comment_line_continuation_20250429122623.md
+++ b/changelog/fix_layout_leading_comment_to_allow_rbs_comment_line_continuation_20250429122623.md
@@ -1,0 +1,1 @@
+* [#14140](https://github.com/rubocop/rubocop/pull/14140): Fix `Layout/LeadingCommentSpace` to allow splitting long inline RBS comment signatures across multiple lines. ([@Morriar][])

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -58,6 +58,12 @@ module RuboCop
       #   attr_reader :name #: String
       #   attr_reader :age  #: Integer?
       #
+      #   #: (
+      #   #|   Integer,
+      #   #|   String
+      #   #| ) -> void
+      #   def foo; end
+      #
       # @example AllowRBSInlineAnnotation: true
       #
       #   # good
@@ -66,6 +72,12 @@ module RuboCop
       #
       #   attr_reader :name #: String
       #   attr_reader :age  #: Integer?
+      #
+      #   #: (
+      #   #|   Integer,
+      #   #|   String
+      #   #| ) -> void
+      #   def foo; end
       #
       # @example AllowSteepAnnotation: false (default)
       #
@@ -175,7 +187,7 @@ module RuboCop
         end
 
         def rbs_inline_annotation?(comment)
-          allow_rbs_inline_annotation? && comment.text.start_with?(/#:|#\[.+\]/)
+          allow_rbs_inline_annotation? && comment.text.start_with?(/#:|#\[.+\]|#\|/)
         end
 
         def allow_steep_annotation?

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -263,6 +263,16 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
                             ^^^^^^^^^ Missing space after `#`.
           attr_reader :age  #: Integer?
                             ^^^^^^^^^^^ Missing space after `#`.
+
+          #: (
+          ^^^^ Missing space after `#`.
+          #|   Integer,
+          ^^^^^^^^^^^^^ Missing space after `#`.
+          #|   String
+          ^^^^^^^^^^^ Missing space after `#`.
+          #| ) -> void
+          ^^^^^^^^^^^^ Missing space after `#`.
+          def foo; end
         RUBY
 
         expect_correction(<<~RUBY)
@@ -270,6 +280,12 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
 
           attr_reader :name # : String
           attr_reader :age  # : Integer?
+
+          # : (
+          # |   Integer,
+          # |   String
+          # | ) -> void
+          def foo; end
         RUBY
       end
     end
@@ -283,6 +299,12 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
 
           attr_reader :name #: String
           attr_reader :age  #: Integer?
+
+          #: (
+          #|   Integer,
+          #|   String
+          #| ) -> void
+          def foo; end
         RUBY
       end
     end


### PR DESCRIPTION
At Shopify we use [RBS inline comments with Sorbet](https://sorbet.org/docs/rbs-support).

We added a syntax to allow splitting long signatures accross multiple lines like this:

```rb
#: (
#|   Integer,
#|   String
#| ) -> void
def foo; end
```

In combination with the syntax highlighting we added to the Ruby LSP, this makes it easier to read:

![image](https://github.com/user-attachments/assets/55bdf4d8-68b1-4167-9493-6698acccaa21)

The issue is that Rubocop's `Layout/LeadingCommentSpace` rule will try to add a space before the `|` even with `AllowRBSInlineAnnotation` enabled.

This PR proposes adding `#|` to the list of allowed characters for RBS inline comments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
