### PR TITLE
[Fix #14544] Fix an incorrect autocorrect for `Lint/Void`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lint_void.md
+++ b/changelog/fix_incorrect_autocorrect_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#14544](https://github.com/rubocop/rubocop/issues/14544): Fix an incorrect autocorrect for `Lint/Void` when using a return value in assignment method definition. ([@koic][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -16,6 +16,12 @@ module RuboCop
       # enumerator.each { |item| item >= 2 } #=> [2, 3]
       # ----
       #
+      # NOTE: Return values in assignment method definitions such as `def foo=(arg)` are
+      # detected because they are in a void context. However, autocorrection does not remove
+      # the return value, as that would change behavior. In such cases, whether to remove
+      # the return value or rename the method to something more appropriate should be left to
+      # the user.
+      #
       # @example CheckForMethodsWithNoSideEffects: false (default)
       #   # bad
       #   def some_method
@@ -233,6 +239,7 @@ module RuboCop
 
         def autocorrect_void_expression(corrector, node)
           return if node.parent.if_type?
+          return if (def_node = node.each_ancestor(:any_def).first) && def_node.assignment_method?
 
           corrector.remove(range_with_surrounding_space(range: node.source_range, side: :left))
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -839,10 +839,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      def foo=(rhs)
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers two offenses for void literals in a class setter method' do
@@ -855,10 +852,7 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      def self.foo=(rhs)
-      end
-    RUBY
+    expect_no_corrections
   end
 
   it 'registers two offenses for void literals in a `#each` method' do


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Lint/Void` when using a return value in assignment method definition.

As a safe Lint cop, autocorrections that could inadvertently break code are not expected.

Fixes #14544.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
