### PR TITLE
Fix `Style/MethodCallWithArgsParentheses` cop error on complex numbers

### DIFF
--- a/changelog/fix_style_method_call_with_args_parentheses_with_complex_numbers_20250501222730.md
+++ b/changelog/fix_style_method_call_with_args_parentheses_with_complex_numbers_20250501222730.md
@@ -1,0 +1,1 @@
+* [#14146](https://github.com/rubocop/rubocop/pull/14146): Fix `Style/MethodCallWithArgsParentheses` cop error on complex numbers when `EnforcedStyle` is set to `omit_parentheses`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -222,7 +222,8 @@ module RuboCop
           end
 
           def unary_literal?(node)
-            (node.numeric_type? && node.sign?) ||
+            (node.complex_type? && node.source.match?(/\A[+-]/)) ||
+              (node.numeric_type? && node.sign?) ||
               (node.parent&.send_type? && node.parent.unary_operation?)
           end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -878,6 +878,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
       expect_no_offenses('foo(+1)')
       expect_no_offenses('foo(+"")')
       expect_no_offenses('foo(-"")')
+      expect_no_offenses('foo(-1 + 3i)')
+      expect_no_offenses('foo(+1 + 3i)')
+      expect_no_offenses('foo(-3i)')
+      expect_no_offenses('foo(+3i)')
+      expect_no_offenses('foo(-1.3i)')
+      expect_no_offenses('foo(+1.3i)')
     end
 
     it 'accepts parens in args splat' do


### PR DESCRIPTION
`EnforcedStyle: omit_parentheses`

```bash
undefined method `sign?' for an instance of RuboCop::AST::Node
     # ./lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb:226:in `unary_literal?'
     # ./lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb:201:in `ambiguous_literal?'
     # ./lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb:146:in `block in call_with_ambiguous_arguments?'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
