### PR TITLE
Fix `Layout/EmptyLinesAroundAccessModifier` cop error on trailing access modifier

### DIFF
--- a/changelog/fix_layout_empty_lines_around_access_modifier_cop_error_on_trailling_modifier_20250525193657.md
+++ b/changelog/fix_layout_empty_lines_around_access_modifier_cop_error_on_trailling_modifier_20250525193657.md
@@ -1,0 +1,1 @@
+* [#14204](https://github.com/rubocop/rubocop/pull/14204): Fix `Layout/EmptyLinesAroundAccessModifier` cop error on trailing access modifier. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -116,7 +116,7 @@ module RuboCop
         def allowed_only_before_style?(node)
           if node.special_modifier?
             return true if processed_source[node.last_line] == 'end'
-            return false if next_line_empty?(node.last_line)
+            return false if next_line_empty_and_exists?(node.last_line)
           end
 
           previous_line_empty?(node.first_line)
@@ -129,7 +129,7 @@ module RuboCop
           when :around
             corrector.insert_after(line, "\n") unless next_line_empty?(node.last_line)
           when :only_before
-            if next_line_empty?(node.last_line)
+            if next_line_empty_and_exists?(node.last_line)
               range = next_empty_line_range(node)
 
               corrector.remove(range)
@@ -152,6 +152,10 @@ module RuboCop
           next_line = processed_source[last_send_line]
 
           body_end?(last_send_line) || next_line.blank?
+        end
+
+        def next_line_empty_and_exists?(last_send_line)
+          next_line_empty?(last_send_line) && last_send_line.next != processed_source.lines.size
         end
 
         def empty_lines_around?(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -566,6 +566,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when modifier is on the last line' do
+        expect_no_offenses(<<~RUBY)
+          #{access_modifier}
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
```bash
echo '1; private' | bundle exec rubocop --stdin bug.rb -c <(echo 'Layout/EmptyLinesAroundAccessModifier:\n EnforcedStyle: only_before') --only Layout/EmptyLinesAroundAccessModifier -d
configuration from /proc/self/fd/18
Default configuration from config/default.yml
Inspecting 1 file
Scanning //bug.rb
An error occurred while Layout/EmptyLinesAroundAccessModifier cop was inspecting //bug.rb:1:3.
The range 11...12 is outside the bounds of the source
/home/viralpraxis/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/parser-3.3.8.0/lib/parser/source/tree_rewriter.rb:406:in 'Parser::Source::TreeRewriter#check_range_validity'
//lib/rubocop/cop/corrector.rb:120:in 'RuboCop::Cop::Corrector#check_range_validity'
/home/viralpraxis/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/parser-3.3.8.0/lib/parser/source/tree_rewriter.rb:398:in 'Parser::Source::TreeRewriter#combine'
/home/viralpraxis/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/parser-3.3.8.0/lib/parser/source/tree_rewriter.rb:194:in 'Parser::Source::TreeRewriter#replace'
/home/viralpraxis/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/parser-3.3.8.0/lib/parser/source/tree_rewriter.rb:218:in 'Parser::Source::TreeRewriter#remove'
//lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb:135:in 'RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#correct_next_line_if_denied_style'
//lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb:99:in 'block in RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier#on_send'
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
