### PR TITLE
[Fix #14587] Fix an error for `Lint/SelfAssignment`

### DIFF
--- a/changelog/fix_an_error_for_lint_self_assignment.md
+++ b/changelog/fix_an_error_for_lint_self_assignment.md
@@ -1,0 +1,1 @@
+* [#14587](https://github.com/rubocop/rubocop/issues/14587): Fix an error for `Lint/SelfAssignment` when using `[]=` assignment with no arguments. ([@koic][])

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -108,7 +108,7 @@ module RuboCop
           value_node = node.last_argument
           node_arguments = node.arguments[0...-1]
 
-          if value_node.send_type? && value_node.method?(:[]) &&
+          if value_node.respond_to?(:method?) && value_node.method?(:[]) &&
              node.receiver == value_node.receiver &&
              node_arguments.none?(&:call_type?) &&
              node_arguments == value_node.arguments

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -345,6 +345,12 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `[]=` assignment with no arguments' do
+    expect_no_offenses(<<~RUBY)
+      foo.[]=
+    RUBY
+  end
+
   describe 'RBS::Inline annotation' do
     context 'when config option is enabled' do
       let(:cop_config) { { 'AllowRBSInlineAnnotation' => true } }


### PR DESCRIPTION
This PR fixes an error for `Lint/SelfAssignment` when using `[]=` assignment with no arguments.

Fixes #14587.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
