### PR TITLE
[Fix #14516] Add `AllowImplicitArrayBrackets` to `Layout/FirstArrayElementLineBreak`

### DIFF
--- a/changelog/new_add_allow_implicit_array_brackets_to_layout_first_array_element_line_break.md
+++ b/changelog/new_add_allow_implicit_array_brackets_to_layout_first_array_element_line_break.md
@@ -1,0 +1,1 @@
+* [#14516](https://github.com/rubocop/rubocop/issues/14516): Add `AllowImplicitArrayLiterals` to `Layout/FirstArrayElementLineBreak`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -835,6 +835,7 @@ Layout/FirstArrayElementLineBreak:
                  multi-line array.
   Enabled: false
   VersionAdded: '0.49'
+  AllowImplicitArrayLiterals: false
   AllowMultilineFinalElement: false
 
 Layout/FirstHashElementIndentation:

--- a/lib/rubocop/cop/layout/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/layout/first_array_element_line_break.rb
@@ -20,6 +20,27 @@ module RuboCop
       #   # good
       #   [:a, :b]
       #
+      # @example AllowImplicitArrayLiterals: false (default)
+      #
+      #   # bad
+      #   a = b,
+      #       c
+      #
+      #   # good
+      #   a =
+      #     b,
+      #     c
+      #
+      # @example AllowImplicitArrayLiterals: true
+      #
+      #   # good
+      #   a = b,
+      #       c
+      #
+      #   a =
+      #     b,
+      #     c
+      #
       # @example AllowMultilineFinalElement: false (default)
       #
       #   # bad
@@ -48,6 +69,7 @@ module RuboCop
 
         def on_array(node)
           return if !node.loc.begin && !assignment_on_same_line?(node)
+          return if allow_implicit_array_brackets? && !node.bracketed?
 
           check_children_line_break(node, node.children, ignore_last: ignore_last_element?)
         end
@@ -57,6 +79,10 @@ module RuboCop
         def assignment_on_same_line?(node)
           source = node.source_range.source_line[0...node.loc.column]
           /\s*=\s*$/.match?(source)
+        end
+
+        def allow_implicit_array_brackets?
+          !!cop_config['AllowImplicitArrayLiterals']
         end
 
         def ignore_last_element?

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -51,49 +51,86 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementLineBreak, :config do
     end
   end
 
-  context 'masgn implicit arrays' do
-    it 'registers and corrects the offense' do
-      expect_offense(<<~RUBY)
-        a, b,
-        c = 1,
-            ^ Add a line break before the first element of a multi-line array.
-        2, 3
-      RUBY
+  context 'when `AllowImplicitArrayLiterals` is false' do
+    let(:cop_config) { { 'AllowImplicitArrayLiterals' => false } }
 
-      expect_correction(<<~RUBY)
+    context 'masgn implicit arrays' do
+      it 'registers and corrects the offense' do
+        expect_offense(<<~RUBY)
+          a, b,
+          c = 1,
+              ^ Add a line break before the first element of a multi-line array.
+          2, 3
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a, b,
+          c =#{trailing_whitespace}
+          1,
+          2, 3
+        RUBY
+      end
+    end
+
+    context 'send implicit arrays' do
+      it 'registers and corrects the offense' do
+        expect_offense(<<~RUBY)
+          a
+          .c = 1,
+               ^ Add a line break before the first element of a multi-line array.
+          2, 3
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a
+          .c =#{trailing_whitespace}
+          1,
+          2, 3
+        RUBY
+      end
+    end
+
+    it 'ignores properly formatted implicit arrays' do
+      expect_no_offenses(<<~RUBY)
         a, b,
-        c =#{trailing_whitespace}
-        1,
-        2, 3
+        c =
+        1, 2,
+        3
       RUBY
     end
   end
 
-  context 'send implicit arrays' do
-    it 'registers and corrects the offense' do
-      expect_offense(<<~RUBY)
-        a
-        .c = 1,
-             ^ Add a line break before the first element of a multi-line array.
-        2, 3
-      RUBY
+  context 'when `AllowImplicitArrayLiterals` is true' do
+    let(:cop_config) { { 'AllowImplicitArrayLiterals' => true } }
 
-      expect_correction(<<~RUBY)
-        a
-        .c =#{trailing_whitespace}
-        1,
-        2, 3
+    context 'masgn implicit arrays' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          a, b,
+          c = 1,
+          2, 3
+        RUBY
+      end
+    end
+
+    context 'send implicit arrays' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          a
+          .c = 1,
+          2, 3
+        RUBY
+      end
+    end
+
+    it 'ignores properly formatted implicit arrays' do
+      expect_no_offenses(<<~RUBY)
+        a, b,
+        c =
+        1, 2,
+        3
       RUBY
     end
-  end
-
-  it 'ignores properly formatted implicit arrays' do
-    expect_no_offenses(<<~RUBY)
-      a, b,
-      c =
-      1, 2,
-      3
-    RUBY
   end
 
   it 'ignores elements listed on a single line' do


### PR DESCRIPTION
This PR adds `AllowImplicitArrayBrackets` to `Layout/FirstArrayElementLineBreak`. To prioritize compatibility with existing implicit array brackets behavior, the default is `AllowImplicitArrayBrackets: false`.

Note that an assignment such as `var = key: value`, where hash braces are omitted, is invalid syntax and results in an error. Therefore, adding an equivalent option to `Layout/FirstHashyElementLineBreak` is unnecessary.

Fixes #14516.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
