### PR TITLE
Fix an infinite loop error for `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon`

### DIFF
--- a/changelog/fix_an_error_for_layout_space_after_semicolon.md
+++ b/changelog/fix_an_error_for_layout_space_after_semicolon.md
@@ -1,0 +1,1 @@
+* [#14148](https://github.com/rubocop/rubocop/pull/14148): Fix an infinite loop error for `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon` when a sequence of semicolons appears. ([@koic][])

--- a/lib/rubocop/cop/layout/space_after_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_after_semicolon.rb
@@ -23,6 +23,16 @@ module RuboCop
         def kind(token)
           'semicolon' if token.semicolon?
         end
+
+        def space_missing?(token1, token2)
+          super && !semicolon_sequence?(token1, token2)
+        end
+
+        private
+
+        def semicolon_sequence?(token, next_token)
+          token.semicolon? && next_token.semicolon?
+        end
       end
     end
   end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1804,6 +1804,16 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon`' do
+    create_file('example.rb', <<~RUBY)
+      foo;;bar
+    RUBY
+    expect(cli.run(%w[-a --only Layout/SpaceAfterSemicolon,Layout/SpaceBeforeSemicolon])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      foo;; bar
+    RUBY
+  end
+
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb', "I18n.t('description',:property_name => property.name)")
     expect(cli.run(%w[-D --autocorrect-all --format emacs

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon, :config do
     expect_no_offenses('x = 1;')
   end
 
+  it 'does not register an offense when semicolons appear consecutively' do
+    expect_no_offenses(<<~RUBY)
+      foo;; bar
+    RUBY
+  end
+
   context 'inside block braces' do
     shared_examples 'common behavior' do
       it 'accepts a space between a semicolon and a closing brace' do


### PR DESCRIPTION
This PR fixes the following error for `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon` when a sequence of semicolons appears.

```console
$ echo "foo;;" | bundle exec rubocop --stdin test.rb --enable-pending-cops -A --only Layout/SpaceAfterSemicolon,Layout/SpaceBeforeSemicolon
Inspecting 1 file
Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/test.rb and caused by Layout/SpaceAfterSemicolon -> Layout/SpaceBeforeSemicolon
C

Offenses:

test.rb:1:4: C: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon.
foo;;
   ^
test.rb:1:5: C: [Corrected] Layout/SpaceBeforeSemicolon: Space found before semicolon.
foo; ;
    ^

1 file inspected, 2 offenses detected, 2 offenses corrected

1 error occurred:
Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/test.rb and caused by Layout/SpaceAfterSemicolon -> Layout/SpaceBeforeSemicolon
Fix an infinite loop error for `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon`

This PR fixes the following error for `Layout/SpaceAfterSemicolon` with `Layout/SpaceBeforeSemicolon`
when a sequence of semicolons appears.

```console
$ echo "foo;;" | bundle exec rubocop --stdin test.rb --enable-pending-cops -A --only Layout/SpaceAfterSemicolon,Layout/SpaceBeforeSemicolon Inspecting 1 file
Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/test.rb and caused by Layout/SpaceAfterSemicolon -> Layout/SpaceBeforeSemicolon C

Offenses:

test.rb:1:4: C: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon. foo;;
   ^
test.rb:1:5: C: [Corrected] Layout/SpaceBeforeSemicolon: Space found before semicolon. foo; ;
    ^

1 file inspected, 2 offenses detected, 2 offenses corrected

1 error occurred:
Infinite loop detected in /Users/koic/src/github.com/rubocop/rubocop/test.rb and caused by Layout/SpaceAfterSemicolon -> Layout/SpaceBeforeSemicolon Errors are usually caused by RuboCop bugs.
Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version. https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report: 1.75.4 (using Parser 3.3.8.0, rubocop-ast 1.44.1, analyzing as Ruby 2.7, running on ruby 3.4.3) [x86_64-darwin24] ====================
foo;;
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
