### PR TITLE
Fix `Style/AccessModifierDeclarations` false positives with `inline` style and missing defs

### DIFF
--- a/changelog/fix_style_access_modifier_declarations_false_positives_when_there_are_no_defs_20250511175839.md
+++ b/changelog/fix_style_access_modifier_declarations_false_positives_when_there_are_no_defs_20250511175839.md
@@ -1,0 +1,1 @@
+* [#14172](https://github.com/rubocop/rubocop/pull/14172): Fix `Style/AccessModifierDeclarations` cop false positives when there are no method definitions and style is `inline`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -224,9 +224,13 @@ module RuboCop
         end
 
         def offense?(node)
-          (group_style? && access_modifier_is_inlined?(node) &&
-            !node.parent&.if_type? && !right_siblings_same_inline_method?(node)) ||
-            (inline_style? && access_modifier_is_not_inlined?(node))
+          if group_style?
+            return false if node.parent&.if_type?
+
+            access_modifier_is_inlined?(node) && !right_siblings_same_inline_method?(node)
+          else
+            access_modifier_is_not_inlined?(node) && select_grouped_def_nodes(node).any?
+          end
         end
 
         def correctable_group_offense?(node)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -633,11 +633,13 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class Test
             %{access_modifier}
             ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+            def foo; end
           end
         RUBY
 
         expect_correction(<<~RUBY)
           class Test
+            #{access_modifier} def foo; end
           end
         RUBY
       end
@@ -647,11 +649,13 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class Test
             %{access_modifier} # hey
             ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+            def foo; end
           end
         RUBY
 
         expect_correction(<<~RUBY)
           class Test
+            #{access_modifier} def foo; end
           end
         RUBY
       end
@@ -683,11 +687,7 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           class TestTwo
             #{access_modifier}
             ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
-          end
-
-          class TestThree
-            #{access_modifier}
-            ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+            def foo; end
           end
         RUBY
 
@@ -697,10 +697,14 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
           end
 
           class TestTwo
+            #{access_modifier} def foo; end
           end
+        RUBY
+      end
 
-          class TestThree
-          end
+      it "does not register an offense for #{access_modifier} without method definitions" do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}
         RUBY
       end
 


### PR DESCRIPTION
When there are no definitions two styles behave inconsistenly:

```ruby
$ echo 'private' | bundle exec rubocop --only Style/AccessModifierDeclarations --stdin /bin/false -c <(echo 'Style/AccessModifierDeclarations:\n EnforcedStyle: group')
Inspecting 1 file
.

1 file inspected, no offenses detected
$ echo 'private' | bundle exec rubocop --only Style/AccessModifierDeclarations --stdin /bin/false -c <(echo 'Style/AccessModifierDeclarations:\n EnforcedStyle: inline')
Inspecting 1 file
C

Offenses:

/bin/false:1:1: C: [Correctable] Style/AccessModifierDeclarations: private should be inlined in method definitions.
private
^^^^^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

I think in both cases there should be no offense (let `Lint/UselessAccessModifier` handle it).

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
