### PR TITLE
Fix false positives for `Style/RedundantRegexpEscape`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_regexp_escape.md
+++ b/changelog/fix_false_positives_for_style_redundant_regexp_escape.md
@@ -1,0 +1,1 @@
+* [#14525](https://github.com/rubocop/rubocop/pull/14525): Fix false positives for `Style/RedundantRegexpEscape` when an escaped variable sigil follows `#` (e.g., `/#\@foo/`, `/#\@@bar/`, `/#\$baz/`). ([@koic][])

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -257,6 +257,30 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape, :config do
       end
     end
 
+    context 'with an escaped instance variable after `#`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          foo = /[#\@not_ivar]/
+        RUBY
+      end
+    end
+
+    context 'with an escaped class variable after `#`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          foo = /[#\@@not_cvar]/
+        RUBY
+      end
+    end
+
+    context 'with an escaped global variable after `#`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          foo = /[#\$not_gvar]/
+        RUBY
+      end
+    end
+
     context 'with an escape inside an interpolated string' do
       it 'does not register an offense' do
         expect_no_offenses('foo = /#{"\""}/')


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantRegexpEscape` when an escaped variable sigil follows `#` (e.g., `/#\@foo/`, `/#\@@bar/`, `/#\$baz/`).

These escapes are required to prevent interpolation (`#@ivar`, `#@@cvar`, `#$gvar`) and should not be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
