### PR TITLE
Fix false positives for `Style/MapToSet`

### DIFF
--- a/changelog/fix_false_positives_for_style_map_to_set.md
+++ b/changelog/fix_false_positives_for_style_map_to_set.md
@@ -1,0 +1,1 @@
+* [#14418](https://github.com/rubocop/rubocop/pull/14418): Fix false positives for `Style/MapToSet` when using `to_set` with block argument. ([@koic][])

--- a/lib/rubocop/cop/style/map_to_set.rb
+++ b/lib/rubocop/cop/style/map_to_set.rb
@@ -40,12 +40,10 @@ module RuboCop
 
         def on_send(node)
           return unless (to_set_node, map_node = map_to_set?(node))
+          return if to_set_node.block_literal?
 
           message = format(MSG, method: map_node.loc.selector.source)
           add_offense(map_node.loc.selector, message: message) do |corrector|
-            # If the `to_set` call already has a block, do not autocorrect.
-            next if to_set_node.block_literal?
-
             autocorrect(corrector, to_set_node, map_node)
           end
         end

--- a/spec/rubocop/cop/style/map_to_set_spec.rb
+++ b/spec/rubocop/cop/style/map_to_set_spec.rb
@@ -116,14 +116,27 @@ RSpec.describe RuboCop::Cop::Style::MapToSet, :config do
       end
     end
 
-    context "`#{method}.to_set` with a block on `to_set`" do
-      it 'registers an offense but does not correct' do
-        expect_offense(<<~RUBY, method: method)
+    context "`#{method}` followed by `to_set` with a block passed to `to_set`" do
+      it 'does not register an offense but does not correct' do
+        expect_no_offenses(<<~RUBY)
           foo.#{method} { |x| x * 2 }.to_set { |x| [x.to_s, x] }
-              ^{method} Pass a block to `to_set` instead of calling `#{method}.to_set`.
         RUBY
+      end
+    end
 
-        expect_no_corrections
+    context "`#{method}` followed by `to_set` with a numbered block passed to `to_set`", :ruby27 do
+      it 'does not register an offense but does not correct' do
+        expect_no_offenses(<<~RUBY)
+          foo.#{method} { |x| x * 2 }.to_set { |x| [x.to_s, x] }
+        RUBY
+      end
+    end
+
+    context "`#{method}` followed by `to_set` with an `it` block passed to `to_set`", :ruby34 do
+      it 'does not register an offense but does not correct' do
+        expect_no_offenses(<<~RUBY)
+          foo.#{method} { |x| x * 2 }.to_set { |x| [x.to_s, x] }
+        RUBY
       end
     end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/MapToSet` when using `to_set` with block argument. This is an issue similar to #14417.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
