### PR TITLE
[Fix #14626] Fix false positives for `Style/ConstantVisibility`

### DIFF
--- a/changelog/fix_false_positives_for_style_constant_visibility.md
+++ b/changelog/fix_false_positives_for_style_constant_visibility.md
@@ -1,0 +1,1 @@
+* [#14626](https://github.com/rubocop/rubocop/issues/14626): Fix false positives in `Style/ConstantVisibility` when visibility is declared with multiple constants. ([@koic][])

--- a/spec/rubocop/cop/style/constant_visibility_spec.rb
+++ b/spec/rubocop/cop/style/constant_visibility_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
           end
         RUBY
       end
+
+      it 'registers an offense when no arguments are used in the visibility declaration' do
+        expect_offense(<<~RUBY)
+          class Foo
+            BAR = 42
+            ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+            private_constant
+          end
+        RUBY
+      end
     end
 
     context 'with a multi-statement body' do
@@ -64,6 +74,16 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when multiple constants are specified in the visibility declaration' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          BAR = 42
+          BAZ = 43
+          public_constant :BAR, :BAZ
+        end
+      RUBY
+    end
   end
 
   it 'registers an offense for module definitions' do
@@ -103,6 +123,28 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
       class Foo
         BAR = 42
         private_constant "BAR"
+      end
+    RUBY
+  end
+
+  it 'registers an offense when passing an array with multiple elements to the visibility declaration' do
+    expect_offense(<<~RUBY)
+      class Foo
+        BAR = 42
+        ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+        BAZ = 43
+        ^^^^^^^^ Explicitly make `BAZ` public or private using either `#public_constant` or `#private_constant`.
+        private_constant ["BAR", "BAZ"]
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when passing a splatted array with multiple elements to the visibility declaration' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        BAR = 42
+        BAZ = 43
+        private_constant *["BAR", "BAZ"]
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes false positives in `Style/ConstantVisibility` when visibility is declared with multiple constants.

Fixes #14626.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
