### PR TITLE
Fix an error for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_error_for_style_sole_nested_conditional.md
+++ b/changelog/fix_an_error_for_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#14631](https://github.com/rubocop/rubocop/pull/14631): Fix an error for `Style/SoleNestedConditional` when using nested single line `if`. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -129,6 +129,7 @@ module RuboCop
           corrector.remove(range_with_surrounding_space(range, newlines: false))
         end
 
+        # rubocop:disable Metrics/AbcSize
         def correct_for_basic_condition_style(corrector, node, if_branch)
           range = range_between(
             node.condition.source_range.end_pos, if_branch.condition.source_range.begin_pos
@@ -137,8 +138,14 @@ module RuboCop
 
           corrector.replace(if_branch.condition, chainable_condition(if_branch))
 
-          corrector.remove(range_by_whole_lines(node.loc.end, include_final_newline: true))
+          end_range = if same_line?(node.loc.end, node.if_branch.loc.end)
+                        node.loc.end
+                      else
+                        range_by_whole_lines(node.loc.end, include_final_newline: true)
+                      end
+          corrector.remove(end_range)
         end
+        # rubocop:enable Metrics/AbcSize
 
         def autocorrect_outer_condition_modify_form(corrector, node, if_branch)
           correct_node(corrector, if_branch)

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -681,6 +681,17 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using nested single line `if`' do
+    expect_offense(<<~RUBY)
+      if foo; if bar; end; end
+              ^^ Consider merging nested conditions into outer `if` conditions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if foo && bar; end;#{' '}
+    RUBY
+  end
+
   context 'when disabling `Style/IfUnlessModifier`' do
     let(:config) { RuboCop::Config.new('Style/IfUnlessModifier' => { 'Enabled' => false }) }
 


### PR DESCRIPTION
This PR fixes the following error for `Style/SoleNestedConditional` when using nested single line `if`:

```console
$ echo "if foo; if bar; end; end" | bundle exec rubocop --stdin example.rb --only Style/SoleNestedConditional -A -d
(snip)

Inspecting 1 file
Scanning /Users/koic/src/github.com/rubocop/rubocop/example.rb
An error occurred while Style/SoleNestedConditional cop was inspecting
/Users/koic/src/github.com/rubocop/rubocop/example.rb:1:0.
/Users/koic/.rbenv/versions/3.5-dev/lib/ruby/gems/3.5.0+4/gems/parser-3.3.10.0/lib/parser/source/tree_rewriter.rb:427:
in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
