### PR TITLE
Fix an error for `Lint/LiteralAsCondition` cop

### DIFF
--- a/changelog/fix_an_error_for_lint_literal_as_condition_cop_20251109191737.md
+++ b/changelog/fix_an_error_for_lint_literal_as_condition_cop_20251109191737.md
@@ -1,0 +1,1 @@
+* [#14649](https://github.com/rubocop/rubocop/pull/14649): Fix an error for `Lint/LiteralAsCondition` when there are literals in multiple branches. ([@viralpraxis][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -269,7 +269,11 @@ module RuboCop
                      end
 
           add_offense(cond) do |corrector|
+            next if part_of_ignored_node?(node)
+
             corrector.replace(node, new_node)
+
+            ignore_node(node)
           end
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    it 'registers offenses for truthy literals in both the branches in `if`' do
+      expect_offense(<<~RUBY, lit: lit)
+        if %{lit}
+           ^{lit} Literal `#{lit}` appeared as a condition.
+          x = 1
+        elsif %{lit}
+              ^{lit} Literal `#{lit}` appeared as a condition.
+          x = 2
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = 1
+      RUBY
+    end
+
     it "registers an offense for truthy literal #{lit} in if-elsif-else" do
       expect_offense(<<~RUBY, lit: lit)
         if condition


### PR DESCRIPTION
```ruby
echo 'if true; 1; elsif true; 2; end' | bundle exec rubocop --stdin bug.rb -d -A

An error occurred while Lint/LiteralAsCondition cop was inspecting rubocop/bug.rb:1:12.
parser-3.3.10.0/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser-3.3.10.0/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser-3.3.10.0/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from parser-3.3.10.0/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
```

The fix is to skip branches whose parent node has already been rewritten (but an offense is still registered for them).

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
