### PR TITLE
Change offense range for Lint/MissingCopEnableDirective to whole comment

### DIFF
--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -52,10 +52,9 @@ module RuboCop
           each_missing_enable do |cop, line_range|
             next if acceptable_range?(cop, line_range)
 
-            range = source_range(processed_source.buffer, line_range.min, 0..0)
             comment = processed_source.comment_at_line(line_range.begin)
 
-            add_offense(range, message: message(cop, comment))
+            add_offense(comment, message: message(cop, comment))
           end
         end
 

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a cop is disabled and never re-enabled' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout/SpaceAroundOperators
-        ^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:enable` after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:enable` after disabling it.
         x =   0
         # Some other code
       RUBY
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a department is disabled and never re-enabled' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout
-        ^ Re-enable Layout department with `# rubocop:enable` after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout department with `# rubocop:enable` after disabling it.
         x =   0
         # Some other code
       RUBY
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a cop is disabled for too many lines' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout/SpaceAroundOperators
-        ^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
         x =   0
         y = 1
         # Some other code
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a cop is disabled and never re-enabled' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout/SpaceAroundOperators
-        ^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
         x =   0
         # Some other code
       RUBY
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a department is disabled for too many lines' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout
-        ^ Re-enable Layout department within 2 lines after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout department within 2 lines after disabling it.
         x =   0
         y = 1
         # Some other code
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     it 'registers an offense when a department is disabled and never re-enabled' do
       expect_offense(<<~RUBY)
         # rubocop:disable Layout
-        ^ Re-enable Layout department within 2 lines after disabling it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout department within 2 lines after disabling it.
         x =   0
         # Some other code
       RUBY


### PR DESCRIPTION
Changes offense range for `Lint/MissingCopEnableDirective` from start of line to whole comment. I think this is useful for IDEs because there's better offense visibility, and because the offense is naturally related to the directive comment.

Before (screenshot from VS Code):
<img width="497" height="115" alt="image" src="https://github.com/user-attachments/assets/df653191-72c6-4cd3-8924-d64d554323b6" />

After:
<img width="498" height="113" alt="image" src="https://github.com/user-attachments/assets/57fc1ebf-4f9b-44fa-a6ef-23ff2700adc8" />

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
