### PR TITLE
[Fix #14477] Fix a false positive for `Style/SafeNavigation`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_safe_navigation_cop.md
+++ b/changelog/fix_a_false_positive_for_style_safe_navigation_cop.md
@@ -1,0 +1,1 @@
+* [#14477](https://github.com/rubocop/rubocop/issues/14477): Fix a false positive for `Style/SafeNavigation` when using ternary expression with index access call with method chain. ([@koic][])

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -262,8 +262,14 @@ module RuboCop
         end
 
         def dotless_operator_call?(method_call)
+          return true if dotless_operator_method?(method_call)
+
           method_call = method_call.parent while method_call.parent.send_type?
 
+          dotless_operator_method?(method_call)
+        end
+
+        def dotless_operator_method?(method_call)
           return false if method_call.loc.dot
 
           method_call.method?(:[]) || method_call.method?(:[]=) || method_call.operator_method?

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -816,6 +816,12 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           RUBY
         end
 
+        it 'allows ternary expression with index access call with method chain' do
+          expect_no_offenses(<<~RUBY)
+            #{variable} ? #{variable}[index].do_something : nil
+          RUBY
+        end
+
         it 'allows ternary expression with indexed assignment call without dot' do
           expect_no_offenses(<<~RUBY)
             #{variable} ? #{variable}[index] = 1 : nil


### PR DESCRIPTION
This PR fixes a false positive for `Style/SafeNavigation` when using ternary expression with index access call with method chain.

Fixes #14477.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
