### PR TITLE
Use consistent verb form of "checks" in cop descriptions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -378,7 +378,7 @@ Gemspec/RubyVersionGlobalsUsage:
 #################### Layout ###########################
 
 Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
+  Description: Checks indentation of private/protected visibility modifiers.
   StyleGuide: '#indent-public-private-protected'
   Enabled: true
   VersionAdded: '0.49'
@@ -1057,7 +1057,7 @@ Layout/LeadingCommentSpace:
   AllowSteepAnnotation: false
 
 Layout/LeadingEmptyLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
+  Description: Checks for unnecessary blank lines at the beginning of a file.
   Enabled: true
   VersionAdded: '0.57'
   VersionChanged: '0.77'
@@ -1147,7 +1147,7 @@ Layout/MultilineArrayLineBreaks:
   AllowMultilineFinalElement: false
 
 Layout/MultilineAssignmentLayout:
-  Description: 'Check for a newline after the assignment operator in multi-line assignments.'
+  Description: 'Checks for a newline after the assignment operator in multi-line assignments.'
   StyleGuide: '#indent-conditional-assignment'
   Enabled: false
   VersionAdded: '0.49'
@@ -1661,7 +1661,7 @@ Lint/BinaryOperatorWithIdenticalOperands:
   VersionChanged: '1.69'
 
 Lint/BooleanSymbol:
-  Description: 'Check for `:true` and `:false` symbols.'
+  Description: 'Checks for `:true` and `:false` symbols.'
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.50'
@@ -1694,7 +1694,7 @@ Lint/ConstantReassignment:
   VersionAdded: '1.70'
 
 Lint/ConstantResolution:
-  Description: 'Check that constants are fully qualified with `::`.'
+  Description: 'Checks that constants are fully qualified with `::`.'
   Enabled: false
   VersionAdded: '0.86'
   # Restrict this cop to only looking at certain names
@@ -1708,7 +1708,7 @@ Lint/CopDirectiveSyntax:
   VersionAdded: '1.72'
 
 Lint/Debugger:
-  Description: 'Check for debugger calls.'
+  Description: 'Checks for debugger calls.'
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '1.63'
@@ -1759,7 +1759,7 @@ Lint/Debugger:
       - debug/start
 
 Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
+  Description: 'Checks for deprecated class method calls.'
   Enabled: true
   VersionAdded: '0.19'
 
@@ -1833,13 +1833,13 @@ Lint/DuplicateElsifCondition:
   VersionAdded: '0.88'
 
 Lint/DuplicateHashKey:
-  Description: 'Check for duplicate keys in hash literals.'
+  Description: 'Checks for duplicate keys in hash literals.'
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.77'
 
 Lint/DuplicateMagicComment:
-  Description: 'Check for duplicated magic comments.'
+  Description: 'Checks for duplicated magic comments.'
   Enabled: pending
   VersionAdded: '1.37'
 
@@ -1849,7 +1849,7 @@ Lint/DuplicateMatchPattern:
   VersionAdded: '1.50'
 
 Lint/DuplicateMethods:
-  Description: 'Check for duplicate method definitions.'
+  Description: 'Checks for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
 
@@ -1859,7 +1859,7 @@ Lint/DuplicateRegexpCharacterClassElement:
   VersionAdded: '1.1'
 
 Lint/DuplicateRequire:
-  Description: 'Check for duplicate `require`s and `require_relative`s.'
+  Description: 'Checks for duplicate `require`s and `require_relative`s.'
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.90'
@@ -1876,12 +1876,12 @@ Lint/DuplicateSetElement:
   VersionAdded: '1.67'
 
 Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
+  Description: 'Checks for immutable argument given to each_with_object.'
   Enabled: true
   VersionAdded: '0.31'
 
 Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
+  Description: 'Checks for odd code arrangement in an else block.'
   Enabled: true
   VersionAdded: '0.17'
   VersionChanged: '1.2'
@@ -2830,7 +2830,7 @@ Migration/DepartmentName:
 #################### Naming ##############################
 
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
+  Description: Checks the naming of accessor methods for get_/set_.
   StyleGuide: '#accessor_mutator_method_names'
   Enabled: true
   VersionAdded: '0.50'
@@ -4237,7 +4237,7 @@ Style/GlobalVars:
   AllowedVariables: []
 
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses.'
+  Description: 'Checks for conditionals that can be replaced with guard clauses.'
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
@@ -5200,7 +5200,7 @@ Style/RandomWithOffset:
   VersionAdded: '0.52'
 
 Style/RedundantArgument:
-  Description: 'Check for a redundant argument passed to certain methods.'
+  Description: 'Checks for a redundant argument passed to certain methods.'
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
@@ -5361,7 +5361,7 @@ Style/RedundantInterpolationUnfreeze:
   VersionAdded: '1.66'
 
 Style/RedundantLineContinuation:
-  Description: 'Check for redundant line continuation.'
+  Description: 'Checks for redundant line continuation.'
   Enabled: pending
   VersionAdded: '1.49'
 
@@ -5655,7 +5655,7 @@ Style/SpecialGlobalVars:
     - use_builtin_english_names
 
 Style/StabbyLambdaParentheses:
-  Description: 'Check for the usage of parentheses around stabby lambda arguments.'
+  Description: 'Checks for the usage of parentheses around stabby lambda arguments.'
   StyleGuide: '#stabby-lambda-with-args'
   Enabled: true
   VersionAdded: '0.35'

--- a/lib/rubocop/cop/internal_affairs/useless_restrict_on_send.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_restrict_on_send.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # Check for useless `RESTRICT_ON_SEND`.
+      # Checks for useless `RESTRICT_ON_SEND`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Check for arguments to `rescue` that will result in a `TypeError`
+      # Checks for arguments to `rescue` that will result in a `TypeError`
       # if an exception is raised.
       #
       # @example

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -4,7 +4,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for uses of braces or do/end around single line or
+      # Checks for uses of braces or do/end around single line or
       # multi-line blocks.
       #
       # Methods that can be either procedural or functional and cannot be

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -111,7 +111,7 @@ module RuboCop
         end
       end
 
-      # Check for `if` and `case` statements where each branch is used for
+      # Checks for `if` and `case` statements where each branch is used for
       # both the assignment and comparison of the same variable
       # when using the return of the condition can be used instead.
       #

--- a/lib/rubocop/cop/style/dig_chain.rb
+++ b/lib/rubocop/cop/style/dig_chain.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for chained `dig` calls that can be collapsed into a single `dig`.
+      # Checks for chained `dig` calls that can be collapsed into a single `dig`.
       #
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for usages of not (`not` or `!`) called on a method
+      # Checks for usages of not (`not` or `!`) called on a method
       # when an inverse of that method can be used instead.
       #
       # Methods that can be inverted by a not (`not` or `!`) should be defined

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for uses of `Object#freeze` on immutable objects.
+      # Checks for uses of `Object#freeze` on immutable objects.
       #
       # NOTE: `Regexp` and `Range` literals are frozen objects since Ruby 3.0.
       #

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for redundant line continuation.
+      # Checks for redundant line continuation.
       #
       # This cop marks a line continuation as redundant if removing the backslash
       # does not result in a syntax error.

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check for parentheses around stabby lambda arguments.
+      # Checks for parentheses around stabby lambda arguments.
       # There are two different styles. Defaults to `require_parentheses`.
       #
       # @example EnforcedStyle: require_parentheses (default)


### PR DESCRIPTION
Updates cop descriptions (in class comments and default.yml) to use `checks` instead of `check` for consistency (eg. 173 uses of "checks" vs 18 of "check" in default.yml).