### PR TITLE
Fix false positives for `Lint/DuplicateMethods` when the self-alias trick is used

### DIFF
--- a/changelog/fix_false_positives_for_lint_duplicate_methods_20250618124754.md
+++ b/changelog/fix_false_positives_for_lint_duplicate_methods_20250618124754.md
@@ -1,0 +1,1 @@
+* [#14300](https://github.com/rubocop/rubocop/pull/14300): Fix false positives for `Lint/DuplicateMethods` cop when self-alias trick is used. ([@viralpraxis][])

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -261,6 +261,17 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       RUBY
     end
 
+    it "does not register an offense for duplicate self-alias in #{type}" do
+      expect_no_offenses(<<~RUBY, 'example.rb')
+        #{opening_line}
+          alias some_method some_method
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+    end
+
     it "doesn't register an offense for non-duplicate alias in #{type}" do
       expect_no_offenses(<<~RUBY)
         #{opening_line}
@@ -280,6 +291,28 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
           end
           alias_method :some_method, :any_method
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+        end
+      RUBY
+    end
+
+    it "does not register an offense for duplicate self-alias_method in #{type}" do
+      expect_no_offenses(<<~RUBY, 'example.rb')
+        #{opening_line}
+          alias_method :some_method, :some_method
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for duplicate self-alias_method with dynamic original name in #{type}" do
+      expect_no_offenses(<<~RUBY, 'example.rb')
+        #{opening_line}
+          alias_method :some_method, unknown()
+          def some_method
+            implement 1
+          end
         end
       RUBY
     end


### PR DESCRIPTION
When there's a self-alias, there's no need to register an offense:

```ruby
class a
  alias foo foo
  # or alias_method :foo, :foo
  def foo; end
end
```

Using the alias-self trick indicates that developer is trying to avoid "method redefinition" warning.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
