### PR TITLE
[Fix #14541] Fix gemspec parsing error when parser_prism is configured

### DIFF
--- a/changelog/fix_gemspec_parsing_with_parser_prism.md
+++ b/changelog/fix_gemspec_parsing_with_parser_prism.md
@@ -1,0 +1,1 @@
+* [#14541](https://github.com/rubocop/rubocop/issues/14541): Fix gemspec parsing error when `ParserEngine: parser_prism` is configured in a base config file. ([@sudoremo][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -110,8 +110,17 @@ module RuboCop
       end
 
       def version_from_gemspec_file(file)
+        # When using parser_prism, we need to use a Ruby version that Prism supports (3.3+)
+        # for parsing the gemspec file. This doesn't affect the detected Ruby version,
+        # it's just for the parsing step.
+        ruby_version_for_parsing = if @config.parser_engine == :parser_prism
+                                     3.3
+                                   else
+                                     DEFAULT_VERSION
+                                   end
+
         processed_source = ProcessedSource.from_file(
-          file, DEFAULT_VERSION, parser_engine: @config.parser_engine
+          file, ruby_version_for_parsing, parser_engine: @config.parser_engine
         )
         return unless processed_source.valid_syntax?
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -283,6 +283,22 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
         end
       end
 
+      context 'when parser_prism is configured' do
+        let(:hash) { { 'AllCops' => { 'ParserEngine' => 'parser_prism' } } }
+
+        it 'can parse gemspec file without error' do
+          content = <<~HEREDOC
+            Gem::Specification.new do |s|
+              s.name = 'test'
+              s.required_ruby_version = '>= 3.3.0'
+              s.licenses = ['MIT']
+            end
+          HEREDOC
+          create_file(gemspec_file_path, content)
+          expect(target_ruby.version).to eq 3.3
+        end
+      end
+
       context 'when file does not contain `required_ruby_version`' do
         before do
           content = <<~HEREDOC


### PR DESCRIPTION
When ParserEngine is set to parser_prism in a base config file and RuboCop needs to parse a gemspec to detect the Ruby version, it was using DEFAULT_VERSION (2.7) which is incompatible with Prism that requires Ruby 3.3+.

This fix ensures that when parser_prism is configured, we use Ruby 3.3 for parsing the gemspec file. The parsing version doesn't affect the detected required_ruby_version - it's only used for the parsing step.

This fixes #14541.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
