### PR TITLE
Clarify `Layout/MultilineOperationIndentation` docs for next-line assignments

### DIFF
--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -10,6 +10,8 @@ module RuboCop
       # condition, an explicit `return` statement, etc. In other contexts, the second operand should
       # be indented regardless of enforced style.
       #
+      # In both styles, operators should be aligned when an assignment begins on the next line.
+      #
       # @example EnforcedStyle: aligned (default)
       #   # bad
       #   if a +


### PR DESCRIPTION
While enabling [`Layout/MultilineOperationIndentation`](https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilineoperationindentation) on a project with `EnforcedStyle: indented`, I expected the cop to autocorrect this:
```ruby
foo =
  bar &&
  baz &&
  qux
```
to this:
```ruby
foo =
  bar &&
    baz &&
    qux
```

However, there were no offenses. I expected this because code like:
```ruby
if bar &&
   baz &&
   qux
```
will autocorrect indentation of `baz` and `qux`. It seems that assignments are treated specially when the operators are on the next line so that they're always aligned, and [this is covered in tests](https://github.com/rubocop/rubocop/blob/cb83c6f61158e8d13b3bb0f8cdd49b88617fce99/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb#L165-L179), so this PR documents that.
