### PR TITLE
Add new `Gemspec/AttributeAssignment` cop

### DIFF
--- a/changelog/new_add_new_gemspec_attribute_assignment_cop_20250601175128.md
+++ b/changelog/new_add_new_gemspec_attribute_assignment_cop_20250601175128.md
@@ -1,0 +1,1 @@
+* [#14223](https://github.com/rubocop/rubocop/pull/14223): Add new `Gemspec/AttributeAssignment` cop. ([@viralpraxis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -281,6 +281,13 @@ Gemspec/AddRuntimeDependency:
   Include:
     - '**/*.gemspec'
 
+Gemspec/AttributeAssignment:
+  Description: 'Use consistent style for Gemspec attributes assignment.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Include:
+    - '**/*.gemspec'
+
 Gemspec/DependencyVersion:
   Description: 'Requires or forbids specifying gem dependency versions.'
   Enabled: false

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -180,6 +180,7 @@ require_relative 'rubocop/cop/bundler/insecure_protocol_source'
 require_relative 'rubocop/cop/bundler/ordered_gems'
 
 require_relative 'rubocop/cop/gemspec/add_runtime_dependency'
+require_relative 'rubocop/cop/gemspec/attribute_assignment'
 require_relative 'rubocop/cop/gemspec/dependency_version'
 require_relative 'rubocop/cop/gemspec/deprecated_attribute_assignment'
 require_relative 'rubocop/cop/gemspec/development_dependencies'

--- a/lib/rubocop/cop/gemspec/attribute_assignment.rb
+++ b/lib/rubocop/cop/gemspec/attribute_assignment.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # Use consistent style for Gemspec attributes assignment.
+      #
+      # @example
+      #
+      #   # bad
+      #   # This example uses two styles for assignment of metadata attribute.
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata = { 'key' => 'value' }
+      #     spec.metadata['another-key'] = 'another-value'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata['key'] = 'value'
+      #     spec.metadata['another-key'] = 'another-value'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata = { 'key' => 'value', 'another-key' => 'another-value' }
+      #   end
+      #
+      #   # bad
+      #   # This example uses two styles for assignment of authors attribute.
+      #   Gem::Specification.new do |spec|
+      #     spec.authors = %w[author-0 author-1]
+      #     spec.authors[2] = 'author-2'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.authors = %w[author-0 author-1 author-2]
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.authors[0] = 'author-0'
+      #     spec.authors[1] = 'author-1'
+      #     spec.authors[2] = 'author-2'
+      #   end
+      #
+      #   # good
+      #   # This example uses consistent assignment per attribute,
+      #   # even though two different styles are used overall.
+      #   Gem::Specification.new do |spec|
+      #     spec.metadata = { 'key' => 'value' }
+      #     spec.authors[0] = 'author-0'
+      #     spec.authors[1] = 'author-1'
+      #     spec.authors[2] = 'author-2'
+      #   end
+      #
+      class AttributeAssignment < Base
+        include GemspecHelp
+
+        MSG = 'Use consistent style for Gemspec attributes assignment.'
+
+        def on_new_investigation
+          return if processed_source.blank?
+
+          assignments = source_assignments(processed_source.ast)
+          indexed_assignments = source_indexed_assignments(processed_source.ast)
+
+          assignments.keys.intersection(indexed_assignments.keys).each do |attribute|
+            indexed_assignments[attribute].each do |node|
+              add_offense(node)
+            end
+          end
+        end
+
+        private
+
+        def source_assignments(ast)
+          assignment_method_declarations(ast)
+            .select(&:assignment_method?)
+            .group_by(&:method_name)
+            .transform_keys { |method_name| method_name.to_s.delete_suffix('=').to_sym }
+        end
+
+        def source_indexed_assignments(ast)
+          indexed_assignment_method_declarations(ast)
+            .group_by { |node| node.children.first.method_name }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -54,22 +54,6 @@ module RuboCop
         MSG = '`%<assignment>s` method calls already given on line ' \
               '%<line_of_first_occurrence>d of the gemspec.'
 
-        # @!method assignment_method_declarations(node)
-        def_node_search :assignment_method_declarations, <<~PATTERN
-          (send
-            (lvar {#match_block_variable_name? :_1 :it}) _ ...)
-        PATTERN
-
-        # @!method indexed_assignment_method_declarations(node)
-        def_node_search :indexed_assignment_method_declarations, <<~PATTERN
-          (send
-            (send (lvar {#match_block_variable_name? :_1 :it}) _)
-            :[]=
-            literal?
-            _
-          )
-        PATTERN
-
         def on_new_investigation
           return if processed_source.blank?
 
@@ -93,12 +77,6 @@ module RuboCop
               assignment = "#{node.children.first.method_name}[#{node.first_argument.source}]="
               register_offense(node, assignment, nodes.first.first_line)
             end
-          end
-        end
-
-        def match_block_variable_name?(receiver_name)
-          gem_specification(processed_source.ast) do |block_variable_name|
-            return block_variable_name == receiver_name
           end
         end
 

--- a/lib/rubocop/cop/mixin/gemspec_help.rb
+++ b/lib/rubocop/cop/mixin/gemspec_help.rb
@@ -25,6 +25,28 @@ module RuboCop
           (args
             (arg $_)) ...)
       PATTERN
+
+      # @!method assignment_method_declarations(node)
+      def_node_search :assignment_method_declarations, <<~PATTERN
+        (send
+          (lvar {#match_block_variable_name? :_1 :it}) _ ...)
+      PATTERN
+
+      # @!method indexed_assignment_method_declarations(node)
+      def_node_search :indexed_assignment_method_declarations, <<~PATTERN
+        (send
+          (send (lvar {#match_block_variable_name? :_1 :it}) _)
+          :[]=
+          literal?
+          _
+        )
+      PATTERN
+
+      def match_block_variable_name?(receiver_name)
+        gem_specification(processed_source.ast) do |block_variable_name|
+          return block_variable_name == receiver_name
+        end
+      end
     end
   end
 end

--- a/spec/rubocop/cop/gemspec/attribute_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/attribute_assignment_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gemspec::AttributeAssignment, :config do
+  it 'does not register an offense when only indexed hash assignment is used' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.metadata['key-0'] = 'value-0'
+        spec.metadata['key-1'] = 'value-1'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when only normal hash assignment is used' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.metadata = { 'key' => 'value' }
+        spec.metadata = { 'key' => 'value' }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when only indexed array assignment is used' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.authors[0] = 'author-0'
+        spec.authors[1] = 'author-1'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when only normal array assignment is used' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.authors = %w[author-1 author-2]
+        spec.authors = %w[author-1 author-2]
+      end
+    RUBY
+  end
+
+  it 'registers an offense for inconsistent hash assignment' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.metadata = { 'key-0' => 'value-0' }
+        spec.metadata['key-1'] = 'value-1'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use consistent style for Gemspec attributes assignment.
+        spec.metadata['key-2'] = 'value-2'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use consistent style for Gemspec attributes assignment.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for inconsistent array assignment' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.authors = %w[author-0 author-1]
+        spec.authors[2] = 'author-2'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use consistent style for Gemspec attributes assignment.
+      end
+    RUBY
+  end
+
+  context 'when the gemspec is blank' do
+    it 'does not register an offense' do
+      expect_no_offenses('', 'my.gemspec')
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/pull/14188#issuecomment-2890385223

The new `Gemspec/ConsistentAssignment` cop discourages mixing "normal" and "indexed" assignment styles.

Bad:

```ruby
spec.metadata = { 'a' => 'b' }
spec.metadata['c'] = 'd'
```

Good:

```ruby
spec.metadata = { 'a' => 'b', 'c' => 'd' }

# or

spec.metadata['a'] = 'b'
spec.metadata['c'] = 'd]
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
