### PR TITLE
Fix doc formatting for `Style/ArrayIntersect`

### DIFF
--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -6,9 +6,11 @@ module RuboCop
       # In Ruby 3.1, `Array#intersect?` has been added.
       #
       # This cop identifies places where:
+      #
       # * `(array1 & array2).any?`
       # * `(array1.intersection(array2)).any?`
       # * `array1.any? { |elem| array2.member?(elem) }`
+      #
       # can be replaced with `array1.intersect?(array2)`.
       #
       # `array1.intersect?(array2)` is faster and more readable.


### PR DESCRIPTION
Small follow-up to https://github.com/rubocop/rubocop/pull/14381, in which I added an unordered list, but with [broken formatting](https://docs.rubocop.org/rubocop/cops_style.html#stylearrayintersect):
<img width="854" height="235" alt="image" src="https://github.com/user-attachments/assets/000900a8-2514-44c4-b2e7-5f55e2dc3d37" />

Adding an empty line before and after the list fixes the formatting:
<img width="1143" height="331" alt="image" src="https://github.com/user-attachments/assets/045d424a-5589-4202-90ff-ec4bab7aad86" />
