### PR TITLE
[Fix #14142] `Layout/SpaceInsideHashLiteralBraces` make aware of hash pattern matching

### DIFF
--- a/changelog/change_make_layout_space_inside_hash_literal_braces_aware_of_hash_pattern.md
+++ b/changelog/change_make_layout_space_inside_hash_literal_braces_aware_of_hash_pattern.md
@@ -1,0 +1,1 @@
+* [#14142](https://github.com/rubocop/rubocop/issues/14142): `Layout/SpaceInsideHashLiteralBraces` make aware of hash pattern matching. ([@koic][])

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -6,6 +6,8 @@ module RuboCop
       # Checks that braces used for hash literals have or don't have
       # surrounding space depending on configuration.
       #
+      # Hash pattern matching is handled in the same way.
+      #
       # @example EnforcedStyle: space (default)
       #   # The `space` style enforces that hash literals have
       #   # surrounding space.
@@ -87,6 +89,7 @@ module RuboCop
           check(tokens[-2], tokens[-1]) if tokens.size > 2
           check_whitespace_only_hash(node) if enforce_no_space_style_for_empty_braces?
         end
+        alias on_hash_pattern on_hash
 
         private
 

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -112,6 +112,72 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     RUBY
   end
 
+  context 'when using hash pattern matching', :ruby27 do
+    it 'registers an offense when hash pattern with no spaces' do
+      expect_offense(<<~RUBY)
+        case foo
+        in {k1: 0, k2: 1}
+                        ^ Space inside } missing.
+           ^ Space inside { missing.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        in { k1: 0, k2: 1 }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when hash pattern with spaces' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        in { k1: 0, k2: 1 }
+        end
+      RUBY
+    end
+  end
+
+  context 'when using one-line hash `in` pattern matching', :ruby27 do
+    it 'registers an offense when hash pattern with no spaces' do
+      expect_offense(<<~RUBY)
+        foo in {k1: 0, k2: 1}
+                            ^ Space inside } missing.
+               ^ Space inside { missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo in { k1: 0, k2: 1 }
+      RUBY
+    end
+
+    it 'does not register an offense when hash pattern with spaces' do
+      expect_no_offenses(<<~RUBY)
+        foo in { k1: 0, k2: 1 }
+      RUBY
+    end
+  end
+
+  context 'when using one-line hash `=>` pattern matching', :ruby30 do
+    it 'registers an offense when hash pattern with no spaces' do
+      expect_offense(<<~RUBY)
+        foo => {k1: 0, k2: 1}
+                            ^ Space inside } missing.
+               ^ Space inside { missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo => { k1: 0, k2: 1 }
+      RUBY
+    end
+
+    it 'does not register an offense when hash pattern with spaces' do
+      expect_no_offenses(<<~RUBY)
+        foo => { k1: 0, k2: 1 }
+      RUBY
+    end
+  end
+
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
@@ -179,6 +245,72 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
       it 'accepts hashes with no spaces' do
         expect_no_offenses(<<~RUBY)
           foo({key: value} => {key: value})
+        RUBY
+      end
+    end
+
+    context 'when using hash pattern matching', :ruby27 do
+      it 'registers an offense when hash with spaces' do
+        expect_offense(<<~RUBY)
+          case foo
+          in { k1: 0, k2: 1 }
+                           ^ Space inside } detected.
+              ^ Space inside { detected.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case foo
+          in {k1: 0, k2: 1}
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when hash pattern with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          case foo
+          in {k1: 0, k2: 1}
+          end
+        RUBY
+      end
+    end
+
+    context 'when using one-line hash `in` pattern matching', :ruby27 do
+      it 'registers an offense when hash with spaces' do
+        expect_offense(<<~RUBY)
+          foo in { k1: 0, k2: 1 }
+                               ^ Space inside } detected.
+                  ^ Space inside { detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo in {k1: 0, k2: 1}
+        RUBY
+      end
+
+      it 'does not register an offense when hash with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo in {k1: 0, k2: 1}
+        RUBY
+      end
+    end
+
+    context 'when using one-line hash `=>` pattern matching', :ruby30 do
+      it 'registers an offense when hash with spaces' do
+        expect_offense(<<~RUBY)
+          foo => { k1: 0, k2: 1 }
+                               ^ Space inside } detected.
+                  ^ Space inside { detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo => {k1: 0, k2: 1}
+        RUBY
+      end
+
+      it 'does not register an offense when hash with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo => {k1: 0, k2: 1}
         RUBY
       end
     end


### PR DESCRIPTION
This PR `Layout/SpaceInsideHashLiteralBraces` makes aware of hash pattern matching.

Hash literals and hash pattern matching are syntactically different features, but it would be practical to extend the existing `Layout/SpaceInsideHashLiteralBraces` cop rather than introducing a new one.

Fixes #14142.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
