### PR TITLE
Fix `Style/ConditionalAssignment` crash on multi-line regex in conditional

### DIFF
--- a/changelog/fix_crash_on_conditional_assign_in_condition_with_multiline_regex.md
+++ b/changelog/fix_crash_on_conditional_assign_in_condition_with_multiline_regex.md
@@ -1,0 +1,1 @@
+* [#14599](https://github.com/rubocop/rubocop/pull/14599): Fix a crash when `Style/ConditionalAssignment` is configured with `assign_inside_conditional` and the conditional contains a multi-line regex. ([@martinemde][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -444,7 +444,7 @@ module RuboCop
             next if child.parent.dstr_type?
 
             white_space = white_space_range(child, column)
-            corrector.remove(white_space) if white_space.source.strip.empty?
+            corrector.remove(white_space) if white_space
           end
 
           if condition.loc.else && !same_line?(condition.else_branch, condition)
@@ -465,9 +465,13 @@ module RuboCop
 
         def white_space_range(node, column)
           expression = node.source_range
-          begin_pos = expression.begin_pos - (expression.column - column - 2)
+          end_pos = expression.begin_pos
+          begin_pos = end_pos - (expression.column - column - 2)
 
-          Parser::Source::Range.new(expression.source_buffer, begin_pos, expression.begin_pos)
+          return nil if begin_pos > end_pos
+
+          white_space = Parser::Source::Range.new(expression.source_buffer, begin_pos, end_pos)
+          white_space if white_space.source.strip.empty?
         end
 
         def assignment(node)

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -777,6 +777,54 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     end
   end
 
+  shared_examples 'with multiline regex in branch' do
+    it 'registers an offense for a multiline %r{} regex' do
+      expect_offense(<<~RUBY)
+        x = if condition
+        ^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+          %r{a
+            b}x
+        else
+          %r{c
+            d}x
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          x = %r{a
+            b}x
+        else
+          x = %r{c
+            d}x
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a multiline regex assignment with interpolation and comments' do
+      expect_offense(<<~'RUBY')
+        x = if condition
+        ^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+          %r{#{foo}
+            b}x
+        else
+          %r{#{bar}
+            d}x
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        if condition
+          x = %r{#{foo}
+            b}x
+        else
+          x = %r{#{bar}
+            d}x
+        end
+      RUBY
+    end
+  end
+
   shared_examples 'with indexed assignment without arguments' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)
@@ -862,6 +910,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
     it_behaves_like('multiline all assignment types allow', '<<')
 
     it_behaves_like('with `dstr` node in branch')
+    it_behaves_like('with multiline regex in branch')
     it_behaves_like('with indexed assignment without arguments')
 
     it 'allows a method call in the subject of a ternary operator' do
@@ -1144,6 +1193,7 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
 
     it_behaves_like('single line condition autocorrect')
     it_behaves_like('with `dstr` node in branch')
+    it_behaves_like('with multiline regex in branch')
     it_behaves_like('with indexed assignment without arguments')
 
     it 'corrects assignment to a multiline if else condition' do


### PR DESCRIPTION
Multi-line regexes caused a crash when trying to apply conditional assignment assign_in_condition.

```
An error occurred while Style/ConditionalAssignment cop was inspecting path/to/file.rb
```

The culprit is multi-line regex. The original had an interpolation, but it still crashes without the interpolation. I chose to keep both tests.

Unfortunately, I had to bypass PerceivedComplexity, but other metrics were already skipped. Not sure if it's worth refactoring.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
