### PR TITLE
[Fix #14326] Fix additional autocorrection errors in `Style/HashConversion` for nested `Hash[]` calls

### DIFF
--- a/changelog/fix_fix_additional_autocorrection_errors_in_20250623101057.md
+++ b/changelog/fix_fix_additional_autocorrection_errors_in_20250623101057.md
@@ -1,0 +1,1 @@
+* [#14326](https://github.com/rubocop/rubocop/issues/14326): Fix additional autocorrection errors in `Style/HashConversion` for nested `Hash[]` calls. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -64,11 +64,11 @@ module RuboCop
           #   Hash[a1, a2, a3, a4] => {a1 => a2, a3 => a4}
           #   ...but don't suggest correction if there is odd number of them (it is a bug)
           node.arguments.one? ? single_argument(node) : multi_argument(node)
+          ignore_node(node)
         end
 
         private
 
-        # rubocop:disable Metrics/MethodLength
         def single_argument(node)
           first_argument = node.first_argument
           if first_argument.hash_type?
@@ -83,11 +83,8 @@ module RuboCop
               replacement = "(#{replacement})" if requires_parens?(first_argument)
               corrector.replace(node, "#{replacement}.to_h")
             end
-
-            ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def use_zip_method_without_argument?(first_argument)
           return false unless first_argument&.send_type?

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects nested `Hash[]` calls with multiple arguments' do
+    expect_offense(<<~RUBY)
+      Hash[1, Hash[k, v]]
+      ^^^^^^^^^^^^^^^^^^^ Prefer literal hash to Hash[arg1, arg2, ...].
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {1 => Hash[k, v]}
+    RUBY
+  end
+
   context 'AllowSplatArgument: true' do
     let(:cop_config) { { 'AllowSplatArgument' => true } }
 


### PR DESCRIPTION
Following #14310, update `Style/HashConversion` to ignore nodes when there are multiple arguments as well.

Fixes #14326.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
