### PR TITLE
Offend missing whitespace between `return` and opening parens in `Layout/SpaceAroundKeyword`

### DIFF
--- a/changelog/change_layout_space_around_keyword_return_whitespace.md
+++ b/changelog/change_layout_space_around_keyword_return_whitespace.md
@@ -1,0 +1,1 @@
+* [#14378](https://github.com/rubocop/rubocop/pull/14378): Change `Layout/SpaceAroundKeyword` to offend for missing whitespace between `return` and opening parenthesis. ([@lovro-bikic][])

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -16,6 +16,8 @@ module RuboCop
       #
       #   something = 123if test
       #
+      #   return(foo + bar)
+      #
       #   # good
       #   something 'test' do |x|
       #   end
@@ -24,6 +26,9 @@ module RuboCop
       #   end
       #
       #   something = 123 if test
+      #
+      #   return (foo + bar)
+      #
       class SpaceAroundKeyword < Base
         extend AutoCorrector
 
@@ -33,7 +38,7 @@ module RuboCop
         DO = 'do'
         SAFE_NAVIGATION = '&.'
         NAMESPACE_OPERATOR = '::'
-        ACCEPT_LEFT_PAREN = %w[break defined? next not rescue return super yield].freeze
+        ACCEPT_LEFT_PAREN = %w[break defined? next not rescue super yield].freeze
         ACCEPT_LEFT_SQUARE_BRACKET = %w[super yield].freeze
         ACCEPT_NAMESPACE_OPERATOR = 'super'
         RESTRICT_ON_SEND = %i[!].freeze

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundKeyword, :config do
   it_behaves_like 'missing after', 'rescue', 'a rescue""', 'a rescue ""'
   it_behaves_like 'accept after', 'rescue', 'begin; rescue(Error); end', 'begin; rescue(Error); end'
   it_behaves_like 'missing after', 'return', 'return""', 'return ""'
-  it_behaves_like 'accept after', '(', 'return(1)'
+  it_behaves_like 'missing after', 'return', 'return(1)', 'return (1)'
   it_behaves_like 'missing after', 'super', 'super""', 'super ""'
   it_behaves_like 'accept after', '(', 'super(1)'
   it_behaves_like 'missing after', 'super', 'super{}', 'super {}'


### PR DESCRIPTION
Currently, `Layout/SpaceAroundKeyword` will allow both of these examples:
```ruby
return(foo + bar)
return (foo + bar)
```
This PR changes the cop to always require a space before the opening parenthesis.

[Style with space](https://github.com/search?q=%2F(%3F-i)%5Csreturn%20%5C(%2F%20lang%3Aruby%20&type=code ) is much more frequent that the [style without space]( https://github.com/search?q=%2F(%3F-i)%5Csreturn%5C(%2F%20lang%3Aruby%20&type=code ), so I'd like to make that explicit in the cop.

Arguments for this change:
- will enforce a consistent style
- is already a much more common style than the no-space style (shown above)
- when closing parens isn't the end of the return expression, no-space style looks weird (e.g. `return (foo + bar) * baz` vs `return(foo + bar) * baz`)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
