### PR TITLE
[Fix #14307] Fix `Style/MethodCallWithArgsParentheses` false positives

### DIFF
--- a/changelog/fix_style_method_call_with_args_parentheses_false_positives_20250619020633.md
+++ b/changelog/fix_style_method_call_with_args_parentheses_false_positives_20250619020633.md
@@ -1,0 +1,1 @@
+* [#14307](https://github.com/rubocop/rubocop/issues/14307): Fix `Style/MethodCallWithArgsParentheses` false positive on forwarded keyword argument with additional arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -251,7 +251,7 @@ module RuboCop
             return false unless (last_argument = node.last_argument)
             return true if last_argument.forwarded_restarg_type?
 
-            last_argument.hash_type? && last_argument.children.first&.forwarded_kwrestarg_type?
+            last_argument.hash_type? && last_argument.children.any?(&:forwarded_kwrestarg_type?)
           end
         end
         # rubocop:enable Metrics/ModuleLength, Metrics/CyclomaticComplexity

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -529,6 +529,14 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when forwarded keyword argument has additional nodes' do
+        expect_no_offenses(<<~RUBY)
+          def foo(**)
+            foo(name: value, **)
+          end
+        RUBY
+      end
     end
 
     it 'registers an offense for parens in method call without args' do


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/14307

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
