### PR TITLE
Make `Lint/RedundantSafeNavigation` aware of builtin methods

### DIFF
--- a/change_make_lint_redundant_safe_navigation_aware_of_builtin_methods.md
+++ b/change_make_lint_redundant_safe_navigation_aware_of_builtin_methods.md
@@ -1,0 +1,1 @@
+* [#14375](https://github.com/rubocop/rubocop/pull/14375): Make `Lint/RedundantSafeNavigation` aware of builtin convert methods `to_s`, `to_i`, `to_f`, `to_a, and `to_h`. ([@koic][])

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -722,4 +722,123 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when `&.` is used for `to_s`' do
+    expect_offense(<<~RUBY)
+      foo.to_s&.strip
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_s.strip
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_s` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_s&.zero?
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_i`' do
+    expect_offense(<<~RUBY)
+      foo.to_i&.zero?
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_i.zero?
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_i` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_i&.zero?
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_f`' do
+    expect_offense(<<~RUBY)
+      foo.to_f&.zero?
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_f.zero?
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_f` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_f&.zero?
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_a`' do
+    expect_offense(<<~RUBY)
+      foo.to_a&.size
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_a.size
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_a` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_a&.zero?
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_h`' do
+    expect_offense(<<~RUBY)
+      foo.to_h&.size
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_h.size
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_h` with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_h&.zero?
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_h` with block' do
+    expect_offense(<<~RUBY)
+      foo.to_h { |entry| do_something(entry) }&.keys
+                                              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_h { |entry| do_something(entry) }.keys
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_h { ... }` with block with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_h { |entry| do_something(entry) }&.keys
+    RUBY
+  end
+
+  it 'registers an offense when `&.` is used for `to_h` with numbered block' do
+    expect_offense(<<~RUBY)
+      foo.to_h { do_something(_1) }&.keys
+                                   ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_h { do_something(_1) }.keys
+    RUBY
+  end
+
+  it 'does not register an offense when `&.` is used for `to_h { ... }` with numbered block with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      foo&.to_h { do_something(_1) }&.keys
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR makes `Lint/RedundantSafeNavigation` aware of builtin convert methods `to_s`, `to_i`, `to_f`, `to_a, and `to_h`.

```ruby
# bad
foo.to_s&.strip
foo.to_i&.zero?
foo.to_f&.zero?
foo.to_a&.size
foo.to_h&.size

# good
foo.to_s.strip
foo.to_i.zero?
foo.to_f.zero?
foo.to_a.size
foo.to_h.size
```

These conversion methods don't return `nil`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
