### PR TITLE
[Fix #11782] Move pending cops warning out of ConfigLoader

### DIFF
--- a/changelog/fix_move_pending_cops_warning_out_of_config_loader_20250703225645.md
+++ b/changelog/fix_move_pending_cops_warning_out_of_config_loader_20250703225645.md
@@ -1,0 +1,1 @@
+* [#11782](https://github.com/rubocop/rubocop/issues/11782): Move pending cops warning out of ConfigLoader. ([@nobuyo][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -812,6 +812,7 @@ require_relative 'rubocop/options'
 require_relative 'rubocop/remote_config'
 require_relative 'rubocop/target_ruby'
 require_relative 'rubocop/yaml_duplication_checker'
+require_relative 'rubocop/pending_cops_reporter'
 
 # rubocop:enable Style/RequireOrder
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -48,6 +48,7 @@ module RuboCop
           validate_options_vs_config
           parallel_by_default!
           apply_default_formatter
+          report_pending_cops
           execute_runners
         end
       end
@@ -155,6 +156,7 @@ module RuboCop
 
     def act_on_options
       set_options_to_config_loader
+      set_options_to_pending_cops_reporter
       handle_editor_mode
 
       @config_store.options_config = @options[:config] if @options[:config]
@@ -177,6 +179,11 @@ module RuboCop
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
       ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
+    end
+
+    def set_options_to_pending_cops_reporter
+      PendingCopsReporter.disable_pending_cops = @options[:disable_pending_cops]
+      PendingCopsReporter.enable_pending_cops = @options[:enable_pending_cops]
     end
 
     def handle_editor_mode
@@ -207,6 +214,10 @@ module RuboCop
         end
         [[formatter, @options[:output_path]]]
       end
+    end
+
+    def report_pending_cops
+      PendingCopsReporter.warn_if_needed(@config_store.for_pwd)
     end
   end
 end

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -22,14 +22,6 @@ module RuboCop
     class << self
       include FileFinder
 
-      PENDING_BANNER = <<~BANNER
-        The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
-
-        Please also note that you can opt-in to new cops by default by adding this to your config:
-          AllCops:
-            NewCops: enable
-      BANNER
-
       attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops,
                     :ignore_unrecognized_cops
       attr_writer :default_configuration
@@ -132,21 +124,7 @@ module RuboCop
           add_excludes_from_files(config, config_file)
         end
 
-        merge_with_default(config, config_file).tap do |merged_config|
-          unless possible_new_cops?(merged_config)
-            pending_cops = pending_cops_only_qualified(merged_config.pending_cops)
-            warn_on_pending_cops(pending_cops) unless pending_cops.empty?
-          end
-        end
-      end
-
-      def pending_cops_only_qualified(pending_cops)
-        pending_cops.select { |cop| Cop::Registry.qualified_cop?(cop.name) }
-      end
-
-      def possible_new_cops?(config)
-        disable_pending_cops || enable_pending_cops ||
-          config.disabled_new_cops? || config.enabled_new_cops?
+        merge_with_default(config, config_file)
       end
 
       def add_excludes_from_files(config, config_file)
@@ -206,21 +184,6 @@ module RuboCop
         WARNING
 
         ConfigFinder.project_root
-      end
-
-      def warn_on_pending_cops(pending_cops)
-        warn Rainbow(PENDING_BANNER).yellow
-
-        pending_cops.each { |cop| warn_pending_cop cop }
-
-        warn Rainbow('For more information: https://docs.rubocop.org/rubocop/versioning.html').yellow
-      end
-
-      def warn_pending_cop(cop)
-        version = cop.metadata['VersionAdded'] || 'N/A'
-
-        warn Rainbow("#{cop.name}: # new in #{version}").yellow
-        warn Rainbow('  Enabled: true').yellow
       end
 
       # Merges the given configuration with the default one.

--- a/lib/rubocop/pending_cops_reporter.rb
+++ b/lib/rubocop/pending_cops_reporter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Reports information about pending cops that are not explicitly configured.
+  #
+  # This class is responsible for displaying warnings when new cops have been added to RuboCop
+  # but have not yet been enabled or disabled in the user's configuration.
+  # It provides a centralized way to determine whether such warnings should be shown,
+  # based on global flags or configuration settings.
+  class PendingCopsReporter
+    class << self
+      PENDING_BANNER = <<~BANNER
+        The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
+
+        Please also note that you can opt-in to new cops by default by adding this to your config:
+          AllCops:
+            NewCops: enable
+      BANNER
+
+      attr_accessor :disable_pending_cops, :enable_pending_cops
+
+      def warn_if_needed(config)
+        return if possible_new_cops?(config)
+
+        pending_cops = pending_cops_only_qualified(config.pending_cops)
+        warn_on_pending_cops(pending_cops) unless pending_cops.empty?
+      end
+
+      private
+
+      def pending_cops_only_qualified(pending_cops)
+        pending_cops.select { |cop| Cop::Registry.qualified_cop?(cop.name) }
+      end
+
+      def possible_new_cops?(config)
+        disable_pending_cops || enable_pending_cops ||
+          config.disabled_new_cops? || config.enabled_new_cops?
+      end
+
+      def warn_on_pending_cops(pending_cops)
+        warn Rainbow(PENDING_BANNER).yellow
+
+        pending_cops.each { |cop| warn_pending_cop cop }
+
+        warn Rainbow('For more information: https://docs.rubocop.org/rubocop/versioning.html').yellow
+      end
+
+      def warn_pending_cop(cop)
+        version = cop.metadata['VersionAdded'] || 'N/A'
+
+        warn Rainbow("#{cop.name}: # new in #{version}").yellow
+        warn Rainbow('  Enabled: true').yellow
+      end
+    end
+  end
+end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1086,7 +1086,10 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           actual = File.read('.rubocop_todo.yml').lines.grep_v(/^(#.*)?$/)
           expect(actual.join).to eq(expected)
 
-          expect(cli.run([])).to eq(0)
+          # NOTE: Reload CLI to ensure updated config with rubocop_todo is properly picked up.
+          #       ConfigStore#for_pwd caches results; re-create CLI to avoid using stale config.
+          fresh_cli = RuboCop::CLI.new
+          expect(fresh_cli.run([])).to eq(0)
         end
       end
 
@@ -1726,7 +1729,11 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
               - '**/*.arb'
               - 'file.rb'
         YAML
-        expect(cli.run([])).to eq(0)
+
+        # NOTE: Reload CLI to ensure updated config with rubocop_todo is properly picked up.
+        #       ConfigStore#for_pwd caches results; re-create CLI to avoid using stale config.
+        fresh_cli = RuboCop::CLI.new
+        expect(fresh_cli.run([])).to eq(0)
       end
     end
   end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -2060,54 +2060,6 @@ RSpec.describe RuboCop::ConfigLoader do
     end
   end
 
-  describe 'when pending cops exist', :isolated_environment do
-    subject(:from_file) { described_class.configuration_from_file('.rubocop.yml') }
-
-    before do
-      create_empty_file('.rubocop.yml')
-
-      # Setup similar to https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb#L16
-      # and https://github.com/runtastic/rt_rubocop_defaults/blob/master/lib/rt_rubocop_defaults/inject.rb#L21
-      config = RuboCop::Config.new(parent_config)
-      described_class.instance_variable_set(:@default_configuration, config)
-    end
-
-    context 'when NewCops is set in a required file' do
-      let(:parent_config) { { 'AllCops' => { 'NewCops' => 'enable' } } }
-
-      it 'does not print a warning' do
-        expect(described_class).not_to receive(:warn_on_pending_cops)
-        from_file
-      end
-    end
-
-    context 'when NewCops is not configured in a required file' do
-      let(:parent_config) { { 'AllCops' => { 'Exclude:' => ['coverage/**/*'] } } }
-
-      context 'when `pending_cops_only_qualified` returns empty array' do
-        before do
-          allow(described_class).to receive(:pending_cops_only_qualified).and_return([])
-        end
-
-        it 'does not print a warning' do
-          expect(described_class).not_to receive(:warn_on_pending_cops)
-          from_file
-        end
-      end
-
-      context 'when `pending_cops_only_qualified` returns not empty array' do
-        before do
-          allow(described_class).to receive(:pending_cops_only_qualified).and_return(['Foo/Bar'])
-        end
-
-        it 'prints a warning' do
-          expect(described_class).to receive(:warn_on_pending_cops)
-          from_file
-        end
-      end
-    end
-  end
-
   describe 'configuration for AssignmentInCondition' do
     describe 'AllowSafeAssignment' do
       it 'is enabled by default' do

--- a/spec/rubocop/pending_cops_reporter_spec.rb
+++ b/spec/rubocop/pending_cops_reporter_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::PendingCopsReporter do
+  include FileHelper
+
+  describe 'when pending cops exist', :isolated_environment do
+    subject(:report_pending_cops) { described_class.warn_if_needed(config) }
+
+    let(:config) { RuboCop::Config.new(parent_config) }
+
+    before do
+      create_empty_file('.rubocop.yml')
+
+      # Setup similar to https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb#L16
+      # and https://github.com/runtastic/rt_rubocop_defaults/blob/master/lib/rt_rubocop_defaults/inject.rb#L21
+      loader = RuboCop::ConfigLoader.configuration_from_file('.rubocop.yml')
+      loader.instance_variable_set(:@default_configuration, config)
+    end
+
+    context 'when NewCops is set in a required file' do
+      let(:parent_config) { { 'AllCops' => { 'NewCops' => 'enable' } } }
+
+      it 'does not print a warning' do
+        expect(described_class).not_to receive(:warn_on_pending_cops)
+        report_pending_cops
+      end
+    end
+
+    context 'when NewCops is not configured in a required file' do
+      let(:parent_config) { { 'AllCops' => { 'Exclude:' => ['coverage/**/*'] } } }
+
+      context 'when `pending_cops_only_qualified` returns empty array' do
+        before do
+          allow(described_class).to receive(:pending_cops_only_qualified).and_return([])
+        end
+
+        it 'does not print a warning' do
+          expect(described_class).not_to receive(:warn_on_pending_cops)
+          report_pending_cops
+        end
+      end
+
+      context 'when `pending_cops_only_qualified` returns not empty array' do
+        before do
+          allow(described_class).to receive(:pending_cops_only_qualified).and_return(['Foo/Bar'])
+        end
+
+        it 'prints a warning' do
+          expect(described_class).to receive(:warn_on_pending_cops)
+          report_pending_cops
+        end
+      end
+    end
+  end
+end

--- a/spec/support/suppress_pending_warning.rb
+++ b/spec/support/suppress_pending_warning.rb
@@ -2,11 +2,11 @@
 
 #
 # This is a file that supports testing. An open class has been applied to
-# `RuboCop::ConfigLoader.warn_on_pending_cops` to suppress pending cop
+# `RuboCop::PendingCopsReporter.warn_on_pending_cops` to suppress pending cop
 # warnings during testing.
 #
 module RuboCop
-  class ConfigLoader
+  class PendingCopsReporter
     class << self
       remove_method :warn_on_pending_cops
       def warn_on_pending_cops(config)


### PR DESCRIPTION
closes #11782 

Previously, `RuboCop::ConfigLoader` emitted pending cops warnings as a side effect of loading configuration files. This caused unintended stdout output during tests and could interfere with CLI operations like `--auto-gen-config`.

This patch moves the responsibility for pending cops reporting to a dedicated `PendingCopsReporter` class. The CLI now explicitly invokes the reporter after loading configuration, ensuring that `ConfigLoader` remains a pure loader without user-facing output.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
