### PR TITLE
Fix `Lint/LiteralAsCondition` cop error on `if` without body

### DIFF
--- a/changelog/fix_lint_literal_as_condition_cop_error_on_if_without_body_20250501225733.md
+++ b/changelog/fix_lint_literal_as_condition_cop_error_on_if_without_body_20250501225733.md
@@ -1,0 +1,1 @@
+* [#14147](https://github.com/rubocop/rubocop/pull/14147): Fix `Lint/LiteralAsCondition` cop error on `if` without body. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -248,7 +248,7 @@ module RuboCop
             add_offense(cond) do |corrector|
               corrector.replace(node, "else\n  #{node.else_branch.source}")
             end
-          elsif result
+          elsif node.if_branch && result
             add_offense(cond) do |corrector|
               corrector.replace(node, node.if_branch.source)
             end

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -674,5 +674,17 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
 
       expect_no_corrections
     end
+
+    it 'registers an offense when there is no body for `if` node' do
+      expect_offense(<<~RUBY)
+        if 42
+           ^^ Literal `42` appeared as a condition.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
```bash
NoMethodError:
       undefined method `source' for nil
     # ./lib/rubocop/cop/lint/literal_as_condition.rb:253:in `block in correct_if_node'
     # ./lib/rubocop/cop/base.rb:426:in `correct'
     # ./lib/rubocop/cop/base.rb:210:in `add_offense'
```

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
