### PR TITLE
Fix autocorrection syntax error for multiline expressions in Style/RedundantParentheses

### DIFF
--- a/changelog/fix_style_redundant_parentheses_multiline.md
+++ b/changelog/fix_style_redundant_parentheses_multiline.md
@@ -1,0 +1,1 @@
+* [#14301](https://github.com/rubocop/rubocop/issues/14301): Fix autocorrection syntax error for multiline expressions in `Style/RedundantParentheses`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -10,8 +10,11 @@ module RuboCop
         COMMA_REGEXP = /(?<=\))\s*,/.freeze
 
         def correct(corrector, node)
-          corrector.remove(node.loc.begin)
-          corrector.remove(node.loc.end)
+          buffer = node.source_range.source_buffer
+          corrector.remove(range_with_surrounding_space(range: node.loc.begin, buffer: buffer,
+                                                        side: :right, whitespace: true))
+          corrector.remove(range_with_surrounding_space(range: node.loc.end, buffer: buffer,
+                                                        side: :left))
           handle_orphaned_comma(corrector, node)
 
           return unless ternary_condition?(node) && next_char_is_question_mark?(node)

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -302,10 +302,8 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        if#{trailing_whitespace}
-          x > 3 &&
+        if x > 3 &&
           x < 10
-
           return true
         end
       RUBY

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -339,8 +339,27 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
     expect_correction(<<~RUBY)
       x.y(foo &&
-        bar
-      )
+        bar)
+    RUBY
+  end
+
+  it 'registers an offense for parens around method call chained to an `&&` expression' do
+    # Style/MultipleComparison autocorrects:
+    # (
+    #   foo == 'a' ||
+    #   foo == 'b' ||
+    #   foo == 'c'
+    # ) && bar
+    # to the following:
+    expect_offense(<<~RUBY)
+      (
+      ^ Don't use parentheses around a method call.
+        ['a', 'b', 'c'].include?(foo)
+      ) && bar
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ['a', 'b', 'c'].include?(foo) && bar
     RUBY
   end
 
@@ -391,8 +410,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      [1
-      ]
+      [1]
     RUBY
   end
 
@@ -410,9 +428,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
         expect_correction(<<~RUBY)
           [
-          #{trailing_whitespace * 2}
-              1
-          #{trailing_whitespace * 2}
+            1
           ]
         RUBY
       end
@@ -442,8 +458,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
         expect_correction(<<~RUBY)
           [
-          #{trailing_whitespace * 2}
-              1,
+            1,
             2
           ]
         RUBY
@@ -462,8 +477,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
         expect_correction(<<~RUBY)
           [
-            x =#{trailing_whitespace}
-              1,
+            x = 1,
             y = 2
           ]
         RUBY
@@ -490,8 +504,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      {a: 1
-      }
+      {a: 1}
     RUBY
   end
 
@@ -1472,8 +1485,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
     expect_correction(<<~RUBY)
       foo(
-      #{trailing_whitespace * 2}
-          1,
+        1,
         2
       )
     RUBY
@@ -1499,15 +1511,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
 
     expect_correction(<<~RUBY)
       [
-      #{trailing_whitespace * 2}
         <<-STRING,
           foo
         STRING
-      #{trailing_whitespace * 2}
         <<-STRING
           bar
         STRING
-      #{trailing_whitespace * 2}
       ]
     RUBY
   end


### PR DESCRIPTION
Given the following example:
```ruby
(
  foo == 'a' ||
  foo == 'b' ||
  foo == 'c'
) && bar
```
`Style/MultipleComparison` will autocorrect it to:
```ruby
(
  ['a', 'b', 'c'].include?(foo)
) && bar
```
and then `Style/RedundantParentheses` will autocorrect that to:
```ruby
# empty line
  ['a', 'b', 'c'].include?(foo)
 && bar
```
which is invalid syntax.

This PR attempts to resolve this by additionally removing space _after_ opening parentheses and _before_ closing parentheses, so that `Style/RedundantParentheses` autocorrects the example to:
```ruby
['a', 'b', 'c'].include?(foo) && bar
```

This of course affects some other examples. Let me know if the error should be resolved another way.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
