### PR TITLE
Enhance `Naming/MethodName` cop to detect offenses within `Data` members

### DIFF
--- a/changelog/new_enhance_naming_method_name_cop_to_detect_offenses_within_data_members_20250719195315.md
+++ b/changelog/new_enhance_naming_method_name_cop_to_detect_offenses_within_data_members_20250719195315.md
@@ -1,0 +1,1 @@
+* [#14374](https://github.com/rubocop/rubocop/pull/14374): Enhance `Naming/MethodName` cop to detect offenses within `Data` members. ([@viralpraxis][])

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -106,11 +106,16 @@ module RuboCop
         # @!method new_struct?(node)
         def_node_matcher :new_struct?, '(send (const {nil? cbase} :Struct) :new ...)'
 
+        # @!method define_data?(node)
+        def_node_matcher :define_data?, '(send (const {nil? cbase} :Data) :define ...)'
+
         def on_send(node)
           if node.method?(:define_method) || node.method?(:define_singleton_method)
             handle_define_method(node)
           elsif new_struct?(node)
             handle_new_struct(node)
+          elsif define_data?(node)
+            handle_define_data(node)
           else
             handle_attr_accessor(node)
           end
@@ -138,6 +143,12 @@ module RuboCop
         def handle_new_struct(node)
           arguments = node.first_argument&.str_type? ? node.arguments[1..] : node.arguments
           arguments.select { |argument| argument.type?(:sym, :str) }.each do |name|
+            handle_method_name(name, name.value)
+          end
+        end
+
+        def handle_define_data(node)
+          node.arguments.select { |argument| argument.type?(:sym, :str) }.each do |name|
             handle_method_name(name, name.value)
           end
         end

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -304,6 +304,17 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
           expect_no_corrections
         end
       end
+
+      context 'for `Data` members' do
+        it 'registers an offense when member with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            Data.define(:%{identifier})
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
     end
   end
 
@@ -371,6 +382,17 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
           expect_offense(<<~RUBY, identifier: identifier)
             Struct.new(:%{identifier})
                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
+          RUBY
+
+          expect_no_corrections
+        end
+      end
+
+      context 'for `Data` members' do
+        it 'registers an offense when member with forbidden name is defined' do
+          expect_offense(<<~RUBY, identifier: identifier)
+            Data.define(:%{identifier})
+                        ^^{identifier} `%{identifier}` is forbidden, use another method name instead.
           RUBY
 
           expect_no_corrections
@@ -498,6 +520,22 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
+    it 'registers an offense for `Data` camelCase member' do
+      expect_offense(<<~RUBY)
+        Data.define(:snake_case, var, *args, :camelCase, :snake_case_2, "camelCase2")
+                                             ^^^^^^^^^^ Use snake_case for method names.
+                                                                        ^^^^^^^^^^^^ Use snake_case for method names.
+      RUBY
+    end
+
+    it 'registers an offense for `::Data` camelCase member' do
+      expect_offense(<<~RUBY)
+        ::Data.define(:snake_case, var, *args, :camelCase, :snake_case_2, "camelCase2")
+                                               ^^^^^^^^^^ Use snake_case for method names.
+                                                                          ^^^^^^^^^^^^ Use snake_case for method names.
+      RUBY
+    end
+
     include_examples 'never accepted',  'snake_case'
     include_examples 'always accepted', 'snake_case'
     include_examples 'multiple attr methods', 'snake_case'
@@ -593,6 +631,22 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
         ::Struct.new("foo_bar", var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
                                             ^^^^^^^^^^^ Use camelCase for method names.
                                                                      ^^^^^^^^^^^^^ Use camelCase for method names.
+      RUBY
+    end
+
+    it 'registers an offense for `Data` camelCase member' do
+      expect_offense(<<~RUBY)
+        Data.define(var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
+                                ^^^^^^^^^^^ Use camelCase for method names.
+                                                         ^^^^^^^^^^^^^ Use camelCase for method names.
+      RUBY
+    end
+
+    it 'registers an offense for `::Data` camelCase member' do
+      expect_offense(<<~RUBY)
+        ::Data.define(var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
+                                  ^^^^^^^^^^^ Use camelCase for method names.
+                                                           ^^^^^^^^^^^^^ Use camelCase for method names.
       RUBY
     end
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rubocop/rubocop/pull/14325.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
