### PR TITLE
[Fix #14165] Add new DefaultToNil option to Style/FetchEnvVar cop

### DIFF
--- a/changelog/new_default_to_nil_option_to_style_fetch_env_var.md
+++ b/changelog/new_default_to_nil_option_to_style_fetch_env_var.md
@@ -1,0 +1,1 @@
+* [#14165](https://github.com/rubocop/rubocop/issues/14165): Add new `DefaultToNil` option to `Style/FetchEnvVar` cop. ([@Yuhi-Sato][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4061,6 +4061,9 @@ Style/FetchEnvVar:
   VersionAdded: '1.28'
   # Environment variables to be excluded from the inspection.
   AllowedVars: []
+  # When `true`, autocorrects `ENV["key"]` to `ENV.fetch("key", nil)`.
+  # When `false`, autocorrects `ENV["key"]` to `ENV.fetch("key")`.
+  DefaultToNil: true
 
 Style/FileEmpty:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -5371,6 +5371,27 @@ specified default value.
 [#examples-stylefetchenvvar]
 === Examples
 
+[#defaulttonil_true_stylefetchenvvar]
+==== DefaultToNil: true (default)
+
+[source,ruby]
+----
+# bad
+ENV['X']
+x = ENV['X']
+
+# good
+ENV.fetch('X', nil)
+x = ENV.fetch('X', nil)
+
+# also good
+!ENV['X']
+ENV['X'].some_method # (e.g. `.nil?`)
+----
+
+[#defaulttonil_false_stylefetchenvvar]
+==== DefaultToNil: false
+
 [source,ruby]
 ----
 # bad
@@ -5395,6 +5416,10 @@ ENV['X'].some_method # (e.g. `.nil?`)
 | AllowedVars
 | `[]`
 | Array
+
+| DefaultToNil 
+| `true`
+| Boolean
 |===
 
 [#references-stylefetchenvvar]

--- a/spec/rubocop/cop/style/fetch_env_var_spec.rb
+++ b/spec/rubocop/cop/style/fetch_env_var_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
-  let(:cop_config) { { 'ExceptedEnvVars' => [] } }
+  let(:cop_config) { { 'AllowedVars' => [] } }
 
   context 'when it is evaluated with no default values' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         ENV['X']
-        ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+        ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
 
       expect_offense(<<~RUBY)
         ENV['X' + 'Y']
-        ^^^^^^^^^^^^^^ Use `ENV.fetch('X' + 'Y')` or `ENV.fetch('X' + 'Y', nil)` instead of `ENV['X' + 'Y']`.
+        ^^^^^^^^^^^^^^ Use `ENV.fetch('X' + 'Y', nil)` instead of `ENV['X' + 'Y']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         y ||= ENV['X']
-              ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+              ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
     end
   end
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         y &&= ENV['X']
-              ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+              ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         some_method(ENV['X'])
-                    ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+                    ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
 
       expect_offense(<<~RUBY)
         x.some_method(ENV['X'])
-                      ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+                      ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -125,11 +125,11 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
         some_method(
           ENV['A'].some_method,
           ENV['B'] || ENV['C'],
-                      ^^^^^^^^ Use `ENV.fetch('C')` or `ENV.fetch('C', nil)` instead of `ENV['C']`.
+                      ^^^^^^^^ Use `ENV.fetch('C', nil)` instead of `ENV['C']`.
           ENV['X'],
-          ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+          ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
           ENV['Y']
-          ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+          ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         )
       RUBY
 
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense when using single assignment' do
       expect_offense(<<~RUBY)
         x = ENV['X']
-            ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+            ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -159,9 +159,9 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense when using multiple assignment' do
       expect_offense(<<~RUBY)
         x, y = ENV['X'],
-               ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+               ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
                ENV['Y']
-               ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+               ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -176,9 +176,9 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       expect_offense(<<~RUBY)
         [
           ENV['X'],
-          ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+          ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
           ENV['Y']
-          ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+          ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         ]
       RUBY
 
@@ -196,9 +196,9 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       expect_offense(<<~RUBY)
         {
           ENV['X'] => :x,
-          ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+          ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
           ENV['Y'] => :y
-          ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+          ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         }
       RUBY
 
@@ -216,9 +216,9 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       expect_offense(<<~RUBY)
         {
           x: ENV['X'],
-             ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+             ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
           y: ENV['Y']
-             ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+             ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         }
       RUBY
 
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         "\#{ENV['X']}"
-           ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+           ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -282,9 +282,9 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense with `case`' do
       expect_offense(<<~RUBY)
         case ENV['X']
-             ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+             ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
         when ENV['Y']
-             ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+             ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
           puts x
         end
       RUBY
@@ -354,7 +354,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       expect_offense(<<~RUBY)
         if ENV['X']
           puts ENV['Y']
-               ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+               ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         end
       RUBY
 
@@ -377,7 +377,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
       expect_offense(<<~RUBY)
         if ENV['X'] = x
           puts ENV['Y']
-               ^^^^^^^^ Use `ENV.fetch('Y')` or `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
+               ^^^^^^^^ Use `ENV.fetch('Y', nil)` instead of `ENV['Y']`.
         end
       RUBY
 
@@ -393,7 +393,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     expect_offense(<<~RUBY)
       if ENV && x
         ENV[x]
-        ^^^^^^ Use `ENV.fetch(x)` or `ENV.fetch(x, nil)` instead of `ENV[x]`.
+        ^^^^^^ Use `ENV.fetch(x, nil)` instead of `ENV[x]`.
       end
     RUBY
 
@@ -408,7 +408,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     expect_offense(<<~RUBY)
       if ENV || x
         ENV[x]
-        ^^^^^^ Use `ENV.fetch(x)` or `ENV.fetch(x, nil)` instead of `ENV[x]`.
+        ^^^^^^ Use `ENV.fetch(x, nil)` instead of `ENV[x]`.
       end
     RUBY
 
@@ -423,7 +423,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     expect_offense(<<~RUBY)
       if a == b
         ENV['X']
-        ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+        ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       end
     RUBY
 
@@ -438,7 +438,7 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     expect_offense(<<~RUBY)
       if a || b && c
         puts ENV['X']
-             ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+             ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       end
     RUBY
 
@@ -463,10 +463,10 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         y || ENV['X']
-             ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+             ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
 
         y || z || ENV['X']
-                  ^^^^^^^^ Use `ENV.fetch('X')` or `ENV.fetch('X', nil)` instead of `ENV['X']`.
+                  ^^^^^^^^ Use `ENV.fetch('X', nil)` instead of `ENV['X']`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -483,6 +483,43 @@ RSpec.describe RuboCop::Cop::Style::FetchEnvVar, :config do
         ENV['X'] || y
 
         z || ENV['X'] || y
+      RUBY
+    end
+  end
+
+  context 'when `DefaultToNil` is false' do
+    let(:cop_config) { { 'DefaultToNil' => false } }
+
+    it 'registers an offense and corrects to ENV.fetch without nil' do
+      expect_offense(<<~RUBY)
+        ENV['X']
+        ^^^^^^^^ Use `ENV.fetch('X')` instead of `ENV['X']`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ENV.fetch('X')
+      RUBY
+    end
+
+    it 'registers an offense for variable assignment' do
+      expect_offense(<<~RUBY)
+        x = ENV['X']
+            ^^^^^^^^ Use `ENV.fetch('X')` instead of `ENV['X']`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = ENV.fetch('X')
+      RUBY
+    end
+
+    it 'registers an offense for method argument' do
+      expect_offense(<<~RUBY)
+        some_method(ENV['X'])
+                    ^^^^^^^^ Use `ENV.fetch('X')` instead of `ENV['X']`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        some_method(ENV.fetch('X'))
       RUBY
     end
   end


### PR DESCRIPTION
This change adds a new configuration option `DefaultToNil` to the Style/FetchEnvVar cop to control whether `ENV["key"] `should be autocorrected to `ENV.fetch("key", nil)` or `ENV.fetch("key")`.

When `DefaultToNil` is true (default), `ENV["key"]` is corrected to `ENV.fetch("key", nil)` to preserve the original behavior. When `DefaultToNil` is false, `ENV["key"]` is corrected to `ENV.fetch("key")` which raises KeyError when the key is missing.

Fixes #14165

## Summary

This PR adds a new configuration option `DefaultToNil` to the `Style/FetchEnvVar` cop to address issue #14165.

## Changes

- Added `DefaultToNil` configuration option (default: `true`)
- When `DefaultToNil: true`: `ENV["key"]` → `ENV.fetch("key", nil)` (current behavior)
- When `DefaultToNil: false`: `ENV["key"]` → `ENV.fetch("key")` (new option)
- Updated documentation and tests
- Added changelog entry

## Motivation

The current cop always suggests `ENV.fetch("key", nil)` which is functionally identical to `ENV["key"]` but more verbose. This change allows users to choose between:

1. Preserving nil-returning behavior with explicit `nil` default
2. Using `ENV.fetch` without default to raise `KeyError` for missing keys

This gives developers more control over how they want to handle missing environment variables.

## Testing

- All existing tests pass
- Added new test cases for `DefaultToNil: false` configuration
- Verified autocorrection works correctly for both configurations

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
