### PR TITLE
[Fix #14329] Fix false positives for `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/fix_false_positives_for_lint_literal_as_condition.md
+++ b/changelog/fix_false_positives_for_lint_literal_as_condition.md
@@ -1,0 +1,1 @@
+* [#14329](https://github.com/rubocop/rubocop/issues/14329): Fix false positives for `Lint/LiteralAsCondition` when a literal is used inside `||` in `case` condition. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -123,7 +123,9 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize
 
         def on_case(case_node)
-          if case_node.condition
+          if (cond = case_node.condition)
+            return if !cond.falsey_literal? && !cond.truthy_literal?
+
             check_case(case_node)
           else
             case_node.when_branches.each do |when_node|

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -323,9 +323,18 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
-    it "accepts literal #{lit} in non-toplevel and/or" do
+    it "accepts literal #{lit} in non-toplevel and/or as an `if` condition" do
       expect_no_offenses(<<~RUBY)
         if (a || #{lit}).something
+          top
+        end
+      RUBY
+    end
+
+    it "accepts literal #{lit} in non-toplevel and/or as a `case` condition" do
+      expect_no_offenses(<<~RUBY)
+        case a || #{lit}
+        when b
           top
         end
       RUBY
@@ -634,6 +643,16 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       expect_correction(<<~RUBY)
         top
         foo
+      RUBY
+    end
+
+    it "registers an offense for falsey literal #{lit} in `case`" do
+      expect_offense(<<~RUBY, lit: lit)
+        case %{lit}
+             ^{lit} Literal `#{lit}` appeared as a condition.
+        when x
+          top
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR fixes false positives for `Lint/LiteralAsCondition` when a literal is used inside `||` in `case` condition.

Fixes #14329.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
