### PR TITLE
[Fix #14309] Update `Style/SoleNestedConditional` to properly correct assignments within `and`

### DIFF
--- a/changelog/fix_update_style_sole_nested_conditional_to_properly_20250716113042.md
+++ b/changelog/fix_update_style_sole_nested_conditional_to_properly_20250716113042.md
@@ -1,0 +1,1 @@
+* [#14309](https://github.com/rubocop/rubocop/issues/14309): Update `Style/SoleNestedConditional` to properly correct assignments within `and`. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -89,6 +89,163 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` as the LHS of an `and`' do
+    # `and` is used in the source code for precedence without parentheses
+    expect_offense(<<~RUBY)
+      if foo = bar and baz
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo = bar and baz && quux
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` as the RHS of an `and`' do
+    expect_offense(<<~RUBY)
+      if baz && foo = bar
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz && (foo = bar) && quux
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` in a multiline `and`' do
+    expect_offense(<<~RUBY)
+      if baz &&
+         foo = bar
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz &&
+         (foo = bar) && quux
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` in a nested `and`' do
+    expect_offense(<<~RUBY)
+      if baz && foo = bar and fred = garply
+        if corge
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz && foo = bar and (fred = garply) && corge
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if (foo = bar)` in an `and`' do
+    expect_offense(<<~RUBY)
+      if baz && (foo = bar)
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if baz && (foo = bar) && quux
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects assignment within nested `if`' do
+    expect_offense(<<~RUBY)
+      if foo
+        if bar = baz
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && (bar = baz)
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects assignment within `and` within nested `if`' do
+    expect_offense(<<~RUBY)
+      if foo
+        if quux && bar = baz
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && quux && (bar = baz)
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` as the LHS of an `or`' do
+    # `or` is used in the source code for precedence without parentheses
+    expect_offense(<<~RUBY)
+      if foo = bar or baz
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (foo = bar or baz) && quux
+          do_something
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using nested `if` within `if foo = bar` as the RHS of an `or`' do
+    expect_offense(<<~RUBY)
+      if baz || foo = bar
+        if quux
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          do_something
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (baz || foo = bar) && quux
+          do_something
+        end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using nested `if` within `unless foo & bar`' do
     expect_offense(<<~RUBY)
       unless foo & bar


### PR DESCRIPTION
When `Style/SoleNestedConditional` autocorrects `if`s containing `and` nodes, and those `and` nodes contain assignments, ensure that the assignments are parenthesized so that operator precedence is maintained.

Fixes #14309.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
