### PR TITLE
[Fix #14394] Fix false positives for `Lint/UselessAssignment` with `retry` in `rescue` branch

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_assignment_rescue_retry.md
+++ b/changelog/fix_false_positives_for_lint_useless_assignment_rescue_retry.md
@@ -1,0 +1,1 @@
+* [#14394](https://github.com/rubocop/rubocop/issues/14394): Fix false positive for `Lint/UselessAssignment` with `retry` in `rescue` branch. ([@earlopain][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -354,9 +354,11 @@ module RuboCop
       end
 
       def reference_assignments(loop_assignments, node)
-        # If inside a case statement, mark all as referenced.
+        # If inside a branching statement, mark all as referenced.
         # Otherwise, mark only the last assignment as referenced.
-        if loop_assignments.first.node.each_ancestor(:if, :case, :case_match).any?
+        # Note that `rescue` must be considered as branching because of
+        # the `retry` keyword.
+        if loop_assignments.first.node.each_ancestor(:if, :rescue, :case, :case_match).any?
           loop_assignments.each { |assignment| assignment.reference!(node) }
         else
           loop_assignments.last&.reference!(node)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2381,6 +2381,20 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when duplicate assignments in `rescue` branch with `retry`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def testing
+        rescue Foo
+          attempts += 1
+          retry
+        rescue Bar
+          attempts += 1
+        end
+      RUBY
+    end
+  end
+
   context 'when duplicate assignments in a case branch inside a loop' do
     context 'while loop' do
       it 'does not register an offense' do


### PR DESCRIPTION
Fix #14394

When handling `rescue` there is this comment:
> Treat begin..rescue..end with retry as a loop.

So, we must do the same here. Updated the comment while I was there as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
