### PR TITLE
Fix Style/SafeNavigation cop to preserve existing safe navigation in check

### DIFF
--- a/changelog/fix_fix_safe_navigation_cop_to_preserve_safe_20250805124624.md
+++ b/changelog/fix_fix_safe_navigation_cop_to_preserve_safe_20250805124624.md
@@ -1,0 +1,1 @@
+* [#14424](https://github.com/rubocop/rubocop/pull/14424): Fix SafeNavigation cop to preserve existing safe navigation in fixed code. ([@martinemde][])

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1437,6 +1437,41 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
               #{variable}&.one&.two(baz) { |e| e.qux }
             RUBY
           end
+
+          it 'corrects a ternary expression with safe navigation object check followed by a chained method call' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable}&.bar ? %{variable}.bar.baz : nil
+              ^{variable}^^^^^^^^^{variable}^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.bar&.baz
+            RUBY
+          end
+
+          it 'corrects an object check with safe navigation followed by a chained method call' do
+            expect_offense(<<~RUBY, variable: variable)
+              %{variable}&.bar && %{variable}.bar.baz
+              ^{variable}^^^^^^^^^^{variable}^^^^^^^^ Use safe navigation (`&.`) instead [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.bar&.baz
+            RUBY
+          end
+
+          it 'corrects a check with safe navigation followed by a chained method call' do
+            expect_offense(<<~RUBY, variable: variable)
+              if %{variable}&.bar
+              ^^^^{variable}^^^^^ Use safe navigation (`&.`) instead [...]
+                %{variable}.bar.baz
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{variable}&.bar&.baz
+            RUBY
+          end
         end
       end
 


### PR DESCRIPTION
Fixes issue where safe navigation is lost when it exists in the check. For example, "check if the variable is not nil and the method call `foo` on that object doesn't return nil, if so, call `bar` on the result, else nil":

```ruby
variable&.foo ? variable.foo.bar : nil # bad
```

This fixes the autocorrect from the incorrect behavior that omits the original safe navigation, to the correct behavior that preserves the existing safe navigation.

```ruby
variable.foo&.bar # incorrect
variable&.foo&.bar # fixed
```

Fixes:
```diff
- foo&.bar && foo.bar.baz
+ foo&.bar&.baz

- if foo&.bar; foo.bar.baz; end
+ foo&.bar&.baz

- foo&.bar ? foo.bar.baz : nil
+ foo&.bar&.baz
```

This relates to a comment I placed in #14420. Fixing the issue with this PR rather than opening a new issue.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
