### PR TITLE
Fix `Lint/ArrayLiteralInRegexp` cop error on empty interpolation

### DIFF
--- a/changelog/fix_array_literal_in_regexp_cop_error_on_empty_interpolation_20250501213318.md
+++ b/changelog/fix_array_literal_in_regexp_cop_error_on_empty_interpolation_20250501213318.md
@@ -1,0 +1,1 @@
+* [#14145](https://github.com/rubocop/rubocop/pull/14145): Fix `Lint/ArrayLiteralInRegexp` cop error on empty interpolation. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/array_literal_in_regexp.rb
+++ b/lib/rubocop/cop/lint/array_literal_in_regexp.rb
@@ -51,10 +51,9 @@ module RuboCop
                       'in a regexp.'
 
         def on_interpolation(begin_node)
-          final_node = begin_node.children.last
-
-          return unless begin_node.parent.regexp_type?
+          return unless (final_node = begin_node.children.last)
           return unless final_node.array_type?
+          return unless begin_node.parent.regexp_type?
 
           if array_of_literal_values?(final_node)
             register_array_of_literal_values(begin_node, final_node)

--- a/spec/rubocop/cop/lint/array_literal_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/array_literal_in_regexp_spec.rb
@@ -82,4 +82,10 @@ RSpec.describe RuboCop::Cop::Lint::ArrayLiteralInRegexp, :config do
       "#{%w[a b c]}"
     RUBY
   end
+
+  it 'does not register an offense with empty interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      /#{}/
+    RUBY
+  end
 end


### PR DESCRIPTION
```bash
echo '/#{}/' | bundle exec rubocop --stdin bug.rb -d
An error occurred while Lint/ArrayLiteralInRegexp cop was inspecting /bug.rb:1:0.
undefined method `array_type?' for nil
lib/rubocop/cop/lint/array_literal_in_regexp.rb:57:in `on_interpolation'
```
Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
