### PR TITLE
Mention RuboCop::Cop::Base#external_dependency_checksum in docs

### DIFF
--- a/docs/modules/ROOT/pages/usage/caching.adoc
+++ b/docs/modules/ROOT/pages/usage/caching.adoc
@@ -20,6 +20,11 @@ bearing on which offenses are reported
 * version of the `rubocop` program (or to be precise, anything in the
 source code of the invoked `rubocop` program)
 
+In rare cases, you may need to invalidate the cache when changing
+external dependencies. This happens when your cop depends on external
+configuration. In this case, override the method
+`RuboCop::Cop::Base#external_dependency_checksum`.
+
 == Enabling and Disabling the Cache
 
 The caching functionality is enabled if the configuration parameter


### PR DESCRIPTION
Recently, I needed to invalidate the RuboCop cache based on the contents of an external config file, and thankfully RuboCop already has an `Rubocop::Cop::Base#external_dependency_checksum` method.

However, it took me some effort to find it. In this request, I added a mention of the method to the RuboCop documentation website.

WDYT?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~~Added tests.~~
* [ ] ~~Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.~~
* [ ] ~~Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~~ (I think in my case it is not worth it)

[1]: https://chris.beams.io/posts/git-commit/
