### PR TITLE
Fix warning on duplicated `Lint/UselessAccessModifier` `MethodsCreationContext` option

### DIFF
--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -274,6 +274,10 @@ module RuboCop
 
         def any_method_definition?(child)
           cop_config.fetch('MethodCreatingMethods', []).any? do |m|
+            # Some users still have `"included"` in their `MethodCreatingMethods` configurations,
+            # so to prevent Ruby method redefinition warnings let's just skip this value.
+            next if m == 'included'
+
             matcher_name = :"#{m}_method?"
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<~PATTERN
@@ -296,7 +300,11 @@ module RuboCop
         end
 
         def any_context_creating_methods?(child)
+          # Some users still have `"included"` in their `ContextCreatingMethods` configurations,
+          # so to prevent Ruby method redefinition warnings let's just skip this value.
           cop_config.fetch('ContextCreatingMethods', []).any? do |m|
+            next if m == 'included'
+
             matcher_name = :"#{m}_block?"
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<~PATTERN


### PR DESCRIPTION
Long time ago there was not built-in check for the `included` method so people had to add it to their configurations manually.

It now produces this warning

```bash
rubocop-1.76.1/lib/rubocop/cop/lint/useless_access_modifier.rb:285: warning: method redefined; discarding old included_block?
rubocop-1.76.1/lib/rubocop/cop/lint/useless_access_modifier.rb:248: warning: previous definition of included_block? was here
```

I think if we want people to know there's no need to specify `included` in their configs there should be an explicit RuboCop-produced warning.

This patch simply skips matcher definition for this method.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
