### PR TITLE
[Fix #14370] Fix comment duplication bug in `Style/AccessorGrouping` separated autocorrect

### DIFF
--- a/changelog/fix_comment_duplication_bug_in_20250717062746.md
+++ b/changelog/fix_comment_duplication_bug_in_20250717062746.md
@@ -1,0 +1,1 @@
+* [#14370](https://github.com/rubocop/rubocop/issues/14370): Fix comment duplication bug in `Style/AccessorGrouping` separated autocorrect. ([@r7kamura][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -84,7 +84,10 @@ module RuboCop
 
         def autocorrect(corrector, node)
           if (preferred_accessors = preferred_accessors(node))
-            corrector.replace(node, preferred_accessors)
+            corrector.replace(
+              grouped_style? ? node : range_with_trailing_argument_comment(node),
+              preferred_accessors
+            )
           else
             range = range_with_surrounding_space(node.source_range, side: :left)
             corrector.remove(range)
@@ -195,6 +198,15 @@ module RuboCop
               lines.map { |line| "#{indent}#{line}" }
             end
           end.join("\n")
+        end
+
+        def range_with_trailing_argument_comment(node)
+          comment = processed_source.ast_with_comments[node.last_argument].last
+          if comment
+            add_range(node.source_range, comment.source_range)
+          else
+            node
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
       RUBY
     end
 
-    context 'when there are comments for attributes' do
+    context 'when there are comments for attributes with parentheses' do
       it 'registers and corrects an offense' do
         expect_offense(<<~RUBY)
           class Foo
@@ -527,6 +527,30 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
             attr_reader :two
             # comment three
             attr_reader :three
+          end
+        RUBY
+      end
+    end
+
+    context 'when there are comments for attributes without parentheses' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_reader :a, # comment a
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use one attribute per `attr_reader`.
+              :b, # comment b
+              :c # comment c
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            # comment a
+          attr_reader :a
+            # comment b
+            attr_reader :b
+            # comment c
+            attr_reader :c
           end
         RUBY
       end


### PR DESCRIPTION
As stated in the title, this addresses the following issue:

- Fix https://github.com/rubocop/rubocop/issues/14370

The logic to prevent comments from being removed during autocorrect was introduced in the following change, so the bug likely dates back to that point:

- https://github.com/rubocop/rubocop/pull/11063

When a method call does not have parentheses, its trailing comment appears to be associated with the last argument rather than the method call itself. As a result, it is possible for the end of the comment associated with `send_node.last_argument` to appear later in the source than the end of `send_node` itself.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
