### PR TITLE
[Fix #14469] Fix an incorrect autocorrect for `Style/BitwisePredicate`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_bitwise_predicate.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_bitwise_predicate.md
@@ -1,0 +1,1 @@
+* [#14469](https://github.com/rubocop/rubocop/issues/14469): Fix an incorrect autocorrect for `Style/BitwisePredicate` when using `&` with LHS flags in conjunction with `==` for comparisons. ([@koic][])

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -70,18 +70,25 @@ module RuboCop
             (send _ :& _))
         PATTERN
 
+        # rubocop:disable Metrics/AbcSize
         def on_send(node)
           return unless node.receiver&.begin_type?
           return unless (preferred_method = preferred_method(node))
 
           bit_operation = node.receiver.children.first
           lhs, _operator, rhs = *bit_operation
-          preferred = "#{lhs.source}.#{preferred_method}(#{rhs.source})"
+
+          preferred = if preferred_method == 'allbits?' && lhs.source == node.first_argument.source
+                        "#{rhs.source}.allbits?(#{lhs.source})"
+                      else
+                        "#{lhs.source}.#{preferred_method}(#{rhs.source})"
+                      end
 
           add_offense(node, message: format(MSG, preferred: preferred)) do |corrector|
             corrector.replace(node, preferred)
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/spec/rubocop/cop/style/bitwise_predicate_spec.rb
+++ b/spec/rubocop/cop/style/bitwise_predicate_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe RuboCop::Cop::Style::BitwisePredicate, :config do
       it 'registers an offense when using `&` with LHS flags in conjunction with `==` for comparisons' do
         expect_offense(<<~RUBY)
           (flags & variable) == flags
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace with `flags.allbits?(variable)` for comparison with bit flags.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace with `variable.allbits?(flags)` for comparison with bit flags.
         RUBY
 
         expect_correction(<<~RUBY)
-          flags.allbits?(variable)
+          variable.allbits?(flags)
         RUBY
       end
 


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/BitwisePredicate` when using `&` with LHS flags in conjunction with `==` for comparisons.

Fixes #14469.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
