### PR TITLE
Fix false negatives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negatives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negatives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14224](https://github.com/rubocop/rubocop/pull/14224): Fix false negatives for `Style/RedundantParentheses` when using one-line pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -124,6 +124,7 @@ module RuboCop
         end
 
         def in_pattern_matching_in_method_argument?(begin_node)
+          return false unless begin_node.parent&.call_type?
           return false unless (node = begin_node.children.first)
 
           target_ruby_version <= 2.7 ? node.match_pattern_type? : node.match_pattern_p_type?
@@ -163,6 +164,8 @@ module RuboCop
           if node.lambda_or_proc? && (node.braces? || node.send_node.lambda_literal?)
             return 'an expression'
           end
+
+          return 'a one-line pattern matching' if node.type?(:match_pattern, :match_pattern_p)
           return 'an interpolated expression' if interpolation?(begin_node)
           return 'a method argument' if argument_of_parenthesized_method_call?(begin_node)
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1155,9 +1155,52 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
+  it 'registers parentheses when using one-line hash `in` pattern matching in a redundant parentheses', :ruby27 do
+    expect_offense(<<~RUBY)
+      (expression in pattern)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expression in pattern
+    RUBY
+  end
+
+  # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
+  it 'registers parentheses when using one-line hash `in` pattern matching in a redundant parentheses', :ruby30 do
+    expect_offense(<<~RUBY)
+      (expression in pattern)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expression in pattern
+    RUBY
+  end
+
+  # Ruby 3.0's one-line `=>` pattern node type is `match-pattern`.
+  it 'registers an offense when using one-line hash `=>` pattern matching in a redundant parentheses', :ruby30 do
+    expect_offense(<<~RUBY)
+      (expression => pattern)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expression => pattern
+    RUBY
+  end
+
+  # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
   it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby27 do
     expect_no_offenses(<<~RUBY)
       foo((bar in baz))
+    RUBY
+  end
+
+  # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
+  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument with safe navigation', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      obj&.foo((bar in baz))
     RUBY
   end
 
@@ -1165,6 +1208,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby30 do
     expect_no_offenses(<<~RUBY)
       foo((bar in baz))
+    RUBY
+  end
+
+  # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
+  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument with safe navigation', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      obj&.foo((bar in baz))
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantParentheses` when using one-line pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
