### PR TITLE
[Fix #14597] Fix an infinite loop error for `Layout/HashAlignment`

### DIFF
--- a/changelog/fix_an_error_for_layout_hash_alignment.md
+++ b/changelog/fix_an_error_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#14597](https://github.com/rubocop/rubocop/issues/14597): Fix an infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`. ([@koic][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -232,6 +232,8 @@ module RuboCop
         end
 
         def argument_before_hash(hash_node)
+          return hash_node.children.first.children.first if hash_node.children.first.kwsplat_type?
+
           hash_node.left_sibling.respond_to?(:loc) ? hash_node.left_sibling : nil
         end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2337,6 +2337,11 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
         arg, foo: bar,
           baz: qux
       )
+
+      do_something(
+        **opts, foo: bar,
+          baz: qux
+      )
     RUBY
 
     create_file('.rubocop.yml', <<~YAML)
@@ -2366,6 +2371,11 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       do_something(
         arg, foo: bar,
+        baz: qux
+      )
+
+      do_something(
+        **opts, foo: bar,
         baz: qux
       )
     RUBY


### PR DESCRIPTION
Fixes #14597.

This PR fixes an infinite loop error for `Layout/HashAlignment` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment`. The issue context is that the first keyword argument and the double splat argument before it are on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
