### PR TITLE
[Fix #14082] Mark `Style/ComparableBetween` as unsafe

### DIFF
--- a/changelog/change_comparable_between_unsafe.md
+++ b/changelog/change_comparable_between_unsafe.md
@@ -1,0 +1,1 @@
+* [#14082](https://github.com/rubocop/rubocop/issues/14082): Mark `Style/ComparableBetween` as unsafe. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3702,7 +3702,9 @@ Style/CommentedKeyword:
 Style/ComparableBetween:
   Description: 'Enforces the use of `Comparable#between?` instead of logical comparison.'
   Enabled: pending
+  Safe: false
   VersionAdded: '1.74'
+  VersionChanged: '<<next>>'
   StyleGuide: '#ranges-or-between'
 
 Style/ComparableClamp:

--- a/lib/rubocop/cop/style/comparable_between.rb
+++ b/lib/rubocop/cop/style/comparable_between.rb
@@ -9,6 +9,9 @@ module RuboCop
       # although the difference generally isn't observable. If you require maximum
       # performance, consider using logical comparison.
       #
+      # @safety
+      #   This cop is unsafe because the receiver may not respond to `between?`.
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
Fixes #14082
Closes #14087

It relies on the fact that between? is available, which it doesn't have to be (especially for types that implement custom comparision methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
