### PR TITLE
Fix `Lint/Void` cop error on nested empty `begin`

### DIFF
--- a/changelog/fix_lint_void_cop_error_on_empty_nested_begin_20250504003158.md
+++ b/changelog/fix_lint_void_cop_error_on_empty_nested_begin_20250504003158.md
@@ -1,0 +1,1 @@
+* [#14151](https://github.com/rubocop/rubocop/pull/14151): Fix `Lint/Void` cop error on nested empty `begin`. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -128,8 +128,8 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_void_op(node, &block)
-          node = node.children.first while node.begin_type?
-          return unless node.call_type? && OPERATORS.include?(node.method_name)
+          node = node.children.first while node&.begin_type?
+          return unless node&.call_type? && OPERATORS.include?(node.method_name)
           if !UNARY_OPERATORS.include?(node.method_name) && node.loc.dot && node.arguments.none?
             return
           end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1151,4 +1151,10 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       puts :ok
     RUBY
   end
+
+  it 'does not register an offense for nested empty `begin`' do
+    expect_no_offenses(<<~RUBY)
+      ((); 1)
+    RUBY
+  end
 end


### PR DESCRIPTION
Not the `begin` keyword actually:

```bash
echo '((); 1)' | be rubocop --stdin bug.rb --only Lint/Void -d

An error occurred while Lint/Void cop was inspecting bug.rb:1:0.
undefined method `begin_type?' for nil
lib/rubocop/cop/lint/void.rb:131:in `check_void_op'
lib/rubocop/cop/lint/void.rb:106:in `block in check_begin'
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
