### PR TITLE
[Fix #14177] Fix false positives for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_false_positives_for_style_sole_nested_conditional.md
+++ b/changelog/fix_false_positives_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#14177](https://github.com/rubocop/rubocop/issues/14177): Fix false positives for `Style/SoleNestedConditional` when using nested `if` and `not` in condition. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -185,8 +185,10 @@ module RuboCop
         end
 
         def add_parentheses?(node)
-          node.assignment? || (node.operator_keyword? && !node.and_type?) ||
-            (node.call_type? && node.arguments.any? && !node.parenthesized?)
+          return true if node.assignment? || (node.operator_keyword? && !node.and_type?)
+          return false unless node.call_type?
+
+          (node.arguments.any? && !node.parenthesized?) || node.prefix_not?
         end
 
         def parenthesized_method_arguments(node)

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -473,6 +473,57 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested `if` and `not` in the inner condition' do
+    expect_offense(<<~RUBY)
+      if foo
+        if not bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && (not bar)
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` and `not` in the outer condition' do
+    expect_offense(<<~RUBY)
+      if not foo
+        if bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (not foo) && bar
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` and `!` in the inner condition' do
+    expect_offense(<<~RUBY)
+      if foo
+        if !bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && !bar
+          do_something
+        end
+    RUBY
+  end
+
   context 'when disabling `Style/IfUnlessModifier`' do
     let(:config) { RuboCop::Config.new('Style/IfUnlessModifier' => { 'Enabled' => false }) }
 


### PR DESCRIPTION
This PR fixes false positives for `Style/SoleNestedConditional` when using nested `if` and `not` in condition.

Fixes #14177.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
