### PR TITLE
Offend access modifiers used on top-level in `Lint/UselessAccessModifier`

### DIFF
--- a/changelog/change_lint_useless_access_modifier_top_level.md
+++ b/changelog/change_lint_useless_access_modifier_top_level.md
@@ -1,0 +1,1 @@
+* [#14264](https://github.com/rubocop/rubocop/pull/14264): Offend access modifiers used on top-level in `Lint/UselessAccessModifier`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -29,6 +29,30 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
     end
   end
 
+  context 'when an access modifier is used on top-level' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        def some_method
+          puts 10
+        end
+        private
+        ^^^^^^^ Useless `private` access modifier.
+        def other_method
+          puts 10
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          puts 10
+        end
+        def other_method
+          puts 10
+        end
+      RUBY
+    end
+  end
+
   context 'when an access modifier has no methods' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Access modifiers have no effect on top-level; methods are by default added as private instance methods on `main` Object, which can be called anywhere:
```ruby
def foo; end

private

def bar; end

public

def baz; end

puts self.class.private_instance_methods.include?(:foo)
# => true

puts self.class.private_instance_methods.include?(:bar)
# => true

puts self.class.public_instance_methods.include?(:baz)
# => true
```
This PR registers all access modifiers on toplevel as offenses.

For simplicity, this PR doesn't register an offense when access modifier is the only line in the file (e.g. the whole file is just `private`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
