### PR TITLE
Remove unnecessary include in the lsp runtime adapter

### DIFF
--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -7,8 +7,6 @@ module RubyLsp
     # Provides an adapter to bridge RuboCop's built-in LSP runtime with Ruby LSP's add-on.
     # @api private
     class RuntimeAdapter
-      include RubyLsp::Requests::Support::Formatter
-
       def initialize
         reload_config
       end


### PR DESCRIPTION
This is meant to be used with sorbet, which we don't do. See this code snippet: https://github.com/Shopify/ruby-lsp/blob/83e7cb0b502a9cd5a7e49a6bfb490f624ced2bd8/jekyll/add-ons.markdown#registering-formatters

> If using Sorbet to develop the add-on, then include this interface to make sure the class is properly implemented

