### PR TITLE
Enhance `Gemspec/DuplicatedAssignment` cop to detect duplicated indexed assignment

### DIFF
--- a/changelog/change_gemspec_duplicated_assignment_cop_to_detect_duplicated_indexed_assignments_20250516224426.md
+++ b/changelog/change_gemspec_duplicated_assignment_cop_to_detect_duplicated_indexed_assignments_20250516224426.md
@@ -1,0 +1,1 @@
+* [#14188](https://github.com/rubocop/rubocop/pull/14188): Enhance `Gemspec/DuplicatedAssignment` cop to detect duplicated indexed assignment. ([@viralpraxis][])


### PR DESCRIPTION
This patch aims to detect gemspecs like this one:

```ruby
...
spec.metadata["foo"] = "bar"
...
spec.metadata["foo"] = "baz" # offense
```

Mixed indexed and normal assignments are fine:

```ruby
spec.metadata = { ?? }
spec.metadata["foo"] = "bar"
```

but we can enhance this cop to detect duplicated keys when using both types of assignment:

```ruby
spec.metadata = { "foo" => "bar" }
spec.metadata["foo"] = "bar" # should be an offense
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
