### PR TITLE
Handle non-specific issues with the Gemfile to allow fallback

### DIFF
--- a/changelog/fix_handle_non_specific_issues_with_the_gemfile_to_20251022091848.md
+++ b/changelog/fix_handle_non_specific_issues_with_the_gemfile_to_20251022091848.md
@@ -1,0 +1,1 @@
+* [#14617](https://github.com/rubocop/rubocop/pull/14617): Handle non-specific issues with the Gemfile to allow fallback. ([@Fryguy][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -295,10 +295,11 @@ module RuboCop
         begin
           gem = Bundler.load.specs[gem_name].first
           gem_path = gem.full_gem_path if gem
-        rescue Bundler::GemfileNotFound
-          # No Gemfile found. Bundler may be loaded manually
-        rescue Bundler::GitError
-          # The Gemfile exists but contains an uninstalled git source
+        rescue StandardError
+          # The Gemfile has a problem, which could be one of:
+          # - No Gemfile found. Bundler may be loaded manually
+          # - The Gemfile exists but contains an uninstalled git source
+          # - The Gemfile exists but cannot be loaded for some other reason
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1351,6 +1351,18 @@ RSpec.describe RuboCop::ConfigLoader do
               expect { configuration_from_file }.not_to raise_error
             end
           end
+
+          context 'when the gemfile fails to load' do
+            before do
+              create_file('Gemfile', <<~GEMFILE)
+                eval_gemfile 'file_that_does_not_exist'
+              GEMFILE
+            end
+
+            it 'loads' do
+              expect { configuration_from_file }.not_to raise_error
+            end
+          end
         end
       end
 


### PR DESCRIPTION
In my specific case, my Gemfile has a eval_gemfile that pulls in another Gemfile in a subdirectory that hasn't been generated yet (similar to an non-updated git submodule). This causes rubocop to blow up with 

```
$ rubocop
No such file or directory @ rb_sysopen - /Users/jfrey/dev/my_app/my_subdir/Gemfile
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:524:in `initialize'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:524:in `open'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:524:in `block in read_file'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/shared_helpers.rb:105:in `filesystem_access'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:523:in `read_file'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:46:in `block in eval_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:314:in `with_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:45:in `eval_gemfile'
/Users/jfrey/dev/my_app/Gemfile:12:in `block in eval_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:47:in `instance_eval'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:47:in `block in eval_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:314:in `with_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:45:in `eval_gemfile'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/dsl.rb:12:in `evaluate'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler/definition.rb:37:in `build'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:236:in `definition'
/Users/jfrey/.gem/ruby/3.3.9/gems/bundler-2.7.1/lib/bundler.rb:218:in `load'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:296:in `gem_config_path'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:84:in `block (2 levels) in resolve_inheritance_from_gems'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:82:in `reverse_each'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:82:in `block in resolve_inheritance_from_gems'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:76:in `each_pair'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader_resolver.rb:76:in `resolve_inheritance_from_gems'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader.rb:58:in `load_file'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_loader.rb:120:in `configuration_from_file'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_store.rb:73:in `for_dir'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/config_store.rb:52:in `for_pwd'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/cli.rb:155:in `parallel_by_default!'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/cli.rb:51:in `block in run'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/cli.rb:87:in `profile_if_needed'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/lib/rubocop/cli.rb:45:in `run'
/Users/jfrey/.gem/ruby/3.3.9/gems/rubocop-1.81.6/exe/rubocop:15:in `<top (required)>'
/Users/jfrey/.rubies/ruby-3.3.9/lib/ruby/site_ruby/3.3.0/rubygems.rb:319:in `load'
/Users/jfrey/.rubies/ruby-3.3.9/lib/ruby/site_ruby/3.3.0/rubygems.rb:319:in `activate_and_load_bin_path'
/Users/jfrey/.gem/ruby/3.3.9/bin/rubocop:25:in `<main>'
```

After this change, everything works fine, because the code falls back to the system installed rubocop

In general, when the Gemfile fails to load for any reason, we want to fallback to try loading from the system gems. (This is is effectively an extension of the handlers in #12976 and #12991)

A non-specific issue could be something like eval_gemfile failing when a submodule that includes the requisite file has not yet been updated.

This commit changes the rescue to the generic StandardError, which subsumes the Bundler errors, and handles other errors as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
