### PR TITLE
Fix two tests printing to stderr

### DIFF
--- a/exe/rubocop
+++ b/exe/rubocop
@@ -12,13 +12,6 @@ if RuboCop::Server.running?
   exit_status = RuboCop::Server::ClientCommand::Exec.new.run
 else
   require 'rubocop'
-
-  cli = RuboCop::CLI.new
-
-  time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-  exit_status = cli.run
-  elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_start
-
-  puts "Finished in #{elapsed_time} seconds" if cli.options[:debug] || cli.options[:display_time]
+  exit_status = RuboCop::CLI.new.run
 end
 exit exit_status

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -37,6 +37,8 @@ module RuboCop
     #
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def run(args = ARGV)
+      time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
       @options, paths = Options.new.parse(args)
       @env = Environment.new(@options, @config_store, paths)
 
@@ -72,6 +74,9 @@ module RuboCop
       warn e.message
       warn e.backtrace
       STATUS_ERROR
+    ensure
+      elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - time_start
+      puts "Finished in #{elapsed_time} seconds" if @options[:debug] || @options[:display_time]
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1091,9 +1091,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       create_file('example1.rb', "\tputs 0")
       expect(cli.run(['--debug', 'example1.rb'])).to eq(1)
       home = File.dirname(File.dirname(File.dirname(File.dirname(__FILE__))))
-      expect($stdout.string.lines.grep(/configuration/).map(&:chomp))
-        .to eq(["For #{abs('')}: " \
-                "Default configuration from #{home}/config/default.yml"])
+      expect($stdout.string)
+        .to include("For #{abs('')}: " \
+                    "Default configuration from #{home}/config/default.yml")
     end
 
     it 'shows cop names' do
@@ -1101,9 +1101,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       file = abs('example1.rb')
 
       expect(cli.run(['--format', 'emacs', '--debug', 'example1.rb'])).to eq(1)
-      expect($stdout.string.lines.to_a[-1])
-        .to eq("#{file}:1:7: C: [Correctable] Layout/TrailingWhitespace: Trailing " \
-               "whitespace detected.\n")
+      expect($stdout.string)
+        .to include("#{file}:1:7: C: [Correctable] Layout/TrailingWhitespace: Trailing " \
+                    "whitespace detected.\n")
     end
   end
 
@@ -1114,13 +1114,15 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
     context 'without --display-time' do
       it 'does not display elapsed time in seconds' do
-        expect(`rubocop example1.rb`).not_to match(regex)
+        expect(cli.run(['example1.rb'])).to eq(0)
+        expect($stdout.string).not_to match(regex)
       end
     end
 
     context 'with --display-time' do
       it 'displays elapsed time in seconds' do
-        expect(`rubocop --display-time example1.rb`).to match(regex)
+        expect(cli.run(['--display-time', 'example1.rb'])).to eq(0)
+        expect($stdout.string).to match(regex)
       end
     end
   end


### PR DESCRIPTION
Because they use backtick-style command execution, their output doesn't get captured like usually.

To fix this, I've moved `--display-time` handling into the CLI class, slightly tweaking some existing specs to be less specific about the output

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
