### PR TITLE
[Fix #14050] In the case of disable-uncorrectable,  `Lint/UselessConstantScoping` doesn't make unintended corrections

### DIFF
--- a/changelog/fix_lint_useless_constant_scoping_cop_not_to_make_unintended_corrections_in_the_case_of_disable_uncorrectable_20250524000105.md
+++ b/changelog/fix_lint_useless_constant_scoping_cop_not_to_make_unintended_corrections_in_the_case_of_disable_uncorrectable_20250524000105.md
@@ -1,0 +1,1 @@
+* [#14049](https://github.com/rubocop/rubocop/issues/14050): Fix `Lint/UselessConstantScoping` cop not to make unintended corrections in the case of disable-uncorrectable. ([@steiley][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'debug'
 module RuboCop
   module Cop
     module Lint
@@ -41,6 +42,9 @@ module RuboCop
           return unless after_private_modifier?(node.left_siblings)
           return if private_constantize?(node.right_siblings, node.name)
 
+          # For handling cases where declarations are on multiple lines
+          set_last_location(node)
+
           add_offense(node)
         end
 
@@ -64,6 +68,13 @@ module RuboCop
           end
 
           private_constant_values.include?(const_value)
+        end
+
+        def set_last_location(node)
+          last_line = node.loc.expression.last_line
+          last_range = node.loc.expression.source_buffer.line_range(last_line)
+          last_location = Parser::Source::Map::Constant.new(nil, node.loc.name, last_range)
+          node.instance_variable_set(:@location, last_location)
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
-  it 'registers an offense when using constant after `private` access modifier' do
-    expect_offense(<<~RUBY)
-      class Foo
-        private
-        CONST = 42
-        ^^^^^^^^^^ Useless `private` access modifier for constant scope.
-      end
-    RUBY
+  context 'When the constant is declared on a single line' do
+    it 'registers an offense when using constant after `private` access modifier' do
+      expect_offense(<<~RUBY)
+        class Foo
+          private
+          CONST = 42
+          ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+        end
+      RUBY
+    end
+  end
+
+  context 'When the constant is declared on multiple lines' do
+    it 'registers an offense when using constant after `private` access modifier' do
+      expect_offense(<<~RUBY)
+        class Foo
+          private
+          CONST = [42,
+                   43].freeze
+                   ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+        end
+      RUBY
+    end
   end
 
   it 'registers an offense when using constant not defined in `private_constant`' do


### PR DESCRIPTION
Fix for https://github.com/rubocop/rubocop/issues/14050

When constant declarations are on multiple lines, unintended corrections of `Lint/UselessConstantScoping` occur in the disable-uncorrectable case.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
