### PR TITLE
support LSP TextDocumentSyncKind.Incremental

### DIFF
--- a/changelog/change_support_lsp_text_document_sync_kind_incremental_20250811135600.md
+++ b/changelog/change_support_lsp_text_document_sync_kind_incremental_20250811135600.md
@@ -1,0 +1,1 @@
+* [#14431](https://github.com/rubocop/rubocop/pull/14431): Support LSP TextDocumentSyncKind.Incremental. ([@tmtm][])

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
         id: 2,
         result: {
           capabilities: {
-            textDocumentSync: { openClose: true, change: 1 },
+            textDocumentSync: { openClose: true, change: 2 },
             documentFormattingProvider: true
           }
         }


### PR DESCRIPTION
Implemented support for TextDocumentSyncKind.Incremental in LSP, so that only text diffs are sent when changes are made in the editor.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
