### PR TITLE
Make `Style/LambdaCall` autocorrection contextual

### DIFF
--- a/changelog/change_make_style_lambda_call_autocorrection_contextual.md
+++ b/changelog/change_make_style_lambda_call_autocorrection_contextual.md
@@ -1,0 +1,1 @@
+* [#14567](https://github.com/rubocop/rubocop/pull/14567): Make `Style/LambdaCall` autocorrection contextual. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4552,8 +4552,9 @@ Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   StyleGuide: '#proc-call'
   Enabled: true
+  AutoCorrect: contextual
   VersionAdded: '0.13'
-  VersionChanged: '0.14'
+  VersionChanged: '<<next>>'
   EnforcedStyle: call
   SupportedStyles:
     - call


### PR DESCRIPTION
`obj.(arg)` should not be autocorrected when it is an unfinished write of `obj.do_something(arg)`. Autocorrecting while editing into `obj.call(arg)` may cause confusion.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
