### PR TITLE
[Fix #14420] Fix false positives for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_for_style_safe_navigation.md
+++ b/changelog/fix_false_positives_for_style_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#14420](https://github.com/rubocop/rubocop/issues/14420): Fix false positives for `Style/SafeNavigation` when ternary expression with operator method call with method chain. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -259,6 +259,8 @@ module RuboCop
         end
 
         def dotless_operator_call?(method_call)
+          method_call = method_call.parent while method_call.parent.send_type?
+
           return false if method_call.loc.dot
 
           method_call.method?(:[]) || method_call.method?(:[]=) || method_call.operator_method?

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -818,6 +818,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'allows ternary expression with indexed assignment call chain without dot' do
+          expect_no_offenses(<<~RUBY)
+            %{variable}.nil? ? nil : %{variable}.foo[index]
+          RUBY
+        end
+
         it 'allows ternary expression with double colon method call' do
           expect_no_offenses(<<~RUBY)
             #{variable} ? #{variable}::foo : nil
@@ -827,6 +833,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
         it 'allows ternary expression with operator method call without dot' do
           expect_no_offenses(<<~RUBY)
             #{variable}.nil? ? nil : #{variable} * 42
+          RUBY
+        end
+
+        it 'allows ternary expression with operator method call chain without dot' do
+          expect_no_offenses(<<~RUBY)
+            %{variable}.nil? ? nil : %{variable}.foo * 42
           RUBY
         end
 
@@ -876,17 +888,6 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           expect_correction(<<~RUBY)
             #{variable}&.*(42)
-          RUBY
-        end
-
-        it 'registers an offense for ternary expression with operator method call with method chain' do
-          expect_offense(<<~RUBY, variable: variable)
-            %{variable}.nil? ? nil : %{variable}.foo * 42
-            ^{variable}^^^^^^^^^^^^^^^{variable}^^^^^^^^^ Use safe navigation (`&.`) instead [...]
-          RUBY
-
-          expect_correction(<<~RUBY)
-            #{variable}&.foo * 42
           RUBY
         end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/SafeNavigation` when ternary expression with operator method call with method chain.

Fixes #14420.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
