### PR TITLE
Fix `Style/RedundantFormat` false positive when a interpolated value is given to a specifier with a width or precision

### DIFF
--- a/changelog/fix_fix_style_redundant_format_false_positive_when_a_20251016162702.md
+++ b/changelog/fix_fix_style_redundant_format_false_positive_when_a_20251016162702.md
@@ -1,0 +1,1 @@
+* [#14604](https://github.com/rubocop/rubocop/issues/14604): Fix `Style/RedundantFormat` false positive when a interpolated value is given to a specifier with a width or precision. ([@dvandersluis][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -134,7 +134,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def all_fields_literal?(string, arguments)
           count = 0
           sequences = RuboCop::Cop::Utils::FormatString.new(string).format_sequences
@@ -147,13 +147,14 @@ module RuboCop
             hash = arguments.detect(&:hash_type?)
             next unless (argument = find_argument(sequence, arguments, hash))
             next unless matching_argument?(sequence, argument)
+            next if (sequence.width || sequence.precision) && argument.dstr_type?
 
             count += 1
           end
 
           sequences.size == count
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         # If the sequence has a variable (`*`) width, it cannot be autocorrected
         # if the width is not given as a numeric literal argument

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -206,6 +206,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it_behaves_like 'offending format specifier', '%10.2f', '5', "'      5.00'"
         it_behaves_like 'offending format specifier', '%-10.2f', '5', "'5.00      '"
 
+        # Width or precision with interpolation
+        it_behaves_like 'non-offending format specifier', '%10s', '"#{foo}"'
+        it_behaves_like 'non-offending format specifier', '%.1s', '"#{foo}"'
+
         it 'is able to handle `%%` specifiers' do
           expect_no_offenses(<<~RUBY)
             #{method}('%% %s', foo)


### PR DESCRIPTION
When `format` or `sprintf` has a specifier with a width or precision, and the related argument is an interpolated string, we cannot register that as a redundant format, as we cannot know ahead of time how wide the resulting string should be since it depends on the value of the interpolation.

Fixes #14604.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
