### PR TITLE
Fix `codespell` rake task if not found in PATH

### DIFF
--- a/tasks/codespell.rake
+++ b/tasks/codespell.rake
@@ -5,7 +5,7 @@ task :codespell do |_task|
   next if Gem.win_platform?
   next if ENV['CI'] # CI has its own workflow for this
 
-  sh 'which codespell &> /dev/null', verbose: false do |ok, _res|
+  sh 'which codespell', verbose: false, out: File::NULL, err: File::NULL do |ok, _res|
     if ok
       sh 'git ls-files --empty-directory | xargs codespell'
     else


### PR DESCRIPTION
Without this patch, running `bundle exec rake default` or `bundle exec rake codespell` without installed `codespell` (or if is not in `$PATH`) leads to an error:

```bash
bundle exec rake
git ls-files --empty-directory | xargs codespell
xargs: codespell: No such file or directory
rake aborted!
Command failed with status (127): [git ls-files --empty-directory | xargs codespell]
tasks/codespell.rake:10:in 'block (2 levels) in <top (required)>'
tasks/codespell.rake:8:in 'block in <top (required)>'
/home/viralpraxis/.asdf/installs/ruby/3.4.4/bin/bundle:25:in 'Kernel#load'
/home/viralpraxis/.asdf/installs/ruby/3.4.4/bin/bundle:25:in '<main>'
Tasks: TOP => default => codespell
(See full trace by running task with --trace)
```

It seems like it should just print the error message and continue:

https://github.com/rubocop/rubocop/blob/26a90a2157465f53f166d0119d72cc41fc147ae3/tasks/codespell.rake#L11-L12

My machine's `/bin/sh` shell is dash:

```bash
➜ /bin/sh -c 'which codespell &> /dev/null'; echo $?
0
➜ /bin/sh -c 'which codespell'; echo $?
1
```

It works if we use `which codespell` and redirect the output streams using the `out` and `err` arguments.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
