### PR TITLE
[Fix #14275] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14275](https://github.com/rubocop/rubocop/issues/14275): Fix false positives for `Style/RedundantParentheses` when using parenthesized one-line pattern matching in endless method definition. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -164,7 +164,7 @@ module RuboCop
           if node.lambda_or_proc? && (node.braces? || node.send_node.lambda_literal?)
             return 'an expression'
           end
-          if node.any_match_pattern_type? && node.each_ancestor.none?(&:operator_keyword?)
+          if disallowed_one_line_pattern_matching?(begin_node, node)
             return 'a one-line pattern matching'
           end
           return 'an interpolated expression' if interpolation?(begin_node)
@@ -252,6 +252,12 @@ module RuboCop
           else
             !raised_to_power_negative_numeric?(begin_node, node)
           end
+        end
+
+        def disallowed_one_line_pattern_matching?(begin_node, node)
+          return false if begin_node.parent&.any_def_type? && begin_node.parent.endless?
+
+          node.any_match_pattern_type? && node.each_ancestor.none?(&:operator_keyword?)
         end
 
         def raised_to_power_negative_numeric?(begin_node, node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1231,6 +1231,90 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses when using parenthesized one-line `in` pattern matching in endless method definition', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      def foo = (bar in baz | qux)
+    RUBY
+  end
+
+  it 'accepts parentheses when using parenthesized one-line `=>` pattern matching in endless method definition', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      def foo = (bar => baz | qux)
+    RUBY
+  end
+
+  it 'accepts parentheses when using parenthesized one-line `in` pattern matching in endless singleton method definition', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      def self.foo = (bar in baz | qux)
+    RUBY
+  end
+
+  it 'accepts parentheses when using parenthesized one-line `=>` pattern matching in endless singleton method definition', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      def self.foo = (bar => baz | qux)
+    RUBY
+  end
+
+  it 'registers parentheses when using parenthesized one-line `in` pattern matching in method definition', :ruby30 do
+    expect_offense(<<~RUBY)
+      def foo
+        (bar in baz | qux)
+        ^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar in baz | qux
+      end
+    RUBY
+  end
+
+  it 'registers parentheses when using parenthesized one-line `=>` pattern matching in method definition', :ruby30 do
+    expect_offense(<<~RUBY)
+      def foo
+        (bar => baz | qux)
+        ^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar => baz | qux
+      end
+    RUBY
+  end
+
+  it 'registers parentheses when using parenthesized one-line `in` pattern matching in singleton method definition', :ruby30 do
+    expect_offense(<<~RUBY)
+      def self.foo
+        (bar in baz | qux)
+        ^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.foo
+        bar in baz | qux
+      end
+    RUBY
+  end
+
+  it 'registers parentheses when using parenthesized one-line `=>` pattern matching in singleton method definition', :ruby30 do
+    expect_offense(<<~RUBY)
+      def self.foo
+        (bar => baz | qux)
+        ^^^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line pattern matching.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.foo
+        bar => baz | qux
+      end
+    RUBY
+  end
+
   context 'when the first argument in a method call begins with a hash literal' do
     it 'accepts parentheses if the argument list is not parenthesized' do
       expect_no_offenses('x ({ y: 1 }), z')


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when using parenthesized one-line pattern matching in endless method definition.

Fixes #14275.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
