### PR TITLE
Exclude `Severity` from configuration parameters

### DIFF
--- a/changelog/change_exclude_severity_from_configuration_parameters_20251119080141.md
+++ b/changelog/change_exclude_severity_from_configuration_parameters_20251119080141.md
@@ -1,0 +1,1 @@
+* [#14668](https://github.com/rubocop/rubocop/pull/14668): Exclude `Severity` from configuration parameters. ([@r7kamura][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -27,6 +27,7 @@ module RuboCop
         References
         Safe
         SafeAutoCorrect
+        Severity
         StyleGuide
         VersionAdded
         VersionChanged

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -607,7 +607,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
           # Offense count: 1
           # This cop supports safe autocorrection (--autocorrect).
-          # Configuration parameters: EnforcedStyleAlignWith, Severity.
+          # Configuration parameters: EnforcedStyleAlignWith.
           # SupportedStylesAlignWith: start_of_line, def
           Layout/DefEndAlignment:
             Exclude:


### PR DESCRIPTION
`Severity` is also a configuration parameter shared by many cops, so it would be better not to display it as if it were an item specific to an individual cop.

This is similar to the following change I submitted earlier:

- https://github.com/rubocop/rubocop/pull/14464

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
