### PR TITLE
Fix the built-in Ruby LSP add-on not restarting when `.rubocop_todo.yml` changes

### DIFF
--- a/changelog/fix_lsp_addon_todo_changes.md
+++ b/changelog/fix_lsp_addon_todo_changes.md
@@ -1,0 +1,1 @@
+* [#14506](https://github.com/rubocop/rubocop/pull/14506): Fix the built-in Ruby LSP add-on not restarting when `.rubocop_todo.yml` changes. ([@earlopain][])


### PR DESCRIPTION
The glob already contained it but it was not acted upon

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
