### PR TITLE
Enhance `Lint/ConstantOverwrittenInRescue` to detect offenses within nested constants

### DIFF
--- a/changelog/change_enhance_constant_overwritten_in_rescue_to_detect_nested_constant_20251002014136.md
+++ b/changelog/change_enhance_constant_overwritten_in_rescue_to_detect_nested_constant_20251002014136.md
@@ -1,0 +1,1 @@
+* [#14575](https://github.com/rubocop/rubocop/pull/14575): Enhance `Lint/ConstantOverwrittenInRescue` cop to detect offenses within nested constants. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
+++ b/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         # @!method overwritten_constant(node)
         def_node_matcher :overwritten_constant, <<~PATTERN
-          (resbody nil? (casgn {cbase nil?} $_) nil?)
+          (resbody nil? (casgn {cbase nil? const} $_) nil?)
         PATTERN
 
         def self.autocorrect_incompatible_with

--- a/spec/rubocop/cop/lint/constant_overwritten_in_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/constant_overwritten_in_rescue_spec.rb
@@ -35,6 +35,40 @@ RSpec.describe RuboCop::Cop::Lint::ConstantOverwrittenInRescue, :config do
     RUBY
   end
 
+  it 'registers an offense when overriding a nested constant' do
+    expect_offense(<<~RUBY)
+      begin
+        something
+      rescue => MyNamespace::MyException
+             ^^ `MyException` is overwritten by `rescue =>`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        something
+      rescue MyNamespace::MyException
+      end
+    RUBY
+  end
+
+  it 'registers an offense when overriding a fully qualified nested constant' do
+    expect_offense(<<~RUBY)
+      begin
+        something
+      rescue => ::MyNamespace::MyException
+             ^^ `MyException` is overwritten by `rescue =>`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        something
+      rescue ::MyNamespace::MyException
+      end
+    RUBY
+  end
+
   it 'does not register an offense when not overriding an exception with an exception result' do
     expect_no_offenses(<<~RUBY)
       begin


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14566

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
