### PR TITLE
[Fix #14233] Fix an error for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_an_error_for_style_safe_navigation_cop.md
+++ b/changelog/fix_an_error_for_style_safe_navigation_cop.md
@@ -1,0 +1,1 @@
+* [#14233](https://github.com/rubocop/rubocop/issues/14233): Fix an error for `Style/SafeNavigation` when using ternary expression with index access call. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -86,6 +86,8 @@ module RuboCop
       #   foo.baz = bar if foo
       #   foo.baz + bar if foo
       #   foo.bar > 2 if foo
+      #
+      #   foo ? foo[index] : nil # Ignored `foo&.[](index)` due to unclear readability benefit.
       class SafeNavigation < Base # rubocop:disable Metrics/ClassLength
         include NilMethods
         include RangeHelp
@@ -146,6 +148,7 @@ module RuboCop
 
           body = extract_if_body(node)
           method_call = receiver.parent
+          return if method_call.method?(:[])
 
           removal_ranges = [begin_range(node, body), end_range(node, body)]
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -806,6 +806,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'allows ternary expression with index access call' do
+          expect_no_offenses(<<~RUBY)
+            #{variable} ? #{variable}[index] : nil
+          RUBY
+        end
+
         it 'registers an offense for ternary expressions in a method argument' do
           expect_offense(<<~RUBY, variable: variable)
             puts(%{variable} ? %{variable}.bar : nil)


### PR DESCRIPTION
This PR fixes an error for `Style/SafeNavigation` when using ternary expression with index access call.

Fixes #14233

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
