### PR TITLE
[Fix #14496] Fix false negatives for `Layout/EmptyLineBetweenDefs` …

### DIFF
--- a/changelog/fix_false_positive_empty_line_defs_macro_no_block.md
+++ b/changelog/fix_false_positive_empty_line_defs_macro_no_block.md
@@ -1,0 +1,1 @@
+* [#14496](https://github.com/rubocop/rubocop/issues/14496): Fix false negatives for `Layout/EmptyLineBetweenDefs` for `AllowAdjacentOneLineDefs: false` and `DefLikeMacros` that take no block. ([@earlopain][])

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -660,7 +660,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   context 'DefLikeMacros: [\'foo\']' do
-    let(:cop_config) { { 'DefLikeMacros' => ['foo'] } }
+    let(:allow_adjacent_one_line_defs) { true }
+    let(:cop_config) do
+      {
+        'DefLikeMacros' => ['foo'],
+        'AllowAdjacentOneLineDefs' => allow_adjacent_one_line_defs
+      }
+    end
 
     it 'registers offense' do
       expect_offense(<<~RUBY)
@@ -776,6 +782,31 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           #foo body
         end
       RUBY
+    end
+
+    it 'does not register an offense for single-line macros' do
+      expect_no_offenses(<<~RUBY)
+        foo :first_attribute
+        foo :second_attribute
+      RUBY
+    end
+
+    context 'and AllowAdjacentOneLineDefs: false' do
+      let(:allow_adjacent_one_line_defs) { false }
+
+      it 'registers an offense for macros that take no block' do
+        expect_offense(<<~RUBY)
+          foo :first_attribute
+          foo :second_attribute
+          ^^^^^^^^^^^^^^^^^^^^^ Expected 1 empty line between send definitions; found 0.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo :first_attribute
+
+          foo :second_attribute
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #14496

… with `AllowAdjacentOneLineDefs: false` for `DefLikeMacros` that take no block

`foo :bar` is just as much a macro as `foo :bar { baz }`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
