### PR TITLE
[Fix #14655] Add `AllowRBSInlineAnnotation` option to `Layout/LineLength`

### DIFF
--- a/changelog/new_add_allow_rbs_inline_annotation_to_layout_line_length.md
+++ b/changelog/new_add_allow_rbs_inline_annotation_to_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#14655](https://github.com/rubocop/rubocop/issues/14655): Add `AllowRBSInlineAnnotation` option to `Layout/LineLength`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1112,6 +1112,9 @@ Layout/LineLength:
   URISchemes:
     - http
     - https
+  # The AllowRBSInlineAnnotation option makes LineLength allow RBS::Inline annotations
+  # such as `#: (?date: Date) -> Foo` when calculating line length.
+  AllowRBSInlineAnnotation: false
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: true

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -252,9 +252,13 @@ module RuboCop
           [max - indentation_difference(line), 0].max
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_line(line, line_index)
           return if line_length(line) <= max
           return if allowed_line?(line, line_index)
+          if allow_rbs_inline_annotation? && rbs_inline_annotation_on_source_line?(line_index)
+            return
+          end
 
           if ignore_cop_directives? && directive_on_source_line?(line_index)
             return check_directive_line(line, line_index)
@@ -263,6 +267,7 @@ module RuboCop
 
           register_offense(excess_range(nil, line, line_index), line, line_index)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def allowed_line?(line, line_index)
           matches_allowed_pattern?(line) ||

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -8,6 +8,19 @@ module RuboCop
 
       private
 
+      def allow_rbs_inline_annotation?
+        config.for_cop('Layout/LineLength')['AllowRBSInlineAnnotation']
+      end
+
+      def rbs_inline_annotation_on_source_line?(line_index)
+        source_line_number = line_index + processed_source.buffer.first_line
+        comment = processed_source.comment_at_line(source_line_number)
+
+        return false unless comment
+
+        comment.text.start_with?(/#:|#\[.+\]|#\|/)
+      end
+
       def ignore_cop_directives?
         config.for_cop('Layout/LineLength')['IgnoreCopDirectives']
       end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -163,7 +163,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Exclude:
@@ -349,8 +349,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                     '',
                     '# Offense count: 1',
                     '# This cop supports safe autocorrection (--autocorrect).',
-                    '# Configuration parameters: AllowHeredoc, ' \
-                    'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
+                    '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, ' \
+                    'URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
                     'AllowedPatterns, SplitStrings.',
                     '# URISchemes: http, https',
                     'Layout/LineLength:',
@@ -427,8 +427,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '',
                 '# Offense count: 1',
                 '# This cop supports safe autocorrection (--autocorrect).',
-                '# Configuration parameters: AllowHeredoc, ' \
-                'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
+                '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, ' \
+                'URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
                 'AllowedPatterns, SplitStrings.',
                 '# URISchemes: http, https',
                 'Layout/LineLength:',
@@ -499,7 +499,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -929,8 +929,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# Offense count: 2',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
+         '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
+         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1023,8 +1023,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# Offense count: 3',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
+         '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
+         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1330,8 +1330,8 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          "    - 'example1.rb'",
          '',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowHeredoc, ' \
-         'AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, ' \
+         '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
+         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1808,6 +1808,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           - AllowURI
           - AllowQualifiedName
           - URISchemes
+          - AllowRBSInlineAnnotation
           - IgnoreCopDirectives
           - AllowedPatterns
           - SplitStrings

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1102,6 +1102,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowHeredoc' => true,
               'AllowURI' => true,
               'URISchemes' => %w[http https],
+              'AllowRBSInlineAnnotation' => false,
               'IgnoreCopDirectives' => true,
               'AllowedPatterns' => [],
               'AllowQualifiedName' => true,
@@ -1207,6 +1208,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,
               'URISchemes' => %w[http https],
+              'AllowRBSInlineAnnotation' => false,
               'IgnoreCopDirectives' => true,
               'AllowedPatterns' => [],
               'AllowQualifiedName' => true,

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -458,6 +458,46 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     end
   end
 
+  context 'when AllowRBSInlineAnnotation is disabled' do
+    let(:cop_config) { { 'Max' => 10, 'AllowRBSInlineAnnotation' => false } }
+
+    it 'registers an offense for a long line with an RBS::Inline annotation' do
+      expect_offense(<<~RUBY)
+        #: () -> String
+                  ^^^^^ Line is too long. [15/10]
+        def hash
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a long line with an RBS::Inline annotation on the same line as the code' do
+      expect_offense(<<~RUBY)
+        def each_address(&block) #: void
+                  ^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [32/10]
+        end
+      RUBY
+    end
+  end
+
+  context 'when AllowRBSInlineAnnotation is enabled' do
+    let(:cop_config) { { 'Max' => 10, 'AllowRBSInlineAnnotation' => true } }
+
+    it 'does not register an offense for a long line with an RBS::Inline annotation' do
+      expect_no_offenses(<<~RUBY)
+        #: () -> String
+        def hash
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a long line with an RBS::Inline annotation on the same line as the code' do
+      expect_no_offenses(<<~RUBY)
+        def each_address(&block) #: void
+        end
+      RUBY
+    end
+  end
+
   context 'when IgnoreCopDirectives is disabled' do
     let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => false } }
 


### PR DESCRIPTION
This PR adds `AllowRBSInlineAnnotation` option to `Layout/LineLength`.

For the name of the new option, it uses `AllowRBSInlineAnnotation`, the same as in `Lint/SelfAssignment` and `Layout/LeadingCommentSpace`, which already have options that take RBS::Inline into account. As with those cops, the option is disabled by default.

Resolves #14655.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
