### PR TITLE
Set a version for the ruby lsp addon

### DIFF
--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -19,6 +19,10 @@ module RubyLsp
         'RuboCop'
       end
 
+      def version
+        ::RuboCop::Version::STRING
+      end
+
       def activate(global_state, message_queue)
         ::RuboCop::LSP::Logger.log(
           "Activating RuboCop LSP addon #{::RuboCop::Version::STRING}.", prefix: '[RuboCop]'

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -14,10 +14,6 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
 
   include_context 'mock console output'
 
-  let(:addon) do
-    RubyLsp::RuboCop::Addon.new
-  end
-
   let(:path) { 'example.rb' }
   let(:uri) { path_to_uri(path) }
   let(:source) do
@@ -35,9 +31,17 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
     RubyLsp::Addon.addons.clear
   end
 
-  describe 'Add-on name' do
-    it 'is RuboCop' do
+  context 'Add-on metadata' do
+    let(:addon) do
+      RubyLsp::RuboCop::Addon.new
+    end
+
+    it 'has a name' do
       expect(addon.name).to eq 'RuboCop'
+    end
+
+    it 'has a version' do
+      expect(addon.version).to match(/\A\d+\.\d+\.\d+\z/)
     end
   end
 


### PR DESCRIPTION
Since a while ago, addons are expected to respond_to `version`: https://github.com/Shopify/ruby-lsp/commit/0a710db07ad6c518a9b39204f2629457e64c2bad

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
