### PR TITLE
[Fix #14050] Modify condition for EOL comment

### DIFF
--- a/changelog/fix_modify_condition_for_eol_comment_20250511123603.md
+++ b/changelog/fix_modify_condition_for_eol_comment_20250511123603.md
@@ -1,0 +1,1 @@
+* [#14050](https://github.com/rubocop/rubocop/issues/14050): Modify condition for `rubocop:todo` EOL comment. ([@jonas054][])

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -99,6 +99,51 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         RUBY
       end
 
+      context 'and the offending line has a multiline %w literal' do
+        it 'adds comment at EOL or before and after depending on where it fits' do
+          create_file('.rubocop.yml', <<~YAML)
+            Lint/UselessConstantScoping:
+              Enabled: true
+            Style/IpAddresses:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            class Foo # :nodoc:
+              private
+
+              ALLOWED_VALUES = %w[ value1
+                                   value2 ].freeze + [ip('1.2.3.4')]
+
+              def lolol; end
+            end
+          RUBY
+          expect(exit_code).to eq(0)
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            W:  6:  3: [Todo] Lint/UselessConstantScoping: Useless private access modifier for constant scope.
+            C:  7: 46: [Todo] Style/IpAddresses: Do not hardcode IP addresses.
+
+            1 file inspected, 2 offenses detected, 2 offenses corrected
+          OUTPUT
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            class Foo # :nodoc:
+              private
+
+              # rubocop:todo Lint/UselessConstantScoping
+              ALLOWED_VALUES = %w[ value1
+                                   value2 ].freeze + [ip('1.2.3.4')] # rubocop:todo Style/IpAddresses
+              # rubocop:enable Lint/UselessConstantScoping
+
+              def lolol; end
+            end
+          RUBY
+        end
+      end
+
       context 'and there are two offenses of the same kind on one line' do
         it 'adds a single one-line disable statement' do
           create_file('.rubocop.yml', <<~YAML)
@@ -276,6 +321,15 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             ARRAY = %i[AAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBB].freeze
           RUBY
           expect(exit_code).to eq(0)
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            C:  3: 31: [Corrected] Layout/LineLength: Line is too long. [60/30]
+            C:  4:  1: [Corrected] Layout/FirstArrayElementIndentation: Use 2 spaces for indentation in an array, relative to the start of the line where the left square bracket is.
+            C:  4: 31: [Todo] Layout/LineLength: Line is too long. [49/30]
+            C:  4: 42: [Corrected] Layout/MultilineArrayBraceLayout: The closing array brace must be on the line after the last array element when the opening brace is on a separate line from the first array element.
+
+            1 file inspected, 4 offenses detected, 4 offenses corrected
+          OUTPUT
           expect(File.read('example.rb')).to eq(<<~RUBY)
             # frozen_string_literal: true
 


### PR DESCRIPTION
When running with `--disable-uncorrectable`, comments are automatically added to disable some offenses. If possible, RuboCop uses end-of-line comments, and otherwise surrounds the offense with comments before and after. One instance in which an EOL comment can't be used is when it would end up inside a multiline literal, e.g., a `%w` array literal.

The condition we used for this case was incorrect. It checked overlap between the offense range and the literal range, when in fact we should be checking if the reported line for the offense falls within the line span of the literal.

We also need to check at an earlier stage than we did, whether the source line with the added EOL comment would exceed the maximum line length. This is to not try and add an EOL comment when it's not possible, and falling back on before/after comments, which becomes too complicated when there are multiline literals to deal with.