### PR TITLE
Fix an error for `Style/PercentQLiterals` cop

### DIFF
--- a/changelog/fix_an_error_for_style_percent_q_literals_cop_20250611140811.md
+++ b/changelog/fix_an_error_for_style_percent_q_literals_cop_20250611140811.md
@@ -1,0 +1,1 @@
+* [#14277](https://github.com/rubocop/rubocop/pull/14277): Fix an error for `Style/PercentQLiterals` cop on parsing error. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -44,7 +44,7 @@ module RuboCop
 
           # Report offense only if changing case doesn't change semantics,
           # i.e., if the string would become dynamic or has special characters.
-          ast = parse(corrected(node.source)).ast
+          ast = parse(corrected(node.source))
           return if node.children != ast&.children
 
           add_offense(node.loc.begin) do |corrector|
@@ -63,6 +63,12 @@ module RuboCop
 
         def corrected(src)
           src.sub(src[1], src[1].swapcase)
+        end
+
+        def parse(source)
+          super.ast
+        rescue ArgumentError => e
+          raise unless e.message.include?('invalid byte sequence')
         end
       end
     end

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
     end
   end
 
+  shared_examples 'with parser error' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~'RUBY')
+        %q(\«)
+      RUBY
+    end
+  end
+
   shared_examples 'accepts any q string with backslash t' do
     context 'with special characters' do
       it 'accepts %q' do
@@ -44,6 +52,7 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
       include_examples 'accepts quote characters'
       include_examples 'accepts any q string with backslash t'
+      include_examples 'with parser error'
     end
 
     context 'with interpolation' do
@@ -57,6 +66,7 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       include_examples 'accepts quote characters'
+      include_examples 'with parser error'
     end
   end
 
@@ -87,6 +97,7 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
       include_examples 'accepts quote characters'
       include_examples 'accepts any q string with backslash t'
+      include_examples 'with parser error'
     end
 
     context 'with interpolation' do
@@ -102,6 +113,7 @@ RSpec.describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       include_examples 'accepts quote characters'
+      include_examples 'with parser error'
     end
   end
 end


### PR DESCRIPTION
It seems to be an issue of Prism, but since the cop is in `Style` department I think it makes sense to ignore these errors for now?

```bash
env RUBOCOP_TARGET_RUBY_VERSION=3.4 PARSER_ENGINE=parser_prism bundle exec rspec spec/rubocop/cop/style/percent_q_literals_spec.rb

Randomized with seed 16470
....F...F................

Failures:

  1) RuboCop::Cop::Style::PercentQLiterals when EnforcedStyle is upper_case_q with interpolation does not register an offense
     Failure/Error: ProcessedSource.new(source, target_ruby_version, path, parser_engine: parser_engine)

     ArgumentError:
       invalid byte sequence in UTF-8
     Shared Example Group: "with parser error" called from ./spec/rubocop/cop/style/percent_q_literals_spec.rb:116
     # ./lib/rubocop/cop/base.rb:301:in 'Class#new'
     # ./lib/rubocop/cop/base.rb:301:in 'RuboCop::Cop::Base#parse'
     # ./lib/rubocop/cop/style/percent_q_literals.rb:69:in 'RuboCop::Cop::Style::PercentQLiterals#parse'
     # ./lib/rubocop/cop/style/percent_q_literals.rb:47:in 'RuboCop::Cop::Style::PercentQLiterals#on_percent_literal'
     # ./lib/rubocop/cop/mixin/percent_literal.rb:20:in 'RuboCop::Cop::PercentLiteral#process'
     # ./lib/rubocop/cop/style/percent_q_literals.rb:37:in 'RuboCop::Cop::Style::PercentQLiterals#on_str'
```

```bash
env RUBOCOP_TARGET_RUBY_VERSION=3.3 PARSER_ENGINE=parser_prism bundle exec rspec spec/rubocop/cop/style/percent_q_literals_spec.rb &>/dev/null; echo $?
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
