### PR TITLE
Remove dependency on `tsort`

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,6 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
   s.add_dependency('rubocop-ast', '>= 1.46.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
-  s.add_dependency('tsort', '>= 0.2.0')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end


### PR DESCRIPTION
It's used by just this single cop. The comment about it being stdlib is no longer true.

Note: `tsort` uses Tarjan's algorithm. I chose Kahn since the implementation is simpler. This is not performance-sensitive and inputs tend to be small, so the more complex implementation is not worth it.

I implemented this via the pseudo-code found on wikipedia https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
