### PR TITLE
Fix `Style/EmptyStringInsideInterpolation` cop error on non-string literal

### DIFF
--- a/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
+++ b/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
@@ -86,7 +86,7 @@ module RuboCop
         def empty_branch_outcome?(branch)
           return false unless branch
 
-          branch.nil_type? || (branch.literal? && branch.value.empty?)
+          branch.nil_type? || (branch.str_type? && branch.value.empty?)
         end
 
         def ternary_style_autocorrect(node, outcome, condition)

--- a/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
         RUBY
       end
 
+      it "registers an offense when #{empty} is the false outcome of a ternary and another value is a non-string literal" do
+        expect_offense(<<~'RUBY', empty: empty)
+          "#{condition ? 42 : %{empty}}"
+             ^^^^^^^^^^^^^^^^^^{empty} Do not return empty strings in string interpolation.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          "#{42 if condition}"
+        RUBY
+      end
+
       it "registers an offense when #{empty} is the false outcome of a single-line conditional" do
         expect_offense(<<~'RUBY', empty: empty)
           "#{if condition; 'foo' else %{empty} end}"


### PR DESCRIPTION
Funny enough, an MRE is the same as in https://github.com/rubocop/rubocop/pull/14213. But in that case it would fail a little bit too early, just before it could fail on integer literal :^)

```shell
echo '"#{cond ? foo : 1}"' | bundle exec rubocop --stdin bug.rb --only Style/EmptyStringInsideInterpolation -d

An error occurred while Style/EmptyStringInsideInterpolation cop was inspecting /home/viralpraxis/Documents/github/rubocop/bug.rb:1:0.
lib/rubocop/cop/style/empty_string_inside_interpolation.rb:89:in 'RuboCop::Cop::Style::EmptyStringInsideInterpolation#empty_branch_outcome?': undefined method 'empty?' for an instance of Integer (NoMethodError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
