### PR TITLE
Fix false negatives for `Style/NumberedParameters` and `ItBlockParameter`

### DIFF
--- a/changelog/fix_false_negative_for_numblock_and_it_block_parameters.md
+++ b/changelog/fix_false_negative_for_numblock_and_it_block_parameters.md
@@ -1,0 +1,1 @@
+* [#14527](https://github.com/rubocop/rubocop/pull/14527): Fix false negatives for `Style/NumberedParameters` and `Style/ItBlockParameter` when using multiline method chain with `EnforcedStyle: allow_single_line`. ([@koic][])

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -102,7 +102,7 @@ module RuboCop
       def reference_urls
         urls = cop_config
                .values_at('References', 'Reference') # Support legacy Reference key
-               .flat_map { Array(_1) }
+               .flat_map { |url| Array(url) }
                .reject(&:empty?)
 
         urls unless urls.empty?

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -94,7 +94,7 @@ module RuboCop
         def on_itblock(node)
           case style
           when :allow_single_line
-            return if node.single_line?
+            return if same_line?(node.source_range.begin, node.source_range.end)
 
             add_offense(node, message: MSG_AVOID_IT_PARAMETER_MULTILINE)
           when :disallow

--- a/lib/rubocop/cop/style/numbered_parameters.rb
+++ b/lib/rubocop/cop/style/numbered_parameters.rb
@@ -36,7 +36,7 @@ module RuboCop
         def on_numblock(node)
           if style == :disallow
             add_offense(node, message: MSG_DISALLOW)
-          elsif node.multiline?
+          elsif !same_line?(node.source_range.begin, node.source_range.end)
             add_offense(node, message: MSG_MULTI_LINE)
           end
         end

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         expect_no_corrections
       end
 
+      it 'registers an offense when using `it` block parameter with multi-line method chain' do
+        expect_offense(<<~RUBY)
+          collection.each
+          ^^^^^^^^^^^^^^^ Avoid using `it` block parameter for multi-line blocks.
+                    .foo { puts it }
+        RUBY
+      end
+
       it 'registers an offense when using a single numbered parameters' do
         expect_offense(<<~RUBY)
           block { do_something(_1) }

--- a/spec/rubocop/cop/style/numbered_parameters_spec.rb
+++ b/spec/rubocop/cop/style/numbered_parameters_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe RuboCop::Cop::Style::NumberedParameters, :config do
         RUBY
       end
 
+      it 'registers an offense when using numbered parameters with multi-line method chain' do
+        expect_offense(<<~RUBY)
+          collection.each
+          ^^^^^^^^^^^^^^^ Avoid using numbered parameters for multi-line blocks.
+                    .foo { puts _1 }
+        RUBY
+      end
+
       it 'does not register an offense when using numbered parameters with single-line blocks' do
         expect_no_offenses(<<~RUBY)
           collection.each { puts _1 }


### PR DESCRIPTION
This PR fixes false negatives for `Style/NumberedParameters` and `ItBlockParameter` when using multiline method chain with `EnforcedStyle: allow_single_line`.

`EnforcedStyle: allow_single_line` allows single-line usage, and numbered block parameters across multiple lines should be detected. This was an implementation bug, and the `same_line?` method should have been used instead of the `single_line?` or `multiline?` methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
