### PR TITLE
Temporarily disable Windows CI matrix for Ruby 2.7

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -65,7 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.7'  # Oldest supported version
+          # FIXME: When the MSYS2 issue https://github.com/ruby/setup-msys2-gcc/pull/26#issuecomment-2874639475 is resolved,
+          # please uncomment the following oldest supported version.
+          # - '2.7'  # Oldest supported version
           - 'ruby' # Latest stable CRuby version
 
     steps:
@@ -110,7 +112,9 @@ jobs:
       matrix:
         os: [ubuntu, windows]
         ruby:
-          - '2.7'  # Oldest supported version
+          # FIXME: When the MSYS2 issue https://github.com/ruby/setup-msys2-gcc/pull/26#issuecomment-2874639475 is resolved,
+          # please uncomment the following oldest supported version.
+          # - '2.7'  # Oldest supported version
           - 'ruby' # Latest stable CRuby version
 
     steps:


### PR DESCRIPTION
This PR　temporarily disables Windows CI matrix for Ruby 2.7 to prevent the following CI error until the MSYS2 issue https://github.com/ruby/setup-msys2-gcc/pull/26#issuecomment-2874639475 is resolved:

```console
C:/hostedtoolcache/windows/Ruby/2.7.8/x64/lib/ruby/2.7.0/yaml.rb:3: warning: It seems your ruby installation is missing psych (for YAML output).
To eliminate this warning, please install libyaml and reinstall your ruby.
    D:/a/rubocop/rubocop/vendor/bundle/ruby/2.7.0/gems/date-3.4.1/lib/date.rb:4:in `require': 127: The specified procedure could not be found.
    D:/a/rubocop/rubocop/vendor/bundle/ruby/2.7.0/gems/date-3.4.1/lib/date_core.so (LoadError)
    from D:/a/rubocop/rubocop/vendor/bundle/ruby/2.7.0/gems/date-3.4.1/lib/date.rb:4:in `<top (required)>'
    from D:/a/rubocop/rubocop/vendor/bundle/ruby/2.7.0/gems/psych-5.2.5/lib/psych.rb:2:in `require'
    from D:/a/rubocop/rubocop/vendor/bundle/ruby/2.7.0/gems/psych-5.2.5/lib/psych.rb:2:in `<top (required)>'
    from C:/hostedtoolcache/windows/Ruby/2.7.8/x64/lib/ruby/2.7.0/yaml.rb:4:in `require'
    from C:/hostedtoolcache/windows/Ruby/2.7.8/x64/lib/ruby/2.7.0/yaml.rb:4:in `<top (required)>'
    from D:/a/rubocop/rubocop/lib/rubocop/config_loader_resolver.rb:4:in `require'
    from D:/a/rubocop/rubocop/lib/rubocop/config_loader_resolver.rb:4:in `<top (required)>'
    from D:/a/rubocop/rubocop/lib/rubocop.rb:769:in `require_relative'
    from D:/a/rubocop/rubocop/lib/rubocop.rb:769:in `<top (required)>'
    from -e:in `require'
```

https://github.com/rubocop/rubocop/actions/runs/14943230758/job/41983280752

Please refer to the following for context:
https://github.com/ruby/psych/issues/730

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
