### PR TITLE
[Fix #14042] Add `Style/RedundantElse` cop

### DIFF
--- a/changelog/fix_add_style_redundant_else_cop.md
+++ b/changelog/fix_add_style_redundant_else_cop.md
@@ -1,0 +1,1 @@
+* [#14042](https://github.com/rubocop/rubocop/issues/14042): Add `Style/RedundantElse` cop. ([@zopolis4][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5461,6 +5461,11 @@ Style/RedundantEach:
   Safe: false
   VersionAdded: '1.38'
 
+Style/RedundantElse:
+  Description: 'Checks for else blocks that are unreachable when the if branch executes.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   StyleGuide: '#no-explicit-runtimeerror'

--- a/lib/rubocop/cop/style.rb
+++ b/lib/rubocop/cop/style.rb
@@ -154,6 +154,7 @@ module RuboCop
       register_cop :RedundantCurrentDirectoryInPath, "#{__dir__}/style/redundant_current_directory_in_path"
       register_cop :RedundantDoubleSplatHashBraces, "#{__dir__}/style/redundant_double_splat_hash_braces"
       register_cop :RedundantEach, "#{__dir__}/style/redundant_each"
+      register_cop :RedundantElse, "#{__dir__}/style/redundant_else"
       register_cop :RedundantFetchBlock, "#{__dir__}/style/redundant_fetch_block"
       register_cop :RedundantFileExtensionInRequire, "#{__dir__}/style/redundant_file_extension_in_require"
       register_cop :RedundantFilterChain, "#{__dir__}/style/redundant_filter_chain"

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -210,10 +210,10 @@ module RuboCop
               end
               registered_block_arg_offense = true
               break
-            else
-              first_arg = forward_rest || forward_kwrest || forward_all_first_argument(send_node)
-              register_forward_all_offense(send_node, send_node, first_arg)
             end
+
+            first_arg = forward_rest || forward_kwrest || forward_all_first_argument(send_node)
+            register_forward_all_offense(send_node, send_node, first_arg)
           end
 
           return if registered_block_arg_offense

--- a/lib/rubocop/cop/style/redundant_else.rb
+++ b/lib/rubocop/cop/style/redundant_else.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Checks for else branches that are unreachable if the if branch executes.
+      # If the if branch unconditionally skips the execution of the else branch,
+      # for example by returning early or skipping to the next iteration of the loop,
+      # the else branch is redundant and its contents can be moved outside.
+      #
+      # @example
+      #
+      #   # bad
+      #   if condition
+      #     foo
+      #     return
+      #   else
+      #     bar
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     foo
+      #     return
+      #   end
+      #
+      #   bar
+      #
+      class RedundantElse < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = 'This else branch is unreachable when the if branch executes.'
+        CONTROL_FLOW = %w[return raise fail].freeze
+        LOOP_CONTROL_FLOW = %w[next break redo].freeze
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def on_if(node)
+          return unless !node.if_branch.nil? && node.else? && !node.else_branch.if_type?
+
+          child_nodes = node.if_branch.child_nodes.filter_map do |node|
+            node.source unless node.parent.if_type?
+          end
+
+          if (CONTROL_FLOW & child_nodes).any? ||
+             ((LOOP_CONTROL_FLOW & child_nodes).any? && node.parent.block_type?)
+            add_offense(node.loc.else) do |corrector|
+              corrector.replace(node.loc.else, "end\n")
+              corrector.remove(range_by_whole_lines(node.loc.end, include_final_newline: true))
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -229,9 +229,9 @@ module RuboCop
             if node.send_node.loc.selector.source == '->'
               corrector.replace(node, "lambda(&:#{node.body.method_name})")
               return
-            else
-              autocorrect_lambda_block(corrector, node)
             end
+
+            autocorrect_lambda_block(corrector, node)
           end
 
           corrector.replace(block_range_with_space(node), "(&:#{node.body.method_name})")

--- a/spec/rubocop/cop/style/redundant_else_spec.rb
+++ b/spec/rubocop/cop/style/redundant_else_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::RedundantElse, :config do
+  %w[redo next break].each do |skip|
+    it "registers an offense on an else made redundant by a #{skip} in a loop" do
+      expect_offense(<<~RUBY, skip: skip)
+        foo.each do |bar|
+          if condition
+            frob
+            #{skip}
+          else
+          ^^^^ This else branch is unreachable when the if branch executes.
+            qux
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.each do |bar|
+          if condition
+            frob
+            #{skip}
+          end
+
+            qux
+        end
+      RUBY
+    end
+  end
+
+  %w[return raise fail].each do |skip|
+    it "registers an offense on an else made redundant by a #{skip}" do
+      expect_offense(<<~RUBY, skip: skip)
+        if condition
+          frob
+          #{skip}
+        else
+        ^^^^ This else branch is unreachable when the if branch executes.
+          qux
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          frob
+          #{skip}
+        end
+
+          qux
+      RUBY
+    end
+  end
+
+  it 'does not register an offense on a non-redundant else' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        frob
+      else
+        qux
+      end
+    RUBY
+  end
+
+  it 'does not register an offense on a condition with an empty if branch' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        # do nothing
+      else
+        qux
+      end
+    RUBY
+  end
+
+  it 'does not register an offense on an elsif' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        foo
+        return
+      elsif bar
+        qux
+      end
+    RUBY
+  end
+
+  it 'does not register an offense on an else where the return in the if is conditional' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        return unless frob
+      else
+        qux
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Fixes #14042.

If the if branch unconditionally skips the execution of the else branch, for example by returning early or skipping to the next iteration of the loop, the else is redundant

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
