### PR TITLE
[Fix #14468] Fix false positives for `Naming/MethodName`

### DIFF
--- a/changelog/fix_false_positives_for_naming_method_name.md
+++ b/changelog/fix_false_positives_for_naming_method_name.md
@@ -1,0 +1,1 @@
+* [#14468](https://github.com/rubocop/rubocop/issues/14468): Fix false positives for `Naming/MethodName` when an operator method is defined using a string. ([@koic][])

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -198,7 +198,7 @@ module RuboCop
 
           if forbidden_name?(name.to_s)
             register_forbidden_name(node)
-          elsif !OPERATOR_METHODS.include?(name)
+          elsif !OPERATOR_METHODS.include?(name.to_sym)
             check_name(node, name, range_position(node))
           end
         end

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -496,6 +496,13 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when an operator method is defined using a string' do
+        expect_no_offenses(<<~RUBY)
+          #{name} '`' do
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes false positives for `Naming/MethodName` when an operator method is defined using a string.

Fixes #14468.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
