### PR TITLE
[Fix #14344] Fix incorrect autocorrect for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_single_line_methods_cop.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_single_line_methods_cop.md
@@ -1,0 +1,1 @@
+* [#14344](https://github.com/rubocop/rubocop/issues/14344): Fix incorrect autocorrect for `Style/SingleLineMethods` when a single-line method definition contains a modifier. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -65,7 +65,7 @@ module RuboCop
           return false if target_ruby_version < 3.0
           return false if disallow_endless_method_style?
           return false unless body_node
-          return false if body_node.parent.assignment_method? ||
+          return false if body_node.basic_conditional? || body_node.parent.assignment_method? ||
                           NOT_SUPPORTED_ENDLESS_METHOD_BODY_TYPES.include?(body_node.type)
 
           !body_node.type?(:begin, :kwbegin)

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -240,6 +240,38 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         end
       end
 
+      it 'registers an offense when a single-line method definition contains `if` modifier' do
+        expect_correction(<<~RUBY.strip, source: 'def foo() bar if baz end')
+          def foo()#{trailing_whitespace}
+            bar if baz#{trailing_whitespace}
+          end
+        RUBY
+      end
+
+      it 'registers an offense when a single-line method definition contains `unless` modifier' do
+        expect_correction(<<~RUBY.strip, source: 'def foo() bar unless baz end')
+          def foo()#{trailing_whitespace}
+            bar unless baz#{trailing_whitespace}
+          end
+        RUBY
+      end
+
+      it 'registers an offense when a single-line method definition contains `while` modifier' do
+        expect_correction(<<~RUBY.strip, source: 'def foo() bar while baz end')
+          def foo()#{trailing_whitespace}
+            bar while baz#{trailing_whitespace}
+          end
+        RUBY
+      end
+
+      it 'registers an offense when a single-line method definition contains `until` modifier' do
+        expect_correction(<<~RUBY.strip, source: 'def foo() bar until baz end')
+          def foo()#{trailing_whitespace}
+            bar until baz#{trailing_whitespace}
+          end
+        RUBY
+      end
+
       it 'does not to an endless class method definition when using `return`' do
         expect_correction(<<~RUBY.strip, source: 'def foo(argument) return bar(argument); end')
           def foo(argument)#{trailing_whitespace}


### PR DESCRIPTION
Fix incorrect autocorrect for `Style/SingleLineMethods` when a single-line method definition contains a modifier.

Fixes #14344.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
