### PR TITLE
Change `Lint/ConstantOverwrittenInRescue` to detect any constant assignment

### DIFF
--- a/changelog/change_lint_constant_verriden_in_rescue_to_detect_any_constant_assignment_20251010170126.md
+++ b/changelog/change_lint_constant_verriden_in_rescue_to_detect_any_constant_assignment_20251010170126.md
@@ -1,0 +1,1 @@
+* [#14596](https://github.com/rubocop/rubocop/pull/14596): Change `Lint/ConstantOverwrittenInRescue` to detect any constant assignment. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
+++ b/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         # @!method overwritten_constant(node)
         def_node_matcher :overwritten_constant, <<~PATTERN
-          (resbody nil? (casgn {cbase nil? const} $_) nil?)
+          (resbody nil? $(casgn _ _) nil?)
         PATTERN
 
         def self.autocorrect_incompatible_with
@@ -41,7 +41,8 @@ module RuboCop
         def on_resbody(node)
           return unless (constant = overwritten_constant(node))
 
-          add_offense(node.loc.assoc, message: format(MSG, constant: constant)) do |corrector|
+          message = format(MSG, constant: constant.source)
+          add_offense(node.loc.assoc, message: message) do |corrector|
             corrector.remove(range_between(node.loc.keyword.end_pos, node.loc.assoc.end_pos))
           end
         end


### PR DESCRIPTION
Since the receiver of a constant assignment can be a method call (or a variable), I think it makes sense to remove the "const receiver" restriction.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
