### PR TITLE
[Fix #14402] Fix false positives for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_assignment.md
+++ b/changelog/fix_false_positives_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#14402](https://github.com/rubocop/rubocop/issues/14402): Fix false positives for `Lint/UselessAssignment` when duplicate assignments appear in `if` branch inside a loop and the variable is used outside `while` loop. ([@koic][])

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2363,6 +2363,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         RUBY
       end
     end
+
+    context 'while loop with parenthesized body' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          while
+            (
+              foo = 1
+              ^^^ Useless assignment to variable - `foo`.
+              foo = 1
+            )
+            p foo
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when duplicate assignments in `if` branch inside a loop' do
@@ -2374,6 +2389,25 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
               var += 1
             else
               var -= 1
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when duplicate assignments appear in `if` branch inside a loop and the variable is used outside `while` loop' do
+    context 'while loop' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          var = false
+          while loop_cond
+            if var
+              var = false
+              foo
+            else
+              var = true
+              bar
             end
           end
         RUBY


### PR DESCRIPTION
This PR fixes false positives for `Lint/UselessAssignment` when duplicate assignments appear in `if` branch inside a loop and the variable is used outside `while` loop.

Fixes #14402.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
