### PR TITLE
Enhance `Naming/MethodName` cop to handle offenses within `Struct` members

### DIFF
--- a/changelog/new_enhance_naming_method_name_cop_to_handle_offenses_within_struct_members_20250623141515.md
+++ b/changelog/new_enhance_naming_method_name_cop_to_handle_offenses_within_struct_members_20250623141515.md
@@ -1,0 +1,1 @@
+* [#14325](https://github.com/rubocop/rubocop/pull/14325): Enhance `Naming/MethodName` cop to handle offenses within `Struct` members. ([@viralpraxis][])


### PR DESCRIPTION
This patch enhances `Naming/MethodName` to detect these offenses:

```ruby
Struct.new(:fooBar) # offense if style is `snake_case`

Struct.new(:foo_bar) # offense if style is `camelCase`
```

Since the first argument of `Struct.new` might be a special string (`class_name`), it's ignored. See https://rubyapi.org/3.4/o/struct#method-c-new

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
