### PR TITLE
Show better message on error with `--debug`

### DIFF
--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -279,7 +279,7 @@ module RuboCop
         @errors << message
         warn message
         if debug?
-          puts error.message, error.backtrace
+          puts error.full_message
         else
           warn 'To see the complete backtrace run rubocop -d.'
         end


### PR DESCRIPTION
It includes the exception class and error highlight.

Before:
```
An error occurred while Style/RedundantFormat cop was inspecting /home/user/code/rubocop/test.rb:1:5.
one hash required
/home/user/code/rubocop/lib/rubocop/cop/style/redundant_format.rb:124:in 'Kernel#format'
/home/user/code/rubocop/lib/rubocop/cop/style/redundant_format.rb:124:in 'RuboCop::Cop::Style::RedundantFormat#register_all_fields_literal'
...
```

After:
```
An error occurred while Style/RedundantFormat cop was inspecting /home/user/code/rubocop/test.rb:1:5.
/home/user/code/rubocop/lib/rubocop/cop/style/redundant_format.rb:124:in 'Kernel#format': one hash required (ArgumentError)

          formatted_string = format(string, *argument_values(arguments))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /home/user/code/rubocop/lib/rubocop/cop/style/redundant_format.rb:124:in 'RuboCop::Cop::Style::RedundantFormat#register_all_fields_literal'
...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
