### PR TITLE
Fix `Style/EmptyStringInsideInterpolation` cop error on non-literal branch node

### DIFF
--- a/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
+++ b/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
@@ -48,11 +48,11 @@ module RuboCop
         def on_interpolation(node)
           node.each_child_node(:if) do |child_node|
             if style == :ternary
-              if empty_if_outcome(child_node)
+              if empty_if_outcome?(child_node)
                 ternary_style_autocorrect(child_node, child_node.else_branch.source, 'unless')
               end
 
-              if empty_else_outcome(child_node)
+              if empty_else_outcome?(child_node)
                 ternary_style_autocorrect(child_node, child_node.if_branch.source, 'if')
               end
             elsif style == :trailing_conditional
@@ -74,12 +74,18 @@ module RuboCop
 
         private
 
-        def empty_if_outcome(node)
-          node.if_branch&.nil_type? || node.if_branch&.value&.empty?
+        def empty_if_outcome?(node)
+          empty_branch_outcome?(node.if_branch)
         end
 
-        def empty_else_outcome(node)
-          node.else_branch&.nil_type? || node.else_branch&.value&.empty?
+        def empty_else_outcome?(node)
+          empty_branch_outcome?(node.else_branch)
+        end
+
+        def empty_branch_outcome?(branch)
+          return false unless branch
+
+          branch.nil_type? || (branch.literal? && branch.value.empty?)
         end
 
         def ternary_style_autocorrect(node, outcome, condition)

--- a/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
@@ -4,6 +4,24 @@ RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
   context 'when EnforcedStyle is ternary' do
     let(:cop_config) { { 'EnforcedStyle' => 'ternary' } }
 
+    it 'does not register an offense when if branch is not a literal' do
+      expect_no_offenses(<<~'RUBY')
+        "#{condition ? send_node : 'foo'}"
+      RUBY
+    end
+
+    it 'does not register an offense when else branch is not a literal' do
+      expect_no_offenses(<<~'RUBY')
+        "#{condition ? 'foo' : send_node}"
+      RUBY
+    end
+
+    it 'does not register an offense when both if and else branches are not literals' do
+      expect_no_offenses(<<~'RUBY')
+        "#{condition ? send_node : another_send_node}"
+      RUBY
+    end
+
     %w['' "" nil].each do |empty|
       it "registers an offense when #{empty} is the false outcome of a ternary" do
         expect_offense(<<~'RUBY', empty: empty)


### PR DESCRIPTION
```shell
echo '"#{cond ? foo : 1}"' | bundle exec rubocop --stdin bug.rb --only Style/EmptyStringInsideInterpolation -d

An error occurred while Style/EmptyStringInsideInterpolation cop was inspecting bug.rb:1:0.
lib/rubocop/cop/style/empty_string_inside_interpolation.rb:78:in 'RuboCop::Cop::Style::EmptyStringInsideInterpolation#empty_if_outcome': undefined method 'value' for an instance of RuboCop::AST::SendNode (NoMethodError)

          node.if_branch&.nil_type? || node.if_branch&.value&.empty?
                                                     ^^^^^^^
	from lib/rubocop/cop/style/empty_string_inside_interpolation.rb:51:in 'block in RuboCop::Cop::Style::EmptyStringInsideInterpolation#on_interpolation'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
