### PR TITLE
Register conditions wrapped in parentheses as offenses in `Style/MinMaxComparison`

### DIFF
--- a/changelog/change_style_min_max_comparison_condition_parentheses.md
+++ b/changelog/change_style_min_max_comparison_condition_parentheses.md
@@ -1,0 +1,1 @@
+* [#14278](https://github.com/rubocop/rubocop/pull/14278): Register conditions wrapped in parentheses as offenses in `Style/MinMaxComparison`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/min_max_comparison_spec.rb
+++ b/spec/rubocop/cop/style/min_max_comparison_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe RuboCop::Cop::Style::MinMaxComparison, :config do
     RUBY
   end
 
+  # Consider `Style/TernaryParentheses` cop with `EnforcedStyle: require_parentheses_when_complex`
+  it 'registers and corrects an offense when using `(a >= b) ? b : a`' do
+    expect_offense(<<~RUBY)
+      (a >= b) ? b : a
+      ^^^^^^^^^^^^^^^^ Use `[a, b].min` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [a, b].min
+    RUBY
+  end
+
   it 'registers and corrects an offense when using `a > b a : b` with `if/else`' do
     expect_offense(<<~RUBY)
       if a > b


### PR DESCRIPTION
Currently, `Style/MinMaxComparison` will register:
```ruby
a >= b ? b : a
```
as an offense, but won't do the same for:
```ruby
(a >= b) ? b : a
```

This PR registers applicable conditions wrapped in parentheses as offenses under this cop. Note that such parentheses are added for example when you use [`Style/TernaryParentheses`](https://docs.rubocop.org/rubocop/cops_style.html#styleternaryparentheses) cop with the `EnforcedStyle: require_parentheses_when_complex` config.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
