### PR TITLE
[Fix #14535] Fix autocorrect for `Style/ExplicitBlockArgument` when there are two methods that share the same implementation

### DIFF
--- a/changelog/fix_autocorrect_explicit_block_duplicate_methods.md
+++ b/changelog/fix_autocorrect_explicit_block_duplicate_methods.md
@@ -1,0 +1,1 @@
+* [#14535](https://github.com/rubocop/rubocop/issues/14535): Fix autocorrect for `Style/ExplicitBlockArgument` when there are two methods that share the same implementation. ([@earlopain][])

--- a/lib/rubocop/cop/style/explicit_block_argument.rb
+++ b/lib/rubocop/cop/style/explicit_block_argument.rb
@@ -56,7 +56,7 @@ module RuboCop
 
         def initialize(config = nil, options = nil)
           super
-          @def_nodes = Set.new
+          @def_nodes = Set.new.compare_by_identity
         end
 
         def on_yield(node)

--- a/spec/rubocop/cop/style/explicit_block_argument_spec.rb
+++ b/spec/rubocop/cop/style/explicit_block_argument_spec.rb
@@ -266,4 +266,47 @@ RSpec.describe RuboCop::Cop::Style::ExplicitBlockArgument, :config do
       end
     RUBY
   end
+
+  it 'registers an offense and corrects when there are two methods with the same implementation and name' do
+    expect_offense(<<~RUBY)
+      def foo
+        bar { |baz| yield baz }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+
+      def foo
+        bar { |baz| yield baz }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(&block)
+        bar(&block)
+      end
+
+      def foo(&block)
+        bar(&block)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when there are nested method definitions' do
+    expect_offense(<<~RUBY)
+      def foo
+        def bar.baz
+          qux { |quux| yield quux }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Consider using explicit block argument in the surrounding method's signature over `yield`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        def bar.baz(&block)
+          qux(&block)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix #14535

Nodes are only compared by their content, not location. So it fails to place the def argument in the second case.

Also added a test that a nested method definition places the block argument at the correct def node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
