### PR TITLE
Fix an error for `Style/RedundantFormat` with invalid format arguments

### DIFF
--- a/changelog/fix_error_redundant_format.md
+++ b/changelog/fix_error_redundant_format.md
@@ -1,0 +1,1 @@
+* [#14209](https://github.com/rubocop/rubocop/pull/14209): Fix an error for `Style/RedundantFormat` with invalid format arguments. ([@earlopain][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -121,7 +121,12 @@ module RuboCop
         def register_all_fields_literal(node, string, arguments)
           return unless all_fields_literal?(string, arguments.dup)
 
-          formatted_string = format(string, *argument_values(arguments))
+          format_arguments = argument_values(arguments)
+          begin
+            formatted_string = format(string, *format_arguments)
+          rescue ArgumentError
+            return
+          end
           replacement = quote(formatted_string, node)
 
           add_offense(node, message: message(node, replacement)) do |corrector|

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -368,6 +368,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             RUBY
           end
         end
+
+        context 'with invalid format arguments' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              format('%{y}-%{m}-%{d}', 2015, 1, 1)
+            RUBY
+          end
+        end
       end
 
       context 'with constants' do


### PR DESCRIPTION
This is code that is catched by `Lint/FormatParameterMismatch`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
