### PR TITLE
Fix incorrect autocorrect for Style/AccessModifierDeclarations

### DIFF
--- a/changelog/fix_fix_incorrect_autocorrect_for_20250709134109.md
+++ b/changelog/fix_fix_incorrect_autocorrect_for_20250709134109.md
@@ -1,0 +1,1 @@
+* [#14354](https://github.com/rubocop/rubocop/pull/14354): Fix incorrect autocorrect for `Style/AccessModifierDeclarations` when using a grouped access modifier declaration. ([@girasquid][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -348,7 +348,7 @@ module RuboCop
         end
 
         def remove_modifier_node_within_begin(corrector, modifier_node, begin_node)
-          def_node = begin_node.children[1]
+          def_node = begin_node.children[begin_node.children.index(modifier_node) + 1]
           range = modifier_node.source_range.begin.join(def_node.source_range.begin)
           corrector.remove(range)
         end

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -735,6 +735,35 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
             end
           RUBY
         end
+
+        it 'registers an offense when using a grouped access modifier declaration' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              def something_else; end
+
+              def a_method_that_is_public; end
+
+              #{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+
+              def my_other_private_method; end
+
+              def bar; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              def something_else; end
+
+              def a_method_that_is_public; end
+
+              #{access_modifier} def my_other_private_method; end
+
+              #{access_modifier} def bar; end
+            end
+          RUBY
+        end
       end
 
       context 'with `begin` parent node' do


### PR DESCRIPTION
I noticed that when running autocorrect for `Style/AccessModifierDeclarations`, the method above the group declaration was being deleted. So this:

```ruby
class MyThing
  def other_method; end

  def a_method_that_is_public; end

  private

  def my_other_private_method; end
end
```

After going through autocorrect would become:
```ruby
class MyThing
  def other_method; end

  private

  private def my_other_private_method; end
end
```

This PR adds a spec demonstrating the behavior with as small a code sample as I could get down to, and then fixes the issue - when trying to change the code it was *always* using index `1`, which wasn't correct if the AST had the entire class body for what needed to be processed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
