### PR TITLE
[Fix #14411] Fix false negatives for `Layout/EmptyLinesAroundClassBody`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_empty_lines_around_class_body.md
+++ b/changelog/fix_false_negatives_for_layout_empty_lines_around_class_body.md
@@ -1,0 +1,1 @@
+* [#14411](https://github.com/rubocop/rubocop/issues/14411): Fix false negatives for `Layout/EmptyLinesAroundClassBody` when a class body starts with a blank line and defines a multiline superclass. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -71,7 +71,7 @@ module RuboCop
         KIND = 'class'
 
         def on_class(node)
-          first_line = node.parent_class.first_line if node.parent_class
+          first_line = node.parent_class.last_line if node.parent_class
 
           check(node, node.body, adjusted_first_line: first_line)
         end

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when a class body starts with a blank line and defines a multiline superclass' do
+      expect_offense(<<~RUBY)
+        class SomeClass < Struct.new(
+          :attr,
+          keyword_init: true
+        )
+
+        ^{} #{extra_begin}
+          do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeClass < Struct.new(
+          :attr,
+          keyword_init: true
+        )
+          do_something
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is empty_lines' do


### PR DESCRIPTION
This PR fixes false negatives for `Layout/EmptyLinesAroundClassBody` when a class body starts with a blank line and defines a multiline superclass.

Fixes #14411.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
