### PR TITLE
Register operator expression range boundaries as offenses in `Lint/AmbiguousRange`

### DIFF
--- a/changelog/change_lint_ambiguous_range_operator_expressions.md
+++ b/changelog/change_lint_ambiguous_range_operator_expressions.md
@@ -1,0 +1,1 @@
+* [#14268](https://github.com/rubocop/rubocop/pull/14268): Register operator expression range boundaries as offenses in `Lint/AmbiguousRange`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -138,7 +138,7 @@ module RuboCop
         end
 
         def previous_line_ignoring_comments(processed_source, send_line)
-          processed_source[0..send_line - 2].reverse.find { |line| !comment_line?(line) }
+          processed_source[0..(send_line - 2)].reverse.find { |line| !comment_line?(line) }
         end
 
         def previous_line_empty?(send_line)

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -27,7 +27,9 @@ module RuboCop
       # @example
       #   # bad
       #   x || 1..2
+      #   x - 1..2
       #   (x || 1..2)
+      #   x || 1..y || 2
       #   1..2.to_a
       #
       #   # good, unambiguous
@@ -41,6 +43,7 @@ module RuboCop
       #
       #   # good, ambiguity removed
       #   x || (1..2)
+      #   (x - 1)..2
       #   (x || 1)..2
       #   (x || 1)..(y || 2)
       #   (1..2).to_a
@@ -95,6 +98,8 @@ module RuboCop
           # Require parentheses when making a method call on a literal
           # to avoid the ambiguity of `1..2.to_a`.
           return false if node.receiver&.basic_literal?
+
+          return false if node.operator_method? && !node.method?(:[])
 
           require_parentheses_for_method_chain? || node.receiver.nil?
         end

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -89,7 +89,7 @@ module RuboCop
 
         if first_non_comment_token
           # `line` is 1-indexed so we need to subtract 1 to get the array index
-          processed_source.lines[0...first_non_comment_token.line - 1]
+          processed_source.lines[0...(first_non_comment_token.line - 1)]
         else
           processed_source.lines
         end

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -97,7 +97,7 @@ module RuboCop
           pipes = tokens.select { |token| token.type == :tPIPE }
           begin_pos, end_pos = pipes.map { |pipe| tokens.index(pipe) }
 
-          tokens[begin_pos + 1..end_pos - 1]
+          tokens[(begin_pos + 1)..(end_pos - 1)]
         end
       end
     end

--- a/spec/rubocop/cop/lint/ambiguous_range_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_range_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when boundary is an operator expression' do
+        expect_offense(<<~RUBY)
+          x - 1#{operator}2
+          ^^^^^ Wrap complex range boundaries with parentheses to avoid ambiguity.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          (x - 1)#{operator}2
+        RUBY
+      end
+
       it 'registers an offense and corrects when the entire range is parenthesized but contains complex boundaries' do
         expect_offense(<<~RUBY)
           (x || 1#{operator}2)
@@ -52,6 +63,12 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousRange, :config do
         expect_no_offenses(<<~RUBY)
           x || (1#{operator}2)
           (x || 1)#{operator}2
+        RUBY
+      end
+
+      it 'does not register an offense when boundary is an element reference' do
+        expect_no_offenses(<<~RUBY)
+          x[1]#{operator}2
         RUBY
       end
 


### PR DESCRIPTION
Registers code like the following:
```ruby
a - b..c
a..b * c
a | b..c
```
as offenses under `Lint/AmbiguousRange`, and autocorrects it to:
```ruby
(a - b)..c
a..(b * c)
(a | b)..c
```

Operator methods [have higher precedence](https://docs.ruby-lang.org/en/3.4/syntax/precedence_rdoc.html) than ranges, so this change makes that precedence explicit.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
