### PR TITLE
[Fix #14292] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14292](https://github.com/rubocop/rubocop/issues/14292): Fix false positives for `Style/RedundantParentheses` when assigning a parenthesized one-line `in` pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -255,7 +255,10 @@ module RuboCop
         end
 
         def disallowed_one_line_pattern_matching?(begin_node, node)
-          return false if begin_node.parent&.any_def_type? && begin_node.parent.endless?
+          if (parent = begin_node.parent)
+            return false if parent.any_def_type? && parent.endless?
+            return false if parent.assignment?
+          end
 
           node.any_match_pattern_type? && node.each_ancestor.none?(&:operator_keyword?)
         end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1231,6 +1231,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses when assigning a parenthesized one-line `in` pattern matching', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      foo = (bar in baz)
+    RUBY
+  end
+
+  it 'accepts parentheses when or-assigning a parenthesized one-line `in` pattern matching', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      foo ||= (bar in baz)
+    RUBY
+  end
+
   it 'accepts parentheses when using parenthesized one-line `in` pattern matching in endless method definition', :ruby30 do
     expect_no_offenses(<<~RUBY)
       def foo = (bar in baz | qux)


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when assigning a parenthesized one-line `in` pattern matching.

Fixes #14292.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
