### PR TITLE
[Fix #14322] Expand the scope of `Style/ItAssignment` to consider all local variable and method parameter names

### DIFF
--- a/changelog/change_expand_the_scope_of_it_assignment_to_consider_all_20250715094540.md
+++ b/changelog/change_expand_the_scope_of_it_assignment_to_consider_all_20250715094540.md
@@ -1,0 +1,1 @@
+* [#14322](https://github.com/rubocop/rubocop/issues/14322): Expand the scope of `Style/ItAssignment` to consider all local variable and method parameter names. ([@dvandersluis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4499,7 +4499,7 @@ Style/IpAddresses:
     - '**/*.gemspec'
 
 Style/ItAssignment:
-  Description: 'Checks for assignment to `it` inside a block.'
+  Description: 'Checks for local variables and method parameters named `it`.'
   Enabled: pending
   VersionAdded: '1.70'
 

--- a/lib/rubocop/cop/style/it_assignment.rb
+++ b/lib/rubocop/cop/style/it_assignment.rb
@@ -3,33 +3,90 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for assignments to a local `it` variable inside a block
+      # Checks for local variables and method parameters named `it`,
       # where `it` can refer to the first anonymous parameter as of Ruby 3.4.
+      # Use a meaningful variable name instead.
       #
-      # Although Ruby allows reassigning `it` in these cases, it could
+      # NOTE: Although Ruby allows reassigning `it` in these cases, it could
       # cause confusion if `it` is used as a block parameter elsewhere.
-      # For consistency, this also applies to numblocks and blocks with
-      # parameters, even though `it` cannot be used in those cases.
       #
       # @example
       #   # bad
-      #   foo { it = 5 }
-      #   foo { |bar| it = bar }
-      #   foo { it = _2 }
+      #   it = 5
       #
-      #   # good - use a different variable name
-      #   foo { var = 5 }
-      #   foo { |bar| var = bar }
-      #   foo { bar = _2 }
+      #   # good
+      #   var = 5
+      #
+      #   # bad
+      #   def foo(it)
+      #   end
+      #
+      #   # good
+      #   def foo(arg)
+      #   end
+      #
+      #   # bad
+      #   def foo(it = 5)
+      #   end
+      #
+      #   # good
+      #   def foo(arg = 5)
+      #   end
+      #
+      #   # bad
+      #   def foo(*it)
+      #   end
+      #
+      #   # good
+      #   def foo(*args)
+      #   end
+      #
+      #   # bad
+      #   def foo(it:)
+      #   end
+      #
+      #   # good
+      #   def foo(arg:)
+      #   end
+      #
+      #   # bad
+      #   def foo(it: 5)
+      #   end
+      #
+      #   # good
+      #   def foo(arg: 5)
+      #   end
+      #
+      #   # bad
+      #   def foo(**it)
+      #   end
+      #
+      #   # good
+      #   def foo(**kwargs)
+      #   end
+      #
+      #   # bad
+      #   def foo(&it)
+      #   end
+      #
+      #   # good
+      #   def foo(&block)
+      #   end
       class ItAssignment < Base
         MSG = '`it` is the default block parameter; consider another name.'
 
         def on_lvasgn(node)
           return unless node.name == :it
-          return unless node.each_ancestor(:any_block).any?
 
           add_offense(node.loc.name)
         end
+        alias on_arg on_lvasgn
+        alias on_optarg on_lvasgn
+        alias on_restarg on_lvasgn
+        alias on_blockarg on_lvasgn
+        alias on_kwarg on_lvasgn
+        alias on_kwoptarg on_lvasgn
+        alias on_kwrestarg on_lvasgn
       end
     end
   end

--- a/spec/rubocop/cop/style/it_assignment_spec.rb
+++ b/spec/rubocop/cop/style/it_assignment_spec.rb
@@ -1,6 +1,69 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ItAssignment, :config do
+  it 'registers an offense when assigning a local `it` variable' do
+    expect_offense(<<~RUBY)
+      it = 5
+      ^^ `it` is the default block parameter; consider another name.
+    RUBY
+  end
+
+  it 'registers an offense when naming a method parameter `it`' do
+    expect_offense(<<~RUBY)
+      def foo(it)
+              ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a kwarg `it`' do
+    expect_offense(<<~RUBY)
+      def foo(it:)
+              ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a method parameter `it` with a default value' do
+    expect_offense(<<~RUBY)
+      def foo(it = 5)
+              ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a kwarg `it` with a default value' do
+    expect_offense(<<~RUBY)
+      def foo(it: 5)
+              ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a method parameter `*it`' do
+    expect_offense(<<~RUBY)
+      def foo(*it)
+               ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a kwarg splat `**it`' do
+    expect_offense(<<~RUBY)
+      def foo(**it)
+                ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when naming a block argument `&it`' do
+    expect_offense(<<~RUBY)
+      def foo(&it)
+               ^^ `it` is the default block parameter; consider another name.
+      end
+    RUBY
+  end
+
   it 'registers an offense when assigning a local `it` variable inside a block' do
     expect_offense(<<~RUBY)
       foo { it = 5 }
@@ -39,9 +102,21 @@ RSpec.describe RuboCop::Cop::Style::ItAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when assigning `self.it`' do
+    expect_no_offenses(<<~RUBY)
+      self.it = 5
+    RUBY
+  end
+
   it 'does not register an offense when assigning `self.it` inside a block' do
     expect_no_offenses(<<~RUBY)
       foo { self.it = 5 }
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `@it`' do
+    expect_no_offenses(<<~RUBY)
+      @it = 5
     RUBY
   end
 
@@ -51,15 +126,44 @@ RSpec.describe RuboCop::Cop::Style::ItAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when assigning `$it`' do
+    expect_no_offenses(<<~RUBY)
+      $it = 5
+    RUBY
+  end
+
   it 'does not register an offense when assigning `$it` inside a block' do
     expect_no_offenses(<<~RUBY)
       foo { $it = 5 }
     RUBY
   end
 
-  it 'does not register an offense when assigning a local `it` variable outside a block' do
+  it 'does not register an offense when assigning a constant `IT`' do
     expect_no_offenses(<<~RUBY)
-      it = 5
+      IT = 5
     RUBY
+  end
+
+  it 'does not register an offense when naming a method `it`' do
+    expect_no_offenses(<<~RUBY)
+      def it
+      end
+    RUBY
+  end
+
+  context 'Ruby < 3.4', :ruby33 do
+    it 'does not register an offense when calling `it` in a block' do
+      expect_no_offenses(<<~RUBY)
+        foo { puts it }
+      RUBY
+    end
+  end
+
+  context 'Ruby >= 3.4', :ruby34 do
+    it 'does not register an offense when calling `it` in a block' do
+      expect_no_offenses(<<~RUBY)
+        foo { puts it }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Expands `Style/ItAssignment` to register offenses for all local variable assignment and method parameters named `it`. 

Fixes #14322.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
