### PR TITLE
Fix the built-in Ruby LSP add-on not respecting `.rubocop` config file

### DIFF
--- a/changelog/fix_lsp_addon_dot_rubocop.md
+++ b/changelog/fix_lsp_addon_dot_rubocop.md
@@ -1,0 +1,1 @@
+* [#14514](https://github.com/rubocop/rubocop/pull/14514): Fix the built-in Ruby LSP add-on not respecting `.rubocop` config file. ([@earlopain][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -164,8 +164,7 @@ module RuboCop
       set_options_to_pending_cops_reporter
       handle_editor_mode
 
-      @config_store.options_config = @options[:config] if @options[:config]
-      @config_store.force_default_config! if @options[:force_default_config]
+      @config_store.apply_options!(@options)
 
       handle_exiting_options
 

--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -83,7 +83,7 @@ module RuboCop
           execute_runner
           @options.delete(:only)
           @config_store = ConfigStore.new
-          @config_store.options_config = @options[:config] if @options[:config]
+          @config_store.apply_options!(@options)
           # Save the todo configuration of the LineLength cop.
           File.read(AUTO_GENERATED_FILE).lines.drop_while { |line| line.start_with?('#') }.join
         end
@@ -99,7 +99,7 @@ module RuboCop
 
         def reset_config_and_auto_gen_file
           @config_store = ConfigStore.new
-          @config_store.options_config = @options[:config] if @options[:config]
+          @config_store.apply_options!(@options)
           File.open(AUTO_GENERATED_FILE, 'w') {} # create or truncate if exists
           add_inheritance_from_auto_generated_file(@options[:config])
         end

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -25,6 +25,11 @@ module RuboCop
       @validated = true
     end
 
+    def apply_options!(options)
+      self.options_config = options[:config] if options[:config]
+      force_default_config! if options[:force_default_config]
+    end
+
     def options_config=(options_config)
       loaded_config = ConfigLoader.load_file(options_config)
       @options_config = ConfigLoader.merge_with_default(loaded_config, options_config)

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -8,7 +8,7 @@ module RubyLsp
   module RuboCop
     # A Ruby LSP add-on for RuboCop.
     class Addon < RubyLsp::Addon
-      RESTART_WATCHERS = %w[.rubocop.yml .rubocop_todo.yml].freeze
+      RESTART_WATCHERS = %w[.rubocop.yml .rubocop_todo.yml .rubocop].freeze
 
       def initialize
         super

--- a/lib/ruby_lsp/rubocop/runtime_adapter.rb
+++ b/lib/ruby_lsp/rubocop/runtime_adapter.rb
@@ -14,7 +14,10 @@ module RubyLsp
 
       def reload_config
         @runtime = nil
+        options, _paths = ::RuboCop::Options.new.parse([])
+
         config_store = ::RuboCop::ConfigStore.new
+        config_store.apply_options!(options)
         @runtime = ::RuboCop::LSP::Runtime.new(config_store)
       rescue ::RuboCop::Error => e
         @message_queue << Notification.window_show_message(

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -84,6 +84,19 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
         Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       MESSAGE
     end
+
+    context 'when `.rubocop` points to a different config file' do
+      before do
+        create_file('.rubocop', '-c custom.yml')
+        create_file('custom.yml', <<~YML)
+          <%= warn "Hello from 'custom.yml'" %>
+        YML
+      end
+
+      it 'uses the config file' do
+        expect { result }.to output(/Hello from 'custom\.yml'/).to_stderr
+      end
+    end
   end
 
   describe 'textDocument/formatting' do
@@ -281,7 +294,7 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
       end
     end
 
-    %w[.rubocop.yml .rubocop_todo.yml].each do |path|
+    %w[.rubocop.yml .rubocop_todo.yml .rubocop].each do |path|
       context "when `#{path}` changes" do
         it 'logs a message that the add-on got re-initialized' do
           expect do


### PR DESCRIPTION
If the user specifies `-c foo.yml`, it should be used.

This consolidates option/cli handling to `apply_options!`. That way `force_default_config` is consistenly used as well.

That now also happens when generating a todo. It seems correct for consistency, but I didn't add a test for it and am ok with dropping that change.

Apart from this, I'm only aware of one extra difference between the ruby-lsp addons but it requires a change in ruby-lsp itself: https://github.com/Shopify/ruby-lsp/issues/3736

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
