### PR TITLE
[Fix #14239] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14239](https://github.com/rubocop/rubocop/issues/14239): Fix false positives for `Style/RedundantParentheses` when using one-line `in` pattern matching in operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -164,8 +164,9 @@ module RuboCop
           if node.lambda_or_proc? && (node.braces? || node.send_node.lambda_literal?)
             return 'an expression'
           end
-
-          return 'a one-line pattern matching' if node.any_match_pattern_type?
+          if node.any_match_pattern_type? && node.each_ancestor.none?(&:operator_keyword?)
+            return 'a one-line pattern matching'
+          end
           return 'an interpolated expression' if interpolation?(begin_node)
           return 'a method argument' if argument_of_parenthesized_method_call?(begin_node, node)
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1156,7 +1156,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
-  it 'registers parentheses when using one-line hash `in` pattern matching in a redundant parentheses', :ruby27 do
+  it 'registers parentheses when using one-line `in` pattern matching in a redundant parentheses', :ruby27 do
     expect_offense(<<~RUBY)
       (expression in pattern)
       ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
@@ -1168,7 +1168,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
-  it 'registers parentheses when using one-line hash `in` pattern matching in a redundant parentheses', :ruby30 do
+  it 'registers parentheses when using one-line `in` pattern matching in a redundant parentheses', :ruby30 do
     expect_offense(<<~RUBY)
       (expression in pattern)
       ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
@@ -1180,7 +1180,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   # Ruby 3.0's one-line `=>` pattern node type is `match-pattern`.
-  it 'registers an offense when using one-line hash `=>` pattern matching in a redundant parentheses', :ruby30 do
+  it 'registers an offense when using one-line `=>` pattern matching in a redundant parentheses', :ruby30 do
     expect_offense(<<~RUBY)
       (expression => pattern)
       ^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
@@ -1192,30 +1192,42 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   end
 
   # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
-  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby27 do
+  it 'accepts parentheses when using one-line `in` pattern matching in a method argument', :ruby27 do
     expect_no_offenses(<<~RUBY)
       foo((bar in baz))
     RUBY
   end
 
   # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
-  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument with safe navigation', :ruby27 do
+  it 'accepts parentheses when using one-line `in` pattern matching in a method argument with safe navigation', :ruby27 do
     expect_no_offenses(<<~RUBY)
       obj&.foo((bar in baz))
     RUBY
   end
 
   # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
-  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument', :ruby30 do
+  it 'accepts parentheses when using one-line `in` pattern matching in a method argument', :ruby30 do
     expect_no_offenses(<<~RUBY)
       foo((bar in baz))
     RUBY
   end
 
   # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
-  it 'accepts parentheses when using one-line hash `in` pattern matching in a method argument with safe navigation', :ruby30 do
+  it 'accepts parentheses when using one-line `in` pattern matching in a method argument with safe navigation', :ruby30 do
     expect_no_offenses(<<~RUBY)
       obj&.foo((bar in baz))
+    RUBY
+  end
+
+  it 'accepts parentheses when using one-line `in` pattern matching in `&&` operator', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      (foo in bar) && (baz in qux)
+    RUBY
+  end
+
+  it 'accepts parentheses when using one-line `in` pattern matching in `||` operator', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      (foo in bar) || (baz in qux)
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when using one-line `in` pattern matching in operator.

Fixes #14239.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
