### PR TITLE
[Fix #14346] Avoid requiring parentheses for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_avoid_requiring_parentheses_for_style_single_line_methods.md
+++ b/changelog/fix_avoid_requiring_parentheses_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#14346](https://github.com/rubocop/rubocop/issues/14346): Avoid requiring parentheses for `Style/SingleLineMethods`. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -130,7 +130,10 @@ module RuboCop
         end
 
         def require_parentheses?(method_body)
-          method_body.send_type? && !method_body.arguments.empty? && !method_body.comparison_method?
+          return false unless method_body.send_type?
+          return false if method_body.arithmetic_operation?
+
+          !method_body.arguments.empty? && !method_body.comparison_method?
         end
 
         def disallow_endless_method_style?

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -232,6 +232,14 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         end
       end
 
+      RuboCop::AST::MethodDispatchNode.const_get(:ARITHMETIC_OPERATORS).each do |op|
+        it "corrects to an endless class method definition when using #{op}" do
+          expect_correction(<<~RUBY.strip, source: "def foo() bar #{op} baz end")
+            def foo() = bar #{op} baz
+          RUBY
+        end
+      end
+
       it 'does not to an endless class method definition when using `return`' do
         expect_correction(<<~RUBY.strip, source: 'def foo(argument) return bar(argument); end')
           def foo(argument)#{trailing_whitespace}


### PR DESCRIPTION
This change ensures that single-line methods containing arithmetic operations (e.g., `foo + bar`) are correctly converted to endless method definitions without adding unnecessary parentheses.

Adds test cases for all arithmetic operators.

Fixes #14346.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
