### PR TITLE
Register array intersection size checks as offenses under `Style/ArrayIntersect`

### DIFF
--- a/changelog/change_style_array_intersect_array_size_false_negatives.md
+++ b/changelog/change_style_array_intersect_array_size_false_negatives.md
@@ -1,0 +1,1 @@
+* [#14448](https://github.com/rubocop/rubocop/pull/14448): Register array intersection size checks as offenses under `Style/ArrayIntersect`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -85,6 +85,75 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
           ([1, 2, 3] & [4, 5, 6]).blank?
         RUBY
       end
+
+      described_class::ARRAY_SIZE_METHODS.each do |method|
+        it "registers an offense when using `.#{method} > 0`" do
+          expect_offense(<<~RUBY, method: method)
+            (a & b).#{method} > 0
+            ^^^^^^^^^{method}^^^^ Use `a.intersect?(b)` instead of `(a & b).#{method} > 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method} == 0`" do
+          expect_offense(<<~RUBY, method: method)
+            (a & b).#{method} == 0
+            ^^^^^^^^^{method}^^^^^ Use `!a.intersect?(b)` instead of `(a & b).#{method} == 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            !a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method} != 0`" do
+          expect_offense(<<~RUBY, method: method)
+            (a & b).#{method} != 0
+            ^^^^^^^^^{method}^^^^^ Use `a.intersect?(b)` instead of `(a & b).#{method} != 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method}.zero?`" do
+          expect_offense(<<~RUBY, method: method)
+            (a & b).#{method}.zero?
+            ^^^^^^^^^{method}^^^^^^ Use `!a.intersect?(b)` instead of `(a & b).#{method}.zero?`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            !a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method}.positive?`" do
+          expect_offense(<<~RUBY, method: method)
+            (a & b).#{method}.positive?
+            ^^^^^^^^^{method}^^^^^^^^^^ Use `a.intersect?(b)` instead of `(a & b).#{method}.positive?`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "does not register an offense when using `.#{method} > 1`" do
+          expect_no_offenses(<<~RUBY)
+            (a & b).#{method} > 1
+          RUBY
+        end
+
+        it "does not register an offense when using `.#{method} == 1`" do
+          expect_no_offenses(<<~RUBY)
+            (a & b).#{method} == 1
+          RUBY
+        end
+      end
     end
 
     context 'with Array#intersection' do
@@ -142,6 +211,86 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         expect_no_offenses(<<~RUBY)
           array1.intersection(array2, array3).any?
         RUBY
+      end
+
+      described_class::ARRAY_SIZE_METHODS.each do |method|
+        it "registers an offense when using `.#{method} > 0`" do
+          expect_offense(<<~RUBY, method: method)
+            a.intersection(b).#{method} > 0
+            ^^^^^^^^^^^^^^^^^^^{method}^^^^ Use `a.intersect?(b)` instead of `a.intersection(b).#{method} > 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method} == 0`" do
+          expect_offense(<<~RUBY, method: method)
+            a.intersection(b).#{method} == 0
+            ^^^^^^^^^^^^^^^^^^^{method}^^^^^ Use `!a.intersect?(b)` instead of `a.intersection(b).#{method} == 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            !a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method} != 0`" do
+          expect_offense(<<~RUBY, method: method)
+            a.intersection(b).#{method} != 0
+            ^^^^^^^^^^^^^^^^^^^{method}^^^^^ Use `a.intersect?(b)` instead of `a.intersection(b).#{method} != 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method}.zero?`" do
+          expect_offense(<<~RUBY, method: method)
+            a.intersection(b).#{method}.zero?
+            ^^^^^^^^^^^^^^^^^^^{method}^^^^^^ Use `!a.intersect?(b)` instead of `a.intersection(b).#{method}.zero?`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            !a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `.#{method}.positive?`" do
+          expect_offense(<<~RUBY, method: method)
+            a.intersection(b).#{method}.positive?
+            ^^^^^^^^^^^^^^^^^^^{method}^^^^^^^^^^ Use `a.intersect?(b)` instead of `a.intersection(b).#{method}.positive?`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a.intersect?(b)
+          RUBY
+        end
+
+        it "registers an offense when using `&.#{method}&.positive?`" do
+          expect_offense(<<~RUBY, method: method)
+            a&.intersection(b)&.#{method}&.positive?
+            ^^^^^^^^^^^^^^^^^^^^^{method}^^^^^^^^^^^ Use `a&.intersect?(b)` instead of `a&.intersection(b)&.#{method}&.positive?`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a&.intersect?(b)
+          RUBY
+        end
+
+        it "does not register an offense when using `.#{method} > 1`" do
+          expect_no_offenses(<<~RUBY)
+            a.intersection(b).#{method} > 1
+          RUBY
+        end
+
+        it "does not register an offense when using `.#{method} == 1`" do
+          expect_no_offenses(<<~RUBY)
+            a.intersection(b).#{method} == 1
+          RUBY
+        end
       end
     end
 


### PR DESCRIPTION
Registers the following code as offenses under `Style/ArrayIntersect`:
```ruby
(a & b).size > 0
(a & b).size != 0
(a & b).size.positive?

(a & b).size == 0
(a & b).size.zero?
```
and autocorrects to:
```ruby
a.intersect?(b)

!a.intersect?(b)
```

In addition to `#size`, the patch takes into account `#length` and `#count` methods as well.

[real-world-rails](https://github.com/eliotsykes/real-world-rails) report:
<details>
<summary>Report</summary>

```ruby
# https://github.com/ivaldi/brimir/blob/35ead7a12471c8f1d1881c7c5ebdb00587198691/app/models/ability.rb#L55
(reply.ticket.label_ids & user.label_ids).size > 0

# https://github.com/ivaldi/brimir/blob/35ead7a12471c8f1d1881c7c5ebdb00587198691/app/models/ability.rb#L64
ticket.user == user || (ticket.label_ids & user.label_ids).size > 0

# https://github.com/ivaldi/brimir/blob/35ead7a12471c8f1d1881c7c5ebdb00587198691/app/models/ability.rb#L83
ticket.user == user || (ticket.label_ids & user.label_ids).size > 0 ||

# https://github.com/ivaldi/brimir/blob/35ead7a12471c8f1d1881c7c5ebdb00587198691/app/models/ability.rb#L89
(reply.ticket.label_ids & user.label_ids).size > 0

# https://github.com/ivaldi/brimir/blob/35ead7a12471c8f1d1881c7c5ebdb00587198691/test/models/ticket_test.rb#L33
assert dave == ticket.user || (ticket.label_ids & dave.label_ids).size > 0

# https://github.com/instructure/canvas-lms/blob/b5fdc8cec7484881e3994f128a541fd232f3f85a/app/models/appointment_group.rb#L149
if (@new_sub_context_codes & context_subs).count == 0

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/app/models/post_analyzer.rb#L66
(Post.allowed_image_classes & dom_class.split).count > 0

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/lib/discourse_tagging.rb#L136
(tag_ids & parent_tag_ids).size == 0 ? parent_tag_ids.first : nil

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/lib/discourse_tagging.rb#L157
next if (tag_ids & parent_tag_ids).size > 0 # tag already has a parent tag

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/lib/site_settings/validations.rb#L42
if (category_ids & default_categories_selected).size > 0

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/lib/site_settings/validations.rb#L113
validate_error :default_tags_already_selected if (tag_names & default_tags_selected).size > 0

# https://github.com/discourse/discourse/blob/758b9dd0ba6f7beb6673db65c3b471b0bbacf0a1/lib/upload_recovery.rb#L23
next if (Post.allowed_image_classes & dom_class.split).count > 0

# https://github.com/ministryofjustice/ds-auth/blob/90662947666f71d1aba5590f424057d4632cda8a/app/policies/user_policy.rb#L41
(user.organisation_ids & record.organisation_ids).length > 0

# https://github.com/samvera-labs/hyku/blob/00a8e6d373d8881557cc9b62d651473a174e525b/app/models/sushi/platform_report.rb#L132
return [] if metric_type_in_params && (metric_types & (ALLOWED_METRIC_TYPES - ['Searches_Platform'])).count.zero?

# https://github.com/loomio/loomio/blob/479656b2c26fb83afde18b65eed6b1d167b9a067/app/controllers/api/v1/memberships_controller.rb#L71
(user.group_ids & current_user.adminable_group_ids).length > 0

# https://github.com/sunlightlabs/politwoops/blob/e1ce513ec75aa2ffc16fd4816630bdc3a1dc6f89/app/controllers/admin/admin_controller.rb#L19
from_monitoring_host = (ips.intersection(monitoring_ips).size > 0)

# https://github.com/zammad/zammad/blob/15c23974f5e21a5a7db0d1563c21d541b152b344/app/models/core_workflow/condition/contains.rb#L5
(value & condition_value).count.positive?

# https://github.com/zammad/zammad/blob/15c23974f5e21a5a7db0d1563c21d541b152b344/app/models/core_workflow/condition/contains_all_not.rb#L5
(value & condition_value).count.zero?

# https://github.com/zammad/zammad/blob/15c23974f5e21a5a7db0d1563c21d541b152b344/app/models/core_workflow/custom/admin_show_group_list_for_agents.rb#L33
return 'show' if (Array.wrap(params['role_ids']).map(&:to_i) & Role.with_permissions('ticket.agent').pluck(:id)).count.positive?

# https://github.com/zammad/zammad/blob/15c23974f5e21a5a7db0d1563c21d541b152b344/app/policies/overview_policy.rb#L42
(user.role_ids.to_set & record.role_ids.to_set).count.zero?
```
</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
