### PR TITLE
Fix `Lint/SelfAssignment` to allow inline RBS comments.

### DIFF
--- a/changelog/fix_lint_self_assignment_to_allow_inline_rbs_comments_20250618115326.md
+++ b/changelog/fix_lint_self_assignment_to_allow_inline_rbs_comments_20250618115326.md
@@ -1,0 +1,1 @@
+* [#14303](https://github.com/rubocop/rubocop/pull/14303): Fix `Lint/SelfAssignment` to allow inline RBS comments. ([@Morriar][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2400,6 +2400,7 @@ Lint/SelfAssignment:
   Description: 'Checks for self-assignments.'
   Enabled: true
   VersionAdded: '0.89'
+  AllowRBSInlineAnnotation: false
 
 Lint/SendWithMixinArgument:
   Description: 'Checks for `send` method when using mixin.'

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -318,4 +318,81 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
     RUBY
   end
+
+  describe 'RBS::Inline annotation' do
+    context 'when config option is enabled' do
+      let(:cop_config) { { 'AllowRBSInlineAnnotation' => true } }
+
+      it 'does not register an offense and it has a comment' do
+        expect_no_offenses(<<~RUBY)
+          foo = foo #: Integer
+          @foo = @foo #: Integer
+          @@foo = @@foo #: Integer
+          $foo = $foo #: Integer
+          Foo = Foo #: Integer
+          foo, bar = foo, bar #: Integer
+          foo ||= foo #: Integer
+          foo &&= foo #: Integer
+          foo.bar = foo.bar #: Integer
+          foo&.bar = foo&.bar #: Integer
+          foo["bar"] = foo["bar"] #: Integer
+          foo&.[]=("bar", foo["bar"]) #: Integer
+        RUBY
+      end
+
+      it 'registers an offense and it has a no comment' do
+        expect_offense(<<~RUBY)
+          foo = foo
+          ^^^^^^^^^ Self-assignment detected.
+          @foo = @foo
+          ^^^^^^^^^^^ Self-assignment detected.
+          @@foo = @@foo
+          ^^^^^^^^^^^^^ Self-assignment detected.
+          $foo = $foo
+          ^^^^^^^^^^^ Self-assignment detected.
+          Foo = Foo
+          ^^^^^^^^^ Self-assignment detected.
+          foo, bar = foo, bar
+          ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo ||= foo
+          ^^^^^^^^^^^ Self-assignment detected.
+          foo &&= foo
+          ^^^^^^^^^^^ Self-assignment detected.
+          foo.bar = foo.bar
+          ^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo&.bar = foo&.bar
+          ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo["bar"] = foo["bar"]
+          ^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo&.[]=("bar", foo["bar"])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+
+          foo = foo # comment
+          ^^^^^^^^^ Self-assignment detected.
+          @foo = @foo # comment
+          ^^^^^^^^^^^ Self-assignment detected.
+          @@foo = @@foo # comment
+          ^^^^^^^^^^^^^ Self-assignment detected.
+          $foo = $foo # comment
+          ^^^^^^^^^^^ Self-assignment detected.
+          Foo = Foo # comment
+          ^^^^^^^^^ Self-assignment detected.
+          foo, bar = foo, bar # comment
+          ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo ||= foo # comment
+          ^^^^^^^^^^^ Self-assignment detected.
+          foo &&= foo # comment
+          ^^^^^^^^^^^ Self-assignment detected.
+          foo.bar = foo.bar # comment
+          ^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo&.bar = foo&.bar # comment
+          ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo["bar"] = foo["bar"] # comment
+          ^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+          foo&.[]=("bar", foo["bar"]) # comment
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using RBS, with Steep for example, it's sometimes useful to [add an inline type annotation](https://github.com/soutaro/steep/blob/6d66d0d174bc8d2fe6cd2ed8925936894c26f5c4/lib/steep.rb#L327).

These type annotations are inserted as comment, generally around assignments, after the rhs:

```rb
foo = [] #: Array[Integer]
```

Sometimes we also need to "cast" the type of a variable:

```rb
foo = foo #: Array[Numeric]
```

In those cases, the `Lint/SelfAssignment` cop will raise an offence for a useless self assignment.

This PR adds an option `AllowRBSInlineAnnotation` to `Lint/SelfAssignment` similar to the one used in (`Layout/LeadingCommentSpace`)[b543aee0a5831/config/default.yml#L1043] so the user can disable the offence when needed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/