### PR TITLE
[Fix #14453] Update `Style/RedundantBegin` to register `begin` blocks inside `if`, `unless`, `case`, `while` and `until` as redundant

### DIFF
--- a/changelog/change_update_style_redundant_begin_to_register_begin_20250818135329.md
+++ b/changelog/change_update_style_redundant_begin_to_register_begin_20250818135329.md
@@ -1,0 +1,1 @@
+* [#14453](https://github.com/rubocop/rubocop/issues/14453): Update `Style/RedundantBegin` to register `begin` blocks inside `if`, `unless`, `case`, `while` and `until` as redundant. ([@dvandersluis][])

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -265,6 +265,296 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when a multiline `begin` block is inside `if`' do
+    expect_offense(<<~RUBY)
+      if condition
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+       #{trailing_whitespace}
+          foo
+          bar
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `unless`' do
+    expect_offense(<<~RUBY)
+      unless condition
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unless condition
+       #{trailing_whitespace}
+          foo
+          bar
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `elsif`' do
+    expect_offense(<<~RUBY)
+      if condition
+        foo
+      elsif condition2
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          bar
+          baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        foo
+      elsif condition2
+       #{trailing_whitespace}
+          bar
+          baz
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `else`' do
+    expect_offense(<<~RUBY)
+      if condition
+        foo
+      else
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          bar
+          baz
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        foo
+      else
+       #{trailing_whitespace}
+          bar
+          baz
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case-when`' do
+    expect_offense(<<~RUBY)
+      case condition
+        when foo
+          begin
+          ^^^^^ Redundant `begin` block detected.
+            bar
+            baz
+          end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case condition
+        when foo
+         #{trailing_whitespace}
+            bar
+            baz
+         #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case-else`' do
+    expect_offense(<<~RUBY)
+      case condition
+        when foo
+          bar
+        else
+          begin
+          ^^^^^ Redundant `begin` block detected.
+            baz
+            quux
+          end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case condition
+        when foo
+          bar
+        else
+         #{trailing_whitespace}
+            baz
+            quux
+         #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `while`' do
+    expect_offense(<<~RUBY)
+      while condition
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while condition
+       #{trailing_whitespace}
+          foo
+          bar
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `until`' do
+    expect_offense(<<~RUBY)
+      until condition
+        begin
+        ^^^^^ Redundant `begin` block detected.
+          foo
+          bar
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      until condition
+       #{trailing_whitespace}
+          foo
+          bar
+       #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `rescue` inside an `if` statement' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        begin
+          foo
+          bar
+        rescue StandardError
+          baz
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `ensure` inside an `if` statement' do
+    expect_no_offenses(<<~RUBY)
+      if condition
+        begin
+          foo
+          bar
+        ensure
+          baz
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `rescue` inside an `case` statement' do
+    expect_no_offenses(<<~RUBY)
+      case condition
+        when foo
+          begin
+            bar
+            baz
+          rescue StandardError
+            quux
+          end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `ensure` inside an `case` statement' do
+    expect_no_offenses(<<~RUBY)
+      case condition
+        when foo
+          begin
+            bar
+            baz
+          ensure
+            quux
+          end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `rescue` inside an `while` statement' do
+    expect_no_offenses(<<~RUBY)
+      while condition
+        begin
+          foo
+          bar
+        rescue StandardError
+          baz
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `ensure` inside an `while` statement' do
+    expect_no_offenses(<<~RUBY)
+      while condition
+        begin
+          foo
+          bar
+        ensure
+          baz
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `rescue` inside an `until` statement' do
+    expect_no_offenses(<<~RUBY)
+      until condition
+        begin
+          foo
+          bar
+        rescue StandardError
+          baz
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `begin` with `ensure` inside an `until` statement' do
+    expect_no_offenses(<<~RUBY)
+      until condition
+        begin
+          foo
+          bar
+        ensure
+          baz
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `begin` with multiple statement for or assignment' do
     expect_no_offenses(<<~RUBY)
       var ||= begin


### PR DESCRIPTION
A `begin` block (without `rescue` or `ensure`) inside `if`, `case`, `while` or `until` is redundant, and can be handled by the cop.

Fixes #14453.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
