### PR TITLE
[Fix #14529] Fix false negative in `Layout/RescueEnsureAlignment` with a block whose send node is split over multiple lines

### DIFF
--- a/changelog/fix_fix_false_negative_in_20250917143110.md
+++ b/changelog/fix_fix_false_negative_in_20250917143110.md
@@ -1,0 +1,1 @@
+* [#14529](https://github.com/rubocop/rubocop/issues/14529): Fix false negative in `Layout/RescueEnsureAlignment` with a block whose send node is split over multiple lines. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -194,6 +194,14 @@ module RuboCop
         def alignment_location(alignment_node)
           if begin_end_alignment_style == 'start_of_line'
             start_line_range(alignment_node)
+          elsif alignment_node.any_block_type?
+            # If the alignment node is a block, the `rescue`/`ensure` keyword should
+            # be aligned to the start of the block. It is possible that the block's
+            # `send_node` spans multiple lines, in which case it should align to the
+            # start of the last line.
+            send_node = alignment_node.send_node
+            range = processed_source.buffer.line_range(send_node.last_line)
+            range.adjust(begin_pos: range.source =~ /\S/)
           else
             alignment_node.source_range
           end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
-  it 'accepts aligned rescue with do-end block that line break with leading dot for method calls' do
+  it 'accepts aligned `rescue` with do-end block that line break with leading dot for method calls' do
     expect_no_offenses(<<~RUBY)
       [1, 2, 3]
         .each do |el|
@@ -470,12 +470,202 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     RUBY
   end
 
-  it 'accepts aligned rescue with do-end block that line break with trailing dot for method calls' do
+  it 'registers an offense and corrects indented `rescue` with do-end block that line break with leading dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+            rescue StandardError => _exception
+            ^^^^^^ `rescue` at 4, 6 is not aligned with `.each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+        rescue StandardError => _exception
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects unindented `rescue` with do-end block that line break with leading dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+      rescue StandardError => _exception
+      ^^^^^^ `rescue` at 4, 0 is not aligned with `.each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+        rescue StandardError => _exception
+          next
+        end
+    RUBY
+  end
+
+  it 'accepts aligned `rescue` with do-end block that line break with trailing dot for method calls' do
     expect_no_offenses(<<~RUBY)
       [1, 2, 3].
         each do |el|
           el.to_s
         rescue StandardError => _exception
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects indented `rescue` with do-end block that line break with trailing dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+            rescue StandardError => _exception
+            ^^^^^^ `rescue` at 4, 6 is not aligned with `each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+        rescue StandardError => _exception
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects unindented `rescue` with do-end block that line break with trailing dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+      rescue StandardError => _exception
+      ^^^^^^ `rescue` at 4, 0 is not aligned with `each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+        rescue StandardError => _exception
+          next
+        end
+    RUBY
+  end
+
+  it 'accepts aligned `ensure` with do-end block that line break with leading dot for method calls' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+        ensure
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects indented `ensure` with do-end block that line break with leading dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+            ensure
+            ^^^^^^ `ensure` at 4, 6 is not aligned with `.each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+        ensure
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects unindented `ensure` with do-end block that line break with leading dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+      ensure
+      ^^^^^^ `ensure` at 4, 0 is not aligned with `.each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3]
+        .each do |el|
+          el.to_s
+        ensure
+          next
+        end
+    RUBY
+  end
+
+  it 'accepts aligned `ensure` with do-end block that line break with trailing dot for method calls' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+        ensure
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects indented `ensure` with do-end block that line break with trailing dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+            ensure
+            ^^^^^^ `ensure` at 4, 6 is not aligned with `each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+        ensure
+          next
+        end
+    RUBY
+  end
+
+  it 'registers an offense and corrects unindented `ensure` with do-end block that line break with trailing dot for method calls' do
+    expect_offense(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+      ensure
+      ^^^^^^ `ensure` at 4, 0 is not aligned with `each do` at 2, 2.
+          next
+        end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1, 2, 3].
+        each do |el|
+          el.to_s
+        ensure
           next
         end
     RUBY


### PR DESCRIPTION
When `rescue` or `ensure` is inside a block where the receiver of the block is split over multiple lines, `Layout/RescueEnsureAlignment` does not register an offense properly if the alignment does not match. This follows the preexisting test for not registering an offense in the case where the keyword aligns; tests for a misalignment were not added at that time.

Fixes #14529.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
