### PR TITLE
[Fix #14621] Fix an error for `Naming/PredicateMethod`

### DIFF
--- a/changelog/fix_an_error_for_naming_predicate_method.md
+++ b/changelog/fix_an_error_for_naming_predicate_method.md
@@ -1,0 +1,1 @@
+* [#14621](https://github.com/rubocop/rubocop/issues/14621): Fix an error for `Naming/PredicateMethod` when using an `in` pattern with empty parentheses body. ([@koic][])

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -193,8 +193,7 @@ module RuboCop
             return_values << extract_return_value(return_node)
           end
 
-          last_value = last_value(node)
-          return_values << last_value if last_value
+          return_values << last_value(node)
 
           process_return_values(return_values)
         end
@@ -247,8 +246,9 @@ module RuboCop
         end
 
         def last_value(node)
-          value = node.begin_type? ? node.children.last : node
-          value&.return_type? ? extract_return_value(value) : value
+          value = node.begin_type? ? node.children.last || s(:nil) : node
+
+          value.return_type? ? extract_return_value(value) : value
         end
 
         def process_return_values(return_values)

--- a/spec/rubocop/cop/naming/predicate_method_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_method_spec.rb
@@ -276,6 +276,17 @@ RSpec.describe RuboCop::Cop::Naming::PredicateMethod, :config do
       RUBY
     end
 
+    it 'does not register an offense for an `in` pattern with empty parentheses body' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          case expr
+          in pattern
+            ()
+          end
+        end
+      RUBY
+    end
+
     context 'bare return' do
       it_behaves_like 'non-predicate', '', implicit: false
 


### PR DESCRIPTION
This PR fixes an error for `Naming/PredicateMethod` when using an `in` pattern with empty parentheses body.

Fixes #14621.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
