### PR TITLE
Add new rake task to verify config references availability

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2689,7 +2689,7 @@ Metrics/AbcSize:
                  A calculated magnitude based on number of assignments,
                  branches, and conditions.
   References:
-    - http://c2.com/cgi/wiki?AbcMetric
+    - https://wiki.c2.com/?AbcMetric
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: true
   VersionAdded: '0.27'
@@ -5006,7 +5006,7 @@ Style/OpenStructUse:
                  Avoid using OpenStruct. As of Ruby 3.0, use is officially discouraged due to performance,
                  version compatibility, and potential security issues.
   References:
-    - https://docs.ruby-lang.org/en/3.0.0/OpenStruct.html#class-OpenStruct-label-Caveats
+    - https://docs.ruby-lang.org/en/3.0/OpenStruct.html#class-OpenStruct-label-Caveats
 
   Enabled: pending
   Safe: false

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -100,6 +100,7 @@ namespace :cut_release do
     Bump::Bump.run(release_type, commit: false, bundle: false, tag: false)
     new_version = Bump::Bump.current
 
+    Rake::Task['references:verify'].invoke
     update_cop_versions(old_version, new_version)
     Rake::Task['update_cops_documentation'].invoke
     update_readme(old_version, new_version)

--- a/tasks/references.rake
+++ b/tasks/references.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+namespace :references do
+  desc 'Verify configuration references availability'
+  task :verify do |_task|
+    config = YAML.load_file('config/default.yml', permitted_classes: [Symbol, Regexp])
+    references = config.values.map do |config_entry|
+      Array(config_entry.fetch('References', config_entry.fetch('Reference', [])))
+    end
+    references.flatten!.map! { |entry| URI(entry) }.select!(&:hostname)
+
+    has_failures = false
+    references.to_set.each do |reference|
+      failure = begin
+        response = Net::HTTP.get_response(reference)
+        response.code if response.code != '200'
+      rescue StandardError => e
+        e
+      end
+
+      if failure
+        has_failures = true
+        puts "ERROR: #{reference} (#{failure})"
+      end
+    end
+
+    exit(1) if has_failures
+  end
+end


### PR DESCRIPTION
Reference URLs in the configuration may become outdated over time. To help catch issues early, especially before releasing a new version, this patch introduces a new rake task: `references:verify`.

The task iterates over existing references and reports any broken or unreachable URLs.

There's a bunch of unnecessary redirects in this repository, but some plugins actually contain unreachable links in their configs, so it'd be good to use this task in other repos too.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
