### PR TITLE
Fix missing quote in sample code

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -446,7 +446,7 @@ class MyCop < Base
   requires_gem "my-gem"
 
   def on_send(node)
-    if target_gem_version("my-gem) < "2.0"
+    if target_gem_version("my-gem") < "2.0"
       # ...
     else
       # ...


### PR DESCRIPTION
Broken sample code on: https://docs.rubocop.org/rubocop/development.html#limit-by-ruby-or-gem-versions