### PR TITLE
Fix `Style/AccessModifierDeclarations` cop error on colon after modifier

### DIFF
--- a/changelog/fix_style_access_modifier_declarations_cop_error_on_semicolon_after_modifier_20250509223009.md
+++ b/changelog/fix_style_access_modifier_declarations_cop_error_on_semicolon_after_modifier_20250509223009.md
@@ -1,0 +1,1 @@
+* [#14170](https://github.com/rubocop/rubocop/pull/14170): Fix `Style/AccessModifierDeclarations` cop error on semicolon after modifier. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -195,15 +195,27 @@ module RuboCop
         def autocorrect(corrector, node)
           case style
           when :group
-            def_nodes = find_corresponding_def_nodes(node)
-            return unless def_nodes.any?
-
-            replace_defs(corrector, node, def_nodes)
+            autocorrect_group_style(corrector, node)
           when :inline
+            autocorrect_inline_style(corrector, node)
+          end
+        end
+
+        def autocorrect_group_style(corrector, node)
+          def_nodes = find_corresponding_def_nodes(node)
+          return unless def_nodes.any?
+
+          replace_defs(corrector, node, def_nodes)
+        end
+
+        def autocorrect_inline_style(corrector, node)
+          if node.parent.begin_type? && node.parent.children.size == 2
+            remove_modifier_node_within_begin(corrector, node.parent)
+          else
             remove_nodes(corrector, node)
-            select_grouped_def_nodes(node).each do |grouped_def_node|
-              insert_inline_modifier(corrector, grouped_def_node, node.method_name)
-            end
+          end
+          select_grouped_def_nodes(node).each do |grouped_def_node|
+            insert_inline_modifier(corrector, grouped_def_node, node.method_name)
           end
         end
 
@@ -329,6 +341,17 @@ module RuboCop
           nodes.each do |node|
             corrector.remove(range_with_comments_and_lines(node))
           end
+        end
+
+        def remove_modifier_node_within_begin(corrector, begin_node)
+          modifier_node = begin_node.children.fetch(0)
+          def_node = begin_node.children.fetch(1)
+          range = Parser::Source::Range.new(
+            modifier_node.source_range.source_buffer,
+            modifier_node.source_range.begin_pos,
+            def_node.source_range.begin_pos
+          )
+          corrector.remove(range)
         end
 
         def def_source(node, def_nodes)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -642,6 +642,37 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         RUBY
       end
 
+      it 'registers an offense when modifier is within `begin` node with the definition' do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          %{access_modifier};
+          ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+          def foo
+          end
+
+          def bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{access_modifier} def foo
+          end
+
+          #{access_modifier} def bar
+          end
+        RUBY
+      end
+
+      it 'registers an offense when modifier is within `begin` node with the definition in the same line' do
+        expect_offense(<<~RUBY, access_modifier: access_modifier)
+          %{access_modifier}; def foo; end
+          ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{access_modifier} def foo; end
+        RUBY
+      end
+
       it "offends when #{access_modifier} is not inlined and has a comment" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)
           class Test


### PR DESCRIPTION
The cop raises during processing this code (with tree clobberring error)

```ruby
private;
def foo
end

private; def foo
end
```

While it's a little bit unusual and there's another cop to detect `;` between statements it looks like the patch is mostly trivial. Alternatively, we can simple omit offense in that case. Let me know what is preferred.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
