### PR TITLE
Fix a false positive for Lint/UselessAssignment

### DIFF
--- a/changelog/fix_false_negative_for_lint_useless_assignment.md
+++ b/changelog/fix_false_negative_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#14377](https://github.com/rubocop/rubocop/pull/14377): Fix a false positive for `Lint/UselessAssignment` when the assignment is inside a loop body. ([@5hun-s][])

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2349,4 +2349,49 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       RUBY
     end
   end
+
+  context 'when duplicate assignments in the loop body' do
+    context 'while loop' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          while
+            foo = 1
+            ^^^ Useless assignment to variable - `foo`.
+            foo = 1
+            p foo
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when duplicate assignments in a case branch inside a loop' do
+    context 'while loop' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          while
+            case
+            when fizz then foo += 1
+            when buzz then foo -= 1
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when duplicate assignments in a case-match branch inside a loop', :ruby27 do
+    context 'while loop' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          while
+            case expr
+            in fizz then foo += 1
+            in buzz then foo -= 1
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-jp/issues/15. (This link is Japanese issue)

This PR fixes a false positive for `Lint/UselessAssignment` when the assignment is inside a loop body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
