### PR TITLE
[Fix #10147] Make `Lint/ElseLayout` allow single-line `else` body in `then` conditional

### DIFF
--- a/changelog/change_make_lint_else_layout_allow_single_line_else_body_in_then_conditional.md
+++ b/changelog/change_make_lint_else_layout_allow_single_line_else_body_in_then_conditional.md
@@ -1,0 +1,1 @@
+* [#10147](https://github.com/rubocop/rubocop/issues/10147): Make `Lint/ElseLayout` allow a single-line `else` body in `then` single-line conditional. ([@koic][])

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -38,6 +38,24 @@ module RuboCop
       #   elsif do_this
       #     do_that
       #   end
+      #
+      #   # bad
+      #
+      #   # For single-line conditionals using `then` the layout is disallowed
+      #   # when the `else` body is multiline because it is treated as a lint offense.
+      #   if something then on_the_same_line_as_then
+      #   else first_line
+      #     second_line
+      #   end
+      #
+      #   # good
+      #
+      #   # For single-line conditional using `then` the layout is allowed
+      #   # when `else` body is a single-line because it is treated as intentional.
+      #
+      #   if something then on_the_same_line_as_then
+      #   else single_line
+      #   end
       class ElseLayout < Base
         include Alignment
         include RangeHelp
@@ -47,6 +65,7 @@ module RuboCop
 
         def on_if(node)
           return if node.ternary?
+          return if node.then? && !node.else_branch&.begin_type?
 
           # If the if is on a single line, it'll be handled by `Style/OneLineConditional`
           return if node.single_line?

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects for the entire else body being on the same line' do
+  it 'registers an offense and corrects for the entire else body being on the same line without `then` single-line' do
     expect_offense(<<~RUBY)
       if something
         test
@@ -37,6 +37,32 @@ RSpec.describe RuboCop::Cop::Lint::ElseLayout, :config do
         test
       else
         something_else
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a part of `else` body being on the same line with `then` single-line' do
+    expect_offense(<<~RUBY)
+      if something then test
+      else something_else
+           ^^^^^^^^^^^^^^ Odd `else` layout detected. Did you mean to use `elsif`?
+        other
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if something then test
+      else
+        something_else
+        other
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the single line `else` body being on the same line with `then` single-line' do
+    expect_no_offenses(<<~RUBY)
+      if something then test
+      else something_else
       end
     RUBY
   end


### PR DESCRIPTION
This PR makes `Lint/ElseLayout` allow a single-line `else` body in `then` single-line conditional.

For single-line conditionals using `then` the layout is disallowed when the `else` body is multiline because it is treated as a lint offense.

```ruby
# bad
if something then on_the_same_line_as_then
else first_line
  second_line
end
```

For single-line conditionals using `then` the layout is allowed when the `else` body is a single-line because it is treated as intentional.

```ruby
# good
if something then on_the_same_line_as_then
else single_line
end
```

Resolves #10147.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
