### PR TITLE
[Fix #14128] Allow long fully-qualified namespace strings to exceed max length

### DIFF
--- a/changelog/new_allow_long_fully_qualified_namespace_strings_20250618172915.md
+++ b/changelog/new_allow_long_fully_qualified_namespace_strings_20250618172915.md
@@ -1,0 +1,1 @@
+* [#14128](https://github.com/rubocop/rubocop/issues/14128): Allow long fully-qualified namespace strings to exceed max length. ([@niranjan-patil][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1102,6 +1102,7 @@ Layout/LineLength:
   # To make it possible to copy or click on URIs in the code, we allow lines
   # containing a URI to be longer than Max.
   AllowURI: true
+  AllowQualifiedName: true
   URISchemes:
     - http
     - https

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -4935,6 +4935,10 @@ bar: "0000000000", baz: "0000000000"}
 | `[]`
 | Array
 
+| AllowQualifiedName
+| `true`
+| Boolean
+
 | SplitStrings
 | `false`
 | Boolean

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -223,8 +223,17 @@ module RuboCop
 
         def too_long_line_based_on_allow_uri?(line)
           if allow_uri?
-            uri_range = find_excessive_uri_range(line)
-            return false if uri_range && allowed_uri_position?(line, uri_range)
+            uri_range = find_excessive_range(line, :uri)
+            return false if uri_range && allowed_position?(line, uri_range)
+          end
+
+          true
+        end
+
+        def too_long_line_based_on_allow_qualified_name?(line)
+          if allow_qualified_name?
+            namespace_range = find_excessive_range(line, :namespace)
+            return false if namespace_range && allowed_position?(line, namespace_range)
           end
 
           true

--- a/lib/rubocop/lsp/diagnostic.rb
+++ b/lib/rubocop/lsp/diagnostic.rb
@@ -79,7 +79,7 @@ module RuboCop
         LanguageServer::Protocol::Interface::CodeDescription.new(href: doc_url)
       end
 
-      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
       def autocorrect_action
         LanguageServer::Protocol::Interface::CodeAction.new(
           title: "Autocorrect #{@offense.cop_name}",
@@ -98,7 +98,7 @@ module RuboCop
           is_preferred: true
         )
       end
-      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength
 
       # rubocop:disable Metrics/MethodLength
       def offense_replacements
@@ -120,7 +120,7 @@ module RuboCop
       end
       # rubocop:enable Metrics/MethodLength
 
-      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
       def disable_line_action
         LanguageServer::Protocol::Interface::CodeAction.new(
           title: "Disable #{@offense.cop_name} for this line",
@@ -138,7 +138,7 @@ module RuboCop
           )
         )
       end
-      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength
 
       def line_disable_comment
         new_text = if @offense.source_line.include?(' # rubocop:disable ')

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -34,7 +34,7 @@ module RubyLsp
         @runtime_adapter = nil
       end
 
-      # rubocop:disable Layout/LineLength, Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
       def register_additional_file_watchers(global_state, message_queue)
         return unless global_state.supports_watching_files
 
@@ -59,7 +59,7 @@ module RubyLsp
           )
         )
       end
-      # rubocop:enable Layout/LineLength, Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength
 
       def workspace_did_change_watched_files(changes)
         return unless changes.any? { |change| change[:uri].end_with?('.rubocop.yml') }

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -163,7 +163,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Exclude:
@@ -350,7 +350,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                     '# Offense count: 1',
                     '# This cop supports safe autocorrection (--autocorrect).',
                     '# Configuration parameters: AllowHeredoc, ' \
-                    'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+                    'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
                     'AllowedPatterns, SplitStrings.',
                     '# URISchemes: http, https',
                     'Layout/LineLength:',
@@ -428,7 +428,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '# Offense count: 1',
                 '# This cop supports safe autocorrection (--autocorrect).',
                 '# Configuration parameters: AllowHeredoc, ' \
-                'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+                'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
                 'AllowedPatterns, SplitStrings.',
                 '# URISchemes: http, https',
                 'Layout/LineLength:',
@@ -499,7 +499,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -930,7 +930,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 2',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1024,7 +1024,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 3',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1328,7 +1328,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, URISchemes, IgnoreCopDirectives, ' \
+         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1891,7 +1891,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     context 'when the cop has the "info" severity' do
       before do
         create_file(target_file, <<~RUBY)
-          Long::Line::Not::Autocorrectable
+          some_object.some_method.another_method.yet_another_method
         RUBY
 
         create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1807,6 +1807,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           - Max
           - AllowHeredoc
           - AllowURI
+          - AllowQualifiedName
           - URISchemes
           - IgnoreCopDirectives
           - AllowedPatterns

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1035,6 +1035,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => true,
               'AllowedPatterns' => [],
+              'AllowQualifiedName' => true,
               'SplitStrings' => false
             },
             'Metrics/MethodLength' => {
@@ -1139,6 +1140,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => true,
               'AllowedPatterns' => [],
+              'AllowQualifiedName' => true,
               'SplitStrings' => false
             }
           )


### PR DESCRIPTION
- `AllowQualifiedName` allows long fully-qualified namespace strings to exceed max length. This works exactly as `AllowURI`.

Fixes https://github.com/rubocop/rubocop/issues/14128

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
