### PR TITLE
Fix false-positive for `Layout/EmptyLinesAfterModuleInclusion` when inclusion is called with modifier

### DIFF
--- a/changelog/fix_false_positive_for_20250801125846.md
+++ b/changelog/fix_false_positive_for_20250801125846.md
@@ -1,0 +1,1 @@
+* [#14408](https://github.com/rubocop/rubocop/pull/14408): Fix false-positive for `Layout/EmptyLinesAfterModuleInclusion` when inclusion is called with modifier. ([@r7kamura][])

--- a/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
+++ b/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
@@ -83,6 +83,8 @@ module RuboCop
         end
 
         def allowed_method?(node)
+          node = node.body if node.respond_to?(:modifier_form?) && node.modifier_form?
+
           return false unless node.send_type?
 
           MODULE_INCLUSION_METHODS.include?(node.method_name)

--- a/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
@@ -241,4 +241,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when module inclusion is called with modifier' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        include Bar
+        include Baz if condition
+        include Qux
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
In the current implementation, I’ve confirmed that the following use of a modifier is flagged as an offense, but I believe it would be preferable not to treat this as an offense.

```ruby
class Foo
  include Bar
  include Baz if condition
  include Qux
end
```

```
example.rb:2:3: C: [Correctable] Layout/EmptyLinesAfterModuleInclusion: Add an empty line after module inclusion.
  include Bar
  ^^^^^^^^^^^
```

```
$ bundle exec rubocop -V
1.79.1 (using Parser 3.3.8.0, rubocop-ast 1.46.0, analyzing as Ruby 2.7, running on ruby 3.4.2) [x86_64-linux]
  - rubocop-performance 1.25.0
  - rubocop-rake 0.7.1
  - rubocop-rspec 3.6.0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
