### PR TITLE
[Fix #14598] Add PreventDisabling configuration option

### DIFF
--- a/changelog/new_add_preventdisabling_config_option.md
+++ b/changelog/new_add_preventdisabling_config_option.md
@@ -1,0 +1,1 @@
+* [#14598](https://github.com/rubocop/rubocop/issues/14598): Add new `PreventDisabling` configuration option to allow cops to prevent being disabled via directive comments. Set to `true` for `Lint/Syntax` by default. ([@rafaelfranca][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2488,6 +2488,7 @@ Lint/SymbolConversion:
 Lint/Syntax:
   Description: 'Checks for syntax errors.'
   Enabled: true
+  PreventDisabling: true
   VersionAdded: '0.9'
 
 Lint/ToEnumArguments:

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -116,7 +116,8 @@ module RuboCop
       registry.disabled(config).each do |cop|
         analyses[cop.cop_name] = analyze_cop(
           analyses[cop.cop_name],
-          DirectiveComment.new(ConfigDisabledCopDirectiveComment.new(cop.cop_name))
+          DirectiveComment.new(ConfigDisabledCopDirectiveComment.new(cop.cop_name),
+                               Cop::Registry.global, config)
         )
       end
     end
@@ -171,7 +172,7 @@ module RuboCop
       return if @no_directives
 
       processed_source.comments.each do |comment|
-        directive = DirectiveComment.new(comment)
+        directive = DirectiveComment.new(comment, Cop::Registry.global, config)
         yield directive if directive.cop_names
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -394,6 +394,25 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string).to include('F:  2:  7: Lint/Syntax: unexpected token tINTEGER')
     end
 
+    it '`Style/DisableCopsWithinSourceCodeDirective` can be prevented from being disabled with PreventDisabling config' do
+      create_file('.rubocop.yml', <<~YAML)
+        Style/DisableCopsWithinSourceCodeDirective:
+          Enabled: true
+          PreventDisabling: true
+      YAML
+      create_file('example.rb', <<~RUBY)
+        # rubocop:disable Style/DisableCopsWithinSourceCodeDirective
+        # rubocop:disable Metrics/AbcSize
+        def foo
+        end
+      RUBY
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include(
+        'Style/DisableCopsWithinSourceCodeDirective: RuboCop disable/enable directives'
+      )
+    end
+
     it '`Naming/FileName` must be be disabled for global offenses' do
       create_file('Example.rb', <<~RUBY)
         # rubocop:disable Naming/FileName


### PR DESCRIPTION
Replace hardcoded cop exclusion with a per-cop configuration option that allows any cop to prevent being disabled via directive comments.

Previously, `Lint/Syntax` was hardcoded to not be disableable. This changes the implementation to use a `PreventDisabling` configuration option instead, providing a flexible way for any cop to opt-in to this behavior.

This allows users to configure cops like `Style/DisableCopsWithinSourceCodeDirective` to be non-disableable by setting `PreventDisabling: true` in their configuration, addressing the issue raised in #14598.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
