### PR TITLE
Fix build error when using Ruby LSP >= 0.24

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,7 @@ gem 'rubocop-performance', '~> 1.25.0'
 gem 'rubocop-rake', '~> 0.7.0'
 gem 'rubocop-rspec', '~> 3.6.0'
 # Ruby LSP supports Ruby 3.0+.
-# FIXME: This is a workaround to avoid build errors in the Ruby LSP add-on with Ruby LSP 0.24.
-#        Once https://github.com/rubocop/rubocop-ast/pull/382 is released,
-#        please specify `~> 0.24` instead of `~> 0.23.0`.
-gem 'ruby-lsp', '~> 0.23.0', platform: :mri if RUBY_VERSION >= '3.0'
+gem 'ruby-lsp', '~> 0.24', platform: :mri if RUBY_VERSION >= '3.0'
 gem 'simplecov', '~> 0.20'
 gem 'stackprof', platform: :mri
 gem 'test-queue'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.45.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.45.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop-ast/pull/382.

This PR fixes the following build error on when using Parser gem with `prism_result` and Ruby LSP >= 0.24. https://github.com/rubocop/rubocop/actions/runs/15497886582/job/43638843391?pr=14251

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
