### PR TITLE
Update `Naming/PredicateMethod` to consider negation (`!`/`not`) as boolean values

### DIFF
--- a/changelog/change_update_naming_predicate_method_to_consider_20250617111757.md
+++ b/changelog/change_update_naming_predicate_method_to_consider_20250617111757.md
@@ -1,0 +1,1 @@
+* [#14295](https://github.com/rubocop/rubocop/pull/14295): Update `Naming/PredicateMethod` to consider negation (`!`/`not`) as boolean values. ([@dvandersluis][])

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -110,8 +110,8 @@ module RuboCop
         def directive_offense_type(directive, actual_name)
           return :missing_directive unless directive
 
-          return :wrong_scope if wrong_scope(directive, actual_name)
-          return :no_scope if no_scope(directive, actual_name)
+          return :wrong_scope if wrong_scope?(directive, actual_name)
+          return :no_scope if no_scope?(directive, actual_name)
 
           # The method directive being prefixed by 'self.' is always an offense.
           # The matched method_name does not contain the receiver but the
@@ -121,11 +121,11 @@ module RuboCop
           end
         end
 
-        def wrong_scope(directive, actual_name)
+        def wrong_scope?(directive, actual_name)
           !actual_name.start_with?('self.') && directive[:has_scope_directive]
         end
 
-        def no_scope(directive, actual_name)
+        def no_scope?(directive, actual_name)
           actual_name.start_with?('self.') && !directive[:has_scope_directive]
         end
 

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -50,6 +50,26 @@ module RuboCop
       #     5
       #   end
       #
+      #   # bad
+      #   def foo
+      #     x == y
+      #   end
+      #
+      #   # good
+      #   def foo?
+      #     x == y
+      #   end
+      #
+      #   # bad
+      #   def foo
+      #     !x
+      #   end
+      #
+      #   # good
+      #   def foo?
+      #     !x
+      #   end
+      #
       #   # bad - returns the value of another predicate method
       #   def foo
       #     bar?
@@ -142,7 +162,9 @@ module RuboCop
         end
 
         def unknown_method_call?(value)
-          value.call_type? && !value.comparison_method? && !value.predicate_method?
+          return false unless value.call_type?
+
+          !value.comparison_method? && !value.predicate_method? && !value.negation_method?
         end
 
         def return_values(node)
@@ -168,8 +190,9 @@ module RuboCop
 
         def boolean_return?(value)
           return true if value.boolean_type?
+          return false unless value.call_type?
 
-          value.call_type? && (value.comparison_method? || value.predicate_method?)
+          value.comparison_method? || value.predicate_method? || value.negation_method?
         end
 
         def potential_non_predicate?(return_values)

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -304,6 +304,13 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       end
     end
 
+    context 'methods returning negations' do
+      ['5', 'true', 'false', 'nil', '[]', 'a', 'a?', '(a == b)'].each do |value|
+        it_behaves_like 'predicate', "!#{value}"
+        it_behaves_like 'predicate', "(not #{value})"
+      end
+    end
+
     context 'methods returning boolean literals' do
       it_behaves_like 'predicate', 'true'
       it_behaves_like 'predicate', 'false'


### PR DESCRIPTION
Negating any ruby value is guaranteed to be a boolean so this updates `Naming/PredicateMethod` to handle an overlooked case.

```ruby
def foo?
  !bar
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
