### PR TITLE
Enhance `Lint/SelfAssignment` to detect offenses within indexed assignment with non-standard arity

### DIFF
--- a/changelog/change_enhance_lint_self_assignment_to_detect_indexed_assignment_with_many_arguments_20250806224151.md
+++ b/changelog/change_enhance_lint_self_assignment_to_detect_indexed_assignment_with_many_arguments_20250806224151.md
@@ -1,0 +1,1 @@
+* [#14428](https://github.com/rubocop/rubocop/pull/14428): Enhance `Lint/SelfAssignment` to handle indexed assignment with multiple arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -45,7 +45,7 @@ module RuboCop
           return if allow_rbs_inline_annotation? && rbs_inline_annotation?(node.receiver)
 
           if node.method?(:[]=)
-            handle_key_assignment(node) if node.arguments.size == 2
+            handle_key_assignment(node)
           elsif node.assignment_method?
             handle_attribute_assignment(node) if node.arguments.size == 1
           end
@@ -105,12 +105,13 @@ module RuboCop
         end
 
         def handle_key_assignment(node)
-          value_node = node.arguments[1]
+          value_node = node.last_argument
+          node_arguments = node.arguments[0...-1]
 
           if value_node.send_type? && value_node.method?(:[]) &&
              node.receiver == value_node.receiver &&
-             !node.first_argument.call_type? &&
-             node.first_argument == value_node.first_argument
+             node_arguments.none?(&:call_type?) &&
+             node_arguments == value_node.arguments
             add_offense(node)
           end
         end

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -319,6 +319,32 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense when ussing `[]=` self-assignment with multiple key arguments' do
+    expect_offense(<<~RUBY)
+      matrix[1, 2] = matrix[1, 2]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'does not register an offense when ussing `[]=` self-assignment with multiple key arguments with arguments mismatch' do
+    expect_no_offenses(<<~RUBY)
+      matrix[1, 2] = matrix[1, 3]
+    RUBY
+  end
+
+  it 'does not register an offense when ussing `[]=` self-assignment with multiple key arguments with method call argument' do
+    expect_no_offenses(<<~RUBY)
+      matrix[1, foo] = matrix[1, foo]
+    RUBY
+  end
+
+  it 'registers an offense when ussing `[]=` self-assignment with using zero key arguments' do
+    expect_offense(<<~RUBY)
+      singleton[] = singleton[]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
   describe 'RBS::Inline annotation' do
     context 'when config option is enabled' do
       let(:cop_config) { { 'AllowRBSInlineAnnotation' => true } }


### PR DESCRIPTION
It now detects:

```ruby
a[] = a[]
a[1, 2] = a[1, 2]
a[1, 2, 3] = a[1, 2, 3]
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
