### PR TITLE
[Fix #14441] Better hash access handling in `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_fix_14441_better_hash_access_handling_in_20250815010135.md
+++ b/changelog/fix_fix_14441_better_hash_access_handling_in_20250815010135.md
@@ -1,0 +1,1 @@
+* [#14441](https://github.com/rubocop/rubocop/issues/14441): Better hash access handling in `Style/SafeNavigation`. ([@issyl0][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -342,10 +342,12 @@ module RuboCop
 
           # Compare receiver and method name, but ignore the difference between
           # safe navigation method call (`&.`) and dot method call (`.`).
-          left_receiver, left_method = left.children.take(2)
-          right_receiver, right_method = right.children.take(2)
+          left_receiver, left_method, *left_args = left.children
+          right_receiver, right_method, *right_args = right.children
 
-          left_method == right_method && matching_nodes?(left_receiver, right_receiver)
+          left_method == right_method &&
+            matching_nodes?(left_receiver, right_receiver) &&
+            left_args == right_args
         end
 
         def chain_length(method_chain, method)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
     expect_no_offenses('foo && foo[:bar]')
   end
 
+  it 'allows hash key access and then a different hash key access' do
+    expect_no_offenses('return if foo[:bar] && foo[:baz].blank?')
+  end
+
   it 'allows an object check before a negated predicate' do
     expect_no_offenses('foo && !foo.bar?')
   end


### PR DESCRIPTION
- Fixes #14441
- Make the `matching_call_nodes?` method account for differences in arguments.
- Code like `foo[:bar] && foo[:baz].blank?` does not need safe navigation because the hash keys are different.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
