### PR TITLE
Prevent --display-time CLI option from invalidating cache

### DIFF
--- a/changelog/fix_dont_invalidate_cache_for_display_time_option.md
+++ b/changelog/fix_dont_invalidate_cache_for_display_time_option.md
@@ -1,0 +1,1 @@
+* [#14479](https://github.com/rubocop/rubocop/issues/14479): Don't invalidate cache when `--display-time` option is used on the CLI. ([@lovro-bikic][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -9,7 +9,7 @@ module RuboCop
   # Provides functionality for caching RuboCop runs.
   # @api private
   class ResultCache
-    NON_CHANGING = %i[color format formatters out debug fail_level
+    NON_CHANGING = %i[color format formatters out debug display_time fail_level
                       fix_layout autocorrect safe_autocorrect autocorrect_all
                       cache fail_fast stdin parallel].freeze
 


### PR DESCRIPTION
Currently, running RuboCop with `--display-time` option will invalidate cache. This PR disables the option from affecting cache.