### PR TITLE
[Fix #14350] Fix `Naming/MethodName` cop false positives with `define_method` and operator name

### DIFF
--- a/changelog/fix_naming_method_name_cop_false_positives_with_define_method_and_operator_20250708164441.md
+++ b/changelog/fix_naming_method_name_cop_false_positives_with_define_method_and_operator_20250708164441.md
@@ -1,0 +1,1 @@
+* [#14350](https://github.com/rubocop/rubocop/issues/14350): Fix `Naming/MethodName` cop false positives with `define_method` and operator names. ([@viralpraxis][])

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -94,6 +94,9 @@ module RuboCop
         MSG = 'Use %<style>s for method names.'
         MSG_FORBIDDEN = '`%<identifier>s` is forbidden, use another method name instead.'
 
+        OPERATOR_METHODS = %i[| ^ & <=> == === =~ > >= < <= << >> + - * /
+                              % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `].to_set.freeze
+
         # @!method sym_name(node)
         def_node_matcher :sym_name, '(sym $_name)'
 
@@ -159,7 +162,7 @@ module RuboCop
 
           if forbidden_name?(name.to_s)
             register_forbidden_name(node)
-          else
+          elsif !OPERATOR_METHODS.include?(name)
             check_name(node, name, range_position(node))
           end
         end

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -139,6 +139,17 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       end
     end
 
+    %i[define_method define_singleton_method].each do |name|
+      %w[== >= <= > < =~ ! [] []= gärten].each do |method_name|
+        it "does not register an offense when `#{name}` is called with a `#{method_name}` method name" do
+          expect_no_offenses(<<~RUBY)
+            #{name} :#{method_name} do
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'when specifying `AllowedPatterns`' do
       let(:cop_config) do
         {
@@ -493,6 +504,9 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'forbidden identifiers', 'super'
     include_examples 'forbidden patterns', '_v1\z', 'api_v1'
     include_examples 'define_method method call', 'snake_case', 'fooBar'
+    include_examples 'define_method method call', 'snake_case', 'fooBar?'
+    include_examples 'define_method method call', 'snake_case', 'fooBar!'
+    include_examples 'define_method method call', 'snake_case', 'fooBar='
   end
 
   context 'when configured for camelCase' do
@@ -588,6 +602,9 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
     include_examples 'forbidden identifiers', 'super'
     include_examples 'forbidden patterns', '_gen\d+\z', 'user_gen1'
     include_examples 'define_method method call', 'camelCase', 'foo_bar'
+    include_examples 'define_method method call', 'camelCase', 'foo_bar?'
+    include_examples 'define_method method call', 'camelCase', 'foo_bar!'
+    include_examples 'define_method method call', 'camelCase', 'foo_bar='
   end
 
   it 'accepts for non-ascii characters' do


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/14350

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
