### PR TITLE
[Fix #14318] Add `WaywardPredicates` config to `Naming/PredicateMethod` to handle methods that look like predicates but aren't

### DIFF
--- a/changelog/change_add_non_boolean_predicates_config_to_20250623094531.md
+++ b/changelog/change_add_non_boolean_predicates_config_to_20250623094531.md
@@ -1,0 +1,1 @@
+* [#14318](https://github.com/rubocop/rubocop/issues/14318): Add `NonBooleanPredicates` config to `Naming/PredicateMethod` to handle methods that look like predicates but aren't. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3072,7 +3072,7 @@ Naming/PredicateMethod:
   Description: 'Checks that predicate methods end with `?` and non-predicate methods do not.'
   Enabled: pending
   VersionAdded: '1.76'
-  VersionChanged: '1.76'
+  VersionChanged: '<<next>>'
   # In `aggressive` mode, the cop will register an offense for predicate methods that
   #   may return a non-boolean value.
   # In `conservative` mode, the cop will *not* register an offense for predicate methods
@@ -3082,6 +3082,9 @@ Naming/PredicateMethod:
     - call
   AllowedPatterns: []
   AllowBangMethods: false
+  # Methods that are known to not return a boolean value, despite ending in `?`.
+  WaywardPredicates:
+    - nonzero?
 
 Naming/PredicatePrefix:
   Description: 'Predicate method names should not be prefixed and end with a `?`.'

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
   let(:allowed_methods) { [] }
   let(:allowed_patterns) { [] }
   let(:allow_bang_methods) { false }
+  let(:wayward_predicates) { [] }
   let(:cop_config) do
     {
       'Mode' => mode,
       'AllowedMethods' => allowed_methods,
       'AllowedPatterns' => allowed_patterns,
-      'AllowBangMethods' => allow_bang_methods
+      'AllowBangMethods' => allow_bang_methods,
+      'WaywardPredicates' => wayward_predicates
     }
   end
 
@@ -583,6 +585,12 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
           end
         RUBY
       end
+    end
+
+    context 'with WaywardPredicates' do
+      let(:wayward_predicates) { %w[nonzero?] }
+
+      it_behaves_like 'acceptable', 'nonzero?'
     end
   end
 


### PR DESCRIPTION
Allows `Naming/PredicateMethod` to be aware of methods that look like predicates but do not return a boolean value, when determining if a method's return value is boolean.

Fixes #14318.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
