### PR TITLE
Fix `Style/ItBlockParameter` cop error on `Always` style and missing block body

### DIFF
--- a/changelog/fix_style_it_block_parameter_cop_error_on_always_20250711053844.md
+++ b/changelog/fix_style_it_block_parameter_cop_error_on_always_20250711053844.md
@@ -1,0 +1,1 @@
+* [#14356](https://github.com/rubocop/rubocop/pull/14356): Fix `Style/ItBlockParameter` cop error on `always` style and missing block body. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -109,6 +109,8 @@ module RuboCop
         private
 
         def find_block_variables(node, block_argument_name)
+          return [] unless node.body
+
           node.body.each_descendant(:lvar).select do |descendant|
             descendant.source == block_argument_name
           end

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
           block { |foo, bar| do_something(foo, bar) }
         RUBY
       end
+
+      it 'does not register an offense for block with parameter and missing body' do
+        expect_no_offenses(<<~RUBY)
+          block do |_|
+          end
+        RUBY
+      end
     end
 
     context 'EnforcedStyle: disallow' do


### PR DESCRIPTION
For `->(_) {}`:

```shell
Failures:

  1) RuboCop::Cop::Style::ItBlockParameter >= Ruby 3.4 EnforcedStyle: always does not register an offense for block with parameter and missing body
     Failure/Error:
       node.body.each_descendant(:lvar).select do |descendant|
         descendant.source == block_argument_name
       end

     NoMethodError:
       undefined method 'each_descendant' for nil
```
-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
