### PR TITLE
Consistently highlight `Metric` cops method name in offense messages

### DIFF
--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -39,7 +39,7 @@ module RuboCop
       class AbcSize < Base
         include MethodComplexity
 
-        MSG = 'Assignment Branch Condition size for %<method>s is too high. ' \
+        MSG = 'Assignment Branch Condition size for `%<method>s` is too high. ' \
               '[%<abc_vector>s %<complexity>.4g/%<max>.4g]'
 
         private

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'registers an offense for an if modifier' do
       expect_offense(<<~RUBY)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<0, 2, 1> 2.24/0]
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<0, 2, 1> 2.24/0]
           call_foo if some_condition # 0 + 2*2 + 1*1
         end
       RUBY
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'registers an offense for an assignment of a local variable' do
       offenses = expect_offense(<<~RUBY)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 0, 0> 1/0]
           x = 1
         end
       RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'registers an offense for an assignment of an element' do
       expect_offense(<<~RUBY)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 2, 0> 2.24/0]
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 2, 0> 2.24/0]
           x[0] = 1
         end
       RUBY
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'registers an offense for complex content including A, B, and C scores' do
       expect_offense(<<~RUBY)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<3, 4, 5> 7.07/0]
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<3, 4, 5> 7.07/0]
           my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 1, 4
           my_options.each do |key, value|           # 2, 1, 1
             p key                                   # 0, 1, 0
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'registers an offense for a `define_method`' do
       expect_offense(<<~RUBY)
         define_method :method_name do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 0, 0> 1/0]
           x = 1
         end
       RUBY
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'registers an offense for a `define_method` with numblock' do
         expect_offense(<<~RUBY)
           define_method :method_name do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 0, 0> 1/0]
             x = _1
           end
         RUBY
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'registers an offense for a `define_method` with itblock' do
         expect_offense(<<~RUBY)
           define_method :method_name do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 0, 0> 1/0]
             x = it
           end
         RUBY
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
     it 'treats safe navigation method calls like regular method calls + a condition' do
       expect_offense(<<~RUBY)
         def method_name
-        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<0, 2, 1> 2.24/0]
+        ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<0, 2, 1> 2.24/0]
           object&.do_something
         end
       RUBY
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'registers an offense for an assignment of a local variable' do
         offenses = expect_offense(<<~RUBY)
           def method_name
-          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [<1, 0, 0> 1/0]
+          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [<1, 0, 0> 1/0]
             x = 1
           end
         RUBY
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'does not count repeated attributes' do
         expect_offense(<<~RUBY)
           def foo
-          ^^^^^^^ Assignment Branch Condition size for foo is too high. [<0, 1, 0> 1/0]
+          ^^^^^^^ Assignment Branch Condition size for `foo` is too high. [<0, 1, 0> 1/0]
             bar
             self.bar
             bar
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'counts repeated attributes' do
         expect_offense(<<~RUBY)
           def foo
-          ^^^^^^^ Assignment Branch Condition size for foo is too high. [<0, 3, 0> 3/0]
+          ^^^^^^^ Assignment Branch Condition size for `foo` is too high. [<0, 3, 0> 3/0]
             bar
             self.bar
             bar
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::Cop::Metrics::AbcSize, :config do
 
         expect_offense(<<~RUBY)
           def method_name
-          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [#{presentation}]
+          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for `method_name` is too high. [#{presentation}]
             #{code.join("\n  ")}
           end
         RUBY


### PR DESCRIPTION
Before this patch `Metric` department cops highlighted method name inconsistently. To be precise, the only cop without highlight is `AbcSize`.

![Screenshot from 2025-05-21 13-19-24](https://github.com/user-attachments/assets/6fd2f0f2-688e-4c9e-bae3-286a5d6e35e4)

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
