### PR TITLE
Minor spelling fixes (non-user facing)

### DIFF
--- a/spec/rubocop/cop/lint/mixed_case_range_spec.rb
+++ b/spec/rubocop/cop/lint/mixed_case_range_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
     RUBY
   end
 
-  it 'registers an offense for unsafe range with full octal escape preceeding' do
+  it 'registers an offense for unsafe range with full octal escape preceding' do
     expect_offense(<<~'RUBY'.sub(/\#{message}/, message))
       foo = /[\001A-z123]/
                   ^^^ #{message}
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::Lint::MixedCaseRange, :config do
     RUBY
   end
 
-  it 'registers an offense for unsafe range with short octal escape preceeding' do
+  it 'registers an offense for unsafe range with short octal escape preceding' do
     expect_offense(<<~'RUBY'.sub(/\#{message}/, message))
       foo = /[\1A-z123]/
                 ^^^ #{message}

--- a/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRegexpQuantifiers, :config do
   end
 
   context 'with multiple redundant quantifiers' do
-    it 'registers offenses and corrects with leading optional quantifer' do
+    it 'registers offenses and corrects with leading optional quantifier' do
       expect_offense(<<~RUBY)
         foo = /(?:(?:a?)+)+/
                         ^^^ Replace redundant quantifiers `+` and `+` with a single `+`.
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRegexpQuantifiers, :config do
       RUBY
     end
 
-    it 'registers offenses and corrects with interspersed optional quantifer' do
+    it 'registers offenses and corrects with interspersed optional quantifier' do
       expect_offense(<<~RUBY)
         foo = /(?:(?:a+)?)+/
                         ^^^ Replace redundant quantifiers `?` and `+` with a single `*`.
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRegexpQuantifiers, :config do
       RUBY
     end
 
-    it 'registers offenses and corrects with trailing optional quantifer' do
+    it 'registers offenses and corrects with trailing optional quantifier' do
       expect_offense(<<~RUBY)
         foo = /(?:(?:a+)+)?/
                         ^^^ Replace redundant quantifiers `+` and `?` with a single `*`.

--- a/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_string_coercion_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantStringCoercion, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects `to_s` with safe naviagation in `puts` arguments' do
+  it 'registers an offense and corrects `to_s` with safe navigation in `puts` arguments' do
     expect_offense(<<~RUBY)
       puts first&.to_s, second&.to_s
                   ^^^^ Redundant use of `Object#to_s` in `puts`.

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       end
     end
 
-    context 'with one-liner class defintiion' do
+    context 'with one-liner class definition' do
       it 'registers an offense for classes with nested one-liner children' do
         expect_offense(<<~RUBY)
           class FooClass
@@ -581,7 +581,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         RUBY
       end
 
-      it 'registers an offense when one-liner class definition has multitple whitespaces before the `end` token' do
+      it 'registers an offense when one-liner class definition has multiple whitespaces before the `end` token' do
         expect_offense(<<~RUBY)
           class A < B
             class C


### PR DESCRIPTION
A few minor spelling fixes that are not user facing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
