### PR TITLE
Update test for `LoadError` message change in JRuby 10.0.2.0

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2066,14 +2066,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           require: unknownlibrary
         YAML
 
-        regexp =
-          if RUBY_ENGINE == 'jruby'
-            /no such file to load -- unknownlibrary/
-          else
-            /cannot load such file -- unknownlibrary/
-          end
         expect(cli.run([])).to eq(2)
-        expect($stderr.string).to match(regexp)
+        expect($stderr.string).to match(/cannot load such file -- unknownlibrary/)
       end
     end
 


### PR DESCRIPTION
This updates a test to reflect the change in the `LoadError` message in JRuby 10.0.2.0:

## JRuby 10.0.1.0

> `LoadError: no such file to load -- unknownlibrary`

```console
$ ruby -ve "load('unknownlibrary')"
jruby 10.0.1.0 (3.4.2) 2025-07-17 0f10d1dfdf Java HotSpot(TM) 64-Bit Server VM 24.0.1+9-30 on 24.0.1+9-30 +indy +jit [arm64-darwin]
LoadError: no such file to load -- unknownlibrary
load at org/jruby/RubyKernel.java:1212
  <main> at -e:1
```

## JRuby 10.0.2.0

> `LoadError: cannot load such file -- unknownlibrary`

```console
$ ruby -ve "load('unknownlibrary')"
jruby 10.0.2.0 (3.4.2) 2025-08-07 cba6031bd0 Java HotSpot(TM) 64-Bit Server VM 24.0.1+9-30 on 24.0.1+9-30 +indy +jit [arm64-darwin]
LoadError: cannot load such file -- unknownlibrary
load at org/jruby/RubyKernel.java:1212
<main> at -e:1
```

This will fix the following test:

```console
$ bundle exec rspec spec/rubocop/cli_spec.rb:2063
(snip)

Failures:

  1) RuboCop::CLI configuration of `require` unknown library is specified exits with 2
     Failure/Error: expect($stderr.string).to match(regexp)

       expected "cannot load such file -- unknownlibrary\n/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/feat...yKernel.java:1212:in
                'load'\n/Users/koic/.rbenv/versions/jruby-10.0.2.0/bin/bundle:25:in '<main>'\n" to match /no such file to load -- unknownlibrary/
       Diff:
       @@ -1 +1,99 @@
       -/no such file to load -- unknownlibrary/
       +cannot load such file -- unknownlibrary
       +/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/feature_loader.rb:46:in 'load'
```

https://github.com/rubocop/rubocop/actions/runs/16893928053/job/47859836538#step:4:628

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
