### PR TITLE
Add a test for `Lint/UselessAssignment`

### DIFF
--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1187,6 +1187,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         end
       RUBY
     end
+
+    it 'registers an offense when the reassignment is the last statement' do
+      expect_offense(<<~RUBY)
+        foo = [1, 2]
+        foo = foo.map { |i| i + 1 }
+        ^^^ Useless assignment to variable - `foo`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = [1, 2]
+        foo.map { |i| i + 1 }
+      RUBY
+    end
   end
 
   context 'when a variable is reassigned with binary operator assignment and referenced' do


### PR DESCRIPTION
I was looking at `VariableForce` and saw `scanned_nodes` which I though could be removed: https://github.com/Earlopain/rubocop/blob/cb83c6f61158e8d13b3bb0f8cdd49b88617fce99/lib/rubocop/cop/variable_force.rb#L373

No tests fail after but I found missing offenses after making the change. Add some test coverage for that.