### PR TITLE
Fix changelog for `Naming/PredicateMethod`

### DIFF
--- a/changelog/change_add_non_boolean_predicates_config_to_20250623094531.md
+++ b/changelog/change_add_non_boolean_predicates_config_to_20250623094531.md
@@ -1,1 +1,1 @@
-* [#14318](https://github.com/rubocop/rubocop/issues/14318): Add `NonBooleanPredicates` config to `Naming/PredicateMethod` to handle methods that look like predicates but aren't. ([@dvandersluis][])
+* [#14318](https://github.com/rubocop/rubocop/issues/14318): Add `WaywardPredicates` config to `Naming/PredicateMethod` to handle methods that look like predicates but aren't. ([@dvandersluis][])


### PR DESCRIPTION
In #14327 the new configuration name was changed but I forgot to update the changelog.
