### PR TITLE
Make `Gemspec/RubyVersionGlobalsUsage` aware of `Ruby::VERSION`

### DIFF
--- a/changelog/change_make_gemspec_ruby_version_globals_usage_aware_of_ruby_version.md
+++ b/changelog/change_make_gemspec_ruby_version_globals_usage_aware_of_ruby_version.md
@@ -1,0 +1,1 @@
+* [#14642](https://github.com/rubocop/rubocop/pull/14642): Make `Gemspec/RubyVersionGlobalsUsage` aware of `Ruby::VERSION`. ([@koic][])

--- a/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
+++ b/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Gemspec
-      # Checks that `RUBY_VERSION` constant is not used in gemspec.
-      # Using `RUBY_VERSION` is dangerous because value of the
+      # Checks that `RUBY_VERSION` and `Ruby::VERSION` constants are not used in gemspec.
+      # Using `RUBY_VERSION` and `Ruby::VERSION` are dangerous because value of the
       # constant is determined by `rake release`.
       # It's possible to have dependency based on ruby version used
       # to execute `rake release` and not user's ruby version.
@@ -28,15 +28,20 @@ module RuboCop
       class RubyVersionGlobalsUsage < Base
         include GemspecHelp
 
-        MSG = 'Do not use `RUBY_VERSION` in gemspec file.'
+        MSG = 'Do not use `%<ruby_version>s` in gemspec file.'
 
         # @!method ruby_version?(node)
-        def_node_matcher :ruby_version?, '(const {cbase nil?} :RUBY_VERSION)'
+        def_node_matcher :ruby_version?, <<~PATTERN
+          {
+            (const {cbase nil?} :RUBY_VERSION)
+            (const (const {cbase nil?} :Ruby) :VERSION)
+          }
+        PATTERN
 
         def on_const(node)
           return unless gem_spec_with_ruby_version?(node)
 
-          add_offense(node)
+          add_offense(node, message: format(MSG, ruby_version: node.source))
         end
 
         private

--- a/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
+++ b/spec/rubocop/cop/gemspec/ruby_version_globals_usage_spec.rb
@@ -14,7 +14,25 @@ RSpec.describe RuboCop::Cop::Gemspec::RubyVersionGlobalsUsage, :config do
     expect_offense(<<~RUBY)
       Gem::Specification.new do |spec|
         ::RUBY_VERSION
-        ^^^^^^^^^^^^^^ Do not use `RUBY_VERSION` in gemspec file.
+        ^^^^^^^^^^^^^^ Do not use `::RUBY_VERSION` in gemspec file.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `Ruby::VERSION`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        Ruby::VERSION
+        ^^^^^^^^^^^^^ Do not use `Ruby::VERSION` in gemspec file.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `::Ruby::VERSION`' do
+    expect_offense(<<~RUBY)
+      Gem::Specification.new do |spec|
+        ::Ruby::VERSION
+        ^^^^^^^^^^^^^^^ Do not use `::Ruby::VERSION` in gemspec file.
       end
     RUBY
   end


### PR DESCRIPTION
This PR makes `Gemspec/RubyVersionGlobalsUsage` aware of `Ruby::VERSION`. `Ruby::VERSION` will be introduce in Ruby 3.5.

```console
$ ruby -ve 'p Ruby::VERSION'
ruby 3.5.0dev (2025-11-05T02:36:55Z master 033ba3c881) +PRISM [arm64-darwin24]
"3.5.0"
```

`Gemspec/RubyVersionGlobalsUsage` is categorized as a Lint cop rather than a Style cop. Therefore, although `Ruby::VERSION` is a constant scheduled to be introduced in Ruby 3.5, the cop also registers offenses about its usage even when targeting earlier Ruby versions.

Ref: https://bugs.ruby-lang.org/issues/20884

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
