### PR TITLE
Make `Style/RedundantBegin` aware of `case` pattern matching

### DIFF
--- a/changelog/change_make_redundant_begin_aware_of_case_match.md
+++ b/changelog/change_make_redundant_begin_aware_of_case_match.md
@@ -1,0 +1,1 @@
+* [#14472](https://github.com/rubocop/rubocop/pull/14472): Make `Style/RedundantBegin` aware of `case` pattern matching. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -94,6 +94,7 @@ module RuboCop
         def on_case(node)
           inspect_branches(node)
         end
+        alias on_case_match on_case
 
         def on_while(node)
           return if node.modifier_form?

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when a multiline `begin` block is inside `case-when`' do
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case`/`when`' do
     expect_offense(<<~RUBY)
       case condition
         when foo
@@ -380,7 +380,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     RUBY
   end
 
-  it 'registers and corrects an offense when a multiline `begin` block is inside `case-else`' do
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case`/`when`/`else`' do
     expect_offense(<<~RUBY)
       case condition
         when foo
@@ -397,6 +397,56 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     expect_correction(<<~RUBY)
       case condition
         when foo
+          bar
+        else
+         #{trailing_whitespace}
+            baz
+            quux
+         #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case`/`in`' do
+    expect_offense(<<~RUBY)
+      case condition
+        in foo
+          begin
+          ^^^^^ Redundant `begin` block detected.
+            bar
+            baz
+          end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case condition
+        in foo
+         #{trailing_whitespace}
+            bar
+            baz
+         #{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'registers and corrects an offense when a multiline `begin` block is inside `case`/`in`/`else`' do
+    expect_offense(<<~RUBY)
+      case condition
+        in foo
+          bar
+        else
+          begin
+          ^^^^^ Redundant `begin` block detected.
+            baz
+            quux
+          end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case condition
+        in foo
           bar
         else
          #{trailing_whitespace}


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14463.

This PR makes `Style/RedundantBegin` aware of `case` pattern matching.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
