### PR TITLE
Fix an error for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_error_for_lint_useless_assignment_cop.md
+++ b/changelog/fix_error_for_lint_useless_assignment_cop.md
@@ -1,0 +1,1 @@
+* [#14164](https://github.com/rubocop/rubocop/pull/14164): Fix an error for `Lint/UselessAssignment` when variables are assigned using unary operator in chained assignment and remain unreferenced. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -104,6 +104,8 @@ module RuboCop
         end
 
         def chained_assignment?(node)
+          return true if node.lvasgn_type? && node.expression&.send_type?
+
           node.respond_to?(:expression) && node.expression&.lvasgn_type?
         end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1359,6 +1359,23 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when variables are assigned using unary operator in chained assignment and remain unreferenced' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo = -bar = do_something
+          ^^^ Useless assignment to variable - `foo`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          -bar = do_something
+        end
+      RUBY
+    end
+  end
+
   context 'when variables are assigned with sequential assignment using the comma operator and unreferenced' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Lint/UselessAssignment` when variables are assigned using unary operator in chained assignment and remain unreferenced.

```console
$ echo "a = -b = c" | bundle exec rubocop --stdin test.rb --enable-pending-cops -A --only Lint/UselessAssignment
Inspecting 1 file
An error occurred while Lint/UselessAssignment cop was inspecting /Users/koic/src/github.com/rubocop/rubocop/test.rb.
To see the complete backtrace run rubocop -d.
W

Offenses:

test.rb:1:1: W: [Corrected] Lint/UselessAssignment: Useless assignment to variable - a.
a = -b = c
^
test.rb:1:2: W: [Corrected] Lint/UselessAssignment: Useless assignment to variable - b.
-b = c
 ^

1 file inspected, 2 offenses detected, 2 offenses corrected

1 error occurred:
An error occurred while Lint/UselessAssignment cop was inspecting /Users/koic/src/github.com/rubocop/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.75.2 (using Parser 3.3.8.0, rubocop-ast 1.44.1, analyzing as Ruby 2.7, running on ruby 3.4.2) [x86_64-darwin23]
====================
-c
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
