### PR TITLE
Expand `Style/DataInheritance` and `Style/StructInheritance` docs

### DIFF
--- a/lib/rubocop/cop/style/data_inheritance.rb
+++ b/lib/rubocop/cop/style/data_inheritance.rb
@@ -4,6 +4,7 @@ module RuboCop
   module Cop
     module Style
       # Checks for inheritance from `Data.define` to avoid creating the anonymous parent class.
+      # Inheriting from `Data.define` adds a superfluous level in inheritance tree.
       #
       # @safety
       #   Autocorrection is unsafe because it will change the inheritance
@@ -17,12 +18,18 @@ module RuboCop
       #     end
       #   end
       #
+      #   Person.ancestors
+      #   # => [Person, #<Class:0x000000010b4e14a0>, Data, (...)]
+      #
       #   # good
       #   Person = Data.define(:first_name, :last_name) do
       #     def age
       #       42
       #     end
       #   end
+      #
+      #   Person.ancestors
+      #   # => [Person, Data, (...)]
       class DataInheritance < Base
         include RangeHelp
         extend AutoCorrector

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -3,7 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for inheritance from Struct.new.
+      # Checks for inheritance from `Struct.new`. Inheriting from `Struct.new`
+      # adds a superfluous level in inheritance tree.
       #
       # @safety
       #   Autocorrection is unsafe because it will change the inheritance
@@ -17,12 +18,18 @@ module RuboCop
       #     end
       #   end
       #
+      #   Person.ancestors
+      #   # => [Person, #<Class:0x000000010b4e14a0>, Struct, (...)]
+      #
       #   # good
       #   Person = Struct.new(:first_name, :last_name) do
       #     def age
       #       42
       #     end
       #   end
+      #
+      #   Person.ancestors
+      #   # => [Person, Struct, (...)]
       class StructInheritance < Base
         include RangeHelp
         extend AutoCorrector


### PR DESCRIPTION
Adds explanation for why these cops are useful. Note that this is already [noted in the style guide](https://rubystyle.guide/#no-extend-struct-new).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
