### PR TITLE
[Fix #14232] Add `AllowedPatterns` and `AllowBangMethods` configuration to `Naming/PredicateMethod`

### DIFF
--- a/changelog/change_add_allowed_patterns_and_allow_bang_methods_20250610090316.md
+++ b/changelog/change_add_allowed_patterns_and_allow_bang_methods_20250610090316.md
@@ -1,0 +1,1 @@
+* [#14232](https://github.com/rubocop/rubocop/issues/14232): Add `AllowedPatterns` and `AllowBangMethods` configuration to `Naming/PredicateMethod`. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3063,6 +3063,7 @@ Naming/PredicateMethod:
   Description: 'Checks that predicate methods end with `?` and non-predicate methods do not.'
   Enabled: pending
   VersionAdded: '1.76'
+  VersionChanged: '<<next>>'
   # In `aggressive` mode, the cop will register an offense for predicate methods that
   #   may return a non-boolean value.
   # In `conservative` mode, the cop will *not* register an offense for predicate methods
@@ -3070,6 +3071,8 @@ Naming/PredicateMethod:
   Mode: conservative
   AllowedMethods:
     - call
+  AllowedPatterns: []
+  AllowBangMethods: false
 
 Naming/PredicatePrefix:
   Description: 'Predicate method names should not be prefixed and end with a `?`.'


### PR DESCRIPTION
* `AllowedPatterns` allows regular expressions to be set for allowing method names.
* `AllowBangMethods` allows method names ending with a bang (`!`) to always be accepted by the cop.

Fixes #14232.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
