### PR TITLE
[Fix #14528] Fix `Style/RedundantFormat` when the format string has a variable width that isn't given as a literal value

### DIFF
--- a/changelog/fix_fix_style_redundant_format_when_the_format_string_20250917121517.md
+++ b/changelog/fix_fix_style_redundant_format_when_the_format_string_20250917121517.md
@@ -1,0 +1,1 @@
+* [#14528](https://github.com/rubocop/rubocop/issues/14528): Fix `Style/RedundantFormat` when the format string has a variable width that isn't given as a literal value. ([@dvandersluis][])

--- a/lib/rubocop/cop/utils/format_string.rb
+++ b/lib/rubocop/cop/utils/format_string.rb
@@ -71,6 +71,16 @@ module RuboCop
             name && @source.include?('{')
           end
 
+          def variable_width?
+            !!width&.start_with?('*')
+          end
+
+          def variable_width_argument_number
+            return unless variable_width?
+
+            width == '*' ? 1 : width.match(DIGIT_DOLLAR)['arg_number'].to_i
+          end
+
           # Number of arguments required for the format sequence
           def arity
             @source.scan('*').count + 1

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -249,7 +249,58 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             RUBY
           end
 
-          it 'does not register an offense when the argument is not literal' do
+          it 'registers an offense and corrects with a negative `*`' do
+            expect_offense(<<~RUBY, method: method)
+              %{method}('%-*d', 5, 14)
+              ^{method}^^^^^^^^^^^^^^^ Use `'14   '` directly instead of `%{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              '14   '
+            RUBY
+          end
+
+          it 'registers an offense and corrects with a variable width and a specified argument' do
+            expect_offense(<<~RUBY, method: method)
+              %{method}('%1$*2$s', 14, 5)
+              ^{method}^^^^^^^^^^^^^^^^^^ Use `'   14'` directly instead of `%{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              '   14'
+            RUBY
+          end
+
+          it 'registers an offense and corrects with a negative variable width and a specified argument' do
+            expect_offense(<<~RUBY, method: method)
+              %{method}('%1$-*2$s', 14, 5)
+              ^{method}^^^^^^^^^^^^^^^^^^^ Use `'14   '` directly instead of `%{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              '14   '
+            RUBY
+          end
+
+          it 'does not register an offense when the variable width argument is not numeric' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%*d', 'a', 'foo')
+            RUBY
+          end
+
+          it 'does not register an offense when the star argument is not literal' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%*s', foo, 'bar')
+            RUBY
+          end
+
+          it 'does not register an offense when the star argument is negative and not literal' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%-*s', foo, 'bar')
+            RUBY
+          end
+
+          it 'does not register an offense when the format argument is not literal' do
             expect_no_offenses(<<~RUBY)
               #{method}('%*d', 5, foo)
             RUBY


### PR DESCRIPTION
Updates `Style/RedundantFormat` to properly handle `*` as a width specifier when the width argument is not literal. Also updated to be able to handle `*` with a variable specifier (ie. `%1$*2$s` uses the 2nd argument as the width).

Fixes #14528.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
