### PR TITLE
Fix a false positive for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_parenses.md
+++ b/changelog/fix_false_positive_for_style_redundant_parenses.md
@@ -1,0 +1,1 @@
+* [#14396](https://github.com/rubocop/rubocop/pull/14396): Fix a false positive for `Style/RedundantParentheses` when parentheses are used around a one-line `rescue` expression inside a ternary operator. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -204,6 +204,7 @@ module RuboCop
         def oneline_rescue_parentheses_required?(begin_node, node)
           return false unless node.rescue_type?
           return false unless (parent = begin_node.parent)
+          return false if parent.if_type? && parent.ternary?
 
           !parent.type?(:call, :array, :pair)
         end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1416,6 +1416,31 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense when parentheses are used around a one-line `rescue` expression inside an `if` expression' do
+    expect_offense(<<~RUBY)
+      if cond
+        (foo rescue bar)
+        ^^^^^^^^^^^^^^^^ Don't use parentheses around a one-line rescue.
+      else
+        42
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if cond
+        foo rescue bar
+      else
+        42
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when parentheses are used around a one-line `rescue` expression inside a ternary operator' do
+    expect_no_offenses(<<~RUBY)
+      cond ? (foo rescue bar) : 42
+    RUBY
+  end
+
   it 'accepts parentheses around a constant passed to when' do
     expect_no_offenses(<<~RUBY)
       case foo


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/14386#issuecomment-3123895283.

This PR fixes a false positive for `Style/RedundantParentheses` when parentheses are used around a one-line `rescue` expression inside a ternary operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
