### PR TITLE
[Fix #14557] Fix false positives for `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_for_style_redundant_parentheses.md
+++ b/changelog/fix_false_positives_for_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14557](https://github.com/rubocop/rubocop/issues/14557): Fix false positives for `Style/RedundantParentheses` when parentheses are used around a one-line `rescue` expression as a condition. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -202,6 +202,7 @@ module RuboCop
           return false unless node.rescue_type?
           return false unless (parent = begin_node.parent)
           return false if parent.if_type? && parent.ternary?
+          return false if parent.conditional? && parent.condition == begin_node
 
           !parent.type?(:call, :array, :pair)
         end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1488,6 +1488,31 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'does not register an offense when parentheses are used around a one-line `rescue` expression as a branch condition' do
+    expect_no_offenses(<<~RUBY)
+      if (foo rescue bar)
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when parentheses are used around a one-line `rescue` expression as a loop condition' do
+    expect_no_offenses(<<~RUBY)
+      while (foo rescue bar)
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when parentheses are used around a one-line `rescue` expression as a case condition' do
+    expect_no_offenses(<<~RUBY)
+      case (foo rescue bar)
+      when foo
+        do_something
+      end
+    RUBY
+  end
+
   it 'does not register an offense when parentheses are used around a one-line `rescue` expression inside an array literal' do
     expect_no_offenses(<<~RUBY)
       [


### PR DESCRIPTION
This PR fixes false positives for `Style/RedundantParentheses` when parentheses are used around a one-line `rescue` expression as a condition.

Fixes #14557.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
