### PR TITLE
[Fix #14563] Fix an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_deprecated_open_ssl_constant.md
@@ -1,0 +1,1 @@
+* [#14563](https://github.com/rubocop/rubocop/issues/14563): Fix incorrect autocorrection for `Lint/DeprecatedOpenSSLConstant` when `Cipher` appears twice. ([@koic][])

--- a/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
+++ b/lib/rubocop/cop/lint/deprecated_open_ssl_constant.rb
@@ -118,8 +118,11 @@ module RuboCop
 
         def replacement_args(node)
           algorithm_constant, = algorithm_const(node)
-          algorithm_name = algorithm_name(algorithm_constant)
+          if algorithm_constant.source == 'OpenSSL::Cipher::Cipher'
+            return node.first_argument.source
+          end
 
+          algorithm_name = algorithm_name(algorithm_constant)
           if openssl_class(algorithm_constant) == 'OpenSSL::Cipher'
             build_cipher_arguments(node, algorithm_name, node.arguments.empty?)
           else

--- a/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_open_ssl_constant_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedOpenSSLConstant, :config do
     RUBY
   end
 
+  it 'registers an offense when the `Cipher` constant appears twice and autocorrects' do
+    expect_offense(<<~RUBY)
+      OpenSSL::Cipher::Cipher.new('AES-256-ECB')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `OpenSSL::Cipher.new('AES-256-ECB')` instead of `OpenSSL::Cipher::Cipher.new('AES-256-ECB')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      OpenSSL::Cipher.new('AES-256-ECB')
+    RUBY
+  end
+
   it 'registers an offense with cipher constant and `ecb` argument and corrects' do
     expect_offense(<<~RUBY)
       OpenSSL::Cipher::BF.new('ecb')


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Lint/DeprecatedOpenSSLConstant` when using twice `Cipher` constant.

Fixes #14563.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
