### PR TITLE
Fix `Layout/SpaceInsideArrayLiteralBrackets` cop error on array pattern without brackets

### DIFF
--- a/changelog/fix_layout_space_inside_array_literal_brackets_for_cop_error_on_array_pattern_without_brackets_20250505143301.md
+++ b/changelog/fix_layout_space_inside_array_literal_brackets_for_cop_error_on_array_pattern_without_brackets_20250505143301.md
@@ -1,0 +1,1 @@
+* [#14152](https://github.com/rubocop/rubocop/pull/14152): Fix `Layout/SpaceInsideArrayLiteralBrackets` cop error on array pattern without brackets. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -87,6 +87,7 @@ module RuboCop
           return if node.array_type? && !node.square_brackets?
 
           tokens, left, right = array_brackets(node)
+          return unless left && right
 
           if empty_brackets?(left, right, tokens: tokens)
             return empty_offenses(node, left, right, EMPTY_MSG)

--- a/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_literal_brackets_spec.rb
@@ -514,10 +514,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     end
   end
 
+  shared_examples 'array pattern without brackets' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        case ary
+        in a, b, c, d
+        end
+      RUBY
+    end
+  end
+
   context 'when EnforcedStyle is space' do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
     it_behaves_like 'space inside arrays'
+    it_behaves_like 'array pattern without brackets'
 
     it 'does not register offense for valid 2-dimensional array' do
       expect_no_offenses(<<~RUBY)
@@ -596,6 +607,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it_behaves_like 'space inside arrays'
+    it_behaves_like 'array pattern without brackets'
 
     it 'does not register offense for valid 2-dimensional array' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Array pattern might have no brackets:

```bash
$ echo 'case a; in a, b, _; end' | bundle exec rubocop --only Layout/SpaceInsideArrayLiteralBrackets --stdin bug.rb -d
An error occurred while Layout/SpaceInsideArrayLiteralBrackets cop was inspecting bug.rb:1:11.
undefined method '+' for nil
lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb:132:in 'RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#next_to_newline?'
rubocop/cop/layout/space_inside_array_literal_brackets.rb:95:in 'RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array'
```

This bug was introduced in https://github.com/rubocop/rubocop/pull/14144

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
