### PR TITLE
[Fix #14628] Fix false positives for `Style/FloatDivision`

### DIFF
--- a/changelog/fix_false_positives_for_style_float_division.md
+++ b/changelog/fix_false_positives_for_style_float_division.md
@@ -1,0 +1,1 @@
+* [#14628](https://github.com/rubocop/rubocop/issues/14628): Fix false positives for `Style/FloatDivision` when using `Regexp.last_match` or nth reference (e.g., `$1`). ([@koic][])

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
       RUBY
     end
 
+    it 'does not register an offense for right coerce with `nth_ref`' do
+      expect_no_offenses(<<~RUBY)
+        a / $1.to_f
+      RUBY
+    end
+
+    it 'does not register an offense for right coerce with `Regexp.last_match(1)`' do
+      expect_no_offenses(<<~RUBY)
+        a / Regexp.last_match(1).to_f
+      RUBY
+    end
+
     it 'registers offense and corrects for both coerce' do
       expect_offense(<<~RUBY)
         a.to_f / b.to_f
@@ -23,6 +35,24 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
 
       expect_correction(<<~RUBY)
         a.to_f / b
+      RUBY
+    end
+
+    it 'does not register an offense for both coerce with `nth_ref`' do
+      expect_no_offenses(<<~RUBY)
+        $1.to_f / $2.to_f
+      RUBY
+    end
+
+    it 'does not register an offense for both coerce with `Regexp.last_match`' do
+      expect_no_offenses(<<~RUBY)
+        Regexp.last_match(1).to_f / Regexp.last_match(1).to_f
+      RUBY
+    end
+
+    it 'does not register an offense for both coerce with `::Regexp.last_match`' do
+      expect_no_offenses(<<~RUBY)
+        ::Regexp.last_match(1).to_f / ::Regexp.last_match(1).to_f
       RUBY
     end
 
@@ -57,6 +87,18 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
 
       expect_correction(<<~RUBY)
         a / b.to_f
+      RUBY
+    end
+
+    it 'does not register an offense for left coerce with `nth_ref`' do
+      expect_no_offenses(<<~RUBY)
+        $1.to_f / b
+      RUBY
+    end
+
+    it 'does not register an offense for left coerce with `Regexp.last_match(1)`' do
+      expect_no_offenses(<<~RUBY)
+        Regexp.last_match(1).to_f / b
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes false positives for `Style/FloatDivision` when using `Regexp.last_match` or nth reference (e.g., `$1`).

For `Regexp.last_match(1)` and `$1`, it assumes that the value is a string matched by a regular expression, and allows conversion with `#to_f`.

This cop is already marked as unsafe, but these issues can be avoided.

Fixes #14628.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
