### PR TITLE
[Fix #14197] Fix infinite loop error for `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_infinite_loop_error_for_layout_first_argument_indentation.md
+++ b/changelog/fix_infinite_loop_error_for_layout_first_argument_indentation.md
@@ -1,0 +1,1 @@
+* [#14197](https://github.com/rubocop/rubocop/issues/14197): Fix infinite loop error for `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and `EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation` and `Layout/HashAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -155,7 +155,7 @@ module RuboCop
         def on_send(node)
           return unless should_check?(node)
           return if same_line?(node, node.first_argument)
-          return if style != :consistent && enforce_first_argument_with_fixed_indentation? &&
+          return if enforce_first_argument_with_fixed_indentation? &&
                     !enable_layout_first_method_argument_line_break?
 
           indent = base_indentation(node) + configured_indentation_width

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2502,6 +2502,46 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
+     '`EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation` and ' \
+     '`Layout/HashAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      do_something(
+         **params,
+        key:,
+        other_key: value,
+      )
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.1
+
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+      Layout/FirstArgumentIndentation:
+        EnforcedStyle: consistent
+    YAML
+
+    expect(
+      cli.run(
+        [
+          '--autocorrect',
+          '--only',
+          'Layout/ArgumentAlignment,Layout/FirstArgumentIndentation,Layout/HashAlignment'
+        ]
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      do_something(
+        **params,
+        key:,
+        other_key: value,
+      )
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArrayAlignment` and ' \
      '`Layout/FirstArrayElementIndentation`' do
     create_file('example.rb', <<~RUBY)


### PR DESCRIPTION
This PR fixes infinite loop error for `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and
`EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation` and `Layout/HashAlignment`.

The condition was probably left unchanged by mistake when #10840 was fixed.

And this behavior already matches the following description in the documentation:

> This cop will respect `Layout/ArgumentAlignment` and will not work when `EnforcedStyle: with_fixed_indentation` is
> specified for `Layout/ArgumentAlignment`.

https://docs.rubocop.org/rubocop/1.75/cops_layout.html#layoutfirstargumentindentation

Fixes #14197.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
