### PR TITLE
[Fix #14333] Fix `Naming/PredicateMethod` ignoring the implicit `nil` from missing `else` branches

### DIFF
--- a/changelog/fix_predicate_method_implicit_nil_in_else.md
+++ b/changelog/fix_predicate_method_implicit_nil_in_else.md
@@ -1,0 +1,1 @@
+* [#14333](https://github.com/rubocop/rubocop/issues/14333): Fix `Naming/PredicateMethod` ignoring the implicit `nil` from missing `else` branches. ([@earlopain][])

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -269,7 +269,10 @@ module RuboCop
             node.body ? [last_value(node.body)] : [s(:nil)]
           else
             # Branches with no value act as an implicit `nil`.
-            node.branches.filter_map { |branch| branch ? last_value(branch) : s(:nil) }
+            branches = node.branches.map { |branch| branch ? last_value(branch) : s(:nil) }
+            # Missing else branches also act as an implicit `nil`.
+            branches.push(s(:nil)) unless node.else_branch
+            branches
           end
         end
 

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -398,12 +398,14 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       it_behaves_like 'predicate', <<~RUBY, explicit: false
         case x
           in y then true
+          else false
         end
       RUBY
 
       it_behaves_like 'predicate', <<~RUBY, explicit: false
         case x
           in y then return true
+          else return false
         end
       RUBY
 
@@ -447,10 +449,6 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
         else
           return baz
         end
-      RUBY
-
-      it_behaves_like 'acceptable', <<~RUBY, explicit: false
-        bar if x
       RUBY
 
       it_behaves_like 'acceptable', <<~RUBY, explicit: false
@@ -647,6 +645,30 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       RUBY
     end
 
+    context 'conditionals without else' do
+      it_behaves_like 'acceptable', <<~RUBY, explicit: false
+        true if x
+      RUBY
+
+      it_behaves_like 'acceptable', <<~RUBY, explicit: false
+        if x
+          true
+        end
+      RUBY
+
+      it_behaves_like 'acceptable', <<~RUBY, explicit: false
+        case x
+          when y then true
+        end
+      RUBY
+
+      it_behaves_like 'acceptable', <<~RUBY, explicit: false
+        case x
+          in y then true
+        end
+      RUBY
+    end
+
     context 'super' do
       it_behaves_like 'acceptable', <<~RUBY, explicit: false
         return if something
@@ -716,6 +738,30 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
         if x
         else
           false
+        end
+      RUBY
+    end
+
+    context 'conditionals without else' do
+      it_behaves_like 'non-predicate', <<~RUBY, explicit: false
+        true if x
+      RUBY
+
+      it_behaves_like 'non-predicate', <<~RUBY, explicit: false
+        if x
+          true
+        end
+      RUBY
+
+      it_behaves_like 'non-predicate', <<~RUBY, explicit: false
+        case x
+          when y then true
+        end
+      RUBY
+
+      it_behaves_like 'non-predicate', <<~RUBY, explicit: false
+        case x
+          in y then true
         end
       RUBY
     end


### PR DESCRIPTION
A missing else branch implies a nil return value.
Tweaks a handful of existing specs with wrong expectations.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
