### PR TITLE
Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#14427](https://github.com/rubocop/rubocop/pull/14427): Fix false positives for `Style/RedundantParentheses` when `do`...`end` block is wrapped in parentheses as a method argument. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -220,7 +220,7 @@ module RuboCop
         end
 
         def call_node?(node)
-          node.call_type? || (node.any_block_type? && !node.lambda_or_proc?)
+          node.call_type? || (node.any_block_type? && node.braces? && !node.lambda_or_proc?)
         end
 
         def check_send(begin_node, node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -683,6 +683,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense when braces block is wrapped in parentheses as a method argument' do
+    expect_offense(<<~RUBY)
+      foo (x.select { |item| item }).y
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use parentheses around a method call.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo x.select { |item| item }.y
+    RUBY
+  end
+
+  it 'does not register an offense when `do`...`end` block is wrapped in parentheses as a method argument' do
+    expect_no_offenses(<<~RUBY)
+      foo (x.select do |item| item end).y
+    RUBY
+  end
+
   it 'registers a multiline expression around block wrapped in parens with a chained method' do
     expect_offense(<<~RUBY)
       (


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14407#issuecomment-3157714513.

This PR fixes false positives for `Style/RedundantParentheses` when `do`...`end` block is wrapped in parentheses as a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
