### PR TITLE
Fix `Style/PercentQLiterals` cop error on Unicode escape sequence

### DIFF
--- a/changelog/fix_style_percent_q_literals_cop_error_on_unicode_escape_sequence.md
+++ b/changelog/fix_style_percent_q_literals_cop_error_on_unicode_escape_sequence.md
@@ -1,0 +1,1 @@
+* [#14153](https://github.com/rubocop/rubocop/pull/14153): Fix `Style/PercentQLiterals` cop error on Unicode escape sequence. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -45,7 +45,7 @@ module RuboCop
           # Report offense only if changing case doesn't change semantics,
           # i.e., if the string would become dynamic or has special characters.
           ast = parse(corrected(node.source)).ast
-          return if node.children != ast.children
+          return if node.children != ast&.children
 
           add_offense(node.loc.begin) do |corrector|
             corrector.replace(node, corrected(node.source))

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
         expect_no_offenses('%Q(hi)')
       end
 
+      it 'does not register an offense when correcting leads to a parsing error' do
+        expect_no_offenses(<<~'RUBY')
+          %q(\u)
+        RUBY
+      end
+
       include_examples 'accepts quote characters'
       include_examples 'accepts any q string with backslash t'
     end


### PR DESCRIPTION
Prior to these changes this cop would try to take `%q(\u)`, change `q` to `Q` and parse it. The result (processed source) would contain the `invalid_unicode_escape` diagnostic error -- but it would be ignored.

Since is that case `ast` is `nil` a `NoMethodError` is thrown.
I don't know if we should only check for this specific diagnostics or all of them.

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
