### PR TITLE
[Fix #14193] Fix `Lint/UselessAssignment` cop error when using nested assignment with splat

### DIFF
--- a/changelog/fix_useless_assign_splat_mlhs.md
+++ b/changelog/fix_useless_assign_splat_mlhs.md
@@ -1,1 +1,1 @@
-* [#14193](https://github.com/rubocop/rubocop/pull/14193): Fix `Lint/UselessAssignment` cop error when using nested assignment with splat. ([@earlopain][])
+* [#14193](https://github.com/rubocop/rubocop/issues/14193): Fix `Lint/UselessAssignment` cop error when using nested assignment with splat. ([@earlopain][])

--- a/changelog/fix_useless_assign_splat_mlhs.md
+++ b/changelog/fix_useless_assign_splat_mlhs.md
@@ -1,0 +1,1 @@
+* [#14193](https://github.com/rubocop/rubocop/pull/14193): Fix `Lint/UselessAssignment` cop error when using nested assignment with splat. ([@earlopain][])

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -110,8 +110,13 @@ module RuboCop
         end
 
         def multiple_assignment_node
-          return nil unless node.parent&.mlhs_type?
-          return nil unless (grandparent_node = node.parent&.parent)
+          return nil unless (candidate_mlhs_node = node.parent)
+
+          # In `(foo, bar), *baz`, the splat node must be traversed as well.
+          candidate_mlhs_node = candidate_mlhs_node.parent if candidate_mlhs_node.splat_type?
+
+          return nil unless candidate_mlhs_node.mlhs_type?
+          return nil unless (grandparent_node = node.parent.parent)
           if (node = find_multiple_assignment_node(grandparent_node))
             return node
           end
@@ -139,7 +144,6 @@ module RuboCop
 
         def find_multiple_assignment_node(grandparent_node)
           return unless grandparent_node.type == MULTIPLE_LEFT_HAND_SIDE_TYPE
-          return if grandparent_node.children.any?(&:splat_type?)
 
           parent = grandparent_node.parent
           return parent if parent.type == MULTIPLE_ASSIGNMENT_TYPE

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1440,12 +1440,48 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when part of a multiple assignment is enclosed in parentheses with splat' do
+    it 'registers an offense when the variable is not used' do
+      expect_offense(<<~RUBY)
+        def some_method
+          (foo, bar), *baz = do_something
+                       ^^^ Useless assignment to variable - `baz`. Use `_` or `_baz` as a variable name to indicate that it won't be used.
+          puts foo, bar
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          (foo, bar), *_ = do_something
+          puts foo, bar
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the variable is not used in nested assignment' do
+      expect_offense(<<~RUBY)
+        def some_method
+          foo, (*bar, baz) = do_something
+                 ^^^ Useless assignment to variable - `bar`. Use `_` or `_bar` as a variable name to indicate that it won't be used.
+          puts foo, baz
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo, (*_, baz) = do_something
+          puts foo, baz
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned with rest assignment and unreferenced' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         def some_method
           foo, *bar = do_something
-                ^^^ Useless assignment to variable - `bar`.
+                ^^^ Useless assignment to variable - `bar`. Use `_` or `_bar` as a variable name to indicate that it won't be used.
           puts foo
         end
       RUBY

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe RuboCop::Cop::VariableForce::Assignment do
         RUBY
       end
 
-      it 'returns splat node' do
-        expect(assignment.meta_assignment_node.type).to eq(:splat)
+      it 'returns masgn node' do
+        expect(assignment.meta_assignment_node.type).to eq(:masgn)
       end
     end
 


### PR DESCRIPTION
Fix #14193

The ast for `(left, right), *rest = foo` looks like this:
```
(masgn
  (mlhs
    (mlhs
      (lvasgn :left)
      (lvasgn :right))
    (splat
      (lvasgn :rest)))
  (send nil :foo))
```

Because of the splat node, it must reach up one furhter to land at the conclusion that this is indeed multiple assignment. Otherwise, it gets treated as normal assignment, where the type of autocorrect is not appropriate.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
