### PR TITLE
Fix an error for `Style/IfUnlessModifierOfIfUnless`

### DIFF
--- a/changelog/fix_an_error_for_style_if_unless_modifier_of_if_unless.md
+++ b/changelog/fix_an_error_for_style_if_unless_modifier_of_if_unless.md
@@ -1,0 +1,1 @@
+* [#14185](https://github.com/rubocop/rubocop/pull/14185): Fix an error for `Style/IfUnlessModifierOfIfUnless` when using nested modifier. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -28,19 +28,16 @@ module RuboCop
 
         MSG = 'Avoid modifier `%<keyword>s` after another conditional.'
 
+        # rubocop:disable Metrics/AbcSize
         def on_if(node)
           return unless node.modifier_form? && node.body.if_type?
 
           add_offense(node.loc.keyword, message: format(MSG, keyword: node.keyword)) do |corrector|
-            keyword = node.if? ? 'if' : 'unless'
-
-            corrector.replace(node, <<~RUBY.chop)
-              #{keyword} #{node.condition.source}
-              #{node.if_branch.source}
-              end
-            RUBY
+            corrector.wrap(node.if_branch, "#{node.keyword} #{node.condition.source}\n", "\nend")
+            corrector.remove(node.if_branch.source_range.end.join(node.condition.source_range.end))
           end
         end
+        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless, :config do
     end
   end
 
+  context 'using nested mofifier' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        condition ? then_part : else_part if inner_condition if outer_condition
+                                                             ^^ Avoid modifier `if` after another conditional.
+                                          ^^ Avoid modifier `if` after another conditional.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if outer_condition
+        if inner_condition
+        condition ? then_part : else_part
+        end
+        end
+      RUBY
+    end
+  end
+
   context 'conditional with modifier' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following error for `Style/IfUnlessModifierOfIfUnless` when using nested modifier:

```console
$ echo "x ? y : z if inner_cond if outer_cond" | bundle exec rubocop --stdin example.rb --only Style/IfUnlessModifierOfIfUnless -A -d
(snip)

An error occurred while Style/IfUnlessModifierOfIfUnless cop was inspecting /Users/koic/src/github.com/rubocop/rubocop/example.rb:1:0.
Parser::Source::TreeRewriter detected clobbering
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
