### PR TITLE
Add autocorrection for `Lint/UselessOr`

### DIFF
--- a/changelog/change_add_autocorrection_for_lint_useless_or_20251117174317.md
+++ b/changelog/change_add_autocorrection_for_lint_useless_or_20251117174317.md
@@ -1,0 +1,1 @@
+* [#14662](https://github.com/rubocop/rubocop/pull/14662): Add autocorrection for `Lint/UselessOr`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2669,7 +2669,10 @@ Lint/UselessNumericOperation:
 Lint/UselessOr:
   Description: 'Checks for useless OR expressions.'
   Enabled: pending
+  SafeAutoCorrect: false
+  AutoCorrect: contextual
   VersionAdded: '1.76'
+  VersionChanged: '<<next>>'
 
 Lint/UselessRescue:
   Description: 'Checks for useless `rescue`s.'

--- a/spec/rubocop/cop/lint/useless_or_spec.rb
+++ b/spec/rubocop/cop/lint/useless_or_spec.rb
@@ -7,12 +7,20 @@ RSpec.describe RuboCop::Cop::Lint::UselessOr, :config do
         x.#{method} || fallback
           _{method} ^^^^^^^^^^^ `fallback` will never evaluate because `x.#{method}` always returns a truthy value.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.#{method}
+      RUBY
     end
 
     it "registers an offense with `x.#{method} or fallback`" do
       expect_offense(<<~RUBY, method: method)
         x.#{method} or fallback
           _{method} ^^^^^^^^^^^ `fallback` will never evaluate because `x.#{method}` always returns a truthy value.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.#{method}
       RUBY
     end
 
@@ -21,6 +29,10 @@ RSpec.describe RuboCop::Cop::Lint::UselessOr, :config do
         x.#{method} || fallback || other_fallback
           _{method} ^^^^^^^^^^^ `fallback` will never evaluate because `x.#{method}` always returns a truthy value.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x.#{method}
+      RUBY
     end
 
     it "registers an offense with `foo || x.#{method} || fallback`" do
@@ -28,12 +40,20 @@ RSpec.describe RuboCop::Cop::Lint::UselessOr, :config do
         foo || x.#{method} || fallback
                  _{method} ^^^^^^^^^^^ `fallback` will never evaluate because `x.#{method}` always returns a truthy value.
       RUBY
+
+      expect_correction(<<~RUBY)
+        foo || x.#{method}
+      RUBY
     end
 
     it "registers an offense with `(foo || x.#{method}) || fallback`" do
       expect_offense(<<~RUBY, method: method)
         (foo || x.#{method}) || fallback
                   _{method}  ^^^^^^^^^^^ `fallback` will never evaluate because `x.#{method}` always returns a truthy value.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (foo || x.#{method})
       RUBY
     end
 


### PR DESCRIPTION
I would like to enable this cop in my project, but since it’s a huge codebase, there are an enormous number of existing offenses, and manually fixing them one by one is no longer realistic.

Although there are two possible ways to correct the offenses, in my case the fix that preserves the current behavior is the desirable one, so I really wished autocorrection were supported. I believe there are other use cases like this as well.

What do you think about providing this as an unsafe autocorrection?
(Alternatively, if using `SafeAutoCorrect: false` for this purpose is not considered appropriate, I would also be fine with it being provided as a safe autocorrection instead.)

Even if an autocorrection is provided that doesn’t match every use case, users can still choose to apply only specific cops' autocorrection. And since most modern code is under version control, it’s easy to selectively apply changes using tools like `git add -p`. It’s true that such an imperfect default behavior may cause some inconvenience for certain users. However, the difficulty of resolving the issue when no autocorrection is provided at all is, in my opinion, much greater.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
