### PR TITLE
[Fix #14269] Fix false positives for `Style/RedundantSelf`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_self.md
+++ b/changelog/fix_false_positives_for_style_redundant_self.md
@@ -1,0 +1,1 @@
+* [#14269](https://github.com/rubocop/rubocop/issues/14269): Fix false positives for `Style/RedundantSelf` when local variable assignment name is used in nested `if`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -123,11 +123,11 @@ module RuboCop
         def on_if(node)
           # Allow conditional nodes to use `self` in the condition if that variable
           # name is used in an `lvasgn` or `masgn` within the `if`.
-          node.child_nodes.each do |child_node|
-            if child_node.lvasgn_type?
-              add_lhs_to_local_variables_scopes(node.condition, child_node.lhs)
-            elsif child_node.masgn_type?
-              add_masgn_lhs_variables(node.condition, child_node.lhs)
+          node.each_descendant(:lvasgn, :masgn) do |descendant_node|
+            if descendant_node.lvasgn_type?
+              add_lhs_to_local_variables_scopes(node.condition, descendant_node.lhs)
+            else
+              add_masgn_lhs_variables(node.condition, descendant_node.lhs)
             end
           end
         end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     expect_no_offenses('a, b = self.a if self.a')
   end
 
+  it 'does not report an offense when lvasgn name is used in nested `if`' do
+    expect_no_offenses(<<~RUBY)
+      if self.a
+        a = self.a
+      end if self.a
+    RUBY
+  end
+
+  it 'does not report an offense when masgn name is used in nested `if`' do
+    expect_no_offenses(<<~RUBY)
+      if self.a
+        a, b = self.a
+      end if self.a
+    RUBY
+  end
+
   it 'does not report an offense when lvasgn name is used in `unless`' do
     expect_no_offenses('a = self.a unless self.a')
   end


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantSelf` when local variable assignment name is used in nested `if`.

Fixes #14269.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
