### PR TITLE
[Fix #14553] Fix false positives for `Style/DoubleNegation`

### DIFF
--- a/changelog/fix_false_positives_for_style_double_negation.md
+++ b/changelog/fix_false_positives_for_style_double_negation.md
@@ -1,0 +1,1 @@
+* [#14553](https://github.com/rubocop/rubocop/issues/14553): Fix false positives when `EnforcedStyle: allowed_in_returns` and `!!` appears across multiple lines in return position. ([@koic][])

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -96,7 +96,7 @@ module RuboCop
           elsif last_child.type?(:pair, :hash) || last_child.parent.array_type?
             false
           else
-            last_child.last_line <= node.last_line
+            last_child.first_line <= node.first_line
           end
         end
 

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -493,6 +493,17 @@ RSpec.describe RuboCop::Cop::Style::DoubleNegation, :config do
       RUBY
     end
 
+    it 'does not register an offense for a line-broken `!!` expression when using `return` keyword' do
+      expect_no_offenses(<<~RUBY)
+        def foo?
+          return !!bar.do_something if condition
+          baz
+          !!qux &&
+            quux
+        end
+      RUBY
+    end
+
     it 'does not register an offense for `!!` when return location by `define_method`' do
       expect_no_offenses(<<~RUBY)
         define_method :foo? do


### PR DESCRIPTION
This PR fixes false positives when `EnforcedStyle: allowed_in_returns` and `!!` appears across multiple lines in return position.

Fixes #14553.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
