### PR TITLE
Fix an unexpected diagnostic with `TextDocumentSyncKind.Incremental` on the LSP

### DIFF
--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -76,9 +76,10 @@ module RuboCop
 
       handle 'textDocument/didChange' do |request|
         params = request[:params]
-        content = params[:contentChanges][0]
-        result = diagnostic(params[:textDocument][:uri], content[:text], content[:range])
-        @server.write(result)
+        params[:contentChanges].each do |content|
+          result = diagnostic(params[:textDocument][:uri], content[:text], content[:range])
+          @server.write(result)
+        end
       end
 
       handle 'textDocument/didOpen' do |request|


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14431#issuecomment-3184481229

This PR fixes an unexpect diagnostic with `TextDocumentSyncKind.Incremental` on the LSP when `contentChanges` contains multiple entries.

Since #14431 changed `TextDocumentSyncKind` from `Full` to `Incremental`, it is necessary to handle the possibility that `params[:contentChanges]` may contain multiple entries.

Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_synchronization


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
