### PR TITLE
[Fix #14260] Fix an error for `Lint/UselessDefaultValueArgument`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_default_value_argument.md
+++ b/changelog/fix_an_error_for_lint_useless_default_value_argument.md
@@ -1,0 +1,1 @@
+* [#14260](https://github.com/rubocop/rubocop/issues/14260): Fix an error for `Lint/UselessDefaultValueArgument` when `fetch` call without a receiver. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_default_value_argument.rb
+++ b/lib/rubocop/cop/lint/useless_default_value_argument.rb
@@ -10,6 +10,9 @@ module RuboCop
       # applies to `Array.new`, `Array#fetch`, `Hash#fetch`, `ENV.fetch` and
       # `Thread#fetch`.
       #
+      # A `fetch` call without a receiver is considered a custom method and does not register
+      # an offense.
+      #
       # @safety
       #   This cop is unsafe because the receiver could have nonstandard implementation
       #   of `fetch`, or be a class other than the one listed above.
@@ -56,7 +59,7 @@ module RuboCop
         def_node_matcher :default_value_argument_and_block, <<~PATTERN
           (any_block
             {
-              (call _receiver :fetch $_key $_default_value)
+              (call !nil? :fetch $_key $_default_value)
               (send (const _ :Array) :new $_size $_default_value)
             }
             _args

--- a/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
+++ b/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessDefaultValueArgument, :config do
         x.fetch(key, **kwarg) { block_value }
       RUBY
     end
+
+    it 'does not register an offense for `fetch(key, default_value) { |arg| arg }`' do
+      expect_no_offenses(<<~RUBY)
+        fetch(key, default_value) { |arg| arg }
+      RUBY
+    end
   end
 
   context 'with `Array.new`' do


### PR DESCRIPTION
This PR fixes an error for `Lint/UselessDefaultValueArgument` when `fetch` call without a receiver.

Fixes #14260.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
