### PR TITLE
Fix an error for `Style/ParallelAssignment`

### DIFF
--- a/changelog/fix_an_error_for_style_parallel_assignment_cop.md
+++ b/changelog/fix_an_error_for_style_parallel_assignment_cop.md
@@ -1,0 +1,1 @@
+* [#14373](https://github.com/rubocop/rubocop/pull/14373): Fix an error for `Style/ParallelAssignment` when a lambda with parallel assignment is used on the RHS. ([@koic][])

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -29,6 +29,8 @@ module RuboCop
         MSG = 'Do not use parallel assignment.'
 
         def on_masgn(node) # rubocop:disable Metrics/AbcSize
+          return if part_of_ignored_node?(node)
+
           rhs = node.rhs
           rhs = rhs.body if rhs.rescue_type?
           rhs_elements = Array(rhs).compact # edge case for one constant
@@ -41,6 +43,7 @@ module RuboCop
           add_offense(range) do |corrector|
             autocorrect(corrector, node, rhs)
           end
+          ignore_node(node)
         end
 
         private

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -192,6 +192,18 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense when a lambda with parallel assignment is used on the RHS' do
+    expect_offense(<<~RUBY)
+      a, b = x, -> { a, b = x, y }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = x
+      b = -> { a, b = x, y }
+    RUBY
+  end
+
   shared_examples('allowed') do |source|
     it "allows assignment of: #{source.gsub(/\s*\n\s*/, '; ')}" do
       expect_no_offenses(source)


### PR DESCRIPTION
This PR fixes the following error for `Style/ParallelAssignment` when a lambda with parallel assignment is used on the RHS.

```console
$ echo 'a, b = x, -> { a, b = x, y}' | \
RUBOCOP_TARGET_RUBY_VERSION=3.0 bundle exec rubocop --stdin example.rb --only Style/ParallelAssignment -a -d
(snip)

An error occurred while Style/ParallelAssignment cop was inspecting
/Users/koic/src/github.com/rubocop/rubocop/example.rb:1:15.
Parser::Source::TreeRewriter detected clobbering
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
