### PR TITLE
Fix build errors on Winsows matrix

### DIFF
--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Server::Cache do
 
       it 'is the specified path' do
         if RuboCop::Platform.windows?
-          expect(cache_class.cache_path).to eq('D:/tmp/rubocop_cache/server')
+          expect(cache_class.cache_path).to eq('C:/tmp/rubocop_cache/server')
         else
           expect(cache_class.cache_path).to eq('/tmp/rubocop_cache/server')
         end
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Server::Cache do
           expect(described_class).to receive(:require).with('yaml')
 
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+            expect(cache_class.cache_path).to eq(cache_path.prepend('C:'))
           else
             expect(cache_class.cache_path).to eq(cache_path)
           end
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Server::Cache do
           YAML
 
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+            expect(cache_class.cache_path).to eq(cache_path.prepend('C:'))
           else
             expect(cache_class.cache_path).to eq(cache_path)
           end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Server::Cache do
           YAML
 
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+            expect(cache_class.cache_path).to eq(File.join('C:/tmp', 'rubocop_cache', 'server'))
           else
             expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
           end
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Server::Cache do
 
         it 'contains the root from `RUBOCOP_CACHE_ROOT`' do
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+            expect(cache_class.cache_path).to eq(cache_path.prepend('C:'))
           else
             expect(cache_class.cache_path).to eq(cache_path)
           end
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Server::Cache do
 
         it 'contains the root from `RUBOCOP_CACHE_ROOT`' do
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+            expect(cache_class.cache_path).to eq(cache_path.prepend('C:'))
           else
             expect(cache_class.cache_path).to eq(cache_path)
           end
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Server::Cache do
 
         it 'contains the root from cache root path' do
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+            expect(cache_class.cache_path).to eq(File.join('C:/tmp', 'rubocop_cache', 'server'))
           else
             expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
           end
@@ -201,7 +201,7 @@ RSpec.describe RuboCop::Server::Cache do
 
         it 'contains the root from `XDG_CACHE_HOME`' do
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(cache_path.prepend('D:'))
+            expect(cache_class.cache_path).to eq(cache_path.prepend('C:'))
           else
             expect(cache_class.cache_path).to eq(cache_path)
           end
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Server::Cache do
 
         it 'contains the root from cache root path' do
           if RuboCop::Platform.windows?
-            expect(cache_class.cache_path).to eq(File.join('D:/tmp', 'rubocop_cache', 'server'))
+            expect(cache_class.cache_path).to eq(File.join('C:/tmp', 'rubocop_cache', 'server'))
           else
             expect(cache_class.cache_path).to eq(File.join('/tmp', 'rubocop_cache', 'server'))
           end


### PR DESCRIPTION
This PR fixes the following build errors on Winsows matrix: https://github.com/rubocop/rubocop/actions/runs/15509910142/job/43669493524

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
