### PR TITLE
Run `references:verify` task before version bump

### DIFF
--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -10,7 +10,7 @@ namespace :cut_release do
 
   %w[major minor patch pre].each do |release_type|
     desc "Cut a new #{release_type} release, create release notes and update documents."
-    task release_type => 'changelog:check_clean' do
+    task release_type => ['references:verify', 'changelog:check_clean'] do
       run(release_type)
     end
   end
@@ -100,7 +100,6 @@ namespace :cut_release do
     Bump::Bump.run(release_type, commit: false, bundle: false, tag: false)
     new_version = Bump::Bump.current
 
-    Rake::Task['references:verify'].invoke
     update_cop_versions(old_version, new_version)
     Rake::Task['update_cops_documentation'].invoke
     update_readme(old_version, new_version)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/commit/8c98655771be6e2d978297a7c6fa7dab69f044ca#r168376284.

This prevents updating `version.rb` when `references:verify` (a special task run inside `rake cut_release:*` that depends on external resources) is interrupted.

Since `version.rb` is updated by `Bump::Bump.run`, the simplest fix is to make `references:verify` a dependency and run it before `Bump::Bump.run`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
