### PR TITLE
Remove `bundler` gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 
 gem 'asciidoctor'
 gem 'bump', require: false
-gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'fiddle', platform: :windows if RUBY_VERSION >= '3.4'
 gem 'irb'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri


### PR DESCRIPTION
This PR removes `bundler` gem from Gemfile to avoid the following error:

```console
$ ruby -v
ruby 3.5.0dev (2025-10-24T15:50:47Z master a9f24aaccb) +PRISM [arm64-darwin24]

$ bundle update
[DEPRECATED] Pass --all to `bundle update` to update everything
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Could not find compatible versions

Because the current Bundler version (4.0.0.dev) does not satisfy bundler >= 1.15.0, < 3.0
  and Gemfile depends on bundler >= 1.15.0, < 3.0,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.7.2` and rerun bundler using `bundle _2.7.2_ update`
```

This issue occurs because the dependency version constraint `< 3.0` conflicts with Bundler 4.0.0.dev. One solution is to relax the dependency version in the Gemfile but the simpler approach is to remove `bundler` gem from Gemfile since it is already bundled by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
