### PR TITLE
Add support for LSP `positionEncoding` `utf-8` and `utf-32`

### DIFF
--- a/changelog/change_support_for_position_encoding_utf_8_and_utf_32_20250830135957.md
+++ b/changelog/change_support_for_position_encoding_utf_8_and_utf_32_20250830135957.md
@@ -1,0 +1,1 @@
+* [#14492](https://github.com/rubocop/rubocop/pull/14492): Add support for LSP `positionEncoding` `utf-8` and `utf-32`. ([@tmtm][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -15,7 +15,7 @@ module RuboCop
   module LSP
     # Routes for Language Server Protocol of RuboCop.
     # @api private
-    class Routes
+    class Routes # rubocop:disable Metrics/ClassLength
       CONFIGURATION_FILE_PATTERNS = [
         RuboCop::ConfigFinder::DOTFILE,
         RuboCop::CLI::Command::AutoGenerateConfig::AUTO_GENERATED_FILE
@@ -42,6 +42,7 @@ module RuboCop
 
       handle 'initialize' do |request|
         initialization_options = extract_initialization_options_from(request)
+        @position_encoding = initialization_options[:position_encoding]
 
         @server.configure(initialization_options)
 
@@ -53,7 +54,8 @@ module RuboCop
               text_document_sync: LanguageServer::Protocol::Interface::TextDocumentSyncOptions.new(
                 change: LanguageServer::Protocol::Constant::TextDocumentSyncKind::INCREMENTAL,
                 open_close: true
-              )
+              ),
+              position_encoding: @position_encoding
             )
           )
         )
@@ -184,12 +186,24 @@ module RuboCop
 
       def extract_initialization_options_from(request)
         safe_autocorrect = request.dig(:params, :initializationOptions, :safeAutocorrect)
+        position_encodings = request.dig(:params, :capabilities, :general, :positionEncodings)
 
         {
           safe_autocorrect: safe_autocorrect.nil? || safe_autocorrect == true,
           lint_mode: request.dig(:params, :initializationOptions, :lintMode) == true,
-          layout_mode: request.dig(:params, :initializationOptions, :layoutMode) == true
+          layout_mode: request.dig(:params, :initializationOptions, :layoutMode) == true,
+          position_encoding: position_encoding(position_encodings)
         }
+      end
+
+      def position_encoding(position_encodings)
+        if position_encodings&.include?('utf-8')
+          'utf-8'
+        elsif position_encodings&.include?('utf-32')
+          'utf-32'
+        else
+          'utf-16'
+        end
       end
 
       def format_file(file_uri, command: nil)
@@ -219,7 +233,8 @@ module RuboCop
           method: 'textDocument/publishDiagnostics',
           params: {
             uri: file_uri,
-            diagnostics: @server.offenses(convert_file_uri_to_path(file_uri), text)
+            diagnostics: @server.offenses(convert_file_uri_to_path(file_uri),
+                                          text, @position_encoding)
           }
         }
       end
@@ -229,9 +244,8 @@ module RuboCop
 
         start_pos = text_pos(orig_text, range[:start])
         end_pos = text_pos(orig_text, range[:end])
-        text_bin = orig_text.b
-        text_bin[start_pos...end_pos] = text.b
-        text_bin.force_encoding(orig_text.encoding)
+        orig_text[start_pos...end_pos] = text
+        orig_text
       end
 
       def text_pos(text, range)
@@ -240,12 +254,25 @@ module RuboCop
         pos = 0
         text.each_line.with_index do |l, i|
           if i == line
-            pos += l.encode('utf-16be').b[0, char * 2].encode('utf-8', 'utf-16be').bytesize
+            pos += line_pos(l, char)
             return pos
           end
-          pos += l.bytesize
+          pos += l.size
         end
         pos
+      end
+
+      def line_pos(line, char)
+        case @position_encoding
+        when 'utf-8'
+          line.byteslice(0, char).size
+        when 'utf-32'
+          char
+        else # 'utf-16'
+          # utf-16 is default position encoding on LSP
+          # https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+          line.encode('utf-16be').byteslice(0, char * 2).size
+        end
       end
 
       def convert_file_uri_to_path(uri)

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -44,14 +44,14 @@ module RuboCop
         @runner.formatted_source
       end
 
-      def offenses(path, text, document_encoding = nil, prism_result: nil)
+      def offenses(path, text, position_encoding, prism_result: nil)
         diagnostic_options = {}
         diagnostic_options[:only] = config_only_options if @lint_mode || @layout_mode
 
         @runner.run(path, text, diagnostic_options, prism_result: prism_result)
         @runner.offenses.map do |offense|
           Diagnostic.new(
-            document_encoding, offense, path, @cop_registry[offense.cop_name]&.first
+            position_encoding, offense, path, @cop_registry[offense.cop_name]&.first
           ).to_lsp_diagnostic(@runner.config_for_working_directory)
         end
       end

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -51,8 +51,8 @@ module RuboCop
         @runtime.format(path, text, command: command)
       end
 
-      def offenses(path, text)
-        @runtime.offenses(path, text)
+      def offenses(path, text, position_encoding)
+        @runtime.offenses(path, text, position_encoding)
       end
 
       def configure(options)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
         result: {
           capabilities: {
             textDocumentSync: { openClose: true, change: 2 },
-            documentFormattingProvider: true
+            documentFormattingProvider: true,
+            positionEncoding: 'utf-16'
           }
         }
       )
@@ -1413,7 +1414,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
   end
 
-  describe 'did change with multibyte character' do
+  describe 'did change with multibyte character (default)' do
     let(:requests) do
       [
         {
@@ -1459,6 +1460,249 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
     it 'handles requests' do
       expect(messages.count).to eq(3)
+      expect(messages.last).to eq(
+        jsonrpc: '2.0', id: 20, result: [
+          {
+            newText: "puts '💎'\n",
+            range: {
+              end: { character: 0, line: 1 }, start: { character: 0, line: 0 }
+            }
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'did change with multibyte character (utf-32)' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 10,
+          method: 'initialize',
+          params: {
+            capabilities: {
+              general: {
+                positionEncodings: ['utf-32']
+              }
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: "puts '🍣🍺'",
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: '💎',
+                range: {
+                  start: { line: 0, character: 6 },
+                  end: { line: 0, character: 8 }
+                }
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(messages.count).to eq(4)
+      expect(messages.first).to eq(
+        jsonrpc: '2.0',
+        id: 10,
+        result: {
+          capabilities: {
+            textDocumentSync: { openClose: true, change: 2 },
+            documentFormattingProvider: true,
+            positionEncoding: 'utf-32'
+          }
+        }
+      )
+      expect(messages.last).to eq(
+        jsonrpc: '2.0', id: 20, result: [
+          {
+            newText: "puts '💎'\n",
+            range: {
+              end: { character: 0, line: 1 }, start: { character: 0, line: 0 }
+            }
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'did change with multibyte character (utf-16)' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 10,
+          method: 'initialize',
+          params: {
+            capabilities: {
+              general: {
+                positionEncodings: ['utf-16']
+              }
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: "puts '🍣🍺'",
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: '💎',
+                range: {
+                  start: { line: 0, character: 6 },
+                  end: { line: 0, character: 10 }
+                }
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(messages.count).to eq(4)
+      expect(messages.first).to eq(
+        jsonrpc: '2.0',
+        id: 10,
+        result: {
+          capabilities: {
+            textDocumentSync: { openClose: true, change: 2 },
+            documentFormattingProvider: true,
+            positionEncoding: 'utf-16'
+          }
+        }
+      )
+      expect(messages.last).to eq(
+        jsonrpc: '2.0', id: 20, result: [
+          {
+            newText: "puts '💎'\n",
+            range: {
+              end: { character: 0, line: 1 }, start: { character: 0, line: 0 }
+            }
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'did change with multibyte character (utf-8)' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          id: 10,
+          method: 'initialize',
+          params: {
+            capabilities: {
+              general: {
+                positionEncodings: ['utf-8']
+              }
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: "puts '🍣🍺'",
+              uri: 'file:///path/to/file.rb',
+              version: 0
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          method: 'textDocument/didChange',
+          params: {
+            contentChanges: [
+              {
+                text: '💎',
+                range: {
+                  start: { line: 0, character: 6 },
+                  end: { line: 0, character: 14 }
+                }
+              }
+            ],
+            textDocument: {
+              uri: 'file:///path/to/file.rb',
+              version: 10
+            }
+          }
+        }, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'textDocument/formatting',
+          params: {
+            options: { insertSpaces: true, tabSize: 2 },
+            textDocument: { uri: 'file:///path/to/file.rb' }
+          }
+        }
+      ]
+    end
+
+    it 'handles requests' do
+      expect(messages.count).to eq(4)
+      expect(messages.first).to eq(
+        jsonrpc: '2.0',
+        id: 10,
+        result: {
+          capabilities: {
+            textDocumentSync: { openClose: true, change: 2 },
+            documentFormattingProvider: true,
+            positionEncoding: 'utf-8'
+          }
+        }
+      )
       expect(messages.last).to eq(
         jsonrpc: '2.0', id: 20, result: [
           {


### PR DESCRIPTION
Add support for positionEncoding 'utf-8' and 'utf-32'

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
