### PR TITLE
[Fix #14522] Fix false negatives for `Layout/MultilineOperationIndentation`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_multiline_operation_indentation.md
+++ b/changelog/fix_false_negatives_for_layout_multiline_operation_indentation.md
@@ -1,0 +1,1 @@
+* [#14522](https://github.com/rubocop/rubocop/issues/14522): Fix false negatives for `Layout/MultilineOperationIndentation` when using indented code on LHS of equality operator in modifier method definition. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -102,10 +102,12 @@ module RuboCop
             return true if begins_its_line?(assignment_rhs.source_range)
           end
 
-          given_style == :aligned &&
-            (kw_node_with_special_indentation(node) ||
-             assignment_node ||
-             argument_in_method_call(node, :with_or_without_parentheses))
+          return false unless given_style == :aligned
+          return true if kw_node_with_special_indentation(node) || assignment_node
+
+          node = argument_in_method_call(node, :with_or_without_parentheses)
+
+          node.respond_to?(:def_modifier?) && !node.def_modifier?
         end
 
         def message(node, lhs, rhs)

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -271,6 +271,40 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
       RUBY
     end
 
+    it 'registers indented code on LHS of equality operator in the method definition' do
+      expect_offense(<<~RUBY)
+        def config_to_allow_offenses
+          a +
+          b == c
+          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def config_to_allow_offenses
+          a +
+            b == c
+        end
+      RUBY
+    end
+
+    it 'registers indented code on LHS of equality operator in the modifier method definition' do
+      expect_offense(<<~RUBY)
+        private def config_to_allow_offenses
+          a +
+          b == c
+          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        private def config_to_allow_offenses
+          a +
+            b == c
+        end
+      RUBY
+    end
+
     it 'accepts indented code on LHS of equality operator' do
       expect_no_offenses(<<~RUBY)
         def config_to_allow_offenses


### PR DESCRIPTION
This PR fixes false negatives for `Layout/MultilineOperationIndentation` when using indented code on LHS of equality operator in modifier method definition.

Fixes #14522.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
