### PR TITLE
[Fix #14499] Fix wrong autocorrect for `Style/StringConcatenation` with escaped quotes and interpolation

### DIFF
--- a/changelog/fix_string_concat_escaped.md
+++ b/changelog/fix_string_concat_escaped.md
@@ -1,0 +1,1 @@
+* [#14499](https://github.com/rubocop/rubocop/issues/14499): Fix wrong autocorrect for `Style/StringConcatenation` when a double-quoted string contains escaped quotes and interpolation. ([@earlopain][])

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -42,7 +42,29 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      "\#{(user.vip? ? "\#{greeting}, " : '')}\#{user.name} <\#{user.email}>"
+      "\#{user.vip? ? "\#{greeting}, " : ''}\#{user.name} <\#{user.email}>"
+    RUBY
+  end
+
+  it 'correctly handles nested concatenatable parts and escaped double-quotes' do
+    expect_offense(<<~'RUBY')
+      "foo" + "\"#{bar}\"" + 'baz'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "foo\"#{bar}\"baz"
+    RUBY
+  end
+
+  it 'correctly handles nested concatenatable parts and escaped single-quotes' do
+    expect_offense(<<~'RUBY')
+      "foo" + "\'#{bar}\'" + 'baz'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "foo'#{bar}'baz"
     RUBY
   end
 


### PR DESCRIPTION
Fixes #14499

The dstr parts also need to have their content adjusted since they may contains strings.

This slightly changes one autocorrect expectation, but the parens inside of the interpolation
are redundant so there is no problem removing them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
