### PR TITLE
Enable Windows CI matrix for Ruby 2.7

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -65,9 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          # FIXME: When the MSYS2 issue https://github.com/ruby/setup-msys2-gcc/pull/26#issuecomment-2874639475 is resolved,
-          # please uncomment the following oldest supported version.
-          # - '2.7'  # Oldest supported version
+          - '2.7'  # Oldest supported version
           - 'ruby' # Latest stable CRuby version
 
     steps:
@@ -112,9 +110,7 @@ jobs:
       matrix:
         os: [ubuntu, windows]
         ruby:
-          # FIXME: When the MSYS2 issue https://github.com/ruby/setup-msys2-gcc/pull/26#issuecomment-2874639475 is resolved,
-          # please uncomment the following oldest supported version.
-          # - '2.7'  # Oldest supported version
+          - '2.7'  # Oldest supported version
           - 'ruby' # Latest stable CRuby version
 
     steps:


### PR DESCRIPTION
This PR enables Windows CI matrix for Ruby 2.7.

Reverts #14175.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
