### PR TITLE
Fix a false negative for `Style/RedundantBegin`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_begin.md
+++ b/changelog/fix_false_negative_for_style_redundant_begin.md
@@ -1,0 +1,1 @@
+* [#14473](https://github.com/rubocop/rubocop/pull/14473): Fix a false negative for `Style/RedundantBegin` using `begin` with multiple statements without `rescue` or `ensure`. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -203,6 +203,8 @@ module RuboCop
         end
 
         def begin_block_has_multiline_statements?(node)
+          return false unless node.parent
+
           node.children.count >= 2
         end
 

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -166,6 +166,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantBegin, :config do
     expect_correction("\n  do_something\n\n")
   end
 
+  it 'registers an offense and corrects when using `begin` with multiple statements without `rescue` or `ensure`' do
+    expect_offense(<<~RUBY)
+      begin
+      ^^^^^ Redundant `begin` block detected.
+        foo
+        bar
+      end
+    RUBY
+
+    expect_correction("\n  foo\n  bar\n\n")
+  end
+
   it 'does not register an offense when using `begin` with `rescue`' do
     expect_no_offenses(<<~RUBY)
       begin


### PR DESCRIPTION
This PR fixes a false negative for `Style/RedundantBegin` using `begin` with multiple statements without `rescue` or `ensure`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
