### PR TITLE
Fix Ruby 2.7 CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'stackprof', platform: :mri
 gem 'test-queue'
 gem 'yard', '~> 0.9'
 
+# FIXME: Remove when the next prism version is released.
+gem 'prism', '< 1.5.0' if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby'
+
 group :test do
   gem 'webmock', require: false
 end


### PR DESCRIPTION
Prism 1.5.0 polyfills `warn` in an incompatible way: https://github.com/ruby/prism/pull/3647

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
