### PR TITLE
[Fix #10173] Fix false positives for `Style/TrailingCommaInArguments`

### DIFF
--- a/changelog/fix_false_positives_for_style_trailing_comma_in_arguments.md
+++ b/changelog/fix_false_positives_for_style_trailing_comma_in_arguments.md
@@ -1,0 +1,1 @@
+* [#10173](https://github.com/rubocop/rubocop/issues/10173): Fix false positives for `Style/TrailingCommaInArguments` when `EnforcedStyleForMultiline` is set to `consistent_comma` and a multiline braced hash argument appears after another argument. ([@koic][])

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -96,11 +96,10 @@ module RuboCop
       end
 
       def method_name_and_arguments_on_same_line?(node)
-        return false unless node.call_type?
+        return false if !node.call_type? || node.last_line != node.last_argument.last_line
+        return true if node.last_argument.hash_type? && node.last_argument.braces?
 
-        line = node.loc.selector.nil? ? node.loc.line : node.loc.selector.line
-
-        line == node.last_argument.last_line && node.last_line == node.last_argument.last_line
+        node.loc.selector.line == node.last_argument.last_line
       end
 
       # A single argument with the closing bracket on the same line as the end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -149,6 +149,25 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
   end
 
+  context 'with a braced hash argument spanning multiple lines after an argument' do
+    context 'when EnforcedStyleForMultiline is consistent_comma' do
+      let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
+
+      [%w[( )], %w[[ ]]].each do |start_bracket, end_bracket|
+        context "with `#{start_bracket}#{end_bracket}` brackets" do
+          it 'accepts multiple arguments with no trailing comma' do
+            expect_no_offenses(<<~RUBY)
+              EmailWorker.perform_async#{start_bracket}arg, {
+                subject: "hey there",
+                email: "foo@bar.com"
+              }#{end_bracket}
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
   context 'with a single argument of anonymous function spanning multiple lines' do
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }


### PR DESCRIPTION
This PR fixes false positives for `Style/TrailingCommaInArguments` when `EnforcedStyleForMultiline` is set to `consistent_comma` and a multiline braced hash argument appears after another argument.

Fixes #10173.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
