### PR TITLE
Fix an error for `Style/StringConcatenation`

### DIFF
--- a/changelog/fix_error_for_style_string_concatenation.md
+++ b/changelog/fix_error_for_style_string_concatenation.md
@@ -1,0 +1,1 @@
+* [#14173](https://github.com/rubocop/rubocop/pull/14173): Fix an error for `Style/StringConcatenation` when using implicit concatenation with string interpolation. ([@koic][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -51,7 +51,6 @@ module RuboCop
       #   Pathname.new('/') + 'test'
       #
       class StringConcatenation < Base
-        include RangeHelp
         extend AutoCorrector
 
         MSG = 'Prefer string interpolation to string concatenation.'
@@ -147,7 +146,7 @@ module RuboCop
             when :str
               adjust_str(part)
             when :dstr
-              part.children.all?(&:str_type?) ? adjust_str(part) : contents_range(part).source
+              part.children.all?(&:str_type?) ? adjust_str(part) : part.value
             else
               "\#{#{part.source}}"
             end

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
         "abcd"
       RUBY
     end
+
+    it 'registers an offense and corrects with string interpolation' do
+      expect_offense(<<~'RUBY')
+        "string #{interpolation}" 'foo' + 'bar'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "string #{interpolation}foobar"
+      RUBY
+    end
   end
 
   context 'multiline' do


### PR DESCRIPTION
This PR fixes the following error for `Style/StringConcatenation` when using implicit concatenation with string interpolation:

```console
$ echo "\"string #{interpolation}\" 'foo' + 'bar'" | bundle exec rubocop --stdin example.rb --only Style/StringConcatenation -A -d
(snip)

An error occurred while Style/StringConcatenation cop was inspecting /Users/koic/src/github.com/rubocop/rubocop/example.rb:1:0.
undefined method 'end_pos' for nil
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/mixin/range_help.rb:34:in 'RuboCop::Cop::RangeHelp#contents_range'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
