### PR TITLE
Make `Layout/SpaceAroundOperators` aware of alternative and as pattern matchings

### DIFF
--- a/changelog/change_make_layout_space_around_operators_aware_of_pattern_matching.md
+++ b/changelog/change_make_layout_space_around_operators_aware_of_pattern_matching.md
@@ -1,0 +1,1 @@
+* [#14360](https://github.com/rubocop/rubocop/pull/14360): Make `Layout/SpaceAroundOperators` aware of alternative and as pattern matchings. ([@koic][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -151,6 +151,14 @@ module RuboCop
           check_operator(:match_pattern, node.loc.operator, node)
         end
 
+        def on_match_alt(node)
+          check_operator(:match_alt, node.loc.operator, node)
+        end
+
+        def on_match_as(node)
+          check_operator(:match_as, node.loc.operator, node)
+        end
+
         alias on_or       on_binary
         alias on_and      on_binary
         alias on_lvasgn   on_assignment

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -280,6 +280,60 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
   context '>= Ruby 2.7', :ruby27 do
     let(:target_ruby_version) { 2.7 }
 
+    it 'registers an offense for alternative pattern matching syntax' do
+      expect_offense(<<~RUBY)
+        case foo
+        in bar|baz|qux
+                  ^ Surrounding space missing for operator `|`.
+              ^ Surrounding space missing for operator `|`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        in bar | baz | qux
+        end
+      RUBY
+    end
+
+    it 'registers an offense for as pattern matching syntax' do
+      expect_offense(<<~RUBY)
+        case foo
+        in bar=>baz
+              ^^ Surrounding space missing for operator `=>`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo
+        in bar => baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for one-line alternative pattern matching syntax' do
+      expect_offense(<<~RUBY)
+        foo in bar|baz|qux
+                      ^ Surrounding space missing for operator `|`.
+                  ^ Surrounding space missing for operator `|`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo in bar | baz | qux
+      RUBY
+    end
+
+    it 'registers an offense for one-line as pattern matching syntax' do
+      expect_offense(<<~RUBY)
+        foo in bar=>baz
+                  ^^ Surrounding space missing for operator `=>`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo in bar => baz
+      RUBY
+    end
+
     # NOTE: It is `Layout/SpaceAroundKeyword` cop's role to detect this offense.
     it 'does not register an offense for one-line pattern matching syntax (`in`)' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR makes `Layout/SpaceAroundOperators` aware of alternative and as pattern matchings.

The example code in the documentation has not been updated, as the behavioral change is minor.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
