### PR TITLE
[Fix #14602] Fix false positives for `Style/EndlessMethod`

### DIFF
--- a/changelog/fix_false_positives_for_style_endless_method.md
+++ b/changelog/fix_false_positives_for_style_endless_method.md
@@ -1,0 +1,1 @@
+* [#14602](https://github.com/rubocop/rubocop/issues/14602): Fix false positives for `Style/EndlessMethod` when heredoc is used in method body. ([@koic][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -144,7 +144,7 @@ module RuboCop
         MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
         def on_def(node)
-          return if node.assignment_method?
+          return if node.assignment_method? || use_heredoc?(node)
 
           case style
           when :allow_single_line, :allow_always
@@ -196,6 +196,13 @@ module RuboCop
           return unless node.endless?
 
           add_offense(node) { |corrector| correct_to_multiline(corrector, node) }
+        end
+
+        def use_heredoc?(node)
+          return false unless (body = node.body)
+          return true if body.str_type? && body.heredoc?
+
+          body.each_descendant(:str).any?(&:heredoc?)
         end
 
         def correct_to_multiline(corrector, node)

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense when heredoc is used only in regular method definition' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            <<~HEREDOC
+              hello
+            HEREDOC
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for heredoc is used in regular method definition' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            puts <<~HEREDOC
+              hello
+            HEREDOC
+          end
+        RUBY
+      end
+
       it 'registers an offense and corrects for a single line method' do
         expect_offense(<<~RUBY)
           def my_method
@@ -387,6 +407,26 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
             begin
               foo && bar
             end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when heredoc is used only in regular method definition' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            <<~HEREDOC
+              hello
+            HEREDOC
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for heredoc is used in regular method definition' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            puts <<~HEREDOC
+              hello
+            HEREDOC
           end
         RUBY
       end


### PR DESCRIPTION
This PR fixes false positives for `Style/EndlessMethod` when heredoc is used in method body.

Fixes #14602.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
