### PR TITLE
Make `Lint/RedundantRequireStatement` aware of `pathname` when analyzing Ruby 4.0

### DIFF
--- a/changelog/change_make_lint_redundant_require_statement_aware_of_pathname.md
+++ b/changelog/change_make_lint_redundant_require_statement_aware_of_pathname.md
@@ -1,0 +1,1 @@
+* [#14661](https://github.com/rubocop/rubocop/pull/14661): Make `Lint/RedundantRequireStatement` aware of `pathname` when analyzing Ruby 4.0. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -19,7 +19,8 @@ module RuboCop
       #   * 2.2+ ... Add `rational` and `complex` above
       #   * 2.7+ ... Add `ruby2_keywords` above
       #   * 3.1+ ... Add `fiber` above
-      #   * 3.2+ ... `set`
+      #   * 3.2+ ... Add `set` above
+      #   * 4.0+ ... Add `pathname` above
       #
       # This cop target those features.
       #
@@ -69,7 +70,8 @@ module RuboCop
             (target_ruby_version >= 2.2 && RUBY_22_LOADED_FEATURES.include?(feature_name)) ||
             (target_ruby_version >= 2.7 && feature_name == 'ruby2_keywords') ||
             (target_ruby_version >= 3.1 && feature_name == 'fiber') ||
-            (target_ruby_version >= 3.2 && feature_name == 'set')
+            (target_ruby_version >= 3.2 && feature_name == 'set') ||
+            (target_ruby_version >= 4.0 && feature_name == 'pathname')
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -199,5 +199,19 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
         RUBY
       end
     end
+
+    context 'target ruby version >= 4.0', :ruby40 do
+      it 'registers an offense and corrects when requiring `pathname`' do
+        expect_offense(<<~RUBY)
+          require 'pathname'
+          ^^^^^^^^^^^^^^^^^^ Remove unnecessary `require` statement.
+          require 'uri'
+        RUBY
+
+        expect_correction(<<~RUBY)
+          require 'uri'
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
`Pathname` has been promoted from a default gem to a core class in Ruby 4.0: https://bugs.ruby-lang.org/issues/17473

This PR makes `Lint/RedundantRequireStatement` aware of `pathname` when `TargetRubyVersion` is 4.0 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
