### PR TITLE
Fix false positives for `Style/RedundantInterpolation`

### DIFF
--- a/changelog/fix_false_positive_for_style_redundant_interpolation.md
+++ b/changelog/fix_false_positive_for_style_redundant_interpolation.md
@@ -1,0 +1,1 @@
+* [#14574](https://github.com/rubocop/rubocop/pull/14574): Fix false positives for `Style/RedundantInterpolation` when using a one-line `=>` pattern matching. ([@koic][])

--- a/spec/rubocop/cop/style/redundant_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_interpolation_spec.rb
@@ -221,6 +221,44 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolation, :config do
     RUBY
   end
 
+  it 'registers an offense for a one-line `in` pattern matching', :ruby27 do
+    # `42 in var` is `match-pattern` node.
+    expect_offense(<<~'RUBY')
+      "#{42 in var}"
+      ^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (42 in var).to_s
+    RUBY
+  end
+
+  it 'registers an offense for a one-line `in` pattern matching', :ruby30 do
+    # `42 in var` is `match-pattern-p` node.
+    expect_offense(<<~'RUBY')
+      "#{42 in var}"
+      ^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (42 in var).to_s
+    RUBY
+  end
+
+  it 'accepts an offense for a one-line `=>` pattern matching', :ruby30 do
+    # `42 => var` is `match-pattern` node.
+    expect_no_offenses(<<~'RUBY')
+      "#{42 => var}"
+    RUBY
+  end
+
+  it 'accepts an offense for a part of one-line `=>` pattern matching', :ruby30 do
+    # `42 => var` is `match-pattern` node.
+    expect_no_offenses(<<~'RUBY')
+      "#{x; 42 => var}"
+    RUBY
+  end
+
   it 'accepts strings with characters before the interpolation' do
     expect_no_offenses('"this is #{@sparta}"')
   end


### PR DESCRIPTION
This PR fixes the following false positive for `Style/RedundantInterpolation` when using a one-line `=>` pattern matching:

```console
$ echo '"#{42 => var}"' | RUBOCOP_TARGET_RUBY_VERSION=3.0 bundle exec rubocop --stdin example.rb -A --only Style/RedundantInterpolation
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/RedundantInterpolation: Prefer to_s over string interpolation.
"#{42 => var}"
^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
(42 => var).to_s
```

This detection results in the following syntax error:

```console
$ ruby -cve '(42 => var).to_s'
ruby 3.4.5 (2025-07-16 revision 20cda200d3) +PRISM [arm64-darwin24]
ruby: -e:1: syntax error found (SyntaxError)
> 1 | (42 => var).to_s
    |  ^~~~~~~~~ unexpected void value expression
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
