### PR TITLE
Improve `Lint/CopDirectiveSyntax` cop examples comment

### DIFF
--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -13,13 +13,22 @@ module RuboCop
       # @example
       #   # bad
       #   # rubocop:disable Layout/LineLength Style/Encoding
-      #   #                                  ^ missing comma
+      #
+      #   # good
+      #   # rubocop:disable Layout/LineLength, Style/Encoding
       #
       #   # bad
       #   # rubocop:disable
       #
+      #   # good
+      #   # rubocop:disable all
+      #
       #   # bad
       #   # rubocop:disable Layout/LineLength # rubocop:disable Style/Encoding
+      #
+      #   # good
+      #   # rubocop:disable Layout/LineLength
+      #   # rubocop:disable Style/Encoding
       #
       #   # bad
       #   # rubocop:wrongmode Layout/LineLength
@@ -27,14 +36,11 @@ module RuboCop
       #   # good
       #   # rubocop:disable Layout/LineLength
       #
-      #   # good
-      #   # rubocop:disable Layout/LineLength, Style/Encoding
+      #   # bad
+      #   # rubocop:disable Layout/LineLength comment
       #
       #   # good
-      #   # rubocop:disable all
-      #
-      #   # good
-      #   # rubocop:disable Layout/LineLength -- This is a good comment.
+      #   # rubocop:disable Layout/LineLength -- comment
       #
       class CopDirectiveSyntax < Base
         COMMON_MSG = 'Malformed directive comment detected.'


### PR DESCRIPTION
In most of the existing cops, both *bad* and *good* examples are provided as pairs, but this cop didn’t follow that pattern, which made it a bit harder to read.

I’ve made the following changes:

- Reordered the examples
- Added missing *bad* or *good* examples where necessary.
- Made some small adjustments for consistency

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
