### PR TITLE
[Fix #14540] Fix an incorrect autocorrect for `Style/UnlessElse`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_unless_else.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_unless_else.md
@@ -1,0 +1,1 @@
+* [#14540](https://github.com/rubocop/rubocop/issues/14540): Fix an incorrect autocorrect for `Style/UnlessElse` when using `unless` with `then`. ([@koic][])

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -85,6 +85,27 @@ RSpec.describe RuboCop::Cop::Style::UnlessElse, :config do
     end
   end
 
+  context 'when using `unless` with `then`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        unless x then
+        ^^^^^^^^^^^^^ Do not use `unless` with `else`. Rewrite these with the positive case first.
+          a = 1
+        else
+          a = 0
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if x then
+          a = 0
+        else
+          a = 1
+        end
+      RUBY
+    end
+  end
+
   context 'unless without else' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/UnlessElse` when using `unless` with `then`.

Fixes #14540.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
