### PR TITLE
[Fix #14392] Remove Code Climate from CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -35,15 +35,8 @@ jobs:
       - name: spec
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
-          CC_TEST_REPORTER_ID: dummy # Value doesn't matter, enables json formatter
           STRICT_WARNINGS: 1
-        run: COVERAGE=true bundle exec rake spec
-      - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-ubuntu-${{ matrix.ruby }}
-          path: coverage/coverage.json
-          if-no-files-found: error
+        run: bundle exec rake spec
 
   spec-jruby:
     name: Spec - JRuby
@@ -81,25 +74,6 @@ jobs:
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
         run: bundle exec rake spec
-
-  upload_coverage:
-    name: Upload Coverage
-    needs: spec-ubuntu
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        name: Download Coverage Artifacts
-        with:
-          pattern: coverage-*
-      - uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        if: ${{ env.CC_TEST_REPORTER_ID != '' }}
-        with:
-          coverageLocations: |
-            ${{github.workspace}}/coverage-*/coverage.json:simplecov
 
   ascii_spec:
     name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-rubocop-brightgreen.svg)](https://github.com/rubocop/rubocop)
 [![Gem Version](https://badge.fury.io/rb/rubocop.svg)](https://badge.fury.io/rb/rubocop)
 [![CI](https://github.com/rubocop/rubocop/actions/workflows/rubocop.yml/badge.svg)](https://github.com/rubocop/rubocop/actions/workflows/rubocop.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/d2d67f728e88ea84ac69/test_coverage)](https://codeclimate.com/github/rubocop/rubocop/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/d2d67f728e88ea84ac69/maintainability)](https://codeclimate.com/github/rubocop/rubocop/maintainability)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg?sanitize=true)](https://discord.gg/wJjWvGRDmm)
 
 > Role models are important. <br/>


### PR DESCRIPTION
See #14392, it's no longer a thing.

I agree with @koic in that it wasn't giving much value, so spending time in setting up an alternative would not be worth it to me at least.