### PR TITLE
[Fix #14475] Fix cop errors during autocorrect for the buildin LSP when analyzing as Ruby 3.4

### DIFF
--- a/changelog/fix_lsp_prism_reuse.md
+++ b/changelog/fix_lsp_prism_reuse.md
@@ -1,0 +1,1 @@
+* [#14475](https://github.com/rubocop/rubocop/issues/14475): Fix cop errors during autocorrect for the build in LSP when analyzing as Ruby 3.4. ([@earlopain][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -273,7 +273,8 @@ module RuboCop
     end
 
     def do_inspection_loop(file)
-      processed_source = get_processed_source(file)
+      # We can reuse the prism result since the source did not change yet.
+      processed_source = get_processed_source(file, prism_result: @prism_result)
       # This variable is 2d array used to track corrected offenses after each
       # inspection iteration. This is used to output meaningful infinite loop
       # error message.
@@ -295,7 +296,8 @@ module RuboCop
         # loop if we find any.
         break unless updated_source_file
 
-        processed_source = get_processed_source(file)
+        # Autocorrect has happened, don't use the prism result since it is stale.
+        processed_source = get_processed_source(file, prism_result: nil)
       end
 
       # Return summary of corrected offenses after all iterations
@@ -482,7 +484,7 @@ module RuboCop
     end
 
     # rubocop:disable Metrics/MethodLength
-    def get_processed_source(file)
+    def get_processed_source(file, prism_result:)
       config = @config_store.for_file(file)
       ruby_version = config.target_ruby_version
       parser_engine = config.parser_engine
@@ -493,7 +495,7 @@ module RuboCop
                              ruby_version,
                              file,
                              parser_engine: parser_engine,
-                             prism_result: @prism_result
+                             prism_result: prism_result
                            )
                          else
                            begin


### PR DESCRIPTION
Fix #14475

After autocorrect happened, it still reused it the parse result from the initial file, causing all kind of trouble.

cc @vinistock

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
