### PR TITLE
[Fix #14367] Fix an incorrect autocorrect for `Style/SingleLineMethods`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_single_line_methods.md
@@ -1,0 +1,1 @@
+* [#14367](https://github.com/rubocop/rubocop/issues/14367): Fix an incorrect autocorrect for `Style/SingleLineMethods` when defining a single-line singleton method. ([@koic][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -86,10 +86,10 @@ module RuboCop
         end
 
         def correct_to_endless(corrector, node)
-          self_receiver = node.self_receiver? ? 'self.' : ''
+          receiver = "#{node.receiver.source}." if node.receiver
           arguments = node.arguments.any? ? node.arguments.source : '()'
           body_source = method_body_source(node.body)
-          replacement = "def #{self_receiver}#{node.method_name}#{arguments} = #{body_source}"
+          replacement = "def #{receiver}#{node.method_name}#{arguments} = #{body_source}"
 
           corrector.replace(node, replacement)
         end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe RuboCop::Cop::Style::SingleLineMethods, :config do
         RUBY
       end
 
+      it 'corrects to an endless singleton method definition' do
+        expect_correction(<<~RUBY.strip, source: 'def foo.some_method; body end')
+          def foo.some_method() = body
+        RUBY
+      end
+
       it 'retains comments' do
         source = 'def some_method; body end # comment'
         expect_correction(<<~RUBY.strip, source: source)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/SingleLineMethods` when defining a single-line singleton method.

Fixes #14367.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
