### PR TITLE
[Fix #14249] Fix false positives for `Style/RedundantArrayFlatten`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_array_flatten.md
+++ b/changelog/fix_false_positives_for_style_redundant_array_flatten.md
@@ -1,0 +1,1 @@
+* [#14249](https://github.com/rubocop/rubocop/issues/14249): Fix false positives for `Style/RedundantArrayFlatten` when `Array#join` is used with an argument other than the default `nil`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_array_flatten.rb
+++ b/lib/rubocop/cop/style/redundant_array_flatten.rb
@@ -12,6 +12,8 @@ module RuboCop
       #   Cop is unsafe because the receiver of `flatten` method might not
       #   be an `Array`, so it's possible it won't respond to `join` method,
       #   or the end result would be different.
+      #   Also, if the global variable `$,` is set to a value other than the default `nil`,
+      #   false positives may occur.
       #
       # @example
       #   # bad
@@ -30,7 +32,7 @@ module RuboCop
 
         # @!method flatten_join?(node)
         def_node_matcher :flatten_join?, <<~PATTERN
-          (call (call !nil? :flatten _?) :join _?)
+          (call (call !nil? :flatten _?) :join (nil)?)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/redundant_array_flatten_spec.rb
+++ b/spec/rubocop/cop/style/redundant_array_flatten_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantArrayFlatten, :config do
     RUBY
   end
 
-  it 'registers an offense for `x.flatten.join(separator)`' do
+  it 'registers an offense for `x.flatten.join(nil)`' do
     expect_offense(<<~RUBY)
-      x.flatten.join(separator)
+      x.flatten.join(nil)
        ^^^^^^^^ Remove the redundant `flatten`.
     RUBY
 
     expect_correction(<<~RUBY)
-      x.join(separator)
+      x.join(nil)
     RUBY
   end
 
@@ -54,6 +54,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantArrayFlatten, :config do
   it 'does not register an offense for `x.flatten`' do
     expect_no_offenses(<<~RUBY)
       x.flatten
+    RUBY
+  end
+
+  it 'does not register an offense for `x.flatten.join(separator)`' do
+    expect_no_offenses(<<~RUBY)
+      x.flatten.join(separator)
     RUBY
   end
 


### PR DESCRIPTION
`Style/RedundantArrayFlatten` cop is already marked as unsafe, but this change prevents false positives when `Array#join` is used with an argument other than the default value `nil`.

Fix #14249.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
