### PR TITLE
Add an option to allow custom RuboCop directive modes

### DIFF
--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -47,7 +47,11 @@ module RuboCop
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            directive_comment = DirectiveComment.new(comment)
+            directive_comment = DirectiveComment.new(
+              comment,
+              custom_modes: config.for_all_cops.fetch('CustomDirectiveModes', [])
+            )
+            next if directive_comment.custom_mode?
             next unless directive_comment.start_with_marker?
             next unless directive_comment.malformed?
 

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -36,6 +36,11 @@ module RuboCop
     MALFORMED_DIRECTIVE_WITHOUT_COP_NAME_REGEXP = Regexp.new(
       "\\A#{DIRECTIVE_HEADER_PATTERN}\\s*\\z".gsub(' ', '\s*')
     )
+    # @api private
+    CUSTOM_MODE_COMMENT_REGEXP = Regexp.new(
+      "#{DIRECTIVE_MARKER_PATTERN}((?:\\S+)).*\\b"
+        .gsub(' ', '\s*')
+    )
 
     def self.before_comment(line)
       line.split(DIRECTIVE_COMMENT_REGEXP).first
@@ -43,11 +48,20 @@ module RuboCop
 
     attr_reader :comment, :cop_registry, :mode, :cops
 
-    def initialize(comment, cop_registry = Cop::Registry.global)
+    def initialize(comment, cop_registry = Cop::Registry.global, custom_modes: [])
       @comment = comment
       @cop_registry = cop_registry
+      @custom_modes = custom_modes
       @match_data = comment.text.match(DIRECTIVE_COMMENT_REGEXP)
       @mode, @cops = match_captures
+    end
+
+    def custom_mode?
+      return false if @custom_modes.empty?
+
+      mode, = CUSTOM_MODE_COMMENT_REGEXP.match(comment.text).captures
+
+      @custom_modes.include?(mode)
     end
 
     # Checks if the comment starts with `# rubocop:` marker

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -102,4 +102,20 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
     RUBY
   end
+
+  context 'with custom modes' do
+    let(:all_cops_config) { { 'CustomDirectiveModes' => ['foobar'] } }
+
+    it 'does not register an offense when configured custom directive mode is used' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:foobar abc
+      RUBY
+    end
+
+    it 'does not register an offense when configured custom directive mode is used without arguments' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:foobar
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This is more of an issue/feature request with a basic implementation proposal.

I am developing a custom RuboCop plugin that performs certain actions when it encounters comments with a specific format, for example:

```ruby
# rubocop:my-custom-directive-mode foobar
# some code
```

Currently, this triggers an offense from  `Lint/CopDirectiveSyntax`.

I propose adding a new configuration option — either specifically for `Lint/CopDirectiveSyntax` or globally under `AllCops`.

This option, named for instance `CustomDirectiveModes`, would default to an empty array (`[]`) and could be overriden by plugin's configuration.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
