### PR TITLE
[Fix #14647] Add `allow_exact_single_line` option to `Style/NumberedParameters` and `Style/ItBlockParameter`

### DIFF
--- a/changelog/new_add_new_allow_exact_single_line_option.md
+++ b/changelog/new_add_new_allow_exact_single_line_option.md
@@ -1,0 +1,1 @@
+* [#14647](https://github.com/rubocop/rubocop/issues/14647): Add a new `allow_exact_single_line` alternative option to `Style/NumberedParameters` and `Style/ItBlockParameter` cops. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4516,6 +4516,7 @@ Style/ItBlockParameter:
   EnforcedStyle: allow_single_line
   SupportedStyles:
     - allow_single_line
+    - allow_exact_single_line
     - only_numbered_parameters
     - always
     - disallow
@@ -4969,6 +4970,7 @@ Style/NumberedParameters:
   EnforcedStyle: allow_single_line
   SupportedStyles:
     - allow_single_line
+    - allow_exact_single_line
     - disallow
 
 Style/NumberedParametersLimit:

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -7,10 +7,11 @@ module RuboCop
       #
       # It provides four `EnforcedStyle` options:
       #
-      # 1. `allow_single_line` (default) ... Always uses the `it` block parameter in a single line.
-      # 2. `only_numbered_parameters` ... Detects only numbered block parameters.
-      # 3. `always` ... Always uses the `it` block parameter.
-      # 4. `disallow` ... Disallows the `it` block parameter.
+      # 1. `allow_single_line` (default) ... Uses the `it` block parameter in a single line.
+      # 2. `allow_exact_single_line` ... Uses the `it` block parameter in an exact single line.
+      # 3. `only_numbered_parameters` ... Detects only numbered block parameters.
+      # 4. `always` ... Always uses the `it` block parameter.
+      # 5. `disallow` ... Disallows the `it` block parameter.
       #
       # A single numbered parameter is detected when `allow_single_line`,
       # `only_numbered_parameters`, or `always`.
@@ -25,6 +26,23 @@ module RuboCop
       #   # good
       #   block { do_something(it) }
       #   block { |named_param| do_something(named_param) }
+      #   block.foo
+      #        .bar { do_something(it) }
+      #   block.foo.bar { do_something(it) }
+      #
+      # @example EnforcedStyle: allow_exact_single_line
+      #   # bad
+      #   block do
+      #     do_something(it)
+      #   end
+      #   block { do_something(_1) }
+      #   block.foo
+      #        .bar { do_something(it) }
+      #
+      #   # good
+      #   block { do_something(it) }
+      #   block { |named_param| do_something(named_param) }
+      #   block.foo.bar { do_something(it) }
       #
       # @example EnforcedStyle: only_numbered_parameters
       #   # bad
@@ -95,6 +113,10 @@ module RuboCop
           case style
           when :allow_single_line
             return if node.single_line?
+
+            add_offense(node, message: MSG_AVOID_IT_PARAMETER_MULTILINE)
+          when :allow_exact_single_line
+            return if same_line?(node.source_range.begin, node.source_range.end)
 
             add_offense(node, message: MSG_AVOID_IT_PARAMETER_MULTILINE)
           when :disallow

--- a/lib/rubocop/cop/style/numbered_parameters.rb
+++ b/lib/rubocop/cop/style/numbered_parameters.rb
@@ -16,6 +16,21 @@ module RuboCop
       #
       #   # good
       #   collection.each { puts _1 }
+      #   collection.foo
+      #             .each { puts _1 }
+      #   collection.foo.each { puts _1 }
+      #
+      # @example EnforcedStyle: allow_exact_single_line
+      #   # bad
+      #   collection.each do
+      #     puts _1
+      #   end
+      #   collection.foo
+      #             .each { puts _1 }
+      #
+      #   # good
+      #   collection.each { puts _1 }
+      #   collection.foo.each { puts _1 }
       #
       # @example EnforcedStyle: disallow
       #   # bad
@@ -34,10 +49,17 @@ module RuboCop
         minimum_target_ruby_version 2.7
 
         def on_numblock(node)
-          if style == :disallow
-            add_offense(node, message: MSG_DISALLOW)
-          elsif node.multiline?
+          case style
+          when :allow_single_line
+            return if node.single_line?
+
             add_offense(node, message: MSG_MULTI_LINE)
+          when :allow_exact_single_line
+            return if same_line?(node.source_range.begin, node.source_range.end)
+
+            add_offense(node, message: MSG_MULTI_LINE)
+          when :disallow
+            add_offense(node, message: MSG_DISALLOW)
           end
         end
       end

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -77,6 +77,82 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
       end
     end
 
+    context 'EnforcedStyle: allow_exact_single_line' do
+      let(:cop_config) { { 'EnforcedStyle' => 'allow_exact_single_line' } }
+
+      it 'registers an offense when using multiline `it` parameters', unsupported_on: :parser do
+        expect_offense(<<~RUBY)
+          block do
+          ^^^^^^^^ Avoid using `it` block parameter for multi-line blocks.
+            do_something(it)
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when using `it` block parameter with multi-line method chain' do
+        expect_offense(<<~RUBY)
+          collection.each
+          ^^^^^^^^^^^^^^^ Avoid using `it` block parameter for multi-line blocks.
+                    .foo { puts it }
+        RUBY
+      end
+
+      it 'registers an offense when using a single numbered parameters' do
+        expect_offense(<<~RUBY)
+          block { do_something(_1) }
+                               ^^ Use `it` block parameter.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          block { do_something(it) }
+        RUBY
+      end
+
+      it 'registers an offense when using twice a single numbered parameters' do
+        expect_offense(<<~RUBY)
+          block do
+            foo(_1)
+                ^^ Use `it` block parameter.
+            bar(_1)
+                ^^ Use `it` block parameter.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          block do
+            foo(it)
+            bar(it)
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using `it` block parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(it) }
+        RUBY
+      end
+
+      it 'does not register an offense when using named block parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { |arg| do_something(arg) }
+        RUBY
+      end
+
+      it 'does not register an offense when using multiple numbered parameters' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(_1, _2) }
+        RUBY
+      end
+
+      it 'does not register an offense when using a single numbered parameters `_2`' do
+        expect_no_offenses(<<~RUBY)
+          block { do_something(_2) }
+        RUBY
+      end
+    end
+
     context 'EnforcedStyle: only_numbered_parameters' do
       let(:cop_config) { { 'EnforcedStyle' => 'only_numbered_parameters' } }
 

--- a/spec/rubocop/cop/style/numbered_parameters_spec.rb
+++ b/spec/rubocop/cop/style/numbered_parameters_spec.rb
@@ -28,6 +28,33 @@ RSpec.describe RuboCop::Cop::Style::NumberedParameters, :config do
       end
     end
 
+    context 'EnforcedStyle: allow_exact_single_line' do
+      let(:cop_config) { { 'EnforcedStyle' => 'allow_exact_single_line' } }
+
+      it 'registers an offense when using numbered parameters with multi-line blocks' do
+        expect_offense(<<~RUBY)
+          collection.each do
+          ^^^^^^^^^^^^^^^^^^ Avoid using numbered parameters for multi-line blocks.
+            puts _1
+          end
+        RUBY
+      end
+
+      it 'registers an offense when using numbered parameters with multi-line method chain' do
+        expect_offense(<<~RUBY)
+          collection.each
+          ^^^^^^^^^^^^^^^ Avoid using numbered parameters for multi-line blocks.
+                    .foo { puts _1 }
+        RUBY
+      end
+
+      it 'does not register an offense when using numbered parameters with single-line blocks' do
+        expect_no_offenses(<<~RUBY)
+          collection.each { puts _1 }
+        RUBY
+      end
+    end
+
     context 'EnforcedStyle: disallow' do
       let(:cop_config) { { 'EnforcedStyle' => 'disallow' } }
 


### PR DESCRIPTION
Reimplementing https://github.com/rubocop/rubocop/pull/14527 as a new `allow_exact_single_line` alternative option for `Style/NumberedParameters` and `Style/ItBlockParameter`. This resolves #14647 without introducing incompatibility for existing users.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
