### PR TITLE
Rename `IgnoreCopDirectives` to `AllowCopDirectives` in `Layout/LineLength`

### DIFF
--- a/changelog/change_rename_ignore_cop_directives_to_allow_cop_directives_in_layout_line_length.md
+++ b/changelog/change_rename_ignore_cop_directives_to_allow_cop_directives_in_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#14660](https://github.com/rubocop/rubocop/pull/14660): Rename `IgnoreCopDirectives` to `AllowCopDirectives` in `Layout/LineLength`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1102,7 +1102,7 @@ Layout/LineLength:
   StyleGuide: '#max-line-length'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '1.69'
+  VersionChanged: '<<next>>'
   Max: 120
   AllowHeredoc: true
   # To make it possible to copy or click on URIs in the code, we allow lines
@@ -1115,9 +1115,9 @@ Layout/LineLength:
   # The AllowRBSInlineAnnotation option makes LineLength allow RBS::Inline annotations
   # such as `#: (?date: Date) -> Foo` when calculating line length.
   AllowRBSInlineAnnotation: false
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # The AllowCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: true
+  AllowCopDirectives: true
   # The AllowedPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -145,6 +145,10 @@ changed_parameters:
   - cops: Layout/CaseIndentation
     parameters: IndentWhenRelativeTo
     alternative: EnforcedStyle
+  - cops: Layout/LineLength
+    parameters: IgnoreCopDirectives
+    alternative: AllowCopDirectives
+    severity: warning
   - cops:
       - Lint/BlockAlignment
       - Layout/BlockAlignment

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -260,7 +260,7 @@ module RuboCop
             return
           end
 
-          if ignore_cop_directives? && directive_on_source_line?(line_index)
+          if allow_cop_directives? && directive_on_source_line?(line_index)
             return check_directive_line(line, line_index)
           end
           return check_line_for_exemptions(line, line_index) if allow_uri? || allow_qualified_name?

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -21,8 +21,14 @@ module RuboCop
         comment.text.start_with?(/#:|#\[.+\]|#\|/)
       end
 
-      def ignore_cop_directives?
-        config.for_cop('Layout/LineLength')['IgnoreCopDirectives']
+      def allow_cop_directives?
+        # TODO: This logic for backward compatibility with deprecated `IgnoreCopDirectives` option.
+        # The following three lines will be removed in RuboCop 2.0.
+        ignore_cop_directives = config.for_cop('Layout/LineLength')['IgnoreCopDirectives']
+        return true if ignore_cop_directives
+        return false if ignore_cop_directives == false
+
+        config.for_cop('Layout/LineLength')['AllowCopDirectives']
       end
 
       def directive_on_source_line?(line_index)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -207,14 +207,14 @@ module RuboCop
         def too_long_line_based_on_config?(range, line)
           return false if matches_allowed_pattern?(line)
 
-          too_long = too_long_line_based_on_ignore_cop_directives?(range, line)
+          too_long = too_long_line_based_on_allow_cop_directives?(range, line)
           return too_long unless too_long == :undetermined
 
           too_long_line_based_on_allow_uri?(line)
         end
 
-        def too_long_line_based_on_ignore_cop_directives?(range, line)
-          if ignore_cop_directives? && directive_on_source_line?(range.line - 1)
+        def too_long_line_based_on_allow_cop_directives?(range, line)
+          if allow_cop_directives? && directive_on_source_line?(range.line - 1)
             return line_length_without_directive(line) > max_line_length
           end
 

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -163,7 +163,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Exclude:
@@ -350,7 +350,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                     '# Offense count: 1',
                     '# This cop supports safe autocorrection (--autocorrect).',
                     '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, ' \
-                    'URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
+                    'URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, ' \
                     'AllowedPatterns, SplitStrings.',
                     '# URISchemes: http, https',
                     'Layout/LineLength:',
@@ -428,7 +428,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
                 '# Offense count: 1',
                 '# This cop supports safe autocorrection (--autocorrect).',
                 '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, ' \
-                'URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
+                'URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, ' \
                 'AllowedPatterns, SplitStrings.',
                 '# URISchemes: http, https',
                 'Layout/LineLength:',
@@ -499,7 +499,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 2
               # This cop supports safe autocorrection (--autocorrect).
-              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
+              # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.
               # URISchemes: http, https
               Layout/LineLength:
                 Max: 138
@@ -930,7 +930,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 2',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
-         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
+         'AllowRBSInlineAnnotation, AllowCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1024,7 +1024,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '# Offense count: 3',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
-         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
+         'AllowRBSInlineAnnotation, AllowCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',
@@ -1331,7 +1331,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# This cop supports safe autocorrection (--autocorrect).',
          '# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, ' \
-         'AllowRBSInlineAnnotation, IgnoreCopDirectives, ' \
+         'AllowRBSInlineAnnotation, AllowCopDirectives, ' \
          'AllowedPatterns, SplitStrings.',
          '# URISchemes: http, https',
          'Layout/LineLength:',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1809,7 +1809,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           - AllowQualifiedName
           - URISchemes
           - AllowRBSInlineAnnotation
-          - IgnoreCopDirectives
+          - AllowCopDirectives
           - AllowedPatterns
           - SplitStrings
         Warning: Style/GlobalVars does not support Min parameter.

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1103,7 +1103,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowURI' => true,
               'URISchemes' => %w[http https],
               'AllowRBSInlineAnnotation' => false,
-              'IgnoreCopDirectives' => true,
+              'AllowCopDirectives' => true,
               'AllowedPatterns' => [],
               'AllowQualifiedName' => true,
               'SplitStrings' => false
@@ -1209,7 +1209,7 @@ RSpec.describe RuboCop::ConfigLoader do
               'AllowURI' => true,
               'URISchemes' => %w[http https],
               'AllowRBSInlineAnnotation' => false,
-              'IgnoreCopDirectives' => true,
+              'AllowCopDirectives' => true,
               'AllowedPatterns' => [],
               'AllowQualifiedName' => true,
               'SplitStrings' => false

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -498,8 +498,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     end
   end
 
-  context 'when IgnoreCopDirectives is disabled' do
-    let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => false } }
+  context 'when AllowCopDirectives is disabled' do
+    let(:cop_config) { { 'Max' => 80, 'AllowCopDirectives' => false } }
 
     context 'and the source is acceptable length' do
       context 'with a trailing RuboCop directive' do
@@ -531,8 +531,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     end
   end
 
-  context 'when IgnoreCopDirectives is enabled' do
-    let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => true } }
+  context 'when AllowCopDirectives is enabled' do
+    let(:cop_config) { { 'Max' => 80, 'AllowCopDirectives' => true } }
 
     context 'and the RuboCop directive is excessively long' do
       it 'accepts the line' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -4,14 +4,14 @@
 # Note: most of these tests probably belong in the shared context "condition modifier cop"
 ######
 RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
-  let(:ignore_cop_directives) { true }
+  let(:allow_cop_directives) { true }
   let(:allow_uri) { true }
   let(:line_length_config) do
     {
       'Enabled' => true,
       'Max' => 80,
       'AllowURI' => allow_uri,
-      'IgnoreCopDirectives' => ignore_cop_directives,
+      'AllowCopDirectives' => allow_cop_directives,
       'URISchemes' => %w[http https]
     }
   end
@@ -141,12 +141,12 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         end
       end
 
-      describe 'IgnoreCopDirectives' do
+      describe 'AllowCopDirectives' do
         let(:spaces) { ' ' * 57 }
         let(:comment) { '# rubocop:disable Style/For' }
         let(:body) { "puts '#{spaces}'" }
 
-        context 'and the long line is allowed because IgnoreCopDirectives is true' do
+        context 'and the long line is allowed because AllowCopDirectives is true' do
           it 'accepts' do
             expect("#{body} if condition".length).to eq(77) # That's 79 including indentation.
             expect_no_offenses(<<~RUBY)
@@ -157,8 +157,8 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
           end
         end
 
-        context 'and the long line is too long because IgnoreCopDirectives is false' do
-          let(:ignore_cop_directives) { false }
+        context 'and the long line is too long because AllowCopDirectives is false' do
+          let(:allow_cop_directives) { false }
 
           it 'registers an offense' do
             expect_offense(<<~RUBY, body: body)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14656#issuecomment-3531187742.

This PR renames `IgnoreCopDirectives` to `AllowCopDirectives` in `Layout/LineLength`. It preserves compatibility for cases where the `IgnoreCopDirectives` setting is present.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
