### PR TITLE
Make `Lint/DuplicateMethods` aware of Active Support's `delegate` method

### DIFF
--- a/changelog/change_make_lint_duplicate_methods_aware_of_active_support_delegate.md
+++ b/changelog/change_make_lint_duplicate_methods_aware_of_active_support_delegate.md
@@ -1,0 +1,1 @@
+* [#14181](https://github.com/rubocop/rubocop/issues/14181): Make `Lint/DuplicateMethods` aware of Active Support's `delegate` method. ([@lovro-bikic][])


### PR DESCRIPTION
This PR adds support for Active Support's method [`delegate`](https://api.rubyonrails.org/classes/Module.html#method-i-delegate) to `Lint/DuplicateMethods`. Previously, code such as:
```ruby
class A
 def foo; end

  delegate :foo, to: :bar
end
```
wouldn't register as offense in a project with Active Support extensions.

After this PR, an offense is registered. When `ActiveSupportExtensionsEnabled` is `false`, an offense is not registered.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
