### PR TITLE
[Fix #14419] Fix false positives for `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_assignment.md
+++ b/changelog/fix_false_positives_for_lint_useless_assignment.md
@@ -1,0 +1,1 @@
+* [#14419](https://github.com/rubocop/rubocop/issues/14419): Fix false positives for `Lint/UselessAssignment` when duplicate assignments appear in nested `if` branches inside a loop and the variable is used outside `while` loop. ([@koic][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -356,17 +356,14 @@ module RuboCop
       end
 
       def reference_assignments(loop_assignments, loop_node)
-        node = loop_assignments.first.node
-
         # If inside a branching statement, mark all as referenced.
         # Otherwise, mark only the last assignment as referenced.
         # Note that `rescue` must be considered as branching because of
         # the `retry` keyword.
-        if node.each_ancestor(*BRANCH_NODES).any? || node.parent.each_descendant(*BRANCH_NODES).any?
-          loop_assignments.each { |assignment| assignment.reference!(loop_node) }
-        else
-          loop_assignments.last&.reference!(loop_node)
+        loop_assignments.each do |assignment|
+          assignment.reference!(loop_node) if assignment.node.each_ancestor(*BRANCH_NODES).any?
         end
+        loop_assignments.last&.reference!(loop_node)
       end
 
       def scanned_node?(node)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2415,6 +2415,33 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when duplicate assignments appear in nested `if` branches inside a loop and the variable is used outside `while` loop' do
+    context 'while loop' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def parse_options
+            index = -1
+            while loop_cond
+              index += 1
+
+              if first_cond
+                index += 1
+              else
+                if second_cond
+                  index += 1
+                else
+                  if third_cond
+                    index += 1
+                  end
+                end
+              end
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'when duplicate assignments in `rescue` branch with `retry`' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes false positives for `Lint/UselessAssignment` when duplicate assignments appear in nested `if` branches inside a loop and the variable is used outside `while` loop.

Fixes #14419.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
