### PR TITLE
[Fix #14622] Fix an error for `Naming/MethodName` when the first argument to `alias` contains interpolation

### DIFF
--- a/changelog/fix_naming_method_name_alias_interpolation.md
+++ b/changelog/fix_naming_method_name_alias_interpolation.md
@@ -1,0 +1,1 @@
+* [#14622](https://github.com/rubocop/rubocop/pull/14622): Fix an error for `Naming/MethodName` when the first argument to `alias` contains interpolation. ([@earlopain][])

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -147,7 +147,9 @@ module RuboCop
         alias on_defs on_def
 
         def on_alias(node)
-          handle_method_name(node.new_identifier, node.new_identifier.value)
+          return unless (new_identifier = node.new_identifier).sym_type?
+
+          handle_method_name(new_identifier, new_identifier.value)
         end
 
         private

--- a/spec/rubocop/cop/naming/method_name_spec.rb
+++ b/spec/rubocop/cop/naming/method_name_spec.rb
@@ -621,10 +621,22 @@ RSpec.describe RuboCop::Cop::Naming::MethodName, :config do
       RUBY
     end
 
+    it 'accepts `alias` with interpolated symbol argument' do
+      expect_no_offenses(<<~'RUBY')
+        alias :"foo#{bar}" :baz
+      RUBY
+    end
+
     it 'registers an offense for `alias_method` snake_case string argument' do
       expect_offense(<<~RUBY)
         alias_method "fooBar", "foo"
                      ^^^^^^^^ Use snake_case for method names.
+      RUBY
+    end
+
+    it 'accepts `alias_method` with interpolated string argument' do
+      expect_no_offenses(<<~'RUBY')
+        alias_method "foo#{bar}", "baz"
       RUBY
     end
 


### PR DESCRIPTION
This is valid syntax. `alias_method` already handles this by explicitly only accepting sym/str arguments but there was no test

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
