### PR TITLE
Fix flaky spec for `rubocop_extra_features`

### DIFF
--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -479,20 +479,4 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       end
     end
   end
-
-  describe '#rubocop_extra_features' do
-    it 'memoizes the value in @rubocop_extra_features' do
-      expect(cache.instance_variable_get(:@rubocop_extra_features)).to be_nil
-
-      first_result = cache.send(:rubocop_extra_features)
-
-      expect(cache.instance_variable_get(:@rubocop_extra_features)).to equal(first_result)
-
-      sentinel = Object.new
-      cache.instance_variable_set(:@rubocop_extra_features, sentinel)
-
-      second_result = cache.send(:rubocop_extra_features)
-      expect(second_result).to equal(sentinel)
-    end
-  end
 end


### PR DESCRIPTION
It's not safe to assume that it is always nil when the test starts since other tests could already have accessed it.

I believe it's also not testing much, except that this method is indeed using a instance variable, so I opted to remove the test.

Writing something that really tests this seems very difficult.

Followup to https://github.com/rubocop/rubocop/pull/14414