### PR TITLE
[Fix #14497] Fix a false positive for `Lint/ShadowedArgument` when assigning inside a `rescue` block

### DIFF
--- a/changelog/fix_shadowing_in_rescue.md
+++ b/changelog/fix_shadowing_in_rescue.md
@@ -1,0 +1,1 @@
+* [#14497](https://github.com/rubocop/rubocop/pull/14497): Fix a false positive for `Lint/ShadowedArgument` when assigning inside a `rescue` block. ([@earlopain][])

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -125,13 +125,13 @@ module RuboCop
             next false if assignment_node.shorthand_asgn?
             next false unless assignment_node.parent
 
-            node_within_block_or_conditional =
-              node_within_block_or_conditional?(assignment_node.parent, argument.scope.node)
+            conditional_assignment =
+              conditional_assignment?(assignment_node.parent, argument.scope.node)
 
             unless uses_var?(assignment_node, argument.name)
               # It's impossible to decide whether a branch or block is executed,
               # so the precise reassignment location is undecidable.
-              next false if node_within_block_or_conditional
+              next false if conditional_assignment
 
               yield(assignment.node, location_known)
               break
@@ -147,13 +147,13 @@ module RuboCop
           node.source_range.begin_pos
         end
 
-        # Check whether the given node is nested into block or conditional.
+        # Check whether the given node is always executed or not
         #
-        def node_within_block_or_conditional?(node, stop_search_node)
+        def conditional_assignment?(node, stop_search_node)
           return false if node == stop_search_node
 
-          node.conditional? || node.block_type? ||
-            node_within_block_or_conditional?(node.parent, stop_search_node)
+          node.conditional? || node.type?(:block, :rescue) ||
+            conditional_assignment?(node.parent, stop_search_node)
         end
 
         # Get argument references without assignments' references

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -395,6 +395,38 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
           end
         end
       end
+
+      context 'and shadowed within `rescue`' do
+        context 'and assigned before the `rescue`' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              def do_something(foo)
+                foo = bar
+                ^^^^^^^^^ Argument `foo` was shadowed by a local variable before it was used.
+                begin
+                rescue
+                  foo = baz
+                end
+                puts foo
+              end
+            RUBY
+          end
+        end
+
+        context 'and the argument was not shadowed outside the `rescue`' do
+          it 'registers no offense' do
+            expect_no_offenses(<<~RUBY)
+                def do_something(foo)
+                begin
+                rescue
+                  foo = bar
+                end
+                puts foo
+              end
+            RUBY
+          end
+        end
+      end
     end
 
     context 'when multiple arguments are shadowed' do


### PR DESCRIPTION
Fix #14497

This is a type of conditional assignment, since the rescue doesn't have to be taken.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
