### PR TITLE
Support `TargetRubyVersion 4.0`

### DIFF
--- a/changelog/new_support_ruby40.md
+++ b/changelog/new_support_ruby40.md
@@ -1,0 +1,1 @@
+* [#14644](https://github.com/rubocop/rubocop/pull/14644): Support `TargetRubyVersion 4.0` (experimental). ([@koic][])

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -36,7 +36,7 @@ The following table is the runtime support matrix.
 | 3.2 | -
 | 3.3 | -
 | 3.4 | -
-| 3.5 (experimental) | -
+| 4.0 (experimental) | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -266,6 +266,6 @@ RSpec.shared_context 'ruby 3.4' do
   let(:ruby_version) { 3.4 }
 end
 
-RSpec.shared_context 'ruby 3.5' do
-  let(:ruby_version) { 3.5 }
+RSpec.shared_context 'ruby 4.0' do
+  let(:ruby_version) { 4.0 }
 end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -30,5 +30,5 @@ RSpec.configure do |config|
   config.include_context 'ruby 3.2', :ruby32
   config.include_context 'ruby 3.3', :ruby33
   config.include_context 'ruby 3.4', :ruby34
-  config.include_context 'ruby 3.5', :ruby35
+  config.include_context 'ruby 4.0', :ruby40
 end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,7 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5].freeze
+    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0].freeze
     DEFAULT_VERSION = 2.7
 
     OBSOLETE_RUBIES = {

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.47.1', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.48.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2024,14 +2024,14 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<~YAML)
           AllCops:
-            TargetRubyVersion: 4.0
+            TargetRubyVersion: 5.0
         YAML
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to start_with(
-          'Error: RuboCop found unknown Ruby version 4.0 in `TargetRubyVersion`'
+          'Error: RuboCop found unknown Ruby version 5.0 in `TargetRubyVersion`'
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5/
+          /Supported versions: 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0/
         )
       end
     end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
   shared_examples 'string literal' do
     # TODO : It is not yet decided when frozen string will be the default.
     # It has been abandoned in the Ruby 3.0 period, but may default in
-    # the long run. So these tests are left with a provisional value of 4.0.
-    if RuboCop::TargetRuby.supported_versions.include?(4.0)
-      context 'when the target ruby version >= 4.0' do
-        let(:ruby_version) { 4.0 }
+    # the long run. So these tests are left with a provisional value of 5.0.
+    if RuboCop::TargetRuby.supported_versions.include?(5.0)
+      context 'when the target ruby version >= 5.0' do
+        let(:ruby_version) { 5.0 }
 
         context 'when the frozen string literal comment is missing' do
           it_behaves_like 'immutable objects', '"#{a}"'

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantFreeze, :config do
   context 'when the receiver is a string literal' do
     # TODO : It is not yet decided when frozen string will be the default.
     # It has been abandoned in the Ruby 3.0 period, but may default in
-    # the long run. So these tests are left with a provisional value of 4.0.
-    if RuboCop::TargetRuby.supported_versions.include?(4.0)
-      context 'when the target ruby version >= 4.0' do
-        let(:ruby_version) { 4.0 }
+    # the long run. So these tests are left with a provisional value of 5.0.
+    if RuboCop::TargetRuby.supported_versions.include?(5.0)
+      context 'when the target ruby version >= 5.0' do
+        let(:ruby_version) { 5.0 }
 
         context 'when the frozen string literal comment is missing' do
           it_behaves_like 'immutable objects', '"#{a}"'


### PR DESCRIPTION
Follow-up https://github.com/rubocop/rubocop-ast/pull/391

This PR supports `TargetRubyVersion 4.0`.

IMPORTANT: Merging this PR requires https://github.com/rubocop/rubocop-ast/pull/391.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
