### PR TITLE
[Fix #14572] Fix an error for `Style/ArrayIntersect`

### DIFF
--- a/changelog/fix_an_error_for_style_array_intersect.md
+++ b/changelog/fix_an_error_for_style_array_intersect.md
@@ -1,0 +1,1 @@
+* [#14572](https://github.com/rubocop/rubocop/issues/14572): Fix an error for `Style/ArrayIntersect` when `intersection(other).any?` is called without a receiver. ([@koic][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -95,7 +95,7 @@ module RuboCop
           $(call
             {
               (begin (send $_ :& $_))
-              (call $_ :intersection $_)
+              (call $!nil? :intersection $_)
             }
             $%1
           )
@@ -107,7 +107,7 @@ module RuboCop
             $(call
               {
                 (begin (send $_ :& $_))
-                (call $_ :intersection $_)
+                (call $!nil? :intersection $_)
               }
               %ARRAY_SIZE_METHODS
             )

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -213,6 +213,12 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         RUBY
       end
 
+      it 'does not register an offense for `intersection(other).any?` without a receiver' do
+        expect_no_offenses(<<~RUBY)
+          intersection(other).any?
+        RUBY
+      end
+
       described_class::ARRAY_SIZE_METHODS.each do |method|
         it "registers an offense when using `.#{method} > 0`" do
           expect_offense(<<~RUBY, method: method)
@@ -289,6 +295,12 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         it "does not register an offense when using `.#{method} == 1`" do
           expect_no_offenses(<<~RUBY)
             a.intersection(b).#{method} == 1
+          RUBY
+        end
+
+        it "does not register an offense for `intersection(other).#{method}` without a receiver" do
+          expect_no_offenses(<<~RUBY)
+            intersection(other).#{method} == 0
           RUBY
         end
       end


### PR DESCRIPTION
This PR fixes an error for `Style/ArrayIntersect`
when `intersection(other).any?` is called without a receiver.

Cases without a receiver are treated as custom methods that may be incompatible with the behavior and are ignored.

Fixes #14572.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
