### PR TITLE
[Fix #11664] Cache wasn't getting used when using parallelization with custom formatters in certain cases

### DIFF
--- a/changelog/fix_cache_wasn_t_getting_used_when_using_20250803020701.md
+++ b/changelog/fix_cache_wasn_t_getting_used_when_using_20250803020701.md
@@ -1,0 +1,1 @@
+* [#11664](https://github.com/rubocop/rubocop/issues/11664): Cache wasn't getting used when using parallelization. ([@jvlara][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -198,20 +198,22 @@ module RuboCop
     end
 
     def rubocop_extra_features
-      lib_root = File.join(File.dirname(__FILE__), '..')
-      exe_root = File.join(lib_root, '..', 'exe')
+      @rubocop_extra_features ||= begin
+        lib_root = File.join(File.dirname(__FILE__), '..')
+        exe_root = File.join(lib_root, '..', 'exe')
 
-      # Make sure to use an absolute path to prevent errors on Windows
-      # when traversing the relative paths with symlinks.
-      exe_root = File.absolute_path(exe_root)
+        # Make sure to use an absolute path to prevent errors on Windows
+        # when traversing the relative paths with symlinks.
+        exe_root = File.absolute_path(exe_root)
 
-      # These are all the files we have `require`d plus everything in the
-      # exe directory. A change to any of them could affect the cop output
-      # so we include them in the cache hash.
-      source_files = $LOADED_FEATURES + Find.find(exe_root).to_a
-      source_files -= ResultCache.rubocop_required_features # Rely on gem versions
+        # These are all the files we have `require`d plus everything in the
+        # exe directory. A change to any of them could affect the cop output
+        # so we include them in the cache hash.
+        source_files = $LOADED_FEATURES + Find.find(exe_root).to_a
+        source_files -= ResultCache.rubocop_required_features # Rely on gem versions
 
-      source_files
+        source_files
+      end
     end
 
     # Return a hash of the options given at invocation, minus the ones that have

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -479,4 +479,20 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       end
     end
   end
+
+  describe '#rubocop_extra_features' do
+    it 'memoizes the value in @rubocop_extra_features' do
+      expect(cache.instance_variable_get(:@rubocop_extra_features)).to be_nil
+
+      first_result = cache.send(:rubocop_extra_features)
+
+      expect(cache.instance_variable_get(:@rubocop_extra_features)).to equal(first_result)
+
+      sentinel = Object.new
+      cache.instance_variable_set(:@rubocop_extra_features, sentinel)
+
+      second_result = cache.send(:rubocop_extra_features)
+      expect(second_result).to equal(sentinel)
+    end
+  end
 end


### PR DESCRIPTION
## Description
https://github.com/rubocop/rubocop/issues/11664

If you had a formatter that is autoloaded, the LOADED_FEATURES at the beggining of the execution does not have it and this is used for the saving of the cache

This causes problems because after the first call when running the inspection of the files, it gets loaded and the main process reads the cache that the parallel process created with this new cache key, causing a invalidation.

We make a memoization to fix the issue so the cache key remains consistent throughout the run.

## How to reproduce the bug
Without this fix
1. Create a custom formatter in a rubocop-plugin gem, in the entrypoint, make the formatter autoloadable, like this 
```ruby
require "rubocop/buk/version"

module RuboCop
  # RuboCop Buk project namespace
  module Buk

    autoload :JsonlFormatter, 'rubocop/buk/jsonl_formatter'
  end
end
```
2. Use the rubocop plugin gem in a rails proyect or something similar
3. Use it in a rubocop command like this 
```zsh
bundle exec rubocop --parallel --format Rubocop::Buk::JsonlFormatter
```
4. Read the logs and check that is not using the cache
<img width="2066" height="1204" alt="image" src="https://github.com/user-attachments/assets/c5e8715e-fba2-4486-ab71-e111d63471d1" />

With this fix make the same steps and check that now the execution uses the cache 
<img width="2080" height="1208" alt="image" src="https://github.com/user-attachments/assets/b28b3665-8146-4bba-b7e0-cac9978ea153" />

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
