### PR TITLE
[Fix #14605] Fix false positive for `Lint/EmptyInterpolation` when interpolation is inside a `%W` literal

### DIFF
--- a/changelog/fix_fix_false_positive_for_lint_empty_interpolation_20251016150606.md
+++ b/changelog/fix_fix_false_positive_for_lint_empty_interpolation_20251016150606.md
@@ -1,0 +1,1 @@
+* [#14605](https://github.com/rubocop/rubocop/issues/14605): Fix false positive for `Lint/EmptyInterpolation` when interpolation is inside a `%W` literal. ([@dvandersluis][])

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -19,11 +19,22 @@ module RuboCop
         MSG = 'Empty interpolation detected.'
 
         def on_interpolation(begin_node)
+          return if in_percent_literal_array?(begin_node)
+
           node_children = begin_node.children.dup
           node_children.delete_if { |e| e.nil_type? || (e.basic_literal? && e.str_content&.empty?) }
           return unless node_children.empty?
 
           add_offense(begin_node) { |corrector| corrector.remove(begin_node) }
+        end
+
+        private
+
+        def in_percent_literal_array?(begin_node)
+          array_node = begin_node.each_ancestor(:array).first
+          return false unless array_node
+
+          array_node.percent_literal?
         end
       end
     end

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -82,4 +82,27 @@ RSpec.describe RuboCop::Cop::Lint::EmptyInterpolation, :config do
       "this is the #{true}"
     RUBY
   end
+
+  it 'does not register an offense for an empty string interpolation inside a `%W` literal' do
+    expect_no_offenses(<<~'RUBY')
+      %W[#{''} one two]
+    RUBY
+  end
+
+  it 'does not register an offense for an empty string interpolation inside a `%I` literal' do
+    expect_no_offenses(<<~'RUBY')
+      %I[#{''} one two]
+    RUBY
+  end
+
+  it 'registers an offense for an empty string interpolation inside an array' do
+    expect_offense(<<~'RUBY')
+      ["#{''}", one, two]
+        ^^^^^ Empty interpolation detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ["", one, two]
+    RUBY
+  end
 end


### PR DESCRIPTION
Interpolating an empty string inside a `%W` literal is a common way to include an empty string in the resulting array.

Fixes #14605.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
