### PR TITLE
Fix `Lint/LiteralAsCondition` autocorrect when branches of a condition have comments

### DIFF
--- a/changelog/fix_lint_literal_as_condition_autocorrect_when_branches_have_comments.md
+++ b/changelog/fix_lint_literal_as_condition_autocorrect_when_branches_have_comments.md
@@ -1,0 +1,1 @@
+* [#14226](https://github.com/rubocop/rubocop/pull/14226): Fix `Lint/LiteralAsCondition` autocorrect when branches of a condition have comments. ([@zopolis4][])

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    it "registers an offense for truthy literal #{lit} in if-elsif-else and preserves comments" do
+      expect_offense(<<~RUBY, lit: lit)
+        if condition
+          top # comment 1
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          foo # comment 2
+        else
+          bar
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          top # comment 1
+        else
+          foo # comment 2
+        end
+      RUBY
+    end
+
     it "registers an offense for truthy literal #{lit} in modifier if" do
       expect_offense(<<~RUBY, lit: lit)
         top if %{lit}
@@ -504,6 +525,27 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
           top
         else
           bar
+        end
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in if-elsif-else and preserves comments" do
+      expect_offense(<<~RUBY, lit: lit)
+        if condition
+          top # comment 1
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          foo # comment 2
+        else
+          bar # comment 3
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          top # comment 1
+        else
+          bar # comment 3
         end
       RUBY
     end


### PR DESCRIPTION
It turns out `IfNodes` can get more complex!

This should cover the relatively simple case, although since nobody's reported anything yet I doubt this is a common code pattern.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
