### PR TITLE
[Fix #14594] Fix false positives for `Style/EndlessMethod`

### DIFF
--- a/changelog/fix_false_positives_for_style_endless_method_cop.md
+++ b/changelog/fix_false_positives_for_style_endless_method_cop.md
@@ -1,0 +1,1 @@
+* [#14594](https://github.com/rubocop/rubocop/issues/14594): Fix false positives for `Style/EndlessMethod` when the endless method would exceed the maximum line length. ([@koic][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -225,7 +225,13 @@ module RuboCop
         def too_long_when_made_endless?(node)
           return false unless config.cop_enabled?('Layout/LineLength')
 
-          endless_replacement(node).length > config.for_cop('Layout/LineLength')['Max']
+          offset = modifier_offset(node)
+
+          endless_replacement(node).length + offset > config.for_cop('Layout/LineLength')['Max']
+        end
+
+        def modifier_offset(node)
+          same_line?(node.parent, node) ? node.loc.column - node.parent.loc.column : 0
         end
       end
     end

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -244,6 +244,19 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects for a single line method with access modifier' do
+        expect_offense(<<~RUBY)
+          private def my_method
+                  ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          private def my_method = x
+        RUBY
+      end
+
       it 'does not register an offense for a single line setter method' do
         expect_no_offenses(<<~RUBY)
           def my_method=(arg)
@@ -256,6 +269,14 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         expect_no_offenses(<<~RUBY)
           def my_method
             'this_string_ends_at_column_75_________________________________________'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the endless with access modifier version excess Metrics/MaxLineLength[Max]' do
+        expect_no_offenses(<<~RUBY)
+          private def my_method
+            'this_string_ends_at_column_75_________________________________'
           end
         RUBY
       end
@@ -273,6 +294,19 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
 
           expect_correction(<<~RUBY)
             def my_method = 'this_string_ends_at_column_75_________________________________________'
+          RUBY
+        end
+
+        it 'registers an offense and corrects for a long single line method with access modifier that is long' do
+          expect_offense(<<~RUBY)
+            private def my_method
+                    ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+              'this_string_ends_at_column_75_________________________________'
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            private def my_method = 'this_string_ends_at_column_75_________________________________'
           RUBY
         end
       end


### PR DESCRIPTION
This PR fixes false positives for `Style/EndlessMethod` when the endless method would exceed the maximum line length.

Fixes #14594.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
