### PR TITLE
Allow implicit block args when the block itself is on one line only

### DIFF
--- a/changelog/change_single_line_implicit_arg.md
+++ b/changelog/change_single_line_implicit_arg.md
@@ -1,0 +1,1 @@
+* [#14565](https://github.com/rubocop/rubocop/pull/14565): Allow multiline method chain for `Style/NumberedParameters` and `Style/ItBlockParameter` with `EnforcedStyle: allow_single_line` when the block itself is on a single line. ([@earlopain][])

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -94,7 +94,7 @@ module RuboCop
         def on_itblock(node)
           case style
           when :allow_single_line
-            return if same_line?(node.source_range.begin, node.source_range.end)
+            return if node.single_line?
 
             add_offense(node, message: MSG_AVOID_IT_PARAMETER_MULTILINE)
           when :disallow

--- a/lib/rubocop/cop/style/numbered_parameters.rb
+++ b/lib/rubocop/cop/style/numbered_parameters.rb
@@ -36,7 +36,7 @@ module RuboCop
         def on_numblock(node)
           if style == :disallow
             add_offense(node, message: MSG_DISALLOW)
-          elsif !same_line?(node.source_range.begin, node.source_range.end)
+          elsif node.multiline?
             add_offense(node, message: MSG_MULTI_LINE)
           end
         end

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         expect_no_corrections
       end
 
-      it 'registers an offense when using `it` block parameter with multi-line method chain' do
-        expect_offense(<<~RUBY)
+      it 'registers no offense when using `it` block parameter with multi-line method chain' do
+        expect_no_offenses(<<~RUBY)
           collection.each
-          ^^^^^^^^^^^^^^^ Avoid using `it` block parameter for multi-line blocks.
                     .foo { puts it }
         RUBY
       end

--- a/spec/rubocop/cop/style/numbered_parameters_spec.rb
+++ b/spec/rubocop/cop/style/numbered_parameters_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe RuboCop::Cop::Style::NumberedParameters, :config do
         RUBY
       end
 
-      it 'registers an offense when using numbered parameters with multi-line method chain' do
-        expect_offense(<<~RUBY)
+      it 'registers no offense when using numbered parameters with multi-line method chain' do
+        expect_no_offenses(<<~RUBY)
           collection.each
-          ^^^^^^^^^^^^^^^ Avoid using numbered parameters for multi-line blocks.
                     .foo { puts _1 }
         RUBY
       end


### PR DESCRIPTION
Basically a revert of https://github.com/rubocop/rubocop/commit/58a895a6f5f4e6705d33c6a2bf0c42838a6b533e

Expectation is that `allow_single_line` targets the block, not what is around it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
