### PR TITLE
Fix wrong autocorrection for `Style/MapToHash` with destructuring argument

### DIFF
--- a/changelog/fix_map_to_hash_wrong_autocorrection.md
+++ b/changelog/fix_map_to_hash_wrong_autocorrection.md
@@ -1,0 +1,1 @@
+* [#14199](https://github.com/rubocop/rubocop/pull/14199): Fix wrong autocorrection for `Style/MapToHash` with destructuring argument. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -45,6 +45,11 @@ module RuboCop
           }
         PATTERN
 
+        # @!method destructuring_argument(node)
+        def_node_matcher :destructuring_argument, <<~PATTERN
+          (args $(mlhs (arg _)+))
+        PATTERN
+
         def self.autocorrect_incompatible_with
           [Layout::SingleLineBlockChain]
         end
@@ -73,6 +78,12 @@ module RuboCop
             corrector.replace(map_dot, to_h.loc.dot.source)
           end
           corrector.replace(map.loc.selector, 'to_h')
+
+          return unless map.parent.block_type?
+
+          if (argument = destructuring_argument(map.parent.arguments))
+            corrector.replace(argument, argument.source[1..-2])
+          end
         end
         # rubocop:enable Metrics/AbcSize
       end

--- a/spec/rubocop/cop/style/map_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/map_to_hash_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe RuboCop::Cop::Style::MapToHash, :config do
         end
       end
 
+      context "for `#{method}.to_h` with block arity 1 and destructuring argument" do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            foo.#{method} { |(k, v)| [k, v * 2] }.to_h
+                ^{method} Pass a block to `to_h` instead of calling `#{method}.to_h`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.to_h { |k, v| [k, v * 2] }
+          RUBY
+        end
+      end
+
       context "for `#{method}.to_h` with block arity 2" do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
Currently, code such as:
```ruby
{ foo: 1 }.map { |(k, v)| [k, v * 2] }.to_h
# => {foo: 2}
```
gets autocorrected by `Style/MapToHash` to:
```ruby
{ foo: 1 }.to_h { |(k, v)| [k, v * 2] }
# undefined method '*' for nil (NoMethodError)
```

`Hash#map` block argument is a single array `[key, value]`, while `Hash#to_h` block args are separate `key` and `value`, so `#map` block can work with either `|(k, v)|` or `|k, v|` arguments, while `#to_h` only works with `|k, v|`.

This PR fixes autocorrection of the above example by removing destructuring parentheses:
```ruby
{ foo: 1 }.to_h { |k, v| [k, v * 2] }
# => {foo: 2}
```

I'm not 100% sure about this patch, it might introduce unexpected behavior I'm not aware of at the moment. An alternative solution is to not autocorrect such cases.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
