### PR TITLE
[Fix #14390] Better handling of `Style/ArgumentsForwarding` for prefix arguments

### DIFF
--- a/changelog/fix_args_forwarding_tripple_dot_self.md
+++ b/changelog/fix_args_forwarding_tripple_dot_self.md
@@ -1,0 +1,1 @@
+* [#14390](https://github.com/rubocop/rubocop/issues/14390): Fix wrong autocorrect for `Style/ArgumentsForwarding` when the method arguments contain `*, **, &` and the method call contains `self` as the first argument. ([@earlopain][])

--- a/spec/rubocop/cop/style/arguments_forwarding_spec.rb
+++ b/spec/rubocop/cop/style/arguments_forwarding_spec.rb
@@ -2343,6 +2343,22 @@ RSpec.describe RuboCop::Cop::Style::ArgumentsForwarding, :config do
       RUBY
     end
 
+    it 'registers an offense if an additional positional parameter `self` is present with anonymous arguments' do
+      expect_offense(<<~RUBY)
+        def foo(m, *, **, &)
+                   ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+          bar(self, *, **, &)
+                    ^^^^^^^^ Use shorthand syntax `...` for arguments forwarding.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(m, ...)
+          bar(self, ...)
+        end
+      RUBY
+    end
+
     it 'does not register an offense when forwarding partial anonymous arguments' do
       expect_no_offenses(<<~RUBY)
         def foo(*, &)


### PR DESCRIPTION
There is a bit of logic to handle preceeding argument nodes that are not being forwarded. But the list is not exhaustive
and is missing for example `self` and `const`.

Instead, rely on the already matched arg nodes to use for autocorrect. `all_anonymous` needs a bit of special handling, because send classification does not contain the first node that is part of forwarding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
