### PR TITLE
Fix wrong autocorrect for `Lint/RedundantSplatExpansion` when splatting a single literal

### DIFF
--- a/changelog/fix_autocorrect_redundant_splat_expansion.md
+++ b/changelog/fix_autocorrect_redundant_splat_expansion.md
@@ -1,0 +1,1 @@
+* [#14650](https://github.com/rubocop/rubocop/pull/14650): Fix wrong autocorrect for `Lint/RedundantSplatExpansion` when splatting a single literal. ([@earlopain][])

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -144,7 +144,9 @@ module RuboCop
             expression = node.parent.source_range if node.parent.array_type?
             [expression, variable.source]
           elsif !variable.array_type?
-            [expression, "[#{variable.source}]"]
+            replacement = variable.source
+            replacement = "[#{replacement}]" if wrap_in_brackets?(node)
+            [expression, replacement]
           elsif redundant_brackets?(node)
             [expression, remove_brackets(variable)]
           else
@@ -174,6 +176,10 @@ module RuboCop
 
           parent.when_type? || method_argument?(node) || part_of_an_array?(node) ||
             grandparent&.resbody_type?
+        end
+
+        def wrap_in_brackets?(node)
+          node.parent.array_type? && !node.parent.bracketed?
         end
 
         def remove_brackets(array)

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          array.push(#{as_array})
+          array.push(#{literal})
         RUBY
       end
     end
@@ -284,6 +284,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
 
       expect_correction(<<~RUBY)
         ["a", "b", "\#{one}", "two"]
+      RUBY
+    end
+
+    it 'registers an offense and corrects expansion of splatted string literal' do
+      expect_offense(<<~RUBY)
+        ["a", "b", *"c"]
+                   ^^^^ Replace splat expansion with comma separated values.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ["a", "b", "c"]
       RUBY
     end
   end


### PR DESCRIPTION
```sh
$ ruby -e "a = []; a.push(*1); pp a"
[1]

$ ruby -e "a = []; a.push([1]); pp a"
[[1]]
```

So it should not be wrapped in brackets but simply become the literal.

However, it should still be wrapped for `a = *1` to keep semantics

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
