### PR TITLE
[Fix #14435] Fix false negatives for regexp cops when `Lint/DuplicateRegexpCharacterClassElement` is enabled

### DIFF
--- a/changelog/fix_false_negatives_regexp_cops.md
+++ b/changelog/fix_false_negatives_regexp_cops.md
@@ -1,0 +1,1 @@
+* [#14435](https://github.com/rubocop/rubocop/issues/14435): Fix false negatives for regexp cops when `Lint/DuplicateRegexpCharacterClassElement` is enabled. ([@earlopain][])

--- a/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
+++ b/lib/rubocop/cop/lint/duplicate_regexp_character_class_element.rb
@@ -24,8 +24,6 @@ module RuboCop
 
         MSG_REPEATED_ELEMENT = 'Duplicate element inside regexp character class'
 
-        OCTAL_DIGITS_AFTER_ESCAPE = 2
-
         def on_regexp(node)
           each_repeated_character_class_element_loc(node) do |loc|
             add_offense(loc, message: MSG_REPEATED_ELEMENT) do |corrector|
@@ -40,9 +38,9 @@ module RuboCop
 
             seen = Set.new
             group_expressions(node, expr.expressions) do |group|
-              group_source = group.map(&:to_s).join
+              group_source = group.to_s
 
-              yield source_range(group) if seen.include?(group_source)
+              yield group.expression if seen.include?(group_source)
 
               seen << group_source
             end
@@ -52,38 +50,11 @@ module RuboCop
         private
 
         def group_expressions(node, expressions)
-          # Create a mutable list to simplify state tracking while we iterate.
-          expressions = expressions.to_a
+          expressions.each do |expression|
+            next if within_interpolation?(node, expression)
 
-          until expressions.empty?
-            # With we may need to compose a group of multiple expressions.
-            group = [expressions.shift]
-            next if within_interpolation?(node, group.first)
-
-            # With regexp_parser < 2.7 escaped octal sequences may be up to 3
-            # separate expressions ("\\0", "0", "1").
-            pop_octal_digits(group, expressions) if escaped_octal?(group.first.to_s)
-
-            yield(group)
+            yield(expression)
           end
-        end
-
-        def pop_octal_digits(current_child, expressions)
-          OCTAL_DIGITS_AFTER_ESCAPE.times do
-            next_child = expressions.first
-            break unless octal?(next_child.to_s)
-
-            current_child << expressions.shift
-          end
-        end
-
-        def source_range(children)
-          return children.first.expression if children.size == 1
-
-          range_between(
-            children.first.expression.begin_pos,
-            children.last.expression.begin_pos + children.last.to_s.length
-          )
         end
 
         def skip_expression?(expr)
@@ -97,14 +68,6 @@ module RuboCop
           parse_tree_child_loc = child.expression
 
           interpolation_locs(node).any? { |il| il.overlaps?(parse_tree_child_loc) }
-        end
-
-        def escaped_octal?(string)
-          string.length == 2 && string[0] == '\\' && octal?(string[1])
-        end
-
-        def octal?(char)
-          ('0'..'7').cover?(char)
         end
 
         def interpolation_locs(node)

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -81,7 +81,7 @@ module RuboCop
 
             content = *sym
             content = content.map { |c| c.is_a?(AST::Node) ? c.source : c }.join
-            content_without_delimiter_pairs = content.gsub(/(\[[^\s\[\]]*\])|(\([^\s\(\)]*\))/, '')
+            content_without_delimiter_pairs = content.gsub(/(\[[^\s\[\]]*\])|(\([^\s()]*\))/, '')
 
             content.include?(' ') || DELIMITERS.any? do |delimiter|
               content_without_delimiter_pairs.include?(delimiter)

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -85,7 +85,7 @@ module RuboCop
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)
       # Escape glob characters in base_dir to avoid unwanted behavior.
-      base_dir = base_dir.gsub(/[\\\{\}\[\]\*\?]/) do |reserved_glob_character|
+      base_dir = base_dir.gsub(/[\\{}\[\]*?]/) do |reserved_glob_character|
         "\\#{reserved_glob_character}"
       end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3974,4 +3974,34 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RESULT
     expect($stderr.string).to eq('')
   end
+
+  it 'registers an offense and corrects for `Style/RedundantRegexpEscape` when `NewCops: enable`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        NewCops: enable
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+    YAML
+    source = <<~'RUBY'
+      /[\.-]/
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run(['--autocorrect-all'])).to eq(0)
+    expect($stdout.string).to eq(<<~'RESULT')
+      Inspecting 1 file
+      C
+
+      Offenses:
+
+      example.rb:1:3: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
+      /[\.-]/
+        ^^
+
+      1 file inspected, 1 offense detected, 1 offense corrected
+    RESULT
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      /[.-]/
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix #14435

It does `expressions = expressions.to_a`, which does not create a copy. So other cops that run after would not see all
the expressions.

`.dup` would solve this, but all this does is work around a bug in `regexp_parser` < 2.7.0. RuboCop now requires >= 2.9.3 so all that code can simply be removed.

I didn't add a new test because the code that would be tested is gone now.

Also see https://github.com/rubocop/rubocop/pull/13875 for something quite similar.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
