### PR TITLE
[Fix #14255] Update `Naming/PredicateMethod` to treat returned predicate method calls as boolean values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,8 +20,8 @@ AllCops:
   SuggestExtensions: false
 
 Naming/PredicateMethod:
-  AllowedMethods:
-    - on_defined?
+  AllowedPatterns:
+    - !ruby/regexp /\Aon_/ # ignore Node#on_* methods
 
 Naming/PredicatePrefix:
   # Method define macros for dynamically generated method.

--- a/changelog/change_update_naming_predicate_method_to_treat_returned_20250617095346.md
+++ b/changelog/change_update_naming_predicate_method_to_treat_returned_20250617095346.md
@@ -1,0 +1,1 @@
+* [#14255](https://github.com/rubocop/rubocop/issues/14255): Update `Naming/PredicateMethod` to treat returned predicate method calls as boolean values. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -94,7 +94,7 @@ module RuboCop
           when :float
             true
           when :send
-            check_send(node)
+            float_send?(node)
           when :begin
             float?(node.children.first)
           else
@@ -108,18 +108,18 @@ module RuboCop
           (node.numeric_type? && node.value.zero?) || node.nil_type?
         end
 
-        def check_send(node)
+        def float_send?(node)
           if node.arithmetic_operation?
             float?(node.receiver) || float?(node.first_argument)
           elsif FLOAT_RETURNING_METHODS.include?(node.method_name)
             true
           elsif node.receiver&.float_type?
             FLOAT_INSTANCE_METHODS.include?(node.method_name) ||
-              check_numeric_returning_method(node)
+              numeric_returning_method?(node)
           end
         end
 
-        def check_numeric_returning_method(node)
+        def numeric_returning_method?(node)
           return false unless node.receiver
 
           case node.method_name

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -228,7 +228,7 @@ module RuboCop
           )
         end
 
-        def condition_evaluation(node, cond)
+        def condition_evaluation?(node, cond)
           if node.unless?
             cond.falsey_literal?
           else
@@ -238,7 +238,7 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def correct_if_node(node, cond)
-          result = condition_evaluation(node, cond)
+          result = condition_evaluation?(node, cond)
 
           new_node = if node.elsif? && result
                        "else\n  #{range_with_comments(node.if_branch).source}"

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -89,7 +89,7 @@ module RuboCop
         private
 
         def inspect_def(node, def_node)
-          return if allowed_arguments(def_node.arguments)
+          return if allowed_arguments?(def_node.arguments)
 
           add_offense(node.loc.selector, message: format(MSG, method_name: def_node.method_name))
         end
@@ -101,7 +101,7 @@ module RuboCop
           definition = find_method_definition(node, method_name)
 
           return unless definition
-          return if allowed_arguments(definition.arguments)
+          return if allowed_arguments?(definition.arguments)
 
           add_offense(node, message: format(MSG, method_name: method_name))
         end
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         # `ruby2_keywords` is only allowed if there's a `restarg` and no keyword arguments
-        def allowed_arguments(arguments)
+        def allowed_arguments?(arguments)
           return false if arguments.empty?
 
           arguments.each_child_node(:restarg).any? &&

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -66,7 +66,7 @@ module RuboCop
       end
 
       # @deprecated Use processed_source.line_with_comment?(line)
-      def end_of_line_comment(line)
+      def end_of_line_comment(line) # rubocop:disable Naming/PredicateMethod
         warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `end_of_line_comment` is deprecated. Use `processed_source.line_with_comment?` instead.
         WARNING

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -152,7 +152,7 @@ module RuboCop
 
             const_namespace, const_name = *const
             next if name != const_name && !match_acronym?(name, const_name)
-            next unless namespace.empty? || match_namespace(child, const_namespace, namespace)
+            next unless namespace.empty? || namespace_matches?(child, const_namespace, namespace)
 
             return node
           end
@@ -169,7 +169,7 @@ module RuboCop
           s(:const, namespace, name) if name
         end
 
-        def match_namespace(node, namespace, expected)
+        def namespace_matches?(node, namespace, expected)
           match_partial = partial_matcher!(expected)
 
           match_partial.call(namespace)

--- a/lib/rubocop/cop/naming/predicate_prefix.rb
+++ b/lib/rubocop/cop/naming/predicate_prefix.rb
@@ -105,7 +105,7 @@ module RuboCop
 
         # @!method dynamic_method_define(node)
         def_node_matcher :dynamic_method_define, <<~PATTERN
-          (send nil? #method_definition_macros
+          (send nil? #method_definition_macro?
             (sym $_)
             ...)
         PATTERN
@@ -195,7 +195,7 @@ module RuboCop
           cop_config['UseSorbetSigs']
         end
 
-        def method_definition_macros(macro_name)
+        def method_definition_macro?(macro_name)
           cop_config['MethodDefinitionMacros'].include?(macro_name.to_s)
         end
       end

--- a/lib/rubocop/cop/style/exponential_notation.rb
+++ b/lib/rubocop/cop/style/exponential_notation.rb
@@ -87,7 +87,7 @@ module RuboCop
           true
         end
 
-        def integral(node)
+        def integral?(node)
           mantissa, = node.source.split('e')
           /^-?[1-9](\d*[1-9])?$/.match?(mantissa)
         end
@@ -101,7 +101,7 @@ module RuboCop
           when :engineering
             !engineering?(node)
           when :integral
-            !integral(node)
+            !integral?(node)
           else
             false
           end

--- a/lib/rubocop/cop/style/fetch_env_var.rb
+++ b/lib/rubocop/cop/style/fetch_env_var.rb
@@ -53,12 +53,12 @@ module RuboCop
 
         def used_as_flag?(node)
           return false if node.root?
-          return true if used_if_condition_in_body(node)
+          return true if used_if_condition_in_body?(node)
 
           node.parent.send_type? && (node.parent.prefix_bang? || node.parent.comparison_method?)
         end
 
-        def used_if_condition_in_body(node)
+        def used_if_condition_in_body?(node)
           if_node = node.ancestors.find(&:if_type?)
 
           return false unless (condition = if_node&.condition)

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -465,7 +465,21 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       it_behaves_like 'acceptable', 'bar'
       it_behaves_like 'acceptable', 'bar()'
       it_behaves_like 'acceptable', 'bar(baz)'
-      it_behaves_like 'acceptable', 'bar?'
+    end
+
+    context 'methods returning other predicates' do
+      it_behaves_like 'predicate', 'bar?'
+      it_behaves_like 'predicate', 'bar?()'
+      it_behaves_like 'predicate', 'bar?(baz)'
+      it_behaves_like 'predicate', 'bar.baz?'
+
+      it_behaves_like 'predicate', <<~RUBY, explicit: false
+        if bar
+          baz?
+        else
+          false
+        end
+      RUBY
     end
 
     context 'variables' do
@@ -633,6 +647,11 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
     context 'method calls' do
       it_behaves_like 'acceptable', <<~RUBY, explicit: false
         return if something
+        true
+      RUBY
+
+      it_behaves_like 'acceptable', <<~RUBY, explicit: false
+        return if something
         bar?
       RUBY
     end
@@ -703,6 +722,11 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
     end
 
     context 'method calls' do
+      it_behaves_like 'non-predicate', <<~RUBY, explicit: false
+        return if something
+        true
+      RUBY
+
       it_behaves_like 'non-predicate', <<~RUBY, explicit: false
         return if something
         bar?


### PR DESCRIPTION
Updates `Naming/PredicateMethod` to treat other predicates as implicit boolean values. This update adds `good` cases such as:

```ruby
def ruby_file?
  name.end_with?('.rb')
end
```

Fixes #14255.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
