### PR TITLE
Remove misspell from CI

### DIFF
--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -16,13 +16,3 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2
-
-  misspell:
-    name: Check spelling of all files in commit with misspell
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install
-        run: wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b .
-      - name: Misspell
-        run: git ls-files --empty-directory | xargs ./misspell -i 'enviromnent' -error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,21 +49,7 @@ $ rubocop -V
 
 ### Spell Checking
 
-We are running [misspell](https://github.com/client9/misspell) which is mainly written in
-[Golang](https://golang.org/) to check spelling with [GitHub Actions](https://github.com/rubocop/rubocop/blob/master/.github/workflows/spell_checking.yml).
-Correct commonly misspelled English words quickly with `misspell`. `misspell` is different from most other spell checkers
-because it doesn't use a custom dictionary. You can run `misspell` locally against all files with:
-
-```console
-$ find . -type f | xargs ./misspell -i 'enviromnent' -error
-```
-
-Notable `misspell` help options or flags are:
-
-* `-i` string: ignore the following corrections, comma separated
-* `-w`: Overwrite file with corrections (default is just to display)
-
-We also run [codespell](https://github.com/codespell-project/codespell) with GitHub Actions to check spelling and
+We are running[codespell](https://github.com/codespell-project/codespell) with GitHub Actions to check spelling and
 [codespell](https://pypi.org/project/codespell/) runs against a [small custom dictionary](https://github.com/rubocop/rubocop/blob/master/.codespellrc).
 
 If you have `codespell` locally available in your `$PATH`, `bundle exec rake` will run it for you.


### PR DESCRIPTION
The repo was archived https://github.com/client9/misspell and we also use codespell. One spell checker seems more than enough.

misspell doesn't run locally (codespell does if available via `bundle exec rake`) and in https://github.com/rubocop/rubocop/pull/14459 I would have to handle excludes for both spellcheckers. codespell seems better anyways since it needs more excludes that misspell just accepts.

Rails has since this was introduced also removed misspell (https://github.com/rails/rails/commit/d7c937b7ff7a3dc5d64ccc36bedb2bb40750bbd1), _but_ codespell was removed later too (https://github.com/rails/rails/commit/3c19732dedad01167f8f0c9efa1ff269e2d9b089)