### PR TITLE
[Fix #14273] Fix an error for `Lint/EmptyInterpolation`

### DIFF
--- a/changelog/fix_an_error_for_lint_empty_interpolation.md
+++ b/changelog/fix_an_error_for_lint_empty_interpolation.md
@@ -1,0 +1,1 @@
+* [#14273](https://github.com/rubocop/rubocop/issues/14273): Fix an error for `Lint/EmptyInterpolation` when using a boolean literal inside interpolation. ([@koic][])

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -20,7 +20,7 @@ module RuboCop
 
         def on_interpolation(begin_node)
           node_children = begin_node.children.dup
-          node_children.delete_if { |e| e.nil_type? || (e.basic_literal? && e.value.to_s.empty?) }
+          node_children.delete_if { |e| e.nil_type? || (e.basic_literal? && e.str_content&.empty?) }
           return unless node_children.empty?
 
           add_offense(begin_node) { |corrector| corrector.remove(begin_node) }

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -76,4 +76,10 @@ RSpec.describe RuboCop::Cop::Lint::EmptyInterpolation, :config do
       "this is the #{1}"
     RUBY
   end
+
+  it 'does not register an offense when using a boolean literal inside interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      "this is the #{true}"
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes an error for `Lint/EmptyInterpolation` when using a boolean literal inside interpolation.

Fixes #14273.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
