### PR TITLE
Fix a false negative for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_negative_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14355](https://github.com/rubocop/rubocop/pull/14355): Fix a false negative for `Style/RedundantParentheses` when using parentheses around a `rescue` expression on a one-line. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -169,6 +169,7 @@ module RuboCop
           end
           return 'an interpolated expression' if interpolation?(begin_node)
           return 'a method argument' if argument_of_parenthesized_method_call?(begin_node, node)
+          return 'a one-line rescue' if !begin_node.parent&.call_type? && node.rescue_type?
 
           return if begin_node.chained?
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1386,6 +1386,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense when parentheses around a `rescue` expression on a one-line' do
+    expect_offense(<<~RUBY)
+      (foo rescue bar)
+      ^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line rescue.
+      (foo rescue bar)
+      ^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line rescue.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo rescue bar
+      foo rescue bar
+    RUBY
+  end
+
   it 'accepts parentheses around a constant passed to when' do
     expect_no_offenses(<<~RUBY)
       case foo


### PR DESCRIPTION
This PR fixes a false negative for `Style/RedundantParentheses` when using parentheses around a `rescue` expression on a one-line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
