### PR TITLE
Fix an error for `InternalAffairsOnSendWithoutOnCSend` with `alias_method` and no arguments

### DIFF
--- a/lib/rubocop/cop/internal_affairs/on_send_without_on_csend.rb
+++ b/lib/rubocop/cop/internal_affairs/on_send_without_on_csend.rb
@@ -76,7 +76,7 @@ module RuboCop
         end
 
         def on_send(node) # rubocop:disable InternalAffairs/OnSendWithoutOnCSend
-          new_identifier = node.first_argument
+          return unless (new_identifier = node.first_argument)
           return unless new_identifier.basic_literal?
 
           new_identifier = new_identifier.value

--- a/spec/rubocop/cop/internal_affairs/on_send_without_on_csend_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/on_send_without_on_csend_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe RuboCop::Cop::InternalAffairs::OnSendWithoutOnCSend, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when `alias_method` takes no arguments' do
+    expect_offense(<<~RUBY)
+      class MyCop < RuboCop::Cop:Base
+        def on_send(node)
+        ^^^^^^^^^^^^^^^^^ Cop defines `on_send` but not `on_csend`.
+          # ...
+        end
+        alias_method
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Code is faulty but may happen when just typing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
