### PR TITLE
Use `Node#any_str_type?` and `Node#any_sym_type?` instead of explicitly using their component types

### DIFF
--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -94,7 +94,7 @@ module RuboCop
       end
 
       def surrounding_heredoc?(node)
-        node.type?(:str, :dstr, :xstr) && node.heredoc?
+        node.any_str_type? && node.heredoc?
       end
 
       def heredoc_range(node)
@@ -106,7 +106,7 @@ module RuboCop
       end
 
       def string_continuation?(node)
-        node.type?(:str, :dstr, :xstr) && node.source.match?(/\\\s*$/)
+        node.any_str_type? && node.source.match?(/\\\s*$/)
       end
 
       def multiline_string?(node)

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -57,7 +57,7 @@ module RuboCop
         def inside_string_ranges(node)
           return [] unless node.is_a?(Parser::AST::Node)
 
-          node.each_node(:str, :dstr, :xstr).filter_map { |n| inside_string_range(n) }
+          node.each_node(:any_str).filter_map { |n| inside_string_range(n) }
         end
 
         def inside_string_range(node)

--- a/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
+++ b/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
@@ -30,6 +30,8 @@ module RuboCop
           any_block: %i[block numblock itblock],
           any_def: %i[def defs],
           any_match_pattern: %i[match_pattern match_pattern_p],
+          any_str: %i[str dstr xstr],
+          any_sym: %i[sym dsym],
           argument: %i[arg optarg restarg kwarg kwoptarg kwrestarg blockarg forward_arg shadowarg],
           boolean: %i[true false],
           call: %i[send csend],
@@ -210,7 +212,7 @@ module RuboCop
         # A heredoc can be a `dstr` without interpolation, but if there is interpolation
         # there'll be a `begin` node, in which case, we cannot evaluate the pattern.
         def acceptable_heredoc?(node)
-          node.type?(:str, :dstr) && node.heredoc? && node.each_child_node(:begin).none?
+          node.any_str_type? && node.heredoc? && node.each_child_node(:begin).none?
         end
 
         def process_pattern(pattern_node)

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -357,7 +357,7 @@ module RuboCop
         end
 
         def find_heredoc(node)
-          node.each_node(:str, :dstr, :xstr).find(&:heredoc?)
+          node.each_node(:any_str).find(&:heredoc?)
         end
 
         def buffer

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -120,7 +120,7 @@ module RuboCop
         end
 
         def heredoc?(node)
-          node.type?(:str, :dstr) && node.heredoc?
+          node.any_str_type? && node.heredoc?
         end
 
         def end_range(node)

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -321,7 +321,7 @@ module RuboCop
         def extract_heredocs(ast)
           return [] unless ast
 
-          ast.each_node(:str, :dstr, :xstr).select(&:heredoc?).map do |node|
+          ast.each_node(:any_str).select(&:heredoc?).map do |node|
             body = node.location.heredoc_body
             delimiter = node.location.heredoc_end.source.strip
             [body.first_line...body.last_line, delimiter]

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -113,7 +113,7 @@ module RuboCop
           return [] unless ast
 
           heredocs = []
-          ast.each_node(:str, :dstr, :xstr) do |node|
+          ast.each_node(:any_str) do |node|
             next unless node.heredoc?
 
             body = node.location.heredoc_body

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -227,7 +227,7 @@ module RuboCop
 
       def chained_to_heredoc?(node)
         while (node = node.receiver)
-          return true if node.type?(:str, :dstr, :xstr) && node.heredoc?
+          return true if node.any_str_type? && node.heredoc?
         end
 
         false

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -212,7 +212,7 @@ module RuboCop
         end
 
         def word_symbol_pair?(pair)
-          return false unless pair.key.type?(:sym, :dsym)
+          return false unless pair.key.any_sym_type?
 
           acceptable_19_syntax_symbol?(pair.key.source)
         end

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -51,7 +51,7 @@ module RuboCop
         end
 
         def string_message?(message)
-          message.type?(:str, :dstr, :xstr)
+          message.any_str_type?
         end
 
         def fix_compact(node)

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -210,6 +210,28 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         end
       end
 
+      context 'with an xstr heredoc' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            my_method.
+                     ^ Place the . on the next line, together with the method name.
+              something(<<~`HERE`).
+                                  ^ Place the . on the next line, together with the method name.
+                ls -la
+              HERE
+              somethingelse
+          RUBY
+
+          expect_correction(<<~RUBY)
+            my_method
+              .something(<<~`HERE`)
+                ls -la
+              HERE
+              .somethingelse
+          RUBY
+        end
+      end
+
       context 'as the first argument' do
         it 'registers an offense' do
           expect_offense(<<~'RUBY')
@@ -282,6 +304,25 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         expect_correction(<<~RUBY)
           <<~HEREDOC
             something
+          HEREDOC
+            .method_name
+        RUBY
+      end
+    end
+
+    context 'when the receiver is an `xstr` heredoc' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          <<~`HEREDOC`.
+                      ^ Place the . on the next line, together with the method name.
+            ls -la
+          HEREDOC
+            method_name
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~`HEREDOC`
+            ls -la
           HEREDOC
             .method_name
         RUBY
@@ -416,6 +457,28 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         end
       end
 
+      context 'with an `xstr` heredoc' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            my_method
+              .something(<<~`HERE`)
+              ^ Place the . on the previous line, together with the method call receiver.
+                ls -la
+              HERE
+              .somethingelse
+              ^ Place the . on the previous line, together with the method call receiver.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            my_method.
+              something(<<~`HERE`).
+                ls -la
+              HERE
+              somethingelse
+          RUBY
+        end
+      end
+
       context 'as the first argument' do
         it 'registers an offense' do
           expect_offense(<<~'RUBY')
@@ -488,6 +551,25 @@ RSpec.describe RuboCop::Cop::Layout::DotPosition, :config do
         expect_correction(<<~RUBY)
           <<~HEREDOC.
             something
+          HEREDOC
+            method_name
+        RUBY
+      end
+    end
+
+    context 'when the receiver is an `xstr` heredoc' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          <<~`HEREDOC`
+            ls -la
+          HEREDOC
+            .method_name
+            ^ Place the . on the previous line, together with the method call receiver.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~`HEREDOC`.
+            ls -la
           HEREDOC
             method_name
         RUBY


### PR DESCRIPTION
Follows rubocop/rubocop-ast#328 and rubocop/rubocop-ast#387. Uses the new type groups (`any_str_type?` and `any_sym_type?`) instead of their component parts. 

I also looked through cases where `str` and `dstr` are specified without `xstr`, and found one (`Layout/DotPosition`) that could be updated to use `any_str_type?` instead (and added tests for this case).