### PR TITLE
Change `Lint/CircularArgumentReference` cop to detect offense within long assignment chains

### DIFF
--- a/changelog/change_lint_circular_argument_reference_for_long_assignment_chains_20251108174915.md
+++ b/changelog/change_lint_circular_argument_reference_for_long_assignment_chains_20251108174915.md
@@ -1,0 +1,1 @@
+* [#14645](https://github.com/rubocop/rubocop/pull/14645): Change `Lint/CircularArgumentReference` to detect offenses within long assignment chains. ([@viralpraxis][])

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -14,6 +14,49 @@ RSpec.describe RuboCop::Cop::Lint::CircularArgumentReference, :config, :ruby34 d
       end
     end
 
+    context 'when the method contains a triple circular argument reference' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          def omg_wow(msg = msg = msg)
+                                  ^^^ Circular argument reference - `msg`.
+            puts msg
+          end
+        RUBY
+      end
+    end
+
+    context 'when the method contains a circular argument reference with intermediate argument' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          def omg_wow(msg = foo = msg)
+                                  ^^^ Circular argument reference - `msg`.
+            puts msg
+          end
+        RUBY
+      end
+    end
+
+    context 'when the method contains a circular argument reference with two intermediate arguments' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          def omg_wow(msg = foo = msg2 = foo)
+                                         ^^^ Circular argument reference - `msg`.
+            puts msg
+          end
+        RUBY
+      end
+    end
+
+    context 'when the method does not contain a circular argument among assignments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def omg_wow(msg = foo = self.msg)
+            puts msg
+          end
+        RUBY
+      end
+    end
+
     context 'when the method does not contain a circular argument reference' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
The cop should detect offenses for methods like this

```ruby
def f(a = a = a); end
```

or (more realistically)

```ruby
def f(a = b = a); end
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
