### PR TITLE
Fix typo and outdated info in Development doc

### DIFF
--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -381,9 +381,9 @@ This can be implemented using the `IgnoredNode` module:
  end
 ----
 
-This works because the correcting a file is implemented by repeating investigation and correction until the file no longer requires correction, meaning all nested nodes will eventually be processed.
+This works because file correction is implemented by repeating investigation and correction until the file no longer requires correction, meaning all nested nodes will eventually be processed.
 
-Note that `expect_correction` in `Cop` specs only asserts the result after one pass.
+Note that `expect_correction` in `Cop` specs asserts the result after all passes.
 
 === Limit by Ruby or Gem versions
 


### PR DESCRIPTION
Fixes a typo and updates sentence on `expect_correction`, which by default runs all investigation and correction passes: https://github.com/rubocop/rubocop/blob/865c92c149e4b076469791d8d8fbf0ffa629ef7e/lib/rubocop/rspec/expect_offense.rb#L144