### PR TITLE
Enhance `Naming/MethodName` cop to detect offenses within `define_method` calls

### DIFF
--- a/changelog/new_enhance_naming_method_name_cop_to_detect_offenses_within_define_method_calls_20250626032151.md
+++ b/changelog/new_enhance_naming_method_name_cop_to_detect_offenses_within_define_method_calls_20250626032151.md
@@ -1,0 +1,1 @@
+* [#14331](https://github.com/rubocop/rubocop/pull/14331): Enhance `Naming/MethodName` cop to detect offenses within `define_method` calls. ([@viralpraxis][])

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -39,12 +39,28 @@ module RuboCop
       #   # good
       #   def foo_bar; end
       #
+      #   # bad
+      #   define_method :fooBar do
+      #   end
+      #
+      #   # good
+      #   define_method :foo_bar do
+      #   end
+      #
       # @example EnforcedStyle: camelCase
       #   # bad
       #   def foo_bar; end
       #
       #   # good
       #   def fooBar; end
+      #
+      #   # bad
+      #   define_method :foo_bar do
+      #   end
+      #
+      #   # good
+      #   define_method :fooBar do
+      #   end
       #
       # @example ForbiddenIdentifiers: ['def', 'super']
       #   # bad
@@ -73,17 +89,10 @@ module RuboCop
         def_node_matcher :str_name, '(str $_name)'
 
         def on_send(node)
-          return unless (attrs = node.attribute_accessor?)
-
-          attrs.last.each do |name_item|
-            name = attr_name(name_item)
-            next if !name || matches_allowed_pattern?(name)
-
-            if forbidden_name?(name.to_s)
-              register_forbidden_name(node)
-            else
-              check_name(node, name, range_position(node))
-            end
+          if node.method?(:define_method) || node.method?(:define_singleton_method)
+            handle_define_method(node)
+          else
+            handle_attr_accessor(node)
           end
         end
 
@@ -100,6 +109,37 @@ module RuboCop
 
         private
 
+        def handle_define_method(node)
+          return unless node.first_argument&.type?(:str, :sym)
+
+          handle_method_name(node, node.first_argument.value)
+        end
+
+        def handle_attr_accessor(node)
+          return unless (attrs = node.attribute_accessor?)
+
+          attrs.last.each do |name_item|
+            name = attr_name(name_item)
+            next if !name || matches_allowed_pattern?(name)
+
+            if forbidden_name?(name.to_s)
+              register_forbidden_name(node)
+            else
+              check_name(node, name, range_position(node))
+            end
+          end
+        end
+
+        def handle_method_name(node, name)
+          return if !name || matches_allowed_pattern?(name)
+
+          if forbidden_name?(name.to_s)
+            register_forbidden_name(node)
+          else
+            check_name(node, name, range_position(node))
+          end
+        end
+
         def forbidden_name?(name)
           forbidden_identifier?(name) || forbidden_pattern?(name)
         end
@@ -108,10 +148,12 @@ module RuboCop
           if node.any_def_type?
             name_node = node.loc.name
             method_name = node.method_name
-          else
-            attrs = node.attribute_accessor?
+          elsif (attrs = node.attribute_accessor?)
             name_node = attrs.last.last
             method_name = attr_name(name_node)
+          else
+            name_node = node.first_argument
+            method_name = node.first_argument.value
           end
           message = format(MSG_FORBIDDEN, identifier: method_name)
           add_offense(name_node, message: message)


### PR DESCRIPTION
ref: https://github.com/rubocop/rubocop/pull/14325#issuecomment-3004010614

This patch enhances `Naming/MethodName` to detect these offenses:

```ruby
define_method(:fooBar) {} # offense if style is `snake_case`

define_method(:foo_bar) {} # offense if style is `camelCase`
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
