### PR TITLE
[Fix #14260] Fix an error for `Lint/UselessDefaultValueArgument` with no receiver

### DIFF
--- a/changelog/new_reset_the_docs_version_20250609133226.md
+++ b/changelog/new_reset_the_docs_version_20250609133226.md
@@ -1,0 +1,1 @@
+* [#14260](https://github.com/rubocop/rubocop/pull/14260): Fix an error for `Lint/UselessDefaultValueArgument` with no receiver. ([@earlopain][])

--- a/lib/rubocop/cop/lint/useless_default_value_argument.rb
+++ b/lib/rubocop/cop/lint/useless_default_value_argument.rb
@@ -67,7 +67,7 @@ module RuboCop
           unless (prev_arg_node, default_value_node = default_value_argument_and_block(node.parent))
             return
           end
-          return if allowed_receiver?(node.receiver)
+          return if node.receiver && allowed_receiver?(node.receiver)
           return if hash_without_braces?(default_value_node)
 
           add_offense(default_value_node) do |corrector|

--- a/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
+++ b/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessDefaultValueArgument, :config do
         x.fetch(key, **kwarg) { block_value }
       RUBY
     end
+
+    it 'registers an offense with no receiver' do
+      expect_offense(<<~RUBY)
+        fetch(key, default_value) { block_value }
+                   ^^^^^^^^^^^^^ Block supersedes default value argument.
+      RUBY
+    end
   end
 
   context 'with `Array.new`' do


### PR DESCRIPTION
Fix #14260

Seems fine to register an offense for cases like this to me.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
