### PR TITLE
[Fix #14306] Fix an error for `Style/HashConversion`

### DIFF
--- a/changelog/fix_an_error_for_style_hash_conversion.md
+++ b/changelog/fix_an_error_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#14306](https://github.com/rubocop/rubocop/issues/14306): Fix an error for `Style/HashConversion` when using nested `Hash[]`. ([@koic][])

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -175,6 +175,28 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'reports an offense when using nested `Hash[]` without arguments' do
+    expect_offense(<<~RUBY)
+      Hash[Hash[]]
+      ^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Hash[].to_h
+    RUBY
+  end
+
+  it 'reports an offense when using nested `Hash[]` with arguments' do
+    expect_offense(<<~RUBY)
+      Hash[Hash[k, v]]
+      ^^^^^^^^^^^^^^^^ Prefer ary.to_h to Hash[ary].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Hash[k, v].to_h
+    RUBY
+  end
+
   context 'AllowSplatArgument: true' do
     let(:cop_config) { { 'AllowSplatArgument' => true } }
 


### PR DESCRIPTION
This PR fixes an error for `Style/HashConversion` when using nested `Hash[]`.

Fixes #14306.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
