### PR TITLE
[Fix #7501] Allow `Lint/RescueException` when re-raising an exception

### DIFF
--- a/changelog/change_allow_lint_rescue_exception_when_reraising_an_exception.md
+++ b/changelog/change_allow_lint_rescue_exception_when_reraising_an_exception.md
@@ -1,0 +1,1 @@
+* [#7501](https://github.com/rubocop/rubocop/issues/7501): Allow `Lint/RescueException` when re-raising an exception. ([@koic][])

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -5,6 +5,19 @@ module RuboCop
     module Lint
       # Checks for `rescue` blocks targeting the `Exception` class.
       #
+      # In cases where re-raising is used as shown below, further exception handling is expected at
+      # the caller, so no offense is registered.
+      #
+      # [source,ruby]
+      # ----
+      # begin
+      #   do_something
+      # rescue Exception
+      #   handle_exception
+      #   raise
+      # end
+      # ----
+      #
       # @example
       #
       #   # bad
@@ -25,12 +38,21 @@ module RuboCop
 
         def on_resbody(node)
           return unless node.exceptions.any? { |exception| targets_exception?(exception) }
+          return if re_raise_in_resbody?(node)
 
           add_offense(node)
         end
 
+        private
+
         def targets_exception?(rescue_arg_node)
           rescue_arg_node.const_name == 'Exception'
+        end
+
+        def re_raise_in_resbody?(node)
+          node.each_descendant(:send).any? do |send_node|
+            send_node.method?(:raise) || send_node.method?(:fail)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -45,6 +45,50 @@ RSpec.describe RuboCop::Cop::Lint::RescueException, :config do
     RUBY
   end
 
+  it 'does not register an offense for rescue from `Exception` and re-raise with `raise`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        something
+      rescue Exception
+        handle_exception
+        raise
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for rescue with `Exception => e` and re-raise with `raise`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        something
+      rescue Exception => e
+        handle_exception
+        raise(e)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for rescue from `Exception` and re-raise with `fail`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        something
+      rescue Exception
+        handle_exception
+        fail
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for rescue with `Exception => e` and re-raise with `fail`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        something
+      rescue Exception => e
+        handle_exception
+        fail(e)
+      end
+    RUBY
+  end
+
   it 'does not register an offense for rescue with no class' do
     expect_no_offenses(<<~RUBY)
       begin


### PR DESCRIPTION
In cases where `Exception` is rescued but immediately re-raised, further exception handling is expected at the caller. Therefore, no offense is registered in such cases.

Resolves #7501.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
