### PR TITLE
[Fix #14445] Fix false positives for `Lint/UselessAssignment` with `for` loops when the variable is referenced in the collection

### DIFF
--- a/changelog/fix_useless_assignment_for_loop.md
+++ b/changelog/fix_useless_assignment_for_loop.md
@@ -1,0 +1,1 @@
+* [#14445](https://github.com/rubocop/rubocop/issues/14445): Fix false positives for `Lint/UselessAssignment` with `for` loops when the variable is referenced in the collection. ([@earlopain][])

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -243,6 +243,11 @@ module RuboCop
           condition_node, body_node = *node
           process_node(body_node)
           process_node(condition_node)
+        elsif node.for_type?
+          # In `for item in items` the rightmost expression is evaluated first.
+          process_node(node.collection)
+          process_node(node.variable)
+          process_node(node.body) if node.body
         else
           process_children(node)
         end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -270,6 +270,34 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is assigned before `for`' do
+    it 'registers an offense when it is not referenced' do
+      expect_offense(<<~RUBY)
+        node = foo
+        ^^^^ Useless assignment to variable - `node`.
+        for node in bar
+          return node if baz?
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo
+        for node in bar
+          return node if baz?
+        end
+      RUBY
+    end
+
+    it 'registers no offense when the variable is referenced in the collection' do
+      expect_no_offenses(<<~RUBY)
+        node = foo
+        for node in node.children
+          return node if bar?
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is assigned and unreferenced in `for` with multiple variables' do
     it 'registers an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fix #14445

In a for-style loop, the children don't appear in the order that they actually execute.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
