### PR TITLE
Add extra spec for `Gemspec/DuplicatedAssignment` cop with array assignments

### DIFF
--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -111,6 +111,18 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when using indexed array assignment' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.authors = []
+        spec.authors[0] = "author-1"
+        spec.authors[1] = "author-2"
+        spec.authors << "author-3"
+        spec.authors << "author-4"
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `metadata#[]=` with same key twice which are not literals' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|


### PR DESCRIPTION
We're already testing hash assignments here but I'd like to make sure array assignment is also not detected since it will be handled by a dedicated cop.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
