### PR TITLE
[Fix #14493] Make `Naming/PredicateMethod` allow the `initialize` method

### DIFF
--- a/changelog/change_make_naming_predicate_method_allow_initialize_method.md
+++ b/changelog/change_make_naming_predicate_method_allow_initialize_method.md
@@ -1,0 +1,1 @@
+* [#14493](https://github.com/rubocop/rubocop/issues/14493): Make `Naming/PredicateMethod` allow the `initialize` method. ([@koic][])

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -14,7 +14,7 @@ module RuboCop
       # method calls are assumed to return boolean values. The cop does not make an assessment
       # if the return type is unknown (non-predicate method calls, variables, etc.).
       #
-      # NOTE: Operator methods (`def ==`, etc.) are ignored.
+      # NOTE: The `initialize` method and operator methods (`def ==`, etc.) are ignored.
       #
       # By default, the cop runs in `conservative` mode, which allows a method to be named
       # with a question mark as long as at least one return value is boolean. In `aggressive`
@@ -149,7 +149,8 @@ module RuboCop
         private
 
         def allowed?(node)
-          allowed_method?(node.method_name) ||
+          node.method?(:initialize) ||
+            allowed_method?(node.method_name) ||
             matches_allowed_pattern?(node.method_name) ||
             allowed_bang_method?(node) ||
             node.operator_method? ||

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -501,6 +501,16 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       it_behaves_like 'non-predicate', '[1, 2]'
     end
 
+    context '`initialize` method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def initialize
+            foo?
+          end
+        RUBY
+      end
+    end
+
     context 'operator methods' do
       it 'does not register an offense if it would otherwise be treated as a predicate' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR makes `Naming/PredicateMethod` allow the `initialize` method.

Fixes #14493.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
