### PR TITLE
[Fix #13854 (old issue)] Introduce a new push/pop system to improve RuboCop usage by allowing local enable/disable scopes

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -265,4 +265,361 @@ RSpec.describe RuboCop::CommentConfig do
       end
     end
   end
+
+  describe 'push/pop directives' do
+    def disabled_lines_of_cop(cop)
+      (1..source.size).each_with_object([]) do |line_number, disabled_lines|
+        enabled = comment_config.cop_enabled_at_line?(cop, line_number)
+        disabled_lines << line_number unless enabled
+      end
+    end
+
+    context 'with basic push/pop' do
+      let(:source) do
+        <<~RUBY
+          x = 'before'                                     # 01
+          # rubocop:push disable Style/StringLiterals
+          x = "inside push"                                # 03
+          # rubocop:pop
+          x = 'after'                                      # 05
+        RUBY
+      end
+
+      it 'disables cop between push and pop' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(3)
+        expect(disabled_lines).not_to include(1, 5)
+      end
+    end
+
+    context 'with nested push/pop' do
+      let(:source) do
+        <<~RUBY
+          x = 'before'                                     # 01
+          # rubocop:push disable Style/StringLiterals
+          x = "inside first"                               # 03
+          # rubocop:push disable Layout/LineLength
+          x = "inside both pushes with a very long line that would normally trigger LineLength, and i know what i'm talking about "  # 05
+          # rubocop:pop
+          x = "after inner pop"                            # 07
+          # rubocop:pop
+          x = 'after outer pop'                            # 09
+        RUBY
+      end
+
+      it 'handles nested push/pop correctly' do
+        string_disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(string_disabled_lines).to include(3, 5, 7)
+        expect(string_disabled_lines).not_to include(1, 9)
+
+        length_disabled_lines = disabled_lines_of_cop('Layout/LineLength')
+        expect(length_disabled_lines).to include(5)
+        expect(length_disabled_lines).not_to include(1, 3, 7, 9)
+      end
+    end
+
+    context 'with push without disable action' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable Style/StringLiterals
+          x = "before push"                                # 02
+          # rubocop:push
+          x = "inside push"                                # 04
+          # rubocop:enable Style/StringLiterals
+          x = 'after enable'                               # 06
+          # rubocop:pop
+          x = "after pop - should be disabled again"      # 08
+        RUBY
+      end
+
+      it 'saves and restores the disabled state' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(2, 4, 8)
+        expect(disabled_lines).not_to include(6)
+      end
+    end
+
+    context 'with push enable' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable Style/StringLiterals
+          x = "before push"                                # 02
+          # rubocop:push enable Style/StringLiterals
+          x = 'inside push - enabled'                      # 04
+          # rubocop:pop
+          x = "after pop - disabled again"                 # 06
+        RUBY
+      end
+
+      it 'enables cop inside push/pop block' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(2, 6)
+        expect(disabled_lines).not_to include(4)
+      end
+    end
+
+    context 'with multiple cops in push' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style/StringLiterals, Layout/LineLength
+          x = "test with very long line that would normally be flagged by LineLength cop"  # 02
+          # rubocop:pop
+          x = 'after'                                      # 04
+        RUBY
+      end
+
+      it 'disables multiple cops' do
+        string_disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(string_disabled_lines).to include(2)
+        expect(string_disabled_lines).not_to include(4)
+
+        length_disabled_lines = disabled_lines_of_cop('Layout/LineLength')
+        expect(length_disabled_lines).to include(2)
+        expect(length_disabled_lines).not_to include(4)
+      end
+    end
+
+    context 'with deeply nested push/pop (5 levels)' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style/StringLiterals
+          # rubocop:push disable Layout/LineLength
+          # rubocop:push disable Metrics/AbcSize
+          # rubocop:push disable Naming/VariableName
+          # rubocop:push disable Security/Eval
+          x = "deeply nested"                              # 06
+          # rubocop:pop
+          # rubocop:pop
+          # rubocop:pop
+          # rubocop:pop
+          # rubocop:pop
+          x = 'all restored'                               # 12
+        RUBY
+      end
+
+      it 'handles deeply nested push/pop correctly' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(6)
+        expect(disabled_lines).not_to include(12)
+      end
+    end
+
+    context 'with push on same line as code (inline)' do
+      let(:source) do
+        <<~RUBY
+          x = 'before'                                     # 01
+          x = "test" # rubocop:push disable Style/StringLiterals
+          x = "inside"                                     # 03
+          # rubocop:pop
+          x = 'after'                                      # 05
+        RUBY
+      end
+
+      it 'handles inline push (single line directive)' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        # Inline directives are treated as single-line directives
+        # So line 2 itself is disabled, but it's treated specially
+        expect(disabled_lines).to include(2)
+        expect(disabled_lines).not_to include(1, 3, 5)
+      end
+    end
+
+    context 'with pop on same line as code (inline)' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style/StringLiterals
+          x = "inside"                                     # 02
+          x = 'after' # rubocop:pop
+          x = 'way after'                                  # 04
+        RUBY
+      end
+
+      it 'handles inline pop (single line directive)' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        # The push at line 1 disables from line 2
+        # The pop at line 3 (inline) closes the range at line 3
+        expect(disabled_lines).to include(2, 3)
+        expect(disabled_lines).not_to include(4)
+      end
+    end
+
+    context 'with multiple push/pop blocks in sequence' do
+      let(:source) do
+        <<~RUBY
+          # First block
+          # rubocop:push disable Style/StringLiterals
+          x = "block1"                                     # 03
+          # rubocop:pop
+          x = 'between'                                    # 05
+          # Second block
+          # rubocop:push disable Style/StringLiterals
+          x = "block2"                                     # 08
+          # rubocop:pop
+          x = 'after'                                      # 10
+        RUBY
+      end
+
+      it 'handles multiple independent push/pop blocks' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(3, 8)
+        expect(disabled_lines).not_to include(5, 10)
+      end
+    end
+
+    context 'with push/pop around already disabled cop from config' do
+      let(:source) do
+        <<~RUBY
+          # Assume cop is disabled globally
+          x = "before push"                                # 02
+          # rubocop:push enable Style/StringLiterals
+          x = 'enabled inside'                             # 04
+          # rubocop:pop
+          x = "after pop - disabled again"                 # 06
+        RUBY
+      end
+
+      it 'handles push enable when cop was enabled' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        # Without config mocking, all lines are enabled by default
+        expect(disabled_lines).not_to include(2, 4, 6)
+      end
+    end
+
+    context 'with interleaved push/pop for different cops' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style/StringLiterals
+          x = "string disabled"                            # 02
+          # rubocop:push disable Layout/LineLength
+          y = "both disabled with very long line here"    # 04
+          # rubocop:pop  -- pops LineLength
+          x = "only string disabled"                       # 06
+          # rubocop:push disable Metrics/AbcSize
+          z = "string and abc disabled"                    # 08
+          # rubocop:pop  -- pops AbcSize
+          x = "only string disabled"                       # 10
+          # rubocop:pop  -- pops StringLiterals
+          x = 'all enabled'                                # 12
+        RUBY
+      end
+
+      it 'handles interleaved push/pop for different cops' do
+        string_disabled = disabled_lines_of_cop('Style/StringLiterals')
+        expect(string_disabled).to include(2, 4, 6, 8, 10)
+        expect(string_disabled).not_to include(12)
+
+        length_disabled = disabled_lines_of_cop('Layout/LineLength')
+        expect(length_disabled).to include(4)
+        expect(length_disabled).not_to include(2, 6, 8, 10, 12)
+
+        abc_disabled = disabled_lines_of_cop('Metrics/AbcSize')
+        expect(abc_disabled).to include(8)
+        expect(abc_disabled).not_to include(2, 4, 6, 10, 12)
+      end
+    end
+
+    context 'with push disable all' do
+      let(:source) do
+        <<~RUBY
+          x = 'before'                                     # 01
+          # rubocop:push disable all
+          x = "everything disabled"                        # 03
+          # rubocop:pop
+          x = 'after'                                      # 05
+        RUBY
+      end
+
+      it 'handles push disable all' do
+        # Test a few cops to ensure "all" works
+        string_disabled = disabled_lines_of_cop('Style/StringLiterals')
+        expect(string_disabled).to include(3)
+        expect(string_disabled).not_to include(1, 5)
+
+        length_disabled = disabled_lines_of_cop('Layout/LineLength')
+        expect(length_disabled).to include(3)
+        expect(length_disabled).not_to include(1, 5)
+      end
+    end
+
+    context 'with empty push (no action)' do
+      let(:source) do
+        <<~RUBY
+          x = 'before'                                     # 01
+          # rubocop:push
+          x = 'inside empty push'                          # 03
+          # rubocop:disable Style/StringLiterals
+          x = "disabled"                                   # 05
+          # rubocop:pop
+          x = 'after - should be enabled'                  # 07
+        RUBY
+      end
+
+      it 'handles empty push that saves and restores state' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(5)
+        expect(disabled_lines).not_to include(1, 3, 7)
+      end
+    end
+
+    context 'with push/pop inside heredoc (should be ignored)' do
+      let(:source) do
+        <<~RUBY
+          text = <<~TEXT
+            # rubocop:push disable Style/StringLiterals
+            This is just text, not a real directive
+            # rubocop:pop
+          TEXT
+          x = "after heredoc"                              # 06
+        RUBY
+      end
+
+      it 'ignores directives inside heredoc' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        # The directives inside heredoc should be ignored
+        expect(disabled_lines).not_to include(6)
+      end
+    end
+
+    context 'with push/pop and departments' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style
+          x = "style disabled"                             # 02
+          # rubocop:pop
+          x = 'after'                                      # 04
+        RUBY
+      end
+
+      it 'handles push/pop with department names' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(2)
+        expect(disabled_lines).not_to include(4)
+      end
+    end
+
+    context 'with rapid push/pop/push/pop sequence' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push disable Style/StringLiterals
+          x = "1"                                          # 02
+          # rubocop:pop
+          x = 'enabled'                                    # 04
+          # rubocop:push disable Style/StringLiterals
+          x = "2"                                          # 06
+          # rubocop:pop
+          x = 'enabled'                                    # 08
+          # rubocop:push disable Style/StringLiterals
+          x = "3"                                          # 10
+          # rubocop:pop
+          x = 'enabled'                                    # 12
+        RUBY
+      end
+
+      it 'handles rapid push/pop sequences' do
+        disabled_lines = disabled_lines_of_cop('Style/StringLiterals')
+        expect(disabled_lines).to include(2, 6, 10)
+        expect(disabled_lines).not_to include(4, 8, 12)
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
   it 'registers an offense for incorrect mode' do
     expect_offense(<<~RUBY)
       # rubocop:disabled Layout/LineLength
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, or `todo`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, `todo`, `push`, or `pop`.
     RUBY
   end
 

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -440,4 +440,124 @@ RSpec.describe RuboCop::DirectiveComment do
       it { is_expected.to eq(%w[Style Lint/Void]) }
     end
   end
+
+  describe '#push?' do
+    subject { directive_comment.push? }
+
+    context 'when push directive' do
+      let(:text) { '# rubocop:push disable Style/StringLiterals' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when not push directive' do
+      let(:text) { '# rubocop:disable Style/StringLiterals' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#pop?' do
+    subject { directive_comment.pop? }
+
+    context 'when pop directive' do
+      let(:text) { '# rubocop:pop' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when not pop directive' do
+      let(:text) { '# rubocop:disable Style/StringLiterals' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe 'push directive parsing' do
+    context 'with disable sub-mode' do
+      let(:text) { '# rubocop:push disable Style/StringLiterals, Layout/LineLength' }
+
+      it 'parses mode correctly' do
+        expect(directive_comment.mode).to eq('push')
+      end
+
+      it 'parses sub_mode correctly' do
+        expect(directive_comment.sub_mode).to eq('disable')
+      end
+
+      it 'parses cops correctly' do
+        expect(directive_comment.cops).to eq('Style/StringLiterals, Layout/LineLength')
+      end
+
+      it 'returns cop names' do
+        expect(directive_comment.cop_names).to eq(%w[Style/StringLiterals Layout/LineLength])
+      end
+
+      it 'is disabled' do
+        expect(directive_comment).to be_disabled
+      end
+    end
+
+    context 'with enable sub-mode' do
+      let(:text) { '# rubocop:push enable Style/StringLiterals' }
+
+      it 'parses sub_mode correctly' do
+        expect(directive_comment.sub_mode).to eq('enable')
+      end
+
+      it 'is enabled' do
+        expect(directive_comment).to be_enabled
+      end
+    end
+
+    context 'without sub-mode' do
+      let(:text) { '# rubocop:push' }
+
+      it 'parses mode correctly' do
+        expect(directive_comment.mode).to eq('push')
+      end
+
+      it 'has no sub_mode' do
+        expect(directive_comment.sub_mode).to be_nil
+      end
+
+      it 'has no cops' do
+        expect(directive_comment.cops).to be_nil
+      end
+
+      it 'returns empty cop names' do
+        expect(directive_comment.cop_names).to eq([])
+      end
+    end
+  end
+
+  describe 'pop directive parsing' do
+    context 'basic pop' do
+      let(:text) { '# rubocop:pop' }
+
+      it 'parses mode correctly' do
+        expect(directive_comment.mode).to eq('pop')
+      end
+
+      it 'has no cops' do
+        expect(directive_comment.cops).to be_nil
+      end
+
+      it 'returns empty cop names' do
+        expect(directive_comment.cop_names).to eq([])
+      end
+    end
+
+    context 'pop with comment' do
+      let(:text) { '# rubocop:pop -- restore previous state' }
+
+      it 'parses mode correctly' do
+        expect(directive_comment.mode).to eq('pop')
+      end
+
+      it 'has no cops' do
+        expect(directive_comment.cops).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This MR introduces support for **push/pop directives** in RuboCop, providing a cleaner and more intuitive way to manage cop state changes in Ruby code. The push/pop mechanism allows developers to temporarily save the current state of cops, make changes, and restore the previous state, similar to stack operations in programming.

## New Directive Syntax

Four new directive modes are now available:

1. **`# rubocop:push disable Cop1, Cop2`** - Saves current state and disables specified cops
2. **`# rubocop:push enable Cop1, Cop2`** - Saves current state and enables specified cops
3. **`# rubocop:push`** - Saves current state without any changes (for later restoration)
4. **`# rubocop:pop`** - Restores the most recently saved state (no cop names allowed)

## Key Features

- **Stack-based state management**: Multiple push directives can be nested, with each pop restoring the corresponding push state
- **Automatic state restoration**: No need to manually track which cops were enabled/disabled before making changes
- **Cleaner syntax**: Replaces verbose `disable/enable` pairs with more semantic `push/pop` operations

## Usage Examples

### Example 1: Basic Push/Pop

**Before (traditional disable/enable):**
```ruby
# rubocop:disable Style/StringLiterals
x = "uses double quotes"
# rubocop:enable Style/StringLiterals
x = 'back to single quotes'
```

**After (with push/pop):**
```ruby
# rubocop:push disable Style/StringLiterals
x = "uses double quotes"
# rubocop:pop
x = 'back to single quotes'
```

### Example 2: Nested Push/Pop

```ruby
# rubocop:push disable Style/StringLiterals
x = "first level"
# rubocop:push disable Layout/LineLength
x = "both disabled with a very long line that would normally trigger LineLength"
# rubocop:pop
x = "only StringLiterals disabled"
# rubocop:pop
x = 'all cops restored'
```

### Example 3: State Preservation

```ruby
# rubocop:disable Style/StringLiterals
x = "disabled"
# rubocop:push  # Save current disabled state
# rubocop:enable Style/StringLiterals
x = 'enabled temporarily'
# rubocop:pop  # Restore to disabled state
x = "disabled again"
```

### Example 4: Multiple Cops

```ruby
# rubocop:push disable Style/StringLiterals, Layout/LineLength
x = "test with very long line that would normally be flagged by LineLength cop"
# rubocop:pop
x = 'after'
```

### Example 5: Push Enable (Temporary Override)

```ruby
# rubocop:disable Style/StringLiterals
x = "before push"
# rubocop:push enable Style/StringLiterals
x = 'inside push - enabled'
# rubocop:pop
x = "after pop - disabled again"
```

Related to https://github.com/rubocop/rubocop/issues/13854
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
