### PR TITLE
Fix an error for `Style/MultilineIfModifier`

### DIFF
--- a/changelog/fix_an_error_for_style_multiline_if_modifier_cop.md
+++ b/changelog/fix_an_error_for_style_multiline_if_modifier_cop.md
@@ -1,0 +1,1 @@
+* [#14176](https://github.com/rubocop/rubocop/pull/14176): Fix an error for `Style/MultilineIfModifier` when using nested modifier. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_if_modifier.rb
+++ b/lib/rubocop/cop/style/multiline_if_modifier.rb
@@ -23,11 +23,13 @@ module RuboCop
               'clause in a multiline statement.'
 
         def on_if(node)
+          return if part_of_ignored_node?(node)
           return unless node.modifier_form? && node.body.multiline?
 
           add_offense(node, message: format(MSG, keyword: node.keyword)) do |corrector|
             corrector.replace(node, to_normal_if(node))
           end
+          ignore_node(node)
         end
 
         private

--- a/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
@@ -48,6 +48,23 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfModifier, :config do
         |  end
       RUBY
     end
+
+    it 'registers an offense when nested modifier' do
+      expect_offense(<<~RUBY)
+        [
+        ^ Favor a normal if-statement over a modifier clause in a multiline statement.
+        ] if inner if outer
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if outer
+          if inner
+            [
+            ]
+          end
+        end
+      RUBY
+    end
   end
 
   context 'unless guard clause' do
@@ -95,6 +112,23 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfModifier, :config do
         |      result: run
         |    }
         |  end
+      RUBY
+    end
+
+    it 'registers an offense when nested modifier' do
+      expect_offense(<<~RUBY)
+        [
+        ^ Favor a normal unless-statement over a modifier clause in a multiline statement.
+        ] unless inner unless outer
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless outer
+          unless inner
+            [
+            ]
+          end
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes the following error for `Style/MultilineIfModifier` when using nested modifier:

```console
$ cat example.rb
[
] unless inner unless outer

$ bundle exec rubocop example.rb --only Style/MultilineIfModifier -a -d
For /tmp: An error occurred while Style/MultilineIfModifier cop was inspecting /tmp/example.rb:1:0.
Parser::Source::TreeRewriter detected clobbering
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
