### PR TITLE
[fix #14205] False negatives in `Style/Safenavigation`

### DIFF
--- a/changelog/fix_false_negatives_in_style_safenavigation_20250530140637.md
+++ b/changelog/fix_false_negatives_in_style_safenavigation_20250530140637.md
@@ -1,0 +1,1 @@
+* [#14205](https://github.com/rubocop/rubocop/issues/14205): False negatives in `Style/SafeNavigation` when a ternary expression is used in a method argument. ([@steiley][])

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -806,6 +806,33 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'registers an offense for ternary expressions in a method argument' do
+          expect_offense(<<~RUBY, variable: variable)
+            puts(%{variable} ? %{variable}.bar : nil)
+                 ^{variable}^^^^{variable}^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+
+            results << (%{variable} ? %{variable}.bar : nil)
+                        ^{variable}^^^^{variable}^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            puts(#{variable}&.bar)
+
+            results << (#{variable}&.bar)
+          RUBY
+        end
+
+        it 'registers an offense for ternary expressions in a collection assignment' do
+          expect_offense(<<~RUBY, variable: variable)
+            results[0] = %{variable} ? %{variable}.bar : nil
+                         ^{variable}^^^^{variable}^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            results[0] = #{variable}&.bar
+          RUBY
+        end
+
         it 'registers an offense for convertible ternary expressions' do
           expect_offense(<<~RUBY, variable: variable)
             %{variable} ? %{variable}.bar : nil


### PR DESCRIPTION
Fix false negatives in Style/SafeNavigation #14205

```
puts(user.nil? ? nil : user.name)          # ❌
results << (user.nil? ? nil : user.name)   # ❌
results[0] = user.nil? ? nil : user.name   # ❌
```

to

```
puts(user.nil? ? nil : user.name)          # ✅ Offense found
results << (user.nil? ? nil : user.name)   # ✅ Offense found
results[0] = user.nil? ? nil : user.name   # ✅ Offense found
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
