### PR TITLE
Follow module inclusion with nonzero args with an empty line

### DIFF
--- a/changelog/fix_follow_module_inclusion_with_nonzero_args_with_an_20250817233441.md
+++ b/changelog/fix_follow_module_inclusion_with_nonzero_args_with_an_20250817233441.md
@@ -1,0 +1,1 @@
+* [#14455](https://github.com/rubocop/rubocop/pull/14455): Follow module inclusion with nonzero args with an empty line. ([@issyl0][])

--- a/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
+++ b/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
@@ -38,7 +38,7 @@ module RuboCop
         RESTRICT_ON_SEND = MODULE_INCLUSION_METHODS
 
         def on_send(node)
-          return if node.receiver || !node.arguments.one?
+          return if node.receiver || node.arguments.empty?
           return if node.parent&.type?(:send, :any_block)
 
           return if next_line_empty_or_enable_directive_comment?(node.last_line)

--- a/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
@@ -94,6 +94,26 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when #{method} has multiple arguments" do
+      expect_offense(<<~RUBY, method: method)
+        class Foo
+          #{method} Bar, Baz
+          ^{method}^^^^^^^^^ Add an empty line after module inclusion.
+          def do_something
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          #{method} Bar, Baz
+
+          def do_something
+          end
+        end
+      RUBY
+    end
+
     it "registers an offense and corrects for code that immediately follows #{method} inside a class" do
       expect_offense(<<~RUBY, method: method)
         class Bar
@@ -242,7 +262,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
     RUBY
   end
 
-  it 'does not register an offense when `include` does not have exactly one argument' do
+  it 'does not register an offense when `include` has zero arguments' do
     expect_no_offenses(<<~RUBY)
       class Foo
         includes = [include, sdk_include].compact.map do |inc|


### PR DESCRIPTION
- The fix for `Layout/EmptyLinesAfterModuleInclusion` cop in 49c140b387fa801662f7bcb7e7723417d3454dbb produced false negatives[1] when `include` and friends were, validly, called with multiple arguments.

[1]: https://github.com/rubocop/rubocop/pull/14444#discussion_r2279911551

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
