### PR TITLE
[Fix #14189] Fix incorrect autocorrect for `Layout/SpaceBeforeBrackets`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_layout_space_before_brackets.md
+++ b/changelog/fix_incorrect_autocorrect_for_layout_space_before_brackets.md
@@ -1,0 +1,1 @@
+* [#14189](https://github.com/rubocop/rubocop/issues/14189): Fix incorrect autocorrect for `Layout/SpaceBeforeBrackets` when using space between receiver and left brackets, and a space inside left bracket. ([@koic][])

--- a/lib/rubocop/cop/layout/space_before_brackets.rb
+++ b/lib/rubocop/cop/layout/space_before_brackets.rb
@@ -22,46 +22,25 @@ module RuboCop
         RESTRICT_ON_SEND = %i[[] []=].freeze
 
         def on_send(node)
-          return unless (first_argument = node.first_argument)
-
-          begin_pos = first_argument.source_range.begin_pos
-          return unless (range = offense_range(node, begin_pos))
-
-          register_offense(range)
-        end
-
-        private
-
-        def offense_range(node, begin_pos)
           receiver_end_pos = node.receiver.source_range.end_pos
           selector_begin_pos = node.loc.selector.begin_pos
           return if receiver_end_pos >= selector_begin_pos
           return if dot_before_brackets?(node, receiver_end_pos, selector_begin_pos)
+          return if !reference_variable_with_brackets?(node) && !node.method?(:[]=)
 
-          if reference_variable_with_brackets?(node)
-            range_between(receiver_end_pos, selector_begin_pos)
-          elsif node.method?(:[]=)
-            offense_range_for_assignment(node, begin_pos)
+          range = range_between(receiver_end_pos, selector_begin_pos)
+
+          add_offense(range) do |corrector|
+            corrector.remove(range)
           end
         end
+
+        private
 
         def dot_before_brackets?(node, receiver_end_pos, selector_begin_pos)
           return false unless node.loc.respond_to?(:dot) && (dot = node.loc.dot)
 
           dot.begin_pos == receiver_end_pos && dot.end_pos == selector_begin_pos
-        end
-
-        def offense_range_for_assignment(node, begin_pos)
-          end_pos = node.receiver.source_range.end_pos
-
-          return if begin_pos - end_pos == 1 ||
-                    (range = range_between(end_pos, begin_pos - 1)).source.start_with?('[')
-
-          range
-        end
-
-        def register_offense(range)
-          add_offense(range) { |corrector| corrector.remove(range) }
         end
 
         def reference_variable_with_brackets?(node)

--- a/spec/rubocop/cop/layout/space_before_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_brackets_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeBrackets, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using space between receiver and left brackets, and a space inside left bracket' do
+      expect_offense(<<~RUBY)
+        @correction [ index_or_key] = :value
+                   ^ Remove the space before the opening brackets.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        @correction[ index_or_key] = :value
+      RUBY
+    end
+
     it 'does not register an offense when not using space between receiver and left brackets' do
       expect_no_offenses(<<~RUBY)
         @correction[index_or_key] = :value


### PR DESCRIPTION
This PR incorrect autocorrect for `Layout/SpaceBeforeBrackets` when using space between receiver and left brackets, and a space inside left bracket.

Fixes #14189.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
