### PR TITLE
[Fix #14667] Fix false positives for `Layout/EndAlignment`

### DIFF
--- a/changelog/fix_false_positives_for_layout_end_alignment.md
+++ b/changelog/fix_false_positives_for_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#14667](https://github.com/rubocop/rubocop/issues/14667): Fix false positives for `Layout/EndAlignment` when a conditional assignment is used on the same line and the `end` with a safe navigation method call is aligned. ([@koic][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -118,7 +118,7 @@ module RuboCop
       def first_part_of_call_chain(node)
         while node
           case node.type
-          when :send
+          when :send, :csend
             node = node.receiver
           when :block
             node = node.send_node

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -438,6 +438,22 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       RUBY
     end
 
+    it 'does not register an offense when using a conditional assignment on the same line and `end` with method call is aligned' do
+      expect_no_offenses(<<~RUBY)
+        value = if condition
+          do_something
+        end.method_call
+      RUBY
+    end
+
+    it 'does not register an offense when using a conditional assignment in a method argument on the same line and `end` with safe navigation method call is aligned' do
+      expect_no_offenses(<<~RUBY)
+        value = if condition
+          do_something
+        end&.method_call
+      RUBY
+    end
+
     it 'registers an offense when using a conditional statement in a method argument on the same line and `end` with method call is not aligned' do
       expect_offense(<<~RUBY)
         do_something case condition


### PR DESCRIPTION
This PR fixes false positives for `Layout/EndAlignment` when a conditional assignment is used on the same line and the `end` with a safe navigation method call is aligned.

Fixes #14667.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
