### PR TITLE
[Fix #14543] Fix an incorrect autocorrect for `Style/RedundantRegexpArgument`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_argument_cop.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_redundant_regexp_argument_cop.md
@@ -1,0 +1,1 @@
+* [#14543](https://github.com/rubocop/rubocop/issues/14543): Fix an incorrect autocorrect for `Style/RedundantRegexpArgument` when using escaped single quote character. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -66,12 +66,15 @@ module RuboCop
           DETERMINISTIC_REGEX.match?(regexp_node.source)
         end
 
+        # rubocop:disable Metrics/MethodLength
         def preferred_argument(regexp_node)
           new_argument = replacement(regexp_node)
 
           if new_argument.include?('"')
             new_argument.gsub!("'", "\\\\'")
             new_argument.gsub!('\"', '"')
+            quote = "'"
+          elsif new_argument.include?("\\'")
             quote = "'"
           elsif new_argument.include?('\'')
             new_argument.gsub!("'", "\\\\'")
@@ -84,6 +87,7 @@ module RuboCop
 
           "#{quote}#{new_argument}#{quote}"
         end
+        # rubocop:enable Metrics/MethodLength
 
         def replacement(regexp_node)
           regexp_content = regexp_node.content

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using escaped single quote character' do
+    expect_offense(<<~'RUBY')
+      str.gsub(/\'/)
+               ^^^^ Use string `'\''` as argument instead of regexp `/\'/`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      str.gsub('\'')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using escaped double quote character' do
     expect_offense(<<~'RUBY')
       str.gsub(/\"/)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Style/RedundantRegexpArgument` when using escaped single quote character.

Fixes #14543.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
