### PR TITLE
[Fix #14413] Fix a false positive for `Layout/EmptyLinesAroundArguments` with multiline strings that contain only whitespace

### DIFF
--- a/changelog/fix_false_positive_empty_lines_argument.md
+++ b/changelog/fix_false_positive_empty_lines_argument.md
@@ -1,0 +1,1 @@
+* [#14413](https://github.com/rubocop/rubocop/issues/14413): Fix a false positive for `Layout/EmptyLinesAroundArguments` with multiline strings that contain only whitespace. ([@earlopain][])

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -300,6 +300,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       RUBY
     end
 
+    it 'ignores a multiline string with only whitespace on one line and []-style method call after' do
+      expect_no_offenses(<<~RUBY)
+        format('%d
+
+        ', 1)[0]
+      RUBY
+    end
+
     context 'with one argument' do
       it 'ignores empty lines inside of method arguments' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fix #14413

The previous implementation was doing a bunch of work to decide if a line was supposed to be considered or not.
For example, Module.new with method definitions may contain newlines that should be ignored.

This new implementation only considers the ranges between arguments. The old implementation seemed to have issues with array-style method calls. To be honest, I did not try to understand the original implementation.

This implementation works by checking each argument (and also the closing bracket), looking to the left of it for whitespace and checking if that range goes over multiple lines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
