### PR TITLE
Fix `Style/ConditionalAssignment` cop error on `if` in condition

### DIFF
--- a/changelog/fix_style_conditional_assignment_cop_error_on_if_in_condition_20250509192327.md
+++ b/changelog/fix_style_conditional_assignment_cop_error_on_if_in_condition_20250509192327.md
@@ -1,0 +1,1 @@
+* [#14168](https://github.com/rubocop/rubocop/pull/14168): Fix `Style/ConditionalAssignment` cop error on `if` in condition. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -232,6 +232,7 @@ module RuboCop
           define_method :"on_#{type}" do |node|
             return if part_of_ignored_node?(node)
             return if node.parent&.shorthand_asgn?
+            return if node.parent&.if_type?
 
             check_assignment_to_condition(node)
           end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -785,6 +785,21 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     end
   end
 
+  shared_examples 'with `if` node in condition' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        if a =
+          if b
+            1
+          else
+            2
+          end
+          42
+        end
+      RUBY
+    end
+  end
+
   context 'SingleLineConditionsOnly true' do
     let(:config) do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
@@ -863,6 +878,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
 
     it_behaves_like('with `dstr` node in branch')
     it_behaves_like('with indexed assignment without arguments')
+    it_behaves_like('with `if` node in condition')
 
     it 'allows a method call in the subject of a ternary operator' do
       expect_no_offenses('bar << foo? ? 1 : 2')
@@ -1111,6 +1127,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     it_behaves_like('single line condition autocorrect')
     it_behaves_like('with `dstr` node in branch')
     it_behaves_like('with indexed assignment without arguments')
+    it_behaves_like('with `if` node in condition')
 
     it 'corrects assignment to a multiline if else condition' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Currently this code leads to an error (with style set to `assign_in_condition`):

```ruby
if a =
  if b
    1
  else
    2
  end
  42
end
```

since this is a very weird code to write and I don't see a way to consistenly correct it I think it might make sense not to register an offense.

By the way, it might be a decent idea to detect `if` inside condition separately.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
