### PR TITLE
Rename `EnforcedStyle` of `Style/EmptyStringInsideInterpolation`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3963,10 +3963,10 @@ Style/EmptyStringInsideInterpolation:
   Description: 'Checks for empty strings being assigned inside string interpolation.'
   StyleGuide: '#empty-strings-in-interpolation'
   Enabled: pending
-  EnforcedStyle: ternary
+  EnforcedStyle: trailing_conditional
   SupportedStyles:
-    - ternary
     - trailing_conditional
+    - ternary
   VersionAdded: '<<next>>'
 
 Style/Encoding:

--- a/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
+++ b/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
@@ -11,7 +11,7 @@ module RuboCop
       # While this cop would also apply to variables that are only going to be used as strings,
       # RuboCop can't detect that, so we only check inside of string interpolation.
       #
-      # @example EnforcedStyle: ternary (default)
+      # @example EnforcedStyle: trailing_conditional (default)
       #   # bad
       #   "#{condition ? 'foo' : ''}"
       #
@@ -24,7 +24,7 @@ module RuboCop
       #   # good
       #   "#{'foo' unless condition}"
       #
-      # @example EnforcedStyle: trailing_conditional
+      # @example EnforcedStyle: ternary
       #   # bad
       #   "#{'foo' if condition}"
       #
@@ -41,13 +41,14 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include Interpolation
         extend AutoCorrector
-        MSG_TERNARY = 'Do not return empty strings in string interpolation.'
+
         MSG_TRAILING_CONDITIONAL = 'Do not use trailing conditionals in string interpolation.'
+        MSG_TERNARY = 'Do not return empty strings in string interpolation.'
 
         # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_interpolation(node)
           node.each_child_node(:if) do |child_node|
-            if style == :ternary
+            if style == :trailing_conditional
               if empty_if_outcome?(child_node)
                 ternary_style_autocorrect(child_node, child_node.else_branch.source, 'unless')
               end
@@ -55,7 +56,7 @@ module RuboCop
               if empty_else_outcome?(child_node)
                 ternary_style_autocorrect(child_node, child_node.if_branch.source, 'if')
               end
-            elsif style == :trailing_conditional
+            elsif style == :ternary
               next unless child_node.modifier_form?
 
               ternary_component = if child_node.unless?

--- a/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
-  context 'when EnforcedStyle is ternary' do
-    let(:cop_config) { { 'EnforcedStyle' => 'ternary' } }
+  context 'when EnforcedStyle is trailing_conditional' do
+    let(:cop_config) { { 'EnforcedStyle' => 'trailing_conditional' } }
 
     it 'does not register an offense when if branch is not a literal' do
       expect_no_offenses(<<~'RUBY')
@@ -66,11 +66,17 @@ RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
           "#{'foo' unless condition}"
         RUBY
       end
+
+      it 'does not register an offense when a trailing if is used inside string interpolation' do
+        expect_no_offenses(<<~'RUBY')
+          "#{'foo' if condition}"
+        RUBY
+      end
     end
   end
 
-  context 'when EnforcedStyle is trailing_conditional' do
-    let(:cop_config) { { 'EnforcedStyle' => 'trailing_conditional' } }
+  context 'when EnforcedStyle is ternary' do
+    let(:cop_config) { { 'EnforcedStyle' => 'ternary' } }
 
     it 'registers an offense when a trailing if is used inside string interpolation' do
       expect_offense(<<~'RUBY')
@@ -91,6 +97,12 @@ RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
 
       expect_correction(<<~'RUBY')
         "#{condition ? '' : 'foo'}"
+      RUBY
+    end
+
+    it 'does not register an offense when empty string is the false outcome of a ternary' do
+      expect_no_offenses(<<~'RUBY')
+        "#{condition ? 'foo' : ''}"
       RUBY
     end
   end


### PR DESCRIPTION
Follow-up to #13266.

The names `EnforcedStyle: trailing_conditional` and `EnforcedStyle: ternary` appear to be reversed. This PR swaps the names accordingly.

## `EnforcedStyle: trailing_conditional` (default)

```ruby
# bad
"#{condition ? 'foo' : ''}"

# good
"#{'foo' if condition}"
```

## `EnforcedStyle: ternary`

```ruby
# bad
"#{'foo' if condition}"

# good
"#{condition ? 'foo' : ''}"
```

Also, since there were no test cases using `expect_no_offenses`, This PR added representative tests for each style. Since this has not been released yet, there is no changelog entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
