### PR TITLE
Fix `Naming/MethodName` cop spec descriptions

### DIFF
--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -703,7 +703,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
-    it 'registers an offense for `Struct` camelCase member' do
+    it 'registers an offense for `Struct` snake_case member' do
       expect_offense(<<~RUBY)
         Struct.new("foo_bar", var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
                                           ^^^^^^^^^^^ Use camelCase for method names.
@@ -711,7 +711,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
-    it 'registers an offense for `::Struct` camelCase member' do
+    it 'registers an offense for `::Struct` snake_case member' do
       expect_offense(<<~RUBY)
         ::Struct.new("foo_bar", var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
                                             ^^^^^^^^^^^ Use camelCase for method names.
@@ -719,7 +719,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
-    it 'registers an offense for `Data` camelCase member' do
+    it 'registers an offense for `Data` snake_case member' do
       expect_offense(<<~RUBY)
         Data.define(var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
                                 ^^^^^^^^^^^ Use camelCase for method names.
@@ -727,7 +727,7 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
-    it 'registers an offense for `::Data` camelCase member' do
+    it 'registers an offense for `::Data` snake_case member' do
       expect_offense(<<~RUBY)
         ::Data.define(var, *args, :snake_case, :camelCase, :snake_case_2, "camelCase2")
                                   ^^^^^^^^^^^ Use camelCase for method names.


### PR DESCRIPTION
Fixing "camelCase" in description when "snake_case" should be used instead

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
