### PR TITLE
[Fix #14217] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -49,6 +49,7 @@ module RuboCop
           empty_parentheses?(node) ||
             first_arg_begins_with_hash_literal?(node) ||
             rescue?(node) ||
+            in_pattern_matching_in_method_argument?(node) ||
             allowed_pin_operator?(node) ||
             allowed_expression?(node)
         end
@@ -120,6 +121,12 @@ module RuboCop
             parenthesized = root_method.parenthesized_call?
           end
           hash_literal && first_argument?(node) && !parentheses?(hash_literal) && !parenthesized
+        end
+
+        def in_pattern_matching_in_method_argument?(begin_node)
+          return false unless (node = begin_node.children.first)
+
+          target_ruby_version <= 2.7 ? node.match_pattern_type? : node.match_pattern_p_type?
         end
 
         def method_chain_begins_with_hash_literal(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1154,6 +1154,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
+  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      foo((bar in baz))
+    RUBY
+  end
+
+  # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
+  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      foo((bar in baz))
+    RUBY
+  end
+
   context 'when the first argument in a method call begins with a hash literal' do
     it 'accepts parentheses if the argument list is not parenthesized' do
       expect_no_offenses('x ({ y: 1 }), z')


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when using one-line hash `in` pattern matching in a method argument.

Fixes #14217.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
