### PR TITLE
[Fix #14336] Fix incorrect autocorrect for `Style/ItBlockParameter`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_it_block_parameter.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_it_block_parameter.md
@@ -1,0 +1,1 @@
+* [#14336](https://github.com/rubocop/rubocop/issues/14336): Fix incorrect autocorrect for `Style/ItBlockParameter` when using a single numbered parameter after multiple numbered parameters in a method chain. ([@koic][])

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -109,7 +109,7 @@ module RuboCop
         private
 
         def find_block_variables(node, block_argument_name)
-          node.each_descendant(:lvar).select do |descendant|
+          node.body.each_descendant(:lvar).select do |descendant|
             descendant.source == block_argument_name
           end
         end

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -102,6 +102,17 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         RUBY
       end
 
+      it 'registers an offense when using a single numbered parameter after multiple numbered parameters in a method chain' do
+        expect_offense(<<~RUBY)
+          foo { bar(_1, _2) }.baz { qux(_1) }
+                                        ^^ Use `it` block parameter.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo { bar(_1, _2) }.baz { qux(it) }
+        RUBY
+      end
+
       it 'does not register an offense when using `it` block parameters' do
         expect_no_offenses(<<~RUBY)
           block { do_something(it) }


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Style/ItBlockParameter` when using a single numbered parameter after multiple numbered parameters in a method chain.

Fixes #14336.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
