### PR TITLE
Add `IncludedMacroPatterns` configuration option to `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/changelog/new_add_includedmacropatterns_configuration_option_20250928183000.md
+++ b/changelog/new_add_includedmacropatterns_configuration_option_20250928183000.md
@@ -1,0 +1,1 @@
+* [#14569](https://github.com/rubocop/rubocop/issues/14569): Add `IncludedMacroPatterns` configuration option to `Style/MethodCallWithArgsParentheses` for pattern-based macro method enforcement. ([@mmenanno][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4631,6 +4631,7 @@ Style/MethodCallWithArgsParentheses:
   AllowedMethods: []
   AllowedPatterns: []
   IncludedMacros: []
+  IncludedMacroPatterns: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
   AllowParenthesesInCamelCaseMethod: false

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -9,17 +9,20 @@ module RuboCop
       # In the default style (require_parentheses), macro methods are allowed.
       # Additional methods can be added to the `AllowedMethods` or
       # `AllowedPatterns` list. These options are valid only in the default
-      # style. Macros can be included by either setting `IgnoreMacros` to false
-      # or adding specific macros to the `IncludedMacros` list.
+      # style. Macros can be included by either setting `IgnoreMacros` to false,
+      # adding specific macros to the `IncludedMacros` list, or using
+      # `IncludedMacroPatterns` for pattern-based matching.
       #
       # Precedence of options is as follows:
       #
       # 1. `AllowedMethods`
       # 2. `AllowedPatterns`
       # 3. `IncludedMacros`
+      # 4. `IncludedMacroPatterns`
       #
-      # If a method is listed in both `IncludedMacros` and `AllowedMethods`,
-      # then the latter takes precedence (that is, the method is allowed).
+      # If a method is listed in both `IncludedMacros`/`IncludedMacroPatterns`
+      # and `AllowedMethods`, then the latter takes precedence (that is, the
+      # method is allowed).
       #
       # In the alternative style (omit_parentheses), there are three additional
       # options.
@@ -147,6 +150,16 @@ module RuboCop
       #   assert_match(/foo/, bar)
       #   # still enforces parentheses on other methods
       #   array.delete(e)
+      #
+      # @example IncludedMacroPatterns: ["^assert", "^refute"]
+      #
+      #   # bad
+      #   assert_equal 'test', x
+      #   refute_nil value
+      #
+      #   # good
+      #   assert_equal('test', x)
+      #   refute_nil(value)
       #
       # @example AllowParenthesesInMultilineCall: false (default)
       #

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
@@ -36,10 +36,21 @@ module RuboCop
             cop_config.fetch('IncludedMacros', []).map(&:to_sym)
           end
 
+          def included_macro_patterns
+            cop_config.fetch('IncludedMacroPatterns', [])
+          end
+
+          def matches_included_macro_pattern?(method_name)
+            included_macro_patterns.any? do |pattern|
+              Regexp.new(pattern).match?(method_name.to_s)
+            end
+          end
+
           def ignored_macro?(node)
             cop_config['IgnoreMacros'] &&
               node.macro? &&
-              !included_macros_list.include?(node.method_name)
+              !included_macros_list.include?(node.method_name) &&
+              !matches_included_macro_pattern?(node.method_name)
           end
         end
       end


### PR DESCRIPTION
Fixes #14569 - The cop failed to detect violations in `test "name" do` blocks while correctly flagging identical violations in `def test_` method definitions.

## **Problem**

The existing `IncludedMacros` option would require listing dozens of assertion methods individually (`assert_equal`, `assert_nil`, `assert_match`, `refute_equal`, `refute_nil`, etc.), making it hard to maintain and prone to missing new assertion methods.

## **Solution**

Add `IncludedMacroPatterns` configuration option that accepts regex patterns. Instead of maintaining a long list, users can simply configure:

```yaml
Style/MethodCallWithArgsParentheses:
  IncludedMacroPatterns: ['^assert', '^refute']
```

This automatically catches all assertion methods and any new ones added in the future.

### **Before/After:**
```ruby
# Before: Only flagged in def test_ methods
class TestClass < Minitest::Test
  def test_with_def_style
    assert_equal 1, 1   # ✅ Flagged
  end

  test "with do/end block" do
    assert_equal 1, 1   # ❌ NOT flagged (THE BUG)
  end
end

# After: Both violations are caught
class TestClass < Minitest::Test
  def test_with_def_style
    assert_equal 1, 1   # ✅ Flagged
  end

  test "with do/end block" do
    assert_equal 1, 1   # ✅ NOW flagged (FIXED!)
  end
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
