### PR TITLE
Add support for or nodes to `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/change_add_support_for_or_nodes_to_lint_literal_as_condition.md
+++ b/changelog/change_add_support_for_or_nodes_to_lint_literal_as_condition.md
@@ -1,0 +1,1 @@
+* [#14389](https://github.com/rubocop/rubocop/pull/14389): Add support for || to `Lint/LiteralAsCondition`. ([@zopolis4][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -54,6 +54,18 @@ module RuboCop
           end
         end
 
+        def on_or(node)
+          return unless node.lhs.falsey_literal?
+
+          add_offense(node.lhs) do |corrector|
+            # Don't autocorrect `'foo' && return` because having `return` as
+            # the leftmost node can lead to a void value expression syntax error.
+            next if node.rhs.type?(:return, :break, :next)
+
+            corrector.replace(node, node.rhs.source)
+          end
+        end
+
         def on_if(node)
           cond = condition(node)
 

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -655,6 +655,21 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         end
       RUBY
     end
+
+    it "registers an offense for falsey literal #{lit} on the lhs of ||" do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit} || x
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          top
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if x
+          top
+        end
+      RUBY
+    end
   end
 
   it 'registers an offense for `nil` literal in `until`' do
@@ -693,6 +708,17 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
         def foo
           puts 123 && return if bar?
                ^^^ Literal `123` appeared as a condition.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense but does not autocorrect when `return` is used after `||`' do
+      expect_offense(<<~RUBY)
+        def foo
+          puts nil || return if bar?
+               ^^^ Literal `nil` appeared as a condition.
         end
       RUBY
 


### PR DESCRIPTION
Just the basic support for now, although I think i might need to match what was done in #13966? @Earlopain, any thoughts?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
