### PR TITLE
Make `Style/RedundantConditional` aware of nil?, present? and blank?

### DIFF
--- a/changelog/change_style_redundant_conditional_predicate_methods.md
+++ b/changelog/change_style_redundant_conditional_predicate_methods.md
@@ -1,0 +1,1 @@
+* [#14384](https://github.com/rubocop/rubocop/pull/14384): Make `Style/RedundantConditional` aware of `nil?`, `present?` and `blank?`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -150,4 +150,83 @@ RSpec.describe RuboCop::Cop::Style::RedundantConditional, :config do
       end
     RUBY
   end
+
+  it 'registers an offense for ternary with `nil?` predicate with negated boolean results' do
+    expect_offense(<<~RUBY)
+      x.nil? ? false : true
+      ^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `!x.nil?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !x.nil?
+    RUBY
+  end
+
+  it 'registers an offense for ternary with `nil?` predicate' do
+    expect_offense(<<~RUBY)
+      x.nil? ? true : false
+      ^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x.nil?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.nil?
+    RUBY
+  end
+
+  it 'registers an offense for ternary with `nil?` predicate without a receiver' do
+    expect_offense(<<~RUBY)
+      nil? ? true : false
+      ^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `nil?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      nil?
+    RUBY
+  end
+
+  context 'when `AllCops/ActiveSupportExtensionsEnabled: false`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => false })
+    end
+
+    it 'does not register an offense for ternary with `present?` predicate' do
+      expect_no_offenses(<<~RUBY)
+        x.present? ? true : false
+      RUBY
+    end
+
+    it 'does not register an offense for ternary with `blank?` predicate' do
+      expect_no_offenses(<<~RUBY)
+        x.blank? ? true : false
+      RUBY
+    end
+  end
+
+  context 'when `AllCops/ActiveSupportExtensionsEnabled: true`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
+    end
+
+    it 'registers an offense for ternary with `present?` predicate' do
+      expect_offense(<<~RUBY)
+        x.present? ? true : false
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x.present?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.present?
+      RUBY
+    end
+
+    it 'registers an offense for ternary with `blank?` predicate' do
+      expect_offense(<<~RUBY)
+        x.blank? ? true : false
+        ^^^^^^^^^^^^^^^^^^^^^^^ This conditional expression can just be replaced by `x.blank?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.blank?
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Updates `Style/RedundantConditional` so it register the following:
```ruby
x.nil? ? true : false
x.present? ? true : false
x.blank? ? true : false
```
as an offense, and autocorrect to:
```ruby
x.nil?
x.present?
x.blank?
```

`present?` and `blank?` are checked only if active support extensions are enabled.

[This GH search](https://github.com/search?q=%2F%5C.(nil%7Cblank%7Cpresent)%5C%3F%20%5C%3F%20(true%7Cfalse)%20%3A%20(true%7Cfalse)%2F%20lang%3Aruby&type=code&p=1) shows arounds 3.2k results that would be caught with this addition to the cop.

Also, here's the [real-world-rails](https://github.com/eliotsykes/real-world-rails) report (11 offenses have been caught):
<details>
<summary>Report</summary>

```ruby
# ~/real-world-rails/apps/accelerated_claims/app/controllers/postcode_lookup_proxy_controller.rb:24:32: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !((URI(request.referer).query =~ /livepc=1/).nil?).
    use_live_postcode_lookup = (URI(request.referer).query =~ /livepc=1/).nil? ? false : true

# ~/real-world-rails/apps/accelerated_claims/lib/email_validator.rb:13:5: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !((address.domain =~ /.+\..+/).nil?).
    (address.domain =~ /.+\..+/).nil? ? false : true

# ~/real-world-rails/apps/alaveteli/app/models/info_request.rb:767:5: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !(external_url.nil?).
    external_url.nil? ? false : true

# ~/real-world-rails/apps/cloudnet/app/models/account.rb:100:7: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by vat_number.present?.
      vat_number.present? ? true : false

# ~/real-world-rails/apps/contrib-hub/app/models/repo.rb:24:5: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !(helped_repo.nil?).
    helped_repo.nil? ? false : true

# ~/real-world-rails/apps/feedbin/app/controllers/application_controller.rb:51:21: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !(subscriptions.present?).
    @show_welcome = subscriptions.present? ? false : true

# ~/real-world-rails/apps/gitlabhq/qa/qa/service/shellout.rb:62:72: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by arg.nil?.
        stream_progress = kwargs.delete(:stream_progress).then { |arg| arg.nil? ? true : false }

# ~/real-world-rails/apps/growstuff/app/controllers/gardens_controller.rb:7:21: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by params[:member_slug].present?.
    @show_jump_to = params[:member_slug].present? ? true : false

# ~/real-world-rails/apps/open-source-billing/app/controllers/estimates_controller.rb:89:15: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by params[:send_and_save].present?.
    @notify = params[:send_and_save].present? ? true : false

# ~/real-world-rails/apps/open-source-billing/app/controllers/invoices_controller.rb:137:15: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !(params[:save_as_draft].present?).
    @notify = params[:save_as_draft].present? ? false : true

# ~/real-world-rails/apps/sharetribe/app/controllers/listing_images_controller.rb:95:38: C: [Correctable] Style/RedundantConditional: This conditional expression can just be replaced by !(url.present?).
    listing_image.image_downloaded = if url.present? then false else true end
```
</details>

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
