### PR TITLE
[Fix #10971] Add `diff_comma` option to Style/TrailingCommaInArguments

### DIFF
--- a/changelog/new_trailing_comma_in_arguments_diff_comma_style_20250827224650.md
+++ b/changelog/new_trailing_comma_in_arguments_diff_comma_style_20250827224650.md
@@ -1,0 +1,1 @@
+* [#10971](https://github.com/rubocop/rubocop/issues/10971): Support `EnforcedStyleForMultiline: diff_comma` in `Style/TrailingCommaInArguments`. ([@akouryy][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5844,10 +5844,14 @@ Style/TrailingCommaInArguments:
   # parenthesized method calls where each argument is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
+  # If `diff_comma`, the cop requires a comma after the last argument, but only
+  # when that argument is followed by an immediate newline, even if
+  # there is an inline comment.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
+    - diff_comma
     - no_comma
 
 Style/TrailingCommaInArrayLiteral:

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -140,7 +140,7 @@ module RuboCop
       end
 
       def last_item_precedes_newline?(node)
-        after_last_item = node.children.last.source_range.end.join(node.loc.end.begin)
+        after_last_item = node.children.last.source_range.end.join(node.source_range.end)
 
         after_last_item.source.start_with?(/,?\s*(#.*)?\n/)
       end

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -10,6 +10,9 @@ module RuboCop
       # for all parenthesized multi-line method calls with arguments.
       # * `comma`: Requires a comma after the last argument, but only for
       # parenthesized method calls where each argument is on its own line.
+      # * `diff_comma`: Requires a comma after the last argument, but only
+      # when that argument is followed by an immediate newline, even if
+      # there is an inline comment on the same line.
       # * `no_comma`: Requires that there is no comma after the last
       # argument.
       #
@@ -74,6 +77,48 @@ module RuboCop
       #     1,
       #     2,
       #   )
+      #
+      # @example EnforcedStyleForMultiline: diff_comma
+      #   # bad
+      #   method(1, 2,)
+      #
+      #   # good
+      #   method(1, 2)
+      #
+      #   # good
+      #   method(
+      #     1, 2,
+      #     3,
+      #   )
+      #
+      #   # good
+      #   method(
+      #     1, 2, 3,
+      #   )
+      #
+      #   # good
+      #   method(
+      #     1,
+      #     2,
+      #   )
+      #
+      #   # bad
+      #   method(1, [
+      #     2,
+      #   ],)
+      #
+      #   # good
+      #   method(1, [
+      #     2,
+      #   ])
+      #
+      #   # bad
+      #   object[1, 2,
+      #          3, 4,]
+      #
+      #   # good
+      #   object[1, 2,
+      #          3, 4]
       #
       # @example EnforcedStyleForMultiline: no_comma (default)
       #   # bad


### PR DESCRIPTION
[Fix #10971] 

Introduce a new EnforcedStyleForMultiline, `diff_comma`, for Style/TrailingCommaInArguments. `diff_comma` requires a trailing comma only when the final argument is followed by an immediate newline. When the closing `)` or `]` shares a line with the last argument, a trailing comma is not allowed.

Examples:

  ```ruby
  # good under diff_comma, bad under consistent_comma
  some_method(a: "b",
              c: "d")

  foo(1, [
    2,
  ])

  # bad under diff_comma, good under consistent_comma
  some_method(a: "b",
              c: "d",)

  foo(1, [
    2,
  ],)
  ```

In line with #13806, this adds a separate style rather than modifying `consistent_comma` to preserve backward compatibility.

Most of the required functionality was already implemented in #13806, so this PR largely reuses that implementation. The only gap was support for the `[]` method; this PR adapts it with minor changes to handle `[]`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
