### PR TITLE
`Layout/SpaceInsideArrayLiteralBrackets` make aware of array pattern matching

### DIFF
--- a/changelog/change_make_layout_space_inside_array_literal_brackets_aware_of_array_pattern.md
+++ b/changelog/change_make_layout_space_inside_array_literal_brackets_aware_of_array_pattern.md
@@ -1,0 +1,1 @@
+* [#14144](https://github.com/rubocop/rubocop/pull/14144): `Layout/SpaceInsideArrayLiteralBrackets` make aware of array pattern matching. ([@koic][])

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -6,6 +6,8 @@ module RuboCop
       # Checks that brackets used for array literals have or don't have
       # surrounding space depending on configuration.
       #
+      # Array pattern matching is handled in the same way.
+      #
       # @example EnforcedStyle: no_space (default)
       #   # The `no_space` style enforces that array literals have
       #   # no surrounding space.
@@ -82,7 +84,7 @@ module RuboCop
         EMPTY_MSG = '%<command>s space inside empty array brackets.'
 
         def on_array(node)
-          return unless node.square_brackets?
+          return if node.array_type? && !node.square_brackets?
 
           tokens, left, right = array_brackets(node)
 
@@ -95,6 +97,7 @@ module RuboCop
 
           issue_offenses(node, left, right, start_ok, end_ok)
         end
+        alias on_array_pattern on_array
 
         private
 

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -293,6 +293,72 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
            ]
       RUBY
     end
+
+    context 'when using array pattern matching', :ruby27 do
+      it 'registers an offense when array pattern with spaces' do
+        expect_offense(<<~RUBY)
+          case foo
+          in [ bar, baz ]
+                       ^ Do not use space inside array brackets.
+              ^ Do not use space inside array brackets.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case foo
+          in [bar, baz]
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          case foo
+          in [bar, baz]
+          end
+        RUBY
+      end
+    end
+
+    context 'when using one-line array `in` pattern matching', :ruby27 do
+      it 'registers an offense when array pattern with spaces' do
+        expect_offense(<<~RUBY)
+          foo in [ bar, baz ]
+                           ^ Do not use space inside array brackets.
+                  ^ Do not use space inside array brackets.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo in [bar, baz]
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo in [bar, baz]
+        RUBY
+      end
+    end
+
+    context 'when using one-line array `=>` pattern matching', :ruby30 do
+      it 'registers an offense when array pattern with spaces' do
+        expect_offense(<<~RUBY)
+          foo => [ bar, baz ]
+                           ^ Do not use space inside array brackets.
+                  ^ Do not use space inside array brackets.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo => [bar, baz]
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with no spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo => [bar, baz]
+        RUBY
+      end
+    end
   end
 
   shared_examples 'space inside arrays' do
@@ -457,6 +523,72 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
       expect_no_offenses(<<~RUBY)
         [ 1, [ 2,3,4 ], [ 5,6,7 ] ]
       RUBY
+    end
+
+    context 'when using array pattern matching', :ruby27 do
+      it 'registers an offense when array pattern with no spaces' do
+        expect_offense(<<~RUBY)
+          case foo
+          in [bar, baz]
+                      ^ Use space inside array brackets.
+             ^ Use space inside array brackets.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case foo
+          in [ bar, baz ]
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with spaces' do
+        expect_no_offenses(<<~RUBY)
+          case foo
+          in [ bar, baz ]
+          end
+        RUBY
+      end
+    end
+
+    context 'when using one-line array `in` pattern matching', :ruby27 do
+      it 'registers an offense when array pattern with no spaces' do
+        expect_offense(<<~RUBY)
+          foo in [bar, baz]
+                          ^ Use space inside array brackets.
+                 ^ Use space inside array brackets.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo in [ bar, baz ]
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo in [ bar, baz ]
+        RUBY
+      end
+    end
+
+    context 'when using one-line array `=>` pattern matching', :ruby30 do
+      it 'registers an offense when array pattern with no spaces' do
+        expect_offense(<<~RUBY)
+          foo => [bar, baz]
+                          ^ Use space inside array brackets.
+                 ^ Use space inside array brackets.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo => [ bar, baz ]
+        RUBY
+      end
+
+      it 'does not register an offense when array pattern with spaces' do
+        expect_no_offenses(<<~RUBY)
+          foo => [ bar, baz ]
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR `Layout/SpaceInsideArrayLiteralBrackets` makes aware of array pattern matching.

The same change as in #14143 will be applied to `Layout/SpaceInsideHashLiteralBraces` cop as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
