### PR TITLE
Fix incorrect behavior when `Layout/LineLength` is disabled

### DIFF
--- a/changelog/fix_incorrect_behavior_when_layout_line_length_is_disabled.md
+++ b/changelog/fix_incorrect_behavior_when_layout_line_length_is_disabled.md
@@ -1,0 +1,1 @@
+* [#14658](https://github.com/rubocop/rubocop/pull/14658): Fix incorrect behavior when `Layout/LineLength` is disabled. ([@koic][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -133,6 +133,8 @@ module RuboCop
       end
 
       def max_line_length
+        return unless config.cop_enabled?('Layout/LineLength')
+
         config.for_cop('Layout/LineLength')['Max'] || 120
       end
 

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -108,10 +108,6 @@ module RuboCop
           config.for_cop('Layout/LineLength')['AllowHeredoc']
         end
 
-        def max_line_length
-          config.for_cop('Layout/LineLength')['Max']
-        end
-
         def adjust_squiggly(corrector, node)
           corrector.replace(node.loc.heredoc_body, indented_body(node))
           corrector.replace(node.loc.heredoc_end, indented_end(node))

--- a/lib/rubocop/cop/mixin/check_single_line_suitability.rb
+++ b/lib/rubocop/cop/mixin/check_single_line_suitability.rb
@@ -27,10 +27,6 @@ module RuboCop
           .gsub(/\s*\\?\n\s*/, ' ')       # Any other line break, with or without backslash
       end
 
-      def max_line_length
-        config.for_cop('Layout/LineLength')['Max']
-      end
-
       def comment_within?(node)
         comment_line_numbers = processed_source.comments.map { |comment| comment.loc.line }
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -100,12 +100,6 @@ module RuboCop
         node.parent.send_type?
       end
 
-      def max_line_length
-        return unless config.cop_enabled?('Layout/LineLength')
-
-        config.for_cop('Layout/LineLength')['Max']
-      end
-
       def comment_disables_cop?(comment)
         regexp_pattern = "# rubocop : (disable|todo) ([^,],)* (all|#{cop_name})"
         Regexp.new(regexp_pattern.gsub(' ', '\s*')).match?(comment)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -213,9 +213,7 @@ module RuboCop
         ASSIGN_TO_CONDITION_MSG = 'Assign variables inside of conditionals.'
         VARIABLE_ASSIGNMENT_TYPES = %i[casgn cvasgn gvasgn ivasgn lvasgn].freeze
         ASSIGNMENT_TYPES = VARIABLE_ASSIGNMENT_TYPES + %i[and_asgn or_asgn op_asgn masgn].freeze
-        LINE_LENGTH = 'Layout/LineLength'
         ENABLED = 'Enabled'
-        MAX = 'Max'
         SINGLE_LINE_CONDITIONS_ONLY = 'SingleLineConditionsOnly'
 
         # The shovel operator `<<` does not have its own type. It is a `send`
@@ -399,7 +397,7 @@ module RuboCop
         # of the longest line + the length of the corrected assignment is
         # greater than the max configured line length
         def correction_exceeds_line_limit?(node, branches)
-          return false unless line_length_cop_enabled?
+          return false unless config.cop_enabled?('Layout/LineLength')
 
           assignment = lhs(tail(branches[0]))
 
@@ -415,14 +413,6 @@ module RuboCop
           lines = node.source.lines.map { |line| line.chomp.sub(assignment_regex, '') }
           longest_line = lines.max_by(&:length)
           assignment + longest_line
-        end
-
-        def line_length_cop_enabled?
-          config.for_cop(LINE_LENGTH)[ENABLED]
-        end
-
-        def max_line_length
-          config.for_cop(LINE_LENGTH)[MAX]
         end
 
         def single_line_conditions_only?

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -107,12 +107,6 @@ module RuboCop
         def expanded_style?
           style == :expanded
         end
-
-        def max_line_length
-          return unless config.cop_enabled?('Layout/LineLength')
-
-          config.for_cop('Layout/LineLength')['Max']
-        end
       end
     end
   end

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -85,10 +85,6 @@ module RuboCop
         def definition_width(node)
           node.source_range.begin.join(node.arguments.source_range.end).length
         end
-
-        def max_line_length
-          config.for_cop('Layout/LineLength')['Max'] || 120
-        end
       end
     end
   end

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -404,6 +404,8 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           create_file('.rubocop.yml', <<~YAML)
             AllCops:
               DisabledByDefault: true
+            Layout/LineLength:
+              Enabled: true
             Lint/DuplicateHashKey:
               Enabled: true
           YAML
@@ -432,6 +434,8 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           create_file('.rubocop.yml', <<~YAML)
             AllCops:
               DisabledByDefault: true
+            Layout/LineLength:
+              Enabled: true
             Lint/DuplicateHashKey:
               Enabled: true
           YAML


### PR DESCRIPTION
This change corrects some cops that previously assumed `Layout/LineLength` was always enabled.
They now respect the cop's actual enablement state, matching the expected behavior in the updated tests.

The update removes hard-coded `max_line_length` lookups, delegates to shared logic, and ensures consistent behavior across cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
