### PR TITLE
[Fix #14228] Fix false positive for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_parentheses_cop.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#14228](https://github.com/rubocop/rubocop/issues/14228): Fix a false positive for `Style/RedundantParentheses` when using a one-line `rescue` expression as a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -142,7 +142,7 @@ module RuboCop
           node = begin_node.children.first
 
           if (message = find_offense_message(begin_node, node))
-            if node.range_type? && !argument_of_parenthesized_method_call?(begin_node)
+            if node.range_type? && !argument_of_parenthesized_method_call?(begin_node, node)
               begin_node = begin_node.parent
             end
 
@@ -167,7 +167,7 @@ module RuboCop
 
           return 'a one-line pattern matching' if node.type?(:match_pattern, :match_pattern_p)
           return 'an interpolated expression' if interpolation?(begin_node)
-          return 'a method argument' if argument_of_parenthesized_method_call?(begin_node)
+          return 'a method argument' if argument_of_parenthesized_method_call?(begin_node, node)
 
           return if begin_node.chained?
 
@@ -190,9 +190,10 @@ module RuboCop
         # @!method interpolation?(node)
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
 
-        def argument_of_parenthesized_method_call?(begin_node)
-          node = begin_node.children.first
-          return false if node.basic_conditional? || method_call_parentheses_required?(node)
+        def argument_of_parenthesized_method_call?(begin_node, node)
+          if node.basic_conditional? || node.rescue_type? || method_call_parentheses_required?(node)
+            return false
+          end
           return false unless (parent = begin_node.parent)
 
           parent.call_type? && parent.parenthesized? && parent.receiver != begin_node

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'plausible', 'while (var = 42); end'
   it_behaves_like 'plausible', 'until (var = 42); end'
   it_behaves_like 'plausible', '(var + 42) > do_something'
+  it_behaves_like 'plausible', 'foo((bar rescue baz))'
 
   it_behaves_like 'redundant', '(!x)', '!x', 'a unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'a unary operation'


### PR DESCRIPTION
This PR fixes a false positive for `Style/RedundantParentheses` when using a one-line `rescue` expression as a method argument.

Fixes #14228.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
