### PR TITLE
Fix wrong autocorrect for `Style/RedundantCondition` with parenthesised method call in condition

### DIFF
--- a/changelog/fix_wrong_autocorrect_style_redundant_condition.md
+++ b/changelog/fix_wrong_autocorrect_style_redundant_condition.md
@@ -1,0 +1,1 @@
+* [#14447](https://github.com/rubocop/rubocop/pull/14447): Fix wrong autocorrect for `Style/RedundantCondition` with a parenthesised method call in the condition. ([@earlopain][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -247,7 +247,7 @@ module RuboCop
             "#{if_branch.receiver.source} #{if_branch.method_name} (#{argument_source}"
           elsif if_branch.true_type?
             condition = if_branch.parent.condition
-            return condition.source if condition.arguments.empty?
+            return condition.source if condition.arguments.empty? || condition.parenthesized?
 
             wrap_arguments_with_parens(condition)
           else

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -678,6 +678,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and autocorrects when true is used the the true branch and the condition is a parenthesized predicate call with arguments' do
+        expect_offense(<<~RUBY)
+          if foo?(arg)
+          ^^^^^^^^^^^^ Use double pipes `||` instead.
+            true
+          else
+            bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo?(arg) || bar
+        RUBY
+      end
+
       it 'registers an offense and autocorrects when true is used as the true branch and the condition takes arguments with safe navigation' do
         expect_offense(<<~RUBY)
           if obj&.foo? arg


### PR DESCRIPTION
When there are already parenthesis, don't do it again. Previously the autocorrect produced the following invalid syntax: `foo?(arg)) || bar`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
