### PR TITLE
[Fix #14362] Update `Lint/RequireRangeParentheses` to not register false positives when range elements span multiple lines

### DIFF
--- a/changelog/fix_update_lint_require_range_parentheses_to_not_20250714114905.md
+++ b/changelog/fix_update_lint_require_range_parentheses_to_not_20250714114905.md
@@ -1,0 +1,1 @@
+* [#14362](https://github.com/rubocop/rubocop/issues/14362): Update `Lint/RequireRangeParentheses` to not register false positives when range elements span multiple lines. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/require_range_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_range_parentheses.rb
@@ -43,7 +43,7 @@ module RuboCop
         def on_irange(node)
           return if node.parent&.begin_type?
           return unless node.begin && node.end
-          return if same_line?(node.begin, node.end)
+          return if same_line?(node.loc.operator, node.end)
 
           message = format(MSG, range: "#{node.begin.source}#{node.loc.operator.source}")
 

--- a/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
@@ -57,4 +57,11 @@ RSpec.describe RuboCop::Cop::Lint::RequireRangeParentheses, :config do
       42..do_something
     RUBY
   end
+
+  it 'does not register an offense when the begin element ends on another line' do
+    expect_no_offenses(<<~RUBY)
+      foo(
+        bar)..baz(quux)
+    RUBY
+  end
 end


### PR DESCRIPTION
Update `Lint/RequireRangeParentheses` to not register a false positive when the begin element spans multiple lines. If the operator is on the same line as the end element, there is no ambiguity.

Fixes #14362.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
