### PR TITLE
Enhance `Gemspec/RequireMFA` cop autocorrect to insert MFA directive after last `metadata` assignment

### DIFF
--- a/changelog/new_enhance_gemspec_require_mfa_cop_autocorrect_to_insert_mfa_after_last_metadata_20250620024931.md
+++ b/changelog/new_enhance_gemspec_require_mfa_cop_autocorrect_to_insert_mfa_after_last_metadata_20250620024931.md
@@ -1,0 +1,1 @@
+* [#14314](https://github.com/rubocop/rubocop/pull/14314): Enhance `Gemspec/RequireMFA` cop autocorrect to insert MFA directive after last `metadata` assignment. ([@viralpraxis][])

--- a/spec/rubocop/cop/gemspec/require_mfa_spec.rb
+++ b/spec/rubocop/cop/gemspec/require_mfa_spec.rb
@@ -121,6 +121,26 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
           end
         RUBY
       end
+
+      context 'when `metadata` assignment is not the last one' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, 'my.gemspec')
+            Gem::Specification.new do |spec|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `metadata['rubygems_mfa_required']` must be set to `'true'`.
+              spec.metadata['foo'] = 'bar'
+              spec.author = 'viralpraxis'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Gem::Specification.new do |spec|
+              spec.metadata['foo'] = 'bar'
+            spec.metadata['rubygems_mfa_required'] = 'true'
+              spec.author = 'viralpraxis'
+            end
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
It's a little bit annoying that the `Gemspec/RequireMFA`' cop autocorrection
inserts MFA directive at the end, even if I grouped all `metadata=` assignments
in one place.

This patch tries to find the last `metadata = { ... }` or `metadata[]=` assignment and inserts `spec.metadata['rubygems_mfa_required'] = 'true'` after this node.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
