### PR TITLE
Fix an incorrect autocorrect for `Style/Semicolon`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_semicolon.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_semicolon.md
@@ -1,0 +1,1 @@
+* [#14577](https://github.com/rubocop/rubocop/pull/14577): Fix an incorrect autocorrect for `Style/Semicolon` when a method call using hash value omission without parentheses is terminated with a semicolon. ([@koic][])

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -267,6 +267,60 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     end
   end
 
+  it 'registers an offense for a method call with keyword arguments without parentheses when terminated with a semicolon' do
+    expect_offense(<<~RUBY)
+      m key: value;
+                  ^ Do not use semicolons to terminate expressions.
+      do_something
+    RUBY
+
+    expect_correction(<<~RUBY)
+      m key: value
+      do_something
+    RUBY
+  end
+
+  context 'Ruby >= 3.1', :ruby31 do
+    it 'registers an offense for a method call using multiple hash value omission without parentheses when terminated with a semicolon' do
+      expect_offense(<<~RUBY)
+        m key1:, key2:;
+                      ^ Do not use semicolons to terminate expressions.
+        do_something
+      RUBY
+
+      expect_correction(<<~RUBY)
+        m(key1:, key2:)
+        do_something
+      RUBY
+    end
+
+    it 'registers an offense for a method call using hash value omission with parentheses when terminated with a semicolon' do
+      expect_offense(<<~RUBY)
+        m(key:);
+               ^ Do not use semicolons to terminate expressions.
+        do_something
+      RUBY
+
+      expect_correction(<<~RUBY)
+        m(key:)
+        do_something
+      RUBY
+    end
+
+    it 'registers an offense for a safe navigation method call using hash value omission without parentheses when terminated with a semicolon' do
+      expect_offense(<<~RUBY)
+        obj&.m key:;
+                   ^ Do not use semicolons to terminate expressions.
+        do_something
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj&.m(key:)
+        do_something
+      RUBY
+    end
+  end
+
   context 'with a multi-expression line without a semicolon' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for Style/Semicolon when a method call using hash value omission without parentheses is terminated with a semicolon:

```console
$ echo 'm key:;do_something' | RUBOCOP_TARGET_RUBY_VERSION=3.1 bundle exec rubocop --stdin example.rb -A --only Style/Semicolon
Inspecting 1 file
C

Offenses:

example.rb:1:7: C: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
m key:;do_something
      ^

1 file inspected, 1 offense detected, 1 offense corrected
====================
m key:
do_something
```

This changes the meaning so that the standalone expression `do_something` is treated as a hash key.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
