### PR TITLE
Fix false negative for `Layout/EndAlignment` when `end` is not on a separate line

### DIFF
--- a/changelog/change_false_negative_for_layout_end_alignment.md
+++ b/changelog/change_false_negative_for_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#14474](https://github.com/rubocop/rubocop/pull/14474): Fix false negative for `Layout/EndAlignment` when `end` is not on a separate line. ([@lovro-bikic][])

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -29,10 +29,13 @@ module RuboCop
         def align_end(corrector, processed_source, node, align_to)
           @processed_source = processed_source
           whitespace = whitespace_range(node)
-          return false unless whitespace.source.strip.empty?
-
           column = alignment_column(align_to)
-          corrector.replace(whitespace, ' ' * column)
+
+          if whitespace.source.strip.empty?
+            corrector.replace(whitespace, ' ' * column)
+          else
+            corrector.insert_after(whitespace, "\n#{' ' * column}")
+          end
         end
 
         private

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -19,8 +19,7 @@ module RuboCop
       def check_end_kw_alignment(node, align_ranges)
         return if ignored_node?(node)
 
-        end_loc = node.loc.end
-        return if accept_end_kw_alignment?(end_loc)
+        return unless (end_loc = node.loc.end)
 
         matching = matching_ranges(end_loc, align_ranges)
 
@@ -55,11 +54,6 @@ module RuboCop
                           align_line: align_with.line,
                           align_col: align_with.column)
         add_offense(end_loc, message: msg) { |corrector| autocorrect(corrector, node) }
-      end
-
-      def accept_end_kw_alignment?(end_loc)
-        end_loc.nil? || # Discard modifier forms of if/while/until.
-          !/\A[ \t]*end/.match?(processed_source.lines[end_loc.line - 1])
       end
 
       def style_parameter_name

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1627,7 +1627,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       module A
         module B
-        end end
+        end
+      end
     RUBY
     uncorrected = $stdout.string.split($RS).select do |line|
       line.include?('example.rb:') && !line.include?('[Corrected]')

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -503,10 +503,37 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   end
 
   context 'when end is preceded by something else than whitespace' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         module A
         puts a end
+               ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module A
+        puts a#{trailing_whitespace}
+        end
+      RUBY
+    end
+  end
+
+  context 'when end is on the same line as `else` body' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        if test
+          foo
+        else
+          bar end
+              ^^^ `end` at 4, 6 is not aligned with `if` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if test
+          foo
+        else
+          bar#{trailing_whitespace}
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Registers offenses for code such as:
```ruby
module Foo
  bar end

if test
  foo
else
  bar end
```
and autocorrects it to:
```ruby
module Foo
  bar
end

if test
  foo
else
  bar
end
```

Note that such offenses have been previously ignored as false positives in https://github.com/rubocop/rubocop/commit/4bfe82e65c22bf17dfb7f524c83dd741da06bb29, which resolved https://github.com/rubocop/rubocop/issues/7778. It mentions introduction of `Layout/BlockEndNewline`, but that cop doesn't handle these kind of offenses, and doesn't seem like the right place for them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
