### PR TITLE
[Fix #14443] Fix false positive in `Layout/EmptyLinesAfterModuleInclusion`

### DIFF
--- a/changelog/fix_fix_false_positive_in_20250814000019.md
+++ b/changelog/fix_fix_false_positive_in_20250814000019.md
@@ -1,0 +1,1 @@
+* [#14443](https://github.com/rubocop/rubocop/issues/14443): Fix false positive in `Layout/EmptyLinesAfterModuleInclusion` when `include` does not have exactly one argument. ([@issyl0][])

--- a/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
+++ b/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
@@ -38,7 +38,7 @@ module RuboCop
         RESTRICT_ON_SEND = MODULE_INCLUSION_METHODS
 
         def on_send(node)
-          return if node.receiver
+          return if node.receiver || !node.arguments.one?
           return if node.parent&.type?(:send, :any_block)
 
           return if next_line_empty_or_enable_directive_comment?(node.last_line)

--- a/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
@@ -242,6 +242,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
     RUBY
   end
 
+  it 'does not register an offense when `include` does not have exactly one argument' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        includes = [include, sdk_include].compact.map do |inc|
+          inc + "blah"
+        end.join(' ')
+      end
+    RUBY
+  end
+
   it 'does not register an offense when module inclusion is called with modifier' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
- Fixes #14443.
- Don't register an offense (and hence don't infinite loop when autocorrecting `Layout/EmptyLinesAfterModuleInclusion` and `Layout/EmptyLinesAroundBlockBody`) when the `include` (or others affected by this cop) send node is/are not followed by a single argument (usually a constant).

Example:

```ruby
includes = [include, sdk_include].compact
```

vs.

```ruby
include SdkIncludeModule
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
