### PR TITLE
Add `DefaultToNil` option to `Style/FetchEnvVar`

### DIFF
--- a/changelog/new_default_to_nil_option_is_added_to_style_envfetchvar_20250610082226.md
+++ b/changelog/new_default_to_nil_option_is_added_to_style_envfetchvar_20250610082226.md
@@ -1,0 +1,1 @@
+* [#14266](https://github.com/rubocop/rubocop/pull/14266): Add DefaultToNil option to `Style/FetchEnvVar`. ([@steiley][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4058,6 +4058,7 @@ Style/FetchEnvVar:
   VersionAdded: '1.28'
   # Environment variables to be excluded from the inspection.
   AllowedVars: []
+  DefaultToNil: true
 
 Style/FileEmpty:
   Description: >-

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -22,6 +22,22 @@ module RuboCop
       #   !ENV['X']
       #   ENV['X'].some_method # (e.g. `.nil?`)
       #
+      # @example DefaultToNil: true (default)
+      #   # Correct with nil argument
+      #   # bad
+      #   ENV['X']
+      #
+      #   # good
+      #   ENV.fetch('X', nil)
+      #
+      # @example DefaultToNil: false
+      #   # Correct without nil argument
+      #   # bad
+      #   ENV['X']
+      #
+      #   # good
+      #   ENV.fetch('X')  # raises KeyError when missing
+      #
       class FetchEnvVar < Base
         extend AutoCorrector
 
@@ -125,7 +141,7 @@ module RuboCop
         end
 
         def new_code(name_node)
-          "ENV.fetch(#{name_node.source}, nil)"
+          "ENV.fetch(#{name_node.source}#{', nil' if cop_config['DefaultToNil']})"
         end
       end
     end

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -1,27 +1,45 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
-  let(:cop_config) { { 'ExceptedEnvVars' => [] } }
+  let(:cop_config) { { 'ExceptedEnvVars' => [], 'DefaultToNil' => default_to_nil } }
+  let(:default_to_nil) { true }
 
   context 'when it is evaluated with no default values' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        ENV['X']
-        ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
-      RUBY
+    context 'when DefaultToNil is true' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          ENV['X']
+          ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        ENV.fetch('X', nil)
-      RUBY
+        expect_correction(<<~RUBY)
+          ENV.fetch('X', nil)
+        RUBY
 
-      expect_offense(<<~RUBY)
-        ENV['X' + 'Y']
-        ^^^^^^^^^^^^^^ Use `ENV.fetch('X' + 'Y')` or `ENV.fetch('X' + 'Y', nil)` instead of `ENV['X' + 'Y']`.
-      RUBY
+        expect_offense(<<~RUBY)
+          ENV['X' + 'Y']
+          ^^^^^^^^^^^^^^ Use `ENV.fetch('X' + 'Y')` or `ENV.fetch('X' + 'Y', nil)` instead of `ENV['X' + 'Y']`.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        ENV.fetch('X' + 'Y', nil)
-      RUBY
+        expect_correction(<<~RUBY)
+          ENV.fetch('X' + 'Y', nil)
+        RUBY
+      end
+    end
+
+    context 'when DefaultToNil is false' do
+      let(:default_to_nil) { false }
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          ENV['X']
+          ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ENV.fetch('X')
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Related #14165

Add a new configuration option `DefaultToNil` to the `Style/FetchEnvVar` cop that allows users to control the autocorrection behavior.

`DefaultToNil`: true (default, preserves current behavior)

```
# bad
ENV['X']

# good
ENV.fetch('X', nil)
```
`DefaultToNil`: false (new option)

```
# bad
ENV['X']

# good
ENV.fetch('X')  # raises KeyError when missing
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
