### PR TITLE
Improve `expect_offense` interpolation documentation

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -282,9 +282,15 @@ describe RuboCop::Cop::Style::SimplifyNotEmptyWithAny, :config do
 end
 ----
 
-If your code has variables of different lengths, you can use `%{foo}`,
-`^{foo}`, and `_{foo}` to format your template; you can also abbreviate
-offense messages with `[...]`:
+If your code has variables of different lengths, you can use the following
+markers to format your template by passing the variables as a keyword
+arguments:
+
+- `%{foo}`: Interpolates `foo`
+- `^{foo}`: Inserts `'^' * foo.size` for dynamic offense range length
+- `_{foo}`: Inserts `' ' * foo.size` for dynamic offense range indentation
+
+You can also abbreviate offense messages with `[...]`.
 
 [source,ruby]
 ----

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -72,9 +72,15 @@ module RuboCop
     #
     #   expect_no_corrections
     #
-    # If your code has variables of different lengths, you can use `%{foo}`,
-    # `^{foo}`, and `_{foo}` to format your template; you can also abbreviate
-    # offense messages with `[...]`:
+    # If your code has variables of different lengths, you can use the
+    # following markers to format your template by passing the variables as a
+    # keyword arguments:
+    #
+    # - `%{foo}`: Interpolates `foo`
+    # - `^{foo}`: Inserts `'^' * foo.size` for dynamic offense range length
+    # - `_{foo}`: Inserts `' ' * foo.size` for dynamic offense range indentation
+    #
+    # You can also abbreviate offense messages with `[...]`.
     #
     #   %w[raise fail].each do |keyword|
     #     expect_offense(<<~RUBY, keyword: keyword)


### PR DESCRIPTION
The existing documentation mentions `%{foo}`, `^{foo}`, & `_{foo}`, but doesn't explicitly explain what they do. The example is good, but we can complement it by explicitly stating their purposes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~Added tests.~ _Not applicable_
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* ~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~ _Not worth including_

[1]: https://chris.beams.io/posts/git-commit/
