### PR TITLE
[Fix #14072] Resolve autocorrect issue in Layout/HashAlignment

### DIFF
--- a/changelog/fix_autocorrect_issue_in_layout_hash_alignment_20250503213254.md
+++ b/changelog/fix_autocorrect_issue_in_layout_hash_alignment_20250503213254.md
@@ -1,0 +1,1 @@
+* [#14072](https://github.com/rubocop/rubocop/issues/14072): Fix autocorrect issue in `Layout/HashAlignment`. ([@jonas054][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -250,7 +250,7 @@ module RuboCop
           reset!
 
           alignment_for(first_pair).each do |alignment|
-            delta = alignment.deltas_for_first_pair(first_pair, node)
+            delta = alignment.deltas_for_first_pair(first_pair)
             check_delta delta, node: first_pair, alignment: alignment
           end
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1375,6 +1375,23 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           }
         RUBY
       end
+
+      it 'corrects a hash with mixed separators into table alignment' do
+        expect_offense(<<~RUBY)
+          other = {
+            foo:  1,
+            ^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+            'bar' => 2,
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          other = {
+            foo:     1,
+            'bar' => 2,
+          }
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This is a fix with two parts.

Part 1 is to remove the attribute `max_key_width`. The `TableAlignment` class, by setting and storing a `max_key_width` value when processing the first key-value pair, didn't support hash literals with mixed separators (colon and hash rocket). The solution is to calculate the value when needed. This is less efficient, but correct.

Part 2 is to calculate the max width of separators (delimiters) in the whole hash literal, rather than assuming the width will be the same for all pairs. This, too, is done to support hashes with mixed separators.