### PR TITLE
Add `tsort` to runtime dependency

### DIFF
--- a/changelog/change_add_tsort_to_runtime_dependency.md
+++ b/changelog/change_add_tsort_to_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#14358](https://github.com/rubocop/rubocop/pull/14358): Add `tsort` gem to runtime dependency for Ruby 3.5-dev. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |s|
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
   s.add_dependency('rubocop-ast', '>= 1.45.1', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
+  s.add_dependency('tsort', '>= 0.2.0')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end


### PR DESCRIPTION
This PR fixes the following build error in the Ruby 3.5 build matrix:

```console
$ bundle exec rake spec
(snip)

==> Failures

  1) RuboCop Project requiring all of `lib` with verbose warnings enabled emits no warnings
     Failure/Error: expect(warnings).to eq []

       expected: []
            got: ["/home/runner/work/rubocop/rubocop/lib/rubocop/cop/style/parallel_assignment.rb:3:
                  warning: tsort wa...om the standard library, but will no longer be part of
                  the default gems starting from Ruby 3.6.0\n"]
```

https://github.com/rubocop/rubocop/actions/runs/16236943172/job/45848342320

Please see for more details:

- https://bugs.ruby-lang.org/issues/21442
- https://github.com/ruby/ruby/pull/13841

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
