### PR TITLE
Enhance `Security/Eval` cop to detect `Kernel.eval` calls

### DIFF
--- a/changelog/new_enhance_security_eval_cop_to_detect_kernel_eval_20250630232046.md
+++ b/changelog/new_enhance_security_eval_cop_to_detect_kernel_eval_20250630232046.md
@@ -1,0 +1,1 @@
+* [#14335](https://github.com/rubocop/rubocop/pull/14335): Enhance `Security/Eval` cop to detect `Kernel.eval` calls. ([@viralpraxis][])

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -11,13 +11,14 @@ module RuboCop
       #
       #   eval(something)
       #   binding.eval(something)
+      #   Kernel.eval(something)
       class Eval < Base
         MSG = 'The use of `eval` is a serious security risk.'
         RESTRICT_ON_SEND = %i[eval].freeze
 
         # @!method eval?(node)
         def_node_matcher :eval?, <<~PATTERN
-          (send {nil? (send nil? :binding)} :eval $!str ...)
+          (send {nil? (send nil? :binding) (const {cbase nil?} :Kernel)} :eval $!str ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/security/eval_spec.rb
+++ b/spec/rubocop/cop/security/eval_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe RuboCop::Cop::Security::Eval, :config do
     RUBY
   end
 
+  it 'registers an offense for `Kernel.eval`' do
+    expect_offense(<<~RUBY)
+      Kernel.eval something
+             ^^^^ The use of `eval` is a serious security risk.
+    RUBY
+  end
+
+  it 'registers an offense for `::Kernel.eval`' do
+    expect_offense(<<~RUBY)
+      ::Kernel.eval something
+               ^^^^ The use of `eval` is a serious security risk.
+    RUBY
+  end
+
   it 'registers an offense for eval with string that has an interpolation' do
     expect_offense(<<~'RUBY')
       eval "something#{foo}"


### PR DESCRIPTION
I'm not sure if `Kernel.eval` is not detected intentionally, but if it's not, here's a patch.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
