### PR TITLE
[Fix #13854 (Old issue)] add push/pop logic for handle local enable/disable

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -908,6 +908,99 @@ class Ingredient
 end
 ----
 
+== Scoped disabling with push/pop directives
+
+When you want to temporarily change cop settings for a specific section of code
+and then automatically restore the previous state, you can use `rubocop:push` and
+`rubocop:pop` directives. This is particularly useful when you need to disable
+cops for a block of code without affecting the rest of the file.
+
+=== Basic push/pop usage
+
+The `push` directive saves the current state of all cop settings, and `pop`
+restores them:
+
+[source,ruby]
+----
+def process_data(input)
+  result = input.upcase
+  # rubocop:push
+  # rubocop:disable Style/GuardClause
+  if result.present?
+    return result.strip
+  end
+  # rubocop:pop
+  nil
+end
+----
+
+After `pop`, the `Style/GuardClause` cop is automatically re-enabled, returning
+to its state before `push`.
+
+=== Inline push arguments
+
+For convenience, you can combine `push` with enable/disable operations using
+inline arguments. Use `-` to disable a cop and `+` to enable a cop:
+
+[source,ruby]
+----
+def process_data(input)
+  result = input.upcase
+  # rubocop:push -Style/GuardClause
+  if result.present?
+    return result.strip
+  end
+  # rubocop:pop
+  nil
+end
+----
+
+You can specify multiple cops with different operations:
+
+[source,ruby]
+----
+# rubocop:disable Style/For
+for x in [1, 2, 3]
+  puts x
+end
+# rubocop:push +Style/For -Style/GuardClause
+for y in [4, 5, 6]  # Style/For is re-enabled here
+  if y > 0
+    return y        # Style/GuardClause is disabled here
+  end
+end
+# rubocop:pop
+# Back to original state: Style/For disabled, Style/GuardClause enabled
+----
+
+=== Nested push/pop
+
+Push/pop directives can be nested for complex scenarios:
+
+[source,ruby]
+----
+# rubocop:disable Metrics/MethodLength
+def complex_method
+  step1
+  # rubocop:push
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:disable Style/GuardClause
+  def helper_method
+    # rubocop:push
+    # rubocop:enable Style/GuardClause
+    if condition
+      return value
+    end
+    # rubocop:pop
+    other_code
+  end
+  # rubocop:pop
+  step2
+end
+----
+
+Each `pop` restores the state to what it was at the corresponding `push`.
+
 == Setting the style guide URL
 
 You can specify the base URL of the style guide using `StyleGuideBaseURL`.

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -46,7 +46,7 @@ module RuboCop
         COMMON_MSG = 'Malformed directive comment detected.'
 
         MISSING_MODE_NAME_MSG = 'The mode name is missing.'
-        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, or `todo`.'
+        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, `todo`, `push`, or `pop`.' # rubocop:disable Layout/LineLength
         MISSING_COP_NAME_MSG = 'The cop name is missing.'
         MALFORMED_COP_NAMES_MSG = 'Cop names must be separated by commas. ' \
                                   'Comment in the directive must start with `--`.'

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
   it 'registers an offense for incorrect mode' do
     expect_offense(<<~RUBY)
       # rubocop:disabled Layout/LineLength
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, or `todo`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, `todo`, `push`, or `pop`.
     RUBY
   end
 

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -81,19 +81,19 @@ RSpec.describe RuboCop::DirectiveComment do
     context 'when disable' do
       let(:text) { '# rubocop:disable all' }
 
-      it { is_expected.to eq(['disable', 'all', nil, nil]) }
+      it { is_expected.to eq(%w[disable all]) }
     end
 
     context 'when enable' do
       let(:text) { '# rubocop:enable Foo/Bar' }
 
-      it { is_expected.to eq(['enable', 'Foo/Bar', nil, 'Foo/']) }
+      it { is_expected.to eq(['enable', 'Foo/Bar']) }
     end
 
     context 'when todo' do
       let(:text) { '# rubocop:todo all' }
 
-      it { is_expected.to eq(['todo', 'all', nil, nil]) }
+      it { is_expected.to eq(%w[todo all]) }
     end
 
     context 'when typo' do


### PR DESCRIPTION
## Summary

This MR introduces support for **push/pop directives** in RuboCop, providing a cleaner and more intuitive way to manage cop state changes in Ruby code. The push/pop mechanism allows developers to temporarily save the current state of cops, make changes, and restore the previous state, similar to stack operations in programming.

## New Directive Syntax

Two new directive modes are now available:

- `# rubocop:push +Style/Foo -Style/Bar` - Saves the current state of all cops onto a stack (to be restored later)
- `# rubocop:pop` - Restores the most recently saved state from the stack

**Note**: Unlike traditional disable/enable directives, push and pop operate on the entire cop state as a snapshot. pop
  does not accept cop names.

## Key Features

- **Stack-based state management**: Multiple push directives can be nested, with each pop restoring the corresponding push state
- **Automatic state restoration**: No need to manually track which cops were enabled/disabled before making changes
- **Cleaner syntax**: Replaces verbose disable/enable pairs with more semantic push/pop operations
- **Preserves all cop states**: Captures the complete state of all cops at the time of push

## Usage Examples

### Example 1: Basic Push/Pop - Temporarily Disable a Cop
```ruby
def process_data(input)
  result = input.upcase
  # rubocop:push -Style/GuardClause
  if result.present?
    return result.strip
  end
  # rubocop:pop
  nil
end
```
### Example 2: Temporarily Enable a Disabled Cop
```ruby
When a cop is already disabled globally, you can temporarily re-enable it:
# rubocop:disable Metrics/MethodLength
def long_method
  line1
  line2
  # rubocop:push +Metrics/MethodLength
  def short_method  # This will be checked by MethodLength
    line3
  end
  # rubocop:pop
  line4  # MethodLength disabled again
  line5
end
```
### Example 3: Multiple Cops with Selective Enable
```ruby
When multiple cops are disabled, you can enable just one temporarily:
# rubocop:disable Style/For, Style/Not
for x in [1, 2, 3]
  not x.nil?
end
# rubocop:push +Style/For -Style/GuardClause
for y in [4, 5, 6]    # Style/For checked here
  not y.nil?          # Style/Not still disabled
  if true             # GuardClause disabled here
    return 1
  end
end
# rubocop:pop
for z in [7, 8, 9]    # Both original states restored
  not z.nil?
end
```
### Example 4: Disable New Cop in Push/Pop, Original Stays Enabled
```ruby
Perfect for temporarily disabling a cop for a specific block:
def process
  x = 1
  y = 2
  # rubocop:push -Style/NumericPredicate +Metrics/MethodLength
  if x.size == 0      # NumericPredicate disabled
    puts 'empty'
  end
  if y.size == 1      # NumericPredicate disabled
    puts 'one'
  end
  # rubocop:pop
  if y.size == 2      # NumericPredicate enabled again
    puts 'two'
  end
end
```

### Example 5: Temporary Disable for Problematic Code Block
```ruby
Perfect for legacy code refactoring or complex multi-line assignments:
def configure(stage)
  # rubocop:push -Layout/SpaceAroundMethodCallOperator
  self.stage =
    if    'macro'  .start_with? stage; X::MACRO
    elsif 'dynamic'.start_with? stage; X::DYNAMIC
    elsif 'static' .start_with? stage; X::STATIC
    else raise ArgumentError, "invalid stage: #{stage}"
    end
  # rubocop:pop
  validate_stage  # Original cop state restored
end
```
Related Issue #13854 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
