### PR TITLE
Fix bug where specifying `--format` disables parallelization

### DIFF
--- a/changelog/fix_bug_where_specifying_format_disables_20250702192712.md
+++ b/changelog/fix_bug_where_specifying_format_disables_20250702192712.md
@@ -1,0 +1,1 @@
+* [#14339](https://github.com/rubocop/rubocop/pull/14339): Fix bug where specifying `--format` disables parallelization. ([@r7kamura][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -12,7 +12,7 @@ module RuboCop
     STATUS_INTERRUPTED = Signal.list['INT'] + 128
     DEFAULT_PARALLEL_OPTIONS = %i[
       color config debug display_style_guide display_time display_only_fail_level_offenses
-      display_only_failed editor_mode except extra_details fail_level fix_layout format
+      display_only_failed editor_mode except extra_details fail_level fix_layout format formatters
       ignore_disable_comments lint only only_guide_cops require safe
       autocorrect safe_autocorrect autocorrect_all
     ].freeze


### PR DESCRIPTION
When `--format` or `-f` CLI option is specified, `@options.keys` becomes `[:format, :formatters]` rather than just `[:format]`.

To ensure the following code works correctly, I believe we need to add `:formatters` to `DEFAULT_PARALLEL_OPTIONS` as well.

https://github.com/rubocop/rubocop/blob/da5d9d4213370d5292f289dc559691a76dc2fda1/lib/rubocop/cli.rb#L148-L153

Before the change, parallel execution was not enabled by default, as shown below:

```
$ bundle exec rubocop Gemfile --debug --format progress | grep "Use parallel by default."
$ echo $?
1
```

After the change, parallel execution is enabled by default.

```
$ bundle exec rubocop Gemfile --debug --format progress | grep "Use parallel by default."
Use parallel by default.
$ echo $?
0
```

FYI: As a background, I often run `bundle exec rubocop --format progress --format github` in GitHub Actions, but I noticed that it consistently takes twice as long as expected on the default 2-core machine. That led me to this issue. For now, I’ve worked around this by explicitly adding `--parallel` option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
