### PR TITLE
Enhance `Gemspec` department cops to detect offenses with `it` or `_1`

### DIFF
--- a/changelog/new_enhance_gemspec_department_cops_with_it_and_numbered_parameters_20250601013924.md
+++ b/changelog/new_enhance_gemspec_department_cops_with_it_and_numbered_parameters_20250601013924.md
@@ -1,0 +1,1 @@
+* [#14221](https://github.com/rubocop/rubocop/pull/14221): Enhance `Gemspec` department cops to detect offenses if specification variable is `it` or a numbered parameter. ([@viralpraxis][])

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -57,13 +57,13 @@ module RuboCop
         # @!method assignment_method_declarations(node)
         def_node_search :assignment_method_declarations, <<~PATTERN
           (send
-            (lvar #match_block_variable_name?) _ ...)
+            (lvar {#match_block_variable_name? :_1 :it}) _ ...)
         PATTERN
 
         # @!method indexed_assignment_method_declarations(node)
         def_node_search :indexed_assignment_method_declarations, <<~PATTERN
           (send
-            (send (lvar #match_block_variable_name?) _)
+            (send (lvar {#match_block_variable_name? :_1 :it}) _)
             :[]=
             literal?
             _

--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -11,6 +11,26 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense when using `name=` twice and using `_1` as a specification variable' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do
+        _1.name = 'rubocop'
+        _1.name = 'rubocop2'
+        ^^^^^^^^^^^^^^^^^^^^ `name=` method calls already given on line 2 of the gemspec.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `name=` twice and using `it` as a specification variable', :ruby34 do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do
+        it.name = 'rubocop'
+        it.name = 'rubocop2'
+        ^^^^^^^^^^^^^^^^^^^^ `name=` method calls already given on line 2 of the gemspec.
+      end
+    RUBY
+  end
+
   it 'registers an offense when using `version=` twice' do
     expect_offense(<<~RUBY)
       require 'rubocop/version'


### PR DESCRIPTION
Since gemspecs can use `_1` or `it` to refer to the specification object (I've seen one!), it makes sense to support this case.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
