### PR TITLE
Fix `Style/RedundantFormat` handling control characters like `\n`

### DIFF
--- a/changelog/fix_fix_style_redundant_format_handling_control_20251016160803.md
+++ b/changelog/fix_fix_style_redundant_format_handling_control_20251016160803.md
@@ -1,0 +1,1 @@
+* [#14607](https://github.com/rubocop/rubocop/pull/14607): Fix `Style/RedundantFormat` handling control characters like `\n`. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -89,7 +89,7 @@ module RuboCop
 
         def on_send(node)
           format_without_additional_args?(node) do |value|
-            replacement = value.source
+            replacement = escape_control_chars(value.source)
 
             add_offense(node, message: message(node, replacement)) do |corrector|
               corrector.replace(node, replacement)
@@ -229,7 +229,12 @@ module RuboCop
             end
           end
 
-          "#{start_delimiter}#{string}#{end_delimiter}"
+          "#{start_delimiter}#{escape_control_chars(string)}#{end_delimiter}"
+        end
+
+        # Escape any control characters in the string (eg. `\t` or `\n` become `\\t` or `\\n`)
+        def escape_control_chars(string)
+          string.gsub(/\p{Cc}/) { |s| s.dump[1..-2] }
         end
 
         def argument_values(arguments)

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -84,6 +84,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             'foo'
           RUBY
         end
+
+        it 'registers an offense when the argument is a control character' do
+          expect_offense(<<~'RUBY', method: method)
+            %{method}("\n")
+            ^{method}^^^^^^ Use `"\n"` directly instead of `%{method}`.
+          RUBY
+
+          expect_correction(<<~'RUBY')
+            "\n"
+          RUBY
+        end
       end
 
       context 'with literal arguments' do
@@ -450,6 +461,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it 'does not register an offense when only argument is a splatted constant' do
           expect_no_offenses(<<~RUBY)
             #{method}(*FORMAT)
+          RUBY
+        end
+      end
+
+      context 'when the string contains control characters' do
+        it 'registers an offense with the correct message' do
+          expect_offense(<<~'RUBY', method: method)
+            %{method}("%s\a\b\t\n\v\f\r\e", 'foo')
+            ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `"foo\a\b\t\n\v\f\r\e"` directly instead of `%{method}`.
+          RUBY
+
+          expect_correction(<<~'RUBY')
+            "foo\a\b\t\n\v\f\r\e"
           RUBY
         end
       end


### PR DESCRIPTION
`Style/RedundantFormat` does not currently handle control characters properly, they need to be kept escaped and not replaced with their actual string representations.

NOTE: `\s` will be replaced with a space regardless, because that's how Ruby handles `\s`, it does not keep it as an escape character.

```
[1] pry(main)> "\s"
=> " "
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
