### PR TITLE
[Fix #14077] Change `nil` representation in todo file comments

### DIFF
--- a/changelog/fix_change_nil_representation_in_todo_file_comments_20250510150728.md
+++ b/changelog/fix_change_nil_representation_in_todo_file_comments_20250510150728.md
@@ -1,0 +1,1 @@
+* [#14077](https://github.com/rubocop/rubocop/issues/14077): Change `nil` representation in todo file comments. ([@jonas054][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -178,6 +178,7 @@ module RuboCop
           next unless value.is_a?(Array)
           next if value.empty?
 
+          value.map! { |v| v.nil? ? '~' : v } # Change nil back to ~ as in the YAML file.
           output_buffer.puts "# #{param}: #{value.uniq.join(', ')}"
         end
       end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -300,6 +300,17 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                                       '#' * 125,
                                       'y ',
                                       'puts x'])
+          create_file('example2.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            module M1::M2
+              class C # :nodoc:
+                def m
+                  puts '!'
+                end
+              end
+            end
+          RUBY
           create_file('.rubocop_todo.yml', <<~YAML)
             Layout/LineLength:
               Enabled: false
@@ -324,6 +335,17 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                     'Layout/TrailingWhitespace:',
                     '  Exclude:',
                     "    - 'example1.rb'",
+                    '',
+                    '# Offense count: 1',
+                    '# This cop supports unsafe autocorrection (--autocorrect-all).',
+                    '# Configuration parameters: EnforcedStyle, EnforcedStyleForClasses, ' \
+                    'EnforcedStyleForModules.',
+                    '# SupportedStyles: nested, compact',
+                    '# SupportedStylesForClasses: ~, nested, compact',
+                    '# SupportedStylesForModules: ~, nested, compact',
+                    'Style/ClassAndModuleChildren:',
+                    '  Exclude:',
+                    "    - 'example2.rb'",
                     '',
                     '# Offense count: 1',
                     '# This cop supports safe autocorrection (--autocorrect).',


### PR DESCRIPTION
Some cops use `nil` as a supported value for enforced style in their configuration. This is expressed using tilde (`~`) in the configuration file. Nil usually means a fallback to some default value.

When we list supported styles in `.rubocop_todo.yml`, we should express these values as `~`, i.e., using YAML syntax. Before this change the `nil` values were shown as empty strings, which was confusing.