### PR TITLE
Fix typos in Cops docs

### DIFF
--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -15,7 +15,7 @@ Cop-related failures are silenced by default but can be turned on using the
 
 == Style
 
-Style cops check for stylistic consistency of your code. Many of the them are
+Style cops check for stylistic consistency of your code. Many of them are
 based on the https://rubystyle.guide[Ruby Style Guide].
 
 == Layout
@@ -52,12 +52,12 @@ found for the inspected code.
 
 == Naming
 
-Naming cops check for naming issue of your code, such as method name, constant
+Naming cops check for naming issues in your code, such as method name, constant
 name, file name, etc.
 
 == Security
 
-Security cops checks for method calls and constructs which are known to be
+Security cops check for method calls and constructs which are known to be
 associated with potential security issues.
 
 == Bundler


### PR DESCRIPTION
### Detail

This pull request fixes a few minor typos in the Cops documentation.






