### PR TITLE
[Fix #14296] Fix false positives for `Style/RedundantSelf`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_self_cop.md
+++ b/changelog/fix_false_positives_for_style_redundant_self_cop.md
@@ -1,0 +1,1 @@
+* [#14296](https://github.com/rubocop/rubocop/issues/14296): Fix false positives for `Style/RedundantSelf` when receiver and lvalue have the same name in or-assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -67,6 +67,9 @@ module RuboCop
 
         def on_or_asgn(node)
           allow_self(node.lhs)
+
+          lhs_name = node.lhs.lvasgn_type? ? node.lhs.name : node.lhs
+          add_lhs_to_local_variables_scopes(node.rhs, lhs_name)
         end
         alias on_and_asgn on_or_asgn
 

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     expect_no_offenses('a = self.a')
   end
 
+  it 'does not report an offense when receiver and lvalue have the same name in or-assignment' do
+    expect_no_offenses('foo ||= self.foo')
+  end
+
+  it 'does not report an offense when receiver and lvalue have the same name in and-assignment' do
+    expect_no_offenses('foo &&= self.foo')
+  end
+
   it 'accepts when nested receiver and lvalue have the same name' do
     expect_no_offenses('a = self.a || b || c')
   end


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantSelf` when receiver and lvalue have the same name in or-assignment.

Fixes #14296.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
