### PR TITLE
Allow to define callbacks like `on_any_block`

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -39,6 +39,14 @@ module RuboCop
         end
       end
 
+      # Contains a mapping of group types to all the node types they contain.
+      # For example, `TYPES_FOR_GROUP[:any_def] == [:def, :defs]`.
+      # @api private
+      TYPES_FOR_GROUP = AST::Node::GROUP_FOR_TYPE.each_with_object({}) do |(node_type, group), hash|
+        hash[group] ||= []
+        hash[group] << node_type
+      end
+
       attr_reader :errors
 
       def initialize(cops, forces = [], options = {})

--- a/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
+++ b/lib/rubocop/cop/internal_affairs/node_pattern_groups.rb
@@ -26,16 +26,6 @@ module RuboCop
 
         MSG = 'Replace `%<names>s` in node pattern union with `%<replacement>s`.'
         RESTRICT_ON_SEND = %i[def_node_matcher def_node_search].freeze
-        NODE_GROUPS = {
-          any_block: %i[block numblock itblock],
-          any_def: %i[def defs],
-          any_match_pattern: %i[match_pattern match_pattern_p],
-          argument: %i[arg optarg restarg kwarg kwoptarg kwrestarg blockarg forward_arg shadowarg],
-          boolean: %i[true false],
-          call: %i[send csend],
-          numeric: %i[int float rational complex],
-          range: %i[irange erange]
-        }.freeze
 
         def on_new_investigation
           @walker = ASTWalker.new

--- a/lib/rubocop/cop/internal_affairs/node_pattern_groups/ast_walker.rb
+++ b/lib/rubocop/cop/internal_affairs/node_pattern_groups/ast_walker.rb
@@ -86,7 +86,7 @@ module RuboCop
             # Find all node groups where all of the members are present in the union
             type_names = types_to_check.map(&:child)
 
-            NODE_GROUPS.select { |_, group| group & type_names == group }.each_key do |name|
+            Commissioner::TYPES_FOR_GROUP.select { |_, group| group & type_names == group }.each_key do |name|
               nodes = get_relevant_nodes(types_to_check, name)
 
               yield name, nodes
@@ -95,7 +95,7 @@ module RuboCop
 
           def get_relevant_nodes(node_types, group_name)
             node_types.each_with_object([]) do |node_type, arr|
-              next unless NODE_GROUPS[group_name].include?(node_type.child)
+              next unless Commissioner::TYPES_FOR_GROUP[group_name].include?(node_type.child)
 
               arr << node_type
             end

--- a/lib/rubocop/cop/internal_affairs/node_type_group.rb
+++ b/lib/rubocop/cop/internal_affairs/node_type_group.rb
@@ -33,7 +33,7 @@ module RuboCop
           symbol_args = node.arguments.select(&:sym_type?)
           return if symbol_args.none?
 
-          NodePatternGroups::NODE_GROUPS.each do |group_name, group_types|
+          Commissioner::TYPES_FOR_GROUP.each do |group_name, group_types|
             next unless group_satisfied?(group_types, symbol_args)
 
             offense_range = arguments_range(node)

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -81,12 +81,9 @@ module RuboCop
            (send equal?(%1) !:[] ...)}
         PATTERN
 
-        def on_block(node)
+        def on_any_block(node)
           check_block_alignment(start_for_block_node(node), node)
         end
-
-        alias on_numblock on_block
-        alias on_itblock on_block
 
         def style_parameter_name
           'EnforcedStyleAlignWith'

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -85,11 +85,11 @@ module RuboCop
         alias on_defs on_def
 
         def on_args(node)
-          node.children.each { |arg| on_argument(arg) }
+          node.children.each { |arg| handle_argument(arg) }
         end
 
         def on_blockarg(node)
-          on_argument(node)
+          handle_argument(node)
         end
 
         def on_masgn(node)
@@ -176,7 +176,7 @@ module RuboCop
             node.implicit_call?)
         end
 
-        def on_argument(node)
+        def handle_argument(node)
           if node.mlhs_type?
             on_args(node)
           elsif node.respond_to?(:name)


### PR DESCRIPTION
There are many places where alias is used to handle all types of blocks, or other node types like def/defs etc. One can already use predicate methods on the node itself to check if any one type is present but for visiting it you need to add all the aliases yourself.

This makes it possible to write `def on_any_block(node); end`, which then automaticaly adds all the aliases automatically. Draft for now, I want to add internal affairs to handle this but before spending time on that, I want to see what others think about this idea.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
