### PR TITLE
[Fix #14156] Make `Style/IfUnlessModifier` allow endless method definition

### DIFF
--- a/changelog/change_make_style_if_unless_modifier_allow_endless_method_definition.md
+++ b/changelog/change_make_style_if_unless_modifier_allow_endless_method_definition.md
@@ -1,0 +1,1 @@
+* [#14156](https://github.com/rubocop/rubocop/issues/14156): Make `Style/IfUnlessModifier` allow endless method definition in the `if` body. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -23,6 +23,17 @@ module RuboCop
       # end
       # ----
       #
+      # The code `def method_name = body if condition` is considered a bad case by
+      # `Style/AmbiguousEndlessMethodDefinition` cop. So, to respect the user's intention to use
+      # an endless method definition in the `if` body, the following code is allowed:
+      #
+      # [source,ruby]
+      # ----
+      # if condition
+      #   def method_name = body
+      # end
+      # ----
+      #
       # NOTE: It is allowed when `defined?` argument has an undefined value,
       # because using the modifier form causes the following incompatibility:
       #
@@ -77,10 +88,14 @@ module RuboCop
           [Style::SoleNestedConditional]
         end
 
+        # rubocop:disable Metrics/AbcSize
         def on_if(node)
+          return if endless_method?(node.body)
+
           condition = node.condition
           return if defined_nodes(condition).any? { |n| defined_argument_is_undefined?(node, n) } ||
                     pattern_matching_nodes(condition).any?
+
           return unless (msg = message(node))
 
           add_offense(node.loc.keyword, message: format(msg, keyword: node.keyword)) do |corrector|
@@ -90,8 +105,13 @@ module RuboCop
             ignore_node(node)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
+
+        def endless_method?(body)
+          body&.any_def_type? && body.endless?
+        end
 
         def defined_nodes(condition)
           if condition.defined_type?

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -426,6 +426,24 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     include_examples 'one-line pattern matching'
   end
 
+  context 'when using endless method definition', :ruby30 do
+    it 'does not register an offense when using method definition in the branch' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          def method_name = body
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using singleton method definition in the branch' do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          def self.method_name = body
+        end
+      RUBY
+    end
+  end
+
   context 'when using omitted hash values in an assignment', :ruby31 do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR makes `Style/IfUnlessModifier` allow endless method definition in the `if` body.

The code `def method_name = body if condition` is considered a bad case by `Style/AmbiguousEndlessMethodDefinition` cop. So, to respect the user's intention to use an endless method definition in the `if` body, the following code is allowed:

```ruby
if condition
  def method_name = body
end
```

Resolves #14156.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
