### PR TITLE
Fix incorrect autocorrect for `Lint/RedundantTypeConversion`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_redundant_type_conversion.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_redundant_type_conversion.md
@@ -1,0 +1,1 @@
+* [#14319](https://github.com/rubocop/rubocop/pull/14319): Fix the following incorrect autocorrect for `Lint/RedundantTypeConversion` when using parentheses with no arguments or any arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -185,9 +185,9 @@ module RuboCop
           (hash (pair (sym :exception) false))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
         def on_send(node)
-          return if hash_or_set_with_block?(node)
+          return if node.arguments.any? || hash_or_set_with_block?(node)
 
           receiver = find_receiver(node)
           return unless literal_receiver?(node, receiver) ||
@@ -198,10 +198,10 @@ module RuboCop
           message = format(MSG, method: node.method_name)
 
           add_offense(node.loc.selector, message: message) do |corrector|
-            corrector.remove(node.loc.dot.join(node.loc.selector))
+            corrector.remove(node.loc.dot.join(node.loc.end || node.loc.selector))
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
         alias on_csend on_send
 
         private

--- a/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_type_conversion_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
 
       expect_correction("#{receiver}#{suffix}\n")
     end
+
+    it "registers an offense and corrects on `#{receiver}.#{conversion}()`" do
+      expect_offense(<<~RUBY, receiver: receiver, conversion: conversion)
+        #{receiver}.#{conversion}()
+        _{receiver} ^{conversion} Redundant `#{conversion}` detected.
+      RUBY
+
+      expect_correction("#{receiver}\n")
+    end
+
+    it "registers an offense and corrects on `#{receiver}&.#{conversion}()`" do
+      expect_offense(<<~RUBY, receiver: receiver, conversion: conversion)
+        #{receiver}&.#{conversion}()
+        _{receiver}  ^{conversion} Redundant `#{conversion}` detected.
+      RUBY
+
+      expect_correction("#{receiver}\n")
+    end
   end
 
   shared_examples 'conversion' do |conversion|
@@ -45,6 +63,16 @@ RSpec.describe RuboCop::Cop::Lint::RedundantTypeConversion, :config do
     it_behaves_like 'accepted', "[].#{conversion}" unless conversion == :to_a
     it_behaves_like 'accepted', "{}.#{conversion}" unless conversion == :to_h
     it_behaves_like 'accepted', "Set.new.#{conversion}" unless conversion == :to_set
+
+    it_behaves_like 'accepted', "'string'.#{conversion}(arg)"
+    it_behaves_like 'accepted', ":sym.#{conversion}(arg)"
+    it_behaves_like 'accepted', "1.#{conversion}(arg)"
+    it_behaves_like 'accepted', "1.0.#{conversion}(arg)"
+    it_behaves_like 'accepted', "1r.#{conversion}(arg)"
+    it_behaves_like 'accepted', "1i.#{conversion}(arg)"
+    it_behaves_like 'accepted', "[].#{conversion}(arg)"
+    it_behaves_like 'accepted', "{}.#{conversion}(arg)"
+    it_behaves_like 'accepted', "Set.new.#{conversion}(arg)"
 
     it "does not register an offense when calling `#{conversion}` on an local variable named `#{conversion}`" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Lint/RedundantTypeConversion` when using parentheses with no arguments or any arguments.

## Case 1: Parentheses with no arguments

First, this applies to parentheses with no arguments.

```console
$ echo '{k => v}.to_h()' | bundle exec rubocop --stdin test.rb -a --only Lint/RedundantTypeConversion
Inspecting 1 file
F

Offenses:

test.rb:1:9: F: Lint/Syntax: unexpected token tLPAREN2
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
{k => v}()
        ^
test.rb:1:10: W: [Corrected] Lint/RedundantTypeConversion: Redundant to_h detected.
{k => v}.to_h()
         ^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
{k => v}()
```

It is currently autocorrected to an invalid syntax with unnecessary parentheses. Since this case is syntactically valid, it will be updated to the correct form `{k => v}` without parentheses.

## Case 2: Parentheses with arguments

Next, the case with arguments.

```console
$ echo '{k => v}.to_h(arg)' | bundle exec rubocop --stdin test.rb -a --only Lint/RedundantTypeConversion
Inspecting 1 file
F

Offenses:

test.rb:1:9: F: Lint/Syntax: unexpected token tLPAREN2
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
{k => v}(arg)
        ^
test.rb:1:10: W: [Corrected] Lint/RedundantTypeConversion: Redundant to_h detected.
{k => v}.to_h(arg)
         ^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
{k => v}(arg)
```

This case also results in an incorrect autocorrection. However, when arguments are present, the method should be assumed to be either overridden or still under programming, and thus ignored. In any case, it cannot be considered safely removable or redundant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
