### PR TITLE
Fix false positives for `Style/DefWithParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_def_with_parentheses.md
+++ b/changelog/fix_false_positives_for_style_def_with_parentheses.md
@@ -1,0 +1,1 @@
+* [#14200](https://github.com/rubocop/rubocop/pull/14200): Fix false positives for `Style/DefWithParentheses` when using endless method definition with empty parentheses and a space before `=`. ([@koic][])

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses, :config do
         def foo = do_something
       RUBY
     end
+
+    it 'reports an offense for endless method definition with empty parens followed by a space before `=`' do
+      expect_offense(<<~RUBY)
+        def foo() =do_something
+               ^^ Omit the parentheses in defs when the method doesn't accept any arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo =do_something
+      RUBY
+    end
+
+    it 'does not register an offense for endless method definition with empty parens followed by no space before `=`' do
+      expect_no_offenses(<<~RUBY)
+        def foo()= do_something
+      RUBY
+    end
+
+    it 'does not register an offense for endless method definition with empty parens followed by no spaces around `=`' do
+      expect_no_offenses(<<~RUBY)
+        def foo()=do_something
+      RUBY
+    end
   end
 
   it 'accepts def with arg and parens' do


### PR DESCRIPTION
This PR fixes false positives for `Style/DefWithParentheses` when using endless method definition with empty parentheses and a space before `=`.

It prevents the following syntax error:

```console
$ echo 'def x()=y' | RUBOCOP_TARGET_RUBY_VERSION=3.0 bundle exec rubocop --stdin example.rb -a --only Style/DefWithParentheses
Inspecting 1 file
F

Offenses:

example.rb:1:6: C: [Corrected] Style/DefWithParentheses: Omit the parentheses in defs when the method doesn't accept any arguments.
def x()=y
     ^^
example.rb:2:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 3.0 parser; configure using TargetRubyVersion parameter, under AllCops)

1 file inspected, 2 offenses detected, 1 offense corrected
====================
def x=y
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
