### PR TITLE
Recognize `prefix` argument for `delegate` method in `Lint/DuplicateMethods`

### DIFF
--- a/changelog/change_lint_duplicate_methods_delegate_prefix.md
+++ b/changelog/change_lint_duplicate_methods_delegate_prefix.md
@@ -1,0 +1,1 @@
+* [#14183](https://github.com/rubocop/rubocop/pull/14183): Recognize `prefix` argument for `delegate` method in `Lint/DuplicateMethods`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
       end
 
-      it "registers an offense for duplicate delegate in #{type}" do
+      it "registers an offense for duplicate delegate with symbol method in #{type}" do
         expect_offense(<<~RUBY, 'example.rb')
           #{opening_line}
             def some_method
@@ -493,6 +493,66 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
             end
             delegate :some_method, to: :foo
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "registers an offense for duplicate delegate with string method in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate 'some_method', to: :foo
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "registers an offense for duplicate delegate with string `to` argument in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :some_method, to: 'foo'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "registers an offense for duplicate delegate with symbol prefix in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :method, to: :foo, prefix: :some
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "registers an offense for duplicate delegate with string prefix in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :method, to: :foo, prefix: 'some'
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "registers an offense for duplicate delegate with prefix true in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :method, to: :some, prefix: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
           end
         RUBY
       end
@@ -505,6 +565,17 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
             end
             delegate :other_method, :some_method, to: :foo
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "does not register an offense for non-duplicate delegate with prefix false in #{type}" do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :method, prefix: false, to: :some
           end
         RUBY
       end
@@ -530,6 +601,42 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
             if cond
               delegate :some_method, to: :foo
             end
+          end
+        RUBY
+      end
+
+      it "does not register an offense for duplicate delegate with splat keyword arguments in #{type}" do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+
+            delegate :some_method, **options
+          end
+        RUBY
+      end
+
+      it "does not register an offense for duplicate delegate without keyword arguments in #{type}" do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+
+            delegate :some_method
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for duplicate delegate without `to` argument' do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+
+            delegate :some_method, prefix: true
           end
         RUBY
       end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14181#issuecomment-2882948451, cc @Earlopain.

Makes `Lint/DuplicateMethods` recognize `prefix` keyword argument for duplicate method created via `delegate`.

Additionally, makes a couple other adjustments (this should have been done in https://github.com/rubocop/rubocop/pull/14181 but it got merged a bit too soon):
- `delegate` method names can be strings or symbols (previously they could be only symbols)
- `to` is now a required keyword argument
- an offense won't be registered when `**kwargs` is used as `delegate` options

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
