### PR TITLE
Use valid `metadata` keys in `Gemspec/DuplicatedAssignment` cop specs

### DIFF
--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
   it 'does not register an offense when using `#[]=` with different keys' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
-        spec.metadata[:foo] = 1
-        spec.metadata[:bar] = 2
+        spec.metadata['foo'] = 1
+        spec.metadata['bar'] = 2
       end
     RUBY
   end
@@ -96,8 +96,8 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
   it 'does not register an offense when using `#[]=` with same keys and different receivers' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
-        spec.misc[:foo] = 1
-        spec.metadata[:foo] = 2
+        spec.misc['foo'] = 1
+        spec.metadata['foo'] = 2
       end
     RUBY
   end
@@ -105,8 +105,8 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
   it 'does not register an offense when using both `metadata#[]=` and `metadata=`' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|
-        spec.metadata = { foo: 1 }
-        spec.metadata[:foo] = 1
+        spec.metadata = { 'foo' => 1 }
+        spec.metadata['foo'] = 1
       end
     RUBY
   end


### PR DESCRIPTION
Nit: according to the spec [0] `metadata` keys should be strings

[0] https://guides.rubygems.org/specification-reference/#metadata

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
