### PR TITLE
Exclude `AutoCorrect` and `Include` from configuration parameters

### DIFF
--- a/changelog/change_exclude_auto_correct_and_include_from_20250819090646.md
+++ b/changelog/change_exclude_auto_correct_and_include_from_20250819090646.md
@@ -1,0 +1,1 @@
+* [#14464](https://github.com/rubocop/rubocop/pull/14464): Exclude `AutoCorrect` and `Include` from configuration parameters. ([@r7kamura][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Formatter
     # This formatter displays a YAML configuration file where all cops that
     # detected any offenses are configured to not detect the offense.
-    class DisabledConfigFormatter < BaseFormatter
+    class DisabledConfigFormatter < BaseFormatter # rubocop:disable Metrics/ClassLength
       include PathUtil
 
       HEADING = <<~COMMENTS
@@ -16,6 +16,22 @@ module RuboCop
         # Note that changes in the inspected code, or installation of new
         # versions of RuboCop, may require this file to be generated again.
       COMMENTS
+
+      EXCLUDED_CONFIG_KEYS = %w[
+        AutoCorrect
+        Description
+        Enabled
+        Exclude
+        Include
+        Reference
+        References
+        Safe
+        SafeAutoCorrect
+        StyleGuide
+        VersionAdded
+        VersionChanged
+        VersionRemoved
+      ].freeze
 
       @config_to_allow_offenses = {}
       @detected_styles = {}
@@ -163,10 +179,7 @@ module RuboCop
       end
 
       def cop_config_params(default_cfg, cfg)
-        default_cfg.keys -
-          %w[Description StyleGuide Reference References Enabled Exclude Safe
-             SafeAutoCorrect VersionAdded VersionChanged VersionRemoved] -
-          cfg.keys
+        default_cfg.keys - EXCLUDED_CONFIG_KEYS - cfg.keys
       end
 
       def output_cop_param_comments(output_buffer, params, default_cfg)


### PR DESCRIPTION
How about excluding these keys from `.rubocop_todo.yml` configuration parameters?

- `AutoCorrect`
- `Include`

Since these keys are common to many cops, I don’t think they should be listed as configuration parameters for any specific cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
