### PR TITLE
Remove unused `autocorrect_source_file` and `autocorrect_source` methods from `lib/rubocop/rspec/cop_helper.rb`

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -72,20 +72,6 @@ module CopHelper
     end
   end
 
-  def autocorrect_source_file(source)
-    Tempfile.open('tmp') { |f| autocorrect_source(source, f) }
-  end
-
-  def autocorrect_source(source, file = nil)
-    RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
-    RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
-    cop.instance_variable_get(:@options)[:autocorrect] = true
-    processed_source = parse_source(source, file)
-    _investigate(cop, processed_source)
-
-    @last_corrector.rewrite
-  end
-
   def _investigate(cop, processed_source)
     team = RuboCop::Cop::Team.new([cop], configuration, raise_error: true)
     report = team.investigate(processed_source)


### PR DESCRIPTION
Stumbled upon these while messing around with re-calling `expect_offense` in my extension-- as far as I can tell, they're completely unused in rubocop itself, and don't appear in any extensions either.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
