### PR TITLE
Recognize inequation in `Lint/IdentityComparison`

### DIFF
--- a/changelog/change_recognize_inequation_in_lint_identity_comparison.md
+++ b/changelog/change_recognize_inequation_in_lint_identity_comparison.md
@@ -1,0 +1,1 @@
+* [#14215](https://github.com/rubocop/rubocop/pull/14215): Recognize inequation (`!=`) in `Lint/IdentityComparison`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/lint/identity_comparison.rb
+++ b/lib/rubocop/cop/lint/identity_comparison.rb
@@ -11,38 +11,42 @@ module RuboCop
       # @example
       #   # bad
       #   foo.object_id == bar.object_id
+      #   foo.object_id != baz.object_id
       #
       #   # good
       #   foo.equal?(bar)
+      #   !foo.equal?(baz)
       #
       class IdentityComparison < Base
         extend AutoCorrector
 
-        MSG = 'Use `equal?` instead `==` when comparing `object_id`.'
-        RESTRICT_ON_SEND = %i[==].freeze
+        MSG = 'Use `%<bang>sequal?` instead of `%<comparison_method>s` when comparing `object_id`.'
+        RESTRICT_ON_SEND = %i[== !=].freeze
+
+        # @!method object_id_comparison(node)
+        def_node_matcher :object_id_comparison, <<~PATTERN
+          (send
+            (send
+              _lhs_receiver :object_id) ${:== :!=}
+            (send
+              _rhs_receiver :object_id))
+        PATTERN
 
         def on_send(node)
-          return unless compare_between_object_id_by_double_equal?(node)
+          return unless (comparison_method = object_id_comparison(node))
 
-          add_offense(node) do |corrector|
+          bang = comparison_method == :== ? '' : '!'
+          add_offense(node,
+                      message: format(MSG, comparison_method: comparison_method,
+                                           bang: bang)) do |corrector|
             receiver = node.receiver.receiver
             argument = node.first_argument.receiver
             return unless receiver && argument
 
-            replacement = "#{receiver.source}.equal?(#{argument.source})"
+            replacement = "#{bang}#{receiver.source}.equal?(#{argument.source})"
 
             corrector.replace(node, replacement)
           end
-        end
-
-        private
-
-        def compare_between_object_id_by_double_equal?(node)
-          object_id_method?(node.receiver) && object_id_method?(node.first_argument)
-        end
-
-        def object_id_method?(node)
-          node.send_type? && node.method?(:object_id)
         end
       end
     end

--- a/spec/rubocop/cop/lint/identity_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/identity_comparison_spec.rb
@@ -4,11 +4,22 @@ RSpec.describe RuboCop::Cop::Lint::IdentityComparison, :config do
   it 'registers an offense and corrects when using `==` for comparison between `object_id`s' do
     expect_offense(<<~RUBY)
       foo.object_id == bar.object_id
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `equal?` instead `==` when comparing `object_id`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `equal?` instead of `==` when comparing `object_id`.
     RUBY
 
     expect_correction(<<~RUBY)
       foo.equal?(bar)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `!=` for comparison between `object_id`s' do
+    expect_offense(<<~RUBY)
+      foo.object_id != bar.object_id
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!equal?` instead of `!=` when comparing `object_id`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !foo.equal?(bar)
     RUBY
   end
 
@@ -18,27 +29,57 @@ RSpec.describe RuboCop::Cop::Lint::IdentityComparison, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `!=` for comparison between `object_id` and other' do
+    expect_no_offenses(<<~RUBY)
+      foo.object_id != bar.do_something
+    RUBY
+  end
+
   it 'does not register an offense when a receiver that is not `object_id` uses `==`' do
     expect_no_offenses(<<~RUBY)
       foo.do_something == bar.object_id
     RUBY
   end
 
-  it 'does not register an offense when using `==`' do
+  it 'does not register an offense when a receiver that is not `object_id` uses `!=`' do
     expect_no_offenses(<<~RUBY)
-      foo.equal(bar)
+      foo.do_something != bar.object_id
     RUBY
   end
 
-  it 'does not register an offense when lhs is `object_id` without receiver' do
+  it 'does not register an offense when using `equal?`' do
+    expect_no_offenses(<<~RUBY)
+      foo.equal?(bar)
+    RUBY
+  end
+
+  it 'does not register an offense when using `!equal?`' do
+    expect_no_offenses(<<~RUBY)
+      !foo.equal?(bar)
+    RUBY
+  end
+
+  it 'does not register an offense when lhs is `object_id` without receiver when using `==`' do
     expect_no_offenses(<<~RUBY)
       object_id == bar.object_id
     RUBY
   end
 
-  it 'does not register an offense when rhs is `object_id` without receiver' do
+  it 'does not register an offense when lhs is `object_id` without receiver when using `!=`' do
+    expect_no_offenses(<<~RUBY)
+      object_id != bar.object_id
+    RUBY
+  end
+
+  it 'does not register an offense when rhs is `object_id` without receiver when using `==`' do
     expect_no_offenses(<<~RUBY)
       foo.object_id == object_id
+    RUBY
+  end
+
+  it 'does not register an offense when rhs is `object_id` without receiver when using `!=`' do
+    expect_no_offenses(<<~RUBY)
+      foo.object_id != object_id
     RUBY
   end
 end


### PR DESCRIPTION
Expands `Lint/IdentityComparison` to register:
```ruby
foo.object_id != bar.object_id
```
as an offense, and autocorrect to:
```ruby
!foo.equal?(bar)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
