### PR TITLE
[Fix #14298] Fix an error for Style/SoleNestedConditional

### DIFF
--- a/changelog/fix_an_error_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_error_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#14298](https://github.com/rubocop/rubocop/issues/14298): Fix an error for `Style/SoleNestedConditional` when autocorrecting nested if/unless/if. ([@ssagara00][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -115,8 +115,9 @@ module RuboCop
         end
 
         def correct_node(corrector, node)
-          corrector.replace(node.loc.keyword, 'if') if node.unless?
+          corrector.replace(node.loc.keyword, 'if') if node.unless? && !part_of_ignored_node?(node)
           corrector.replace(node.condition, chainable_condition(node))
+          ignore_node(node)
         end
 
         def correct_for_guard_condition_style(corrector, node, if_branch)

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -1001,4 +1001,24 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
       RUBY
     end
   end
+
+  it 'registers an offense and corrects when using nested `unless` within `if` followed by another `if`' do
+    expect_offense(<<~RUBY)
+      if foo
+        unless bar
+        ^^^^^^ Consider merging nested conditions into outer `if` conditions.
+          if baz
+          ^^ Consider merging nested conditions into outer `unless` conditions.
+            do_something
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && !bar && baz
+            do_something
+          end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes an error for `Style/SoleNestedConditional` when autocorrecting nested if/unless/if.

Fix #14298.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
