### PR TITLE
[Fix #14552] Improve `Security/JSONLoad` documentation and implementation

### DIFF
--- a/changelog/fix_security_json_load_create_additions.md
+++ b/changelog/fix_security_json_load_create_additions.md
@@ -1,0 +1,1 @@
+* [#14552](https://github.com/rubocop/rubocop/issues/14552): Fix a false positive for `Security/JSONLoad` when `create_additions` is explicitly specified. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3207,6 +3207,7 @@ Security/JSONLoad:
                  security issues. See reference for more information.
   References:
     - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
+    - 'https://bugs.ruby-lang.org/issues/19528'
   Enabled: true
   VersionAdded: '0.43'
   VersionChanged: '1.22'

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1221,12 +1221,13 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     it 'shows reference entry' do
       create_file('example1.rb', "JSON.load('{}')")
       file = abs('example1.rb')
-      url = 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
+      urls = 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load, ' \
+             'https://bugs.ruby-lang.org/issues/19528'
 
       expect(cli.run(['--format', 'emacs', '--display-style-guide', 'example1.rb'])).to eq(1)
 
       output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
-               "Prefer `JSON.parse` over `JSON.load`. (#{url})"
+               "Prefer `JSON.parse` over `JSON.load`. (#{urls})"
       expect($stdout.string.lines.to_a[-1]).to eq([output, ''].join("\n"))
     end
 

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
     RUBY
   end
 
+  it 'registers no offense when `create_additions` option is passed' do
+    expect_no_offenses(<<~RUBY)
+      JSON.load(arg, create_additions: true)
+      ::JSON.load(arg, create_additions: false)
+    RUBY
+  end
+
+  it 'registers an offense when an unrelated option is passed' do
+    expect_offense(<<~RUBY)
+      JSON.load(arg, max_nesting: 1)
+           ^^^^ Prefer `JSON.parse` over `JSON.load`.
+      ::JSON.load(arg, max_nesting: 1)
+             ^^^^ Prefer `JSON.parse` over `JSON.load`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      JSON.parse(arg, max_nesting: 1)
+      ::JSON.parse(arg, max_nesting: 1)
+    RUBY
+  end
+
   it 'registers an offense and corrects JSON.restore' do
     expect_offense(<<~RUBY)
       JSON.restore(arg)


### PR DESCRIPTION
Fix #14552

Things have somewhat changed since this cop was added.

In addition, it should not register an offense when `create_additions` is explicitly passed. `create_additions` is the option that controls deserialization behavior. If it is specified, we should assume the user knows what is going on.

Removed docs for `quirks_mode`, that has been gone since 2.0.0 from the 2015. It just works now, no need to bother users with this anymore.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
