### PR TITLE
Add @example for AllowedMethods and AllowedPatterns to MethodCallWithArgsParentheses cop

### DIFF
--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -132,6 +132,23 @@ module RuboCop
       #     bar :baz
       #   end
       #
+      # @example AllowedMethods: ["puts", "print"]
+      #
+      #   # good
+      #   puts "Hello world"
+      #   print "Hello world"
+      #   # still enforces parentheses on other methods
+      #   array.delete(e)
+      #
+      # @example AllowedPatterns: ["^assert"]
+      #
+      #   # good
+      #   assert_equal 'test', x
+      #   assert_match(/foo/, bar)
+      #   # still enforces parentheses on other methods
+      #   array.delete(e)
+
+      #
       # @example AllowParenthesesInMultilineCall: false (default)
       #
       #   # bad


### PR DESCRIPTION
This PR adds @example usage documentation for the AllowedMethods and AllowedPatterns configuration options in the Style/MethodCallWithArgsParentheses cop.

These examples clarify how users can customize the cop to allow or disallow parentheses for certain method calls, improving the clarity and usefulness of the cop’s documentation.

This work addresses issue #12520.