### PR TITLE
Gracefully handle invalid configs during LSP addon startup

### DIFF
--- a/changelog/fix_lsp_addon_invalid_config_on_startup.md
+++ b/changelog/fix_lsp_addon_invalid_config_on_startup.md
@@ -1,0 +1,1 @@
+* [#14508](https://github.com/rubocop/rubocop/pull/14508): Fix the built-in Ruby LSP add-on getting in an irrecoverable state when the config is invalid on startup. ([@earlopain][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -75,7 +75,9 @@ module RuboCop
 
         puts "configuration from #{absolute_path}" if debug?
 
-        raise(TypeError, "Malformed configuration in #{absolute_path}") unless hash.is_a?(Hash)
+        unless hash.is_a?(Hash)
+          raise(ValidationError, "Malformed configuration in #{absolute_path}")
+        end
 
         hash
       end

--- a/lib/rubocop/lsp/stdin_runner.rb
+++ b/lib/rubocop/lsp/stdin_runner.rb
@@ -40,7 +40,6 @@ module RuboCop
         super(@options, config_store)
       end
 
-      # rubocop:disable Metrics/MethodLength
       def run(path, contents, options, prism_result: nil)
         @options = options.merge(DEFAULT_RUBOCOP_OPTIONS)
         @options[:stdin] = contents
@@ -54,22 +53,7 @@ module RuboCop
         super([path])
 
         raise Interrupt if aborting?
-      rescue RuboCop::Runner::InfiniteCorrectionLoop => e
-        if defined?(::RubyLsp::Requests::Formatting::Error)
-          raise ::RubyLsp::Requests::Formatting::Error, e.message
-        end
-
-        raise e
-      rescue RuboCop::ValidationError => e
-        raise ConfigurationError, e.message
-      rescue StandardError => e
-        if defined?(::RubyLsp::Requests::Formatting::Error)
-          raise ::RubyLsp::Requests::Support::InternalRuboCopError, e
-        end
-
-        raise e
       end
-      # rubocop:enable Metrics/MethodLength
 
       def formatted_source
         @options[:stdin]

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -24,7 +24,7 @@ module RubyLsp
           "Activating RuboCop LSP addon #{::RuboCop::Version::STRING}.", prefix: '[RuboCop]'
         )
 
-        @runtime_adapter = RuntimeAdapter.new
+        @runtime_adapter = RuntimeAdapter.new(message_queue)
         global_state.register_formatter('rubocop', @runtime_adapter)
         register_additional_file_watchers(global_state, message_queue)
 

--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -9,32 +9,42 @@ module RubyLsp
     class RuntimeAdapter
       include RubyLsp::Requests::Support::Formatter
 
-      def initialize
+      def initialize(message_queue)
+        @message_queue = message_queue
         reload_config
       end
 
       def reload_config
+        @runtime = nil
         config_store = ::RuboCop::ConfigStore.new
-
         @runtime = ::RuboCop::LSP::Runtime.new(config_store)
+      rescue ::RuboCop::Error => e
+        @message_queue << Notification.window_show_message(
+          "RuboCop configuration error: #{e.message}. Formatting will not be available.",
+          type: Constant::MessageType::ERROR
+        )
       end
 
       def run_diagnostic(uri, document)
-        @runtime.offenses(
-          uri_to_path(uri),
-          document.source,
-          document.encoding,
-          prism_result: prism_result(document)
-        )
+        with_error_handling do
+          @runtime.offenses(
+            uri_to_path(uri),
+            document.source,
+            document.encoding,
+            prism_result: prism_result(document)
+          )
+        end
       end
 
       def run_formatting(uri, document)
-        @runtime.format(
-          uri_to_path(uri),
-          document.source,
-          command: 'rubocop.formatAutocorrects',
-          prism_result: prism_result(document)
-        )
+        with_error_handling do
+          @runtime.format(
+            uri_to_path(uri),
+            document.source,
+            command: 'rubocop.formatAutocorrects',
+            prism_result: prism_result(document)
+          )
+        end
       end
 
       def run_range_formatting(_uri, _partial_source, _base_indentation)
@@ -46,6 +56,25 @@ module RubyLsp
       end
 
       private
+
+      def with_error_handling
+        return unless @runtime
+
+        yield
+      rescue StandardError => e
+        ::RuboCop::LSP::Logger.log(e.full_message, prefix: '[RuboCop]')
+
+        message = if e.is_a?(::RuboCop::ErrorWithAnalyzedFileLocation)
+                    "for the #{e.cop.name} cop"
+                  else
+                    "- #{e.message}"
+                  end
+        raise Requests::Formatting::Error, <<~MSG
+          An internal error occurred #{message}.
+          Updating to a newer version of RuboCop may solve this.
+          For more details, run RuboCop on the command line.
+        MSG
+      end
 
       # duplicated from: lib/standard/lsp/routes.rb
       # modified to incorporate Ruby LSP's to_standardized_path method

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1788,10 +1788,10 @@ RSpec.describe RuboCop::ConfigLoader do
       expect(configuration['Style/Encoding']).to eq('Exclude' => [abs('dir/c.rb')])
     end
 
-    it 'fails with a TypeError when loading a malformed configuration file' do
+    it 'fails with a ValidationError when loading a malformed configuration file' do
       create_file(configuration_path, 'This string is not a YAML hash')
       expect { load_file }.to raise_error(
-        TypeError, /^Malformed configuration in .*\.rubocop\.yml$/
+        RuboCop::ValidationError, /^Malformed configuration in .*\.rubocop\.yml$/
       )
     end
 

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -134,6 +134,93 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
         end
       end
     end
+
+    context 'when an error occurs' do
+      context 'when `.rubocop.yml` is invalid' do
+        it 'handles it gracefully' do
+          create_file('.rubocop.yml', 'Not valid YAML!')
+          server.global_state.index.index_all(uris: [])
+
+          init_response = server.pop_response
+          expect(init_response).to be_an_instance_of(RubyLsp::Notification)
+          expect(init_response.params.attributes[:message]).to match(
+            /RuboCop configuration error: Malformed configuration/
+          )
+
+          process_message(
+            'textDocument/formatting',
+            textDocument: { uri: uri },
+            position: { line: 0, character: 0 }
+          )
+          formatting_response = server.pop_response
+
+          expect(formatting_response).to be_an_instance_of(RubyLsp::Result)
+          expect(formatting_response.response).to be_nil
+
+          create_empty_file('.rubocop.yml')
+          expect do
+            process_message(
+              'workspace/didChangeWatchedFiles',
+              changes: [{
+                uri: path_to_uri('.rubocop.yml').to_s,
+                type: RubyLsp::Constant::FileChangeType::CHANGED
+              }]
+            )
+          end.to output.to_stderr
+
+          process_message(
+            'textDocument/formatting',
+            textDocument: { uri: uri },
+            position: { line: 0, character: 0 }
+          )
+          formatting_response = server.pop_response
+
+          expect(formatting_response).to be_an_instance_of(RubyLsp::Result)
+          expect(formatting_response.response).not_to be_nil
+        end
+      end
+
+      context 'runtime error' do
+        before do
+          allow_any_instance_of(RuboCop::Cop::Style::StringLiterals) # rubocop:disable RSpec/AnyInstance
+            .to receive(:on_str)
+            .and_raise(RuntimeError, 'oops')
+        end
+
+        let(:source) { '""' }
+
+        it 'handles infinite loop errors' do
+          expect { result }.to output.to_stderr
+          expect(result).to be_an_instance_of(RubyLsp::Notification)
+          expect(result.params.attributes[:message]).to match(<<~MSG)
+            Formatting error: An internal error occurred for the Style/StringLiterals cop.
+          MSG
+        end
+      end
+
+      context 'infinite loop error' do
+        before do
+          allow(RuboCop::Cop::Registry).to receive(:all).and_return([cop])
+        end
+
+        let(:cop) { RuboCop::Cop::Test::InfiniteLoopDuringAutocorrectWithChangeCop }
+
+        let(:source) do
+          <<~RUBY
+            class Test
+            end
+          RUBY
+        end
+
+        it 'handles infinite loop errors' do
+          expect { result }.to output.to_stderr
+          expect(result).to be_an_instance_of(RubyLsp::Notification)
+          expect(result.params.attributes[:message]).to match(<<~MSG)
+            Formatting error: An internal error occurred - Infinite loop detected in #{uri} and caused by #{cop.badge}.
+          MSG
+        end
+      end
+    end
   end
 
   describe 'workspace/didChangeWatchedFiles' do


### PR DESCRIPTION
If the config is invalid for any reason during startup, the addon will be left in a state which it cannot recover from.
This fixes this by instead showing a notification to the user. After the config is fixed, it will be properly reloaded. While it is invalid, no diagnostics will be shown.

I have also:
* Removed reliance on `RubyLsp::Requests::Support::InternalRuboCopError`
* Moved lsp specific error handling into the addon itself
* Logged the full error

The main goal was to gracefully handle editing the config, where it may be invalid shortly, however due to a ruby-lsp bug no feedback is given in that case yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
