### PR TITLE
Fix the built-in Ruby LSP add-on not restarting when config files change

### DIFF
--- a/changelog/fix_lsp_addon_config_changes.md
+++ b/changelog/fix_lsp_addon_config_changes.md
@@ -1,0 +1,1 @@
+* [#14507](https://github.com/rubocop/rubocop/pull/14507): Fix the built-in Ruby LSP add-on not restarting when config files (`.rubocop.yml`, `.rubocop_todo.yml`) change. ([@earlopain][])

--- a/changelog/fix_lsp_addon_todo_changes.md
+++ b/changelog/fix_lsp_addon_todo_changes.md
@@ -1,1 +1,0 @@
-* [#14506](https://github.com/rubocop/rubocop/pull/14506): Fix the built-in Ruby LSP add-on not restarting when `.rubocop_todo.yml` changes. ([@earlopain][])

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -10,7 +10,8 @@ module RubyLsp
     class Addon < RubyLsp::Addon
       RESTART_WATCHERS = %w[.rubocop.yml .rubocop_todo.yml].freeze
 
-      def initializer
+      def initialize
+        super
         @runtime_adapter = nil
       end
 
@@ -65,7 +66,7 @@ module RubyLsp
 
       def workspace_did_change_watched_files(changes)
         if (changed_config_file = changed_config_file(changes))
-          @runtime_adapter = RuntimeAdapter.new
+          @runtime_adapter.reload_config
 
           ::RuboCop::LSP::Logger.log(<<~MESSAGE, prefix: '[RuboCop]')
             Re-initialized RuboCop LSP addon #{::RuboCop::Version::STRING} due to #{changed_config_file} change.

--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -10,6 +10,10 @@ module RubyLsp
       include RubyLsp::Requests::Support::Formatter
 
       def initialize
+        reload_config
+      end
+
+      def reload_config
         config_store = ::RuboCop::ConfigStore.new
 
         @runtime = ::RuboCop::LSP::Runtime.new(config_store)


### PR DESCRIPTION
I did not actually verify https://github.com/rubocop/rubocop/pull/14506 by making changes to a todo.

Since the adapter is given over to ruby-lsp, simply overwriting the instance variable doesn't do anything.

I've adapted tests to check for the presence of the reload log message, and added one that actually goes through and checks config changes in detail.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
