### PR TITLE
Fix autocorrect for `Style/HashConversion` to avoid syntax error

### DIFF
--- a/changelog/fix_autocorrect_for_style_hash_conversion.md
+++ b/changelog/fix_autocorrect_for_style_hash_conversion.md
@@ -1,0 +1,1 @@
+* [#14343](https://github.com/rubocop/rubocop/pull/14343): Fix autocorrect code for `Style/HashConversion` to avoid syntax error. ([@koic][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -128,7 +128,9 @@ module RuboCop
               corrector.replace(node, args_to_hash(node.arguments))
 
               parent = node.parent
-              add_parentheses(parent, corrector) if parent&.send_type? && !parent.parenthesized?
+              if parent&.send_type? && !parent.method?(:to_h) && !parent.parenthesized?
+                add_parentheses(parent, corrector)
+              end
             end
           end
         end

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -208,6 +208,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'reports an offense for `Hash[].to_h`' do
+    expect_offense(<<~RUBY)
+      Hash[].to_h
+      ^^^^^^ Prefer literal hash to `Hash[arg1, arg2, ...]`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      {}.to_h
+    RUBY
+  end
+
   context 'AllowSplatArgument: true' do
     let(:cop_config) { { 'AllowSplatArgument' => true } }
 


### PR DESCRIPTION
This PR fixes autocorrect code for `Style/HashConversion` to avoid syntax error.

## Before

Autocorrection causes a syntax error.

```console
echo "Hash[].to_h" | bundle exec rubocop --stdin example.rb -A
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/EmptyLiteral: Use hash literal {} instead of Hash[].
Hash[].to_h
^^^^^^
example.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
Hash[].to_h
^
example.rb:1:1: C: [Corrected] Style/HashConversion: Prefer literal hash to Hash[arg1, arg2, ...].
Hash[].to_h
^^^^^^
example.rb:1:8: W: [Corrected] Lint/RedundantTypeConversion: Redundant to_h detected.
Hash[].to_h
^^^^
example.rb:2:3: F: Lint/Syntax: unexpected token tLPAREN2
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
{}()
^

1 file inspected, 5 offenses detected, 4 offenses corrected
====================
# frozen_string_literal: true
{}()
```

## After

No syntax errors.

```console
$ echo "Hash[].to_h" | bundle exec rubocop --stdin example.rb -A
Inspecting 1 file
W

Offenses:

example.rb:1:1: C: [Corrected] Style/EmptyLiteral: Use hash literal {} instead of Hash[].
Hash[].to_h
^^^^^^
example.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
Hash[].to_h
^
example.rb:1:1: C: [Corrected] Style/HashConversion: Prefer literal hash to Hash[arg1, arg2, ...].
Hash[].to_h
^^^^^^
example.rb:1:8: W: [Corrected] Lint/RedundantTypeConversion: Redundant to_h detected.
Hash[].to_h
^^^^
example.rb:2:1: C: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
{}
^

1 file inspected, 5 offenses detected, 5 offenses corrected
====================
# frozen_string_literal: true

{}
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
