### PR TITLE
Expand `InternalAffairs/LocationExists` to detect more cases where `Node#loc?` can be used

### DIFF
--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -76,9 +76,7 @@ module RuboCop
         #   nil.
         # - The source map of `__FILE__` responds to neither :begin nor :end.
         def delimited_string_literal?(node)
-          loc = node.location
-
-          loc.respond_to?(:begin) && loc.begin && loc.respond_to?(:end) && loc.end
+          node.loc?(:begin) && node.loc?(:end)
         end
 
         def block_comment_within?(expr)

--- a/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
+++ b/lib/rubocop/cop/layout/heredoc_argument_closing_parenthesis.rb
@@ -168,7 +168,7 @@ module RuboCop
 
         def subsequent_closing_parentheses_in_same_line?(outermost_send)
           last_arg_of_outer_send = outermost_send.last_argument
-          return false unless last_arg_of_outer_send&.loc.respond_to?(:end) &&
+          return false unless last_arg_of_outer_send&.loc?(:end) &&
                               (end_of_last_arg_of_outer_send = last_arg_of_outer_send.loc.end)
 
           end_of_outer_send = outermost_send.loc.end
@@ -230,7 +230,7 @@ module RuboCop
 
         def find_most_bottom_of_heredoc_end(arguments)
           arguments.filter_map do |argument|
-            argument.loc.heredoc_end.end_pos if argument.loc.respond_to?(:heredoc_end)
+            argument.loc.heredoc_end.end_pos if argument.loc?(:heredoc_end)
           end.max
         end
 

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -99,7 +99,7 @@ module RuboCop
 
             if str.heredoc?
               ranges << loc.heredoc_body
-            elsif loc.respond_to?(:begin) && loc.begin
+            elsif str.loc?(:begin)
               ranges << loc.expression
             end
           end

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -101,7 +101,7 @@ module RuboCop
               ranges << loc.expression
             elsif literal.heredoc?
               ranges << loc.heredoc_body
-            elsif (loc.respond_to?(:begin) && loc.begin) || ignored_parent?(literal)
+            elsif literal.loc?(:begin) || ignored_parent?(literal)
               ranges << loc.expression
             end
           end

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -406,9 +406,7 @@ module RuboCop
 
         def string_delimiter(node)
           delimiter = node.loc.begin
-          if node.parent&.dstr_type? && node.parent.loc.respond_to?(:begin)
-            delimiter ||= node.parent.loc.begin
-          end
+          delimiter ||= node.parent.loc.begin if node.parent&.dstr_type? && node.parent.loc?(:begin)
           delimiter = delimiter&.source
 
           delimiter if %w[' "].include?(delimiter)

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -167,7 +167,7 @@ module RuboCop
 
         def check(node, locations, begin_keyword = DO)
           locations.each do |loc|
-            next unless node.loc.respond_to?(loc)
+            next unless node.loc?(loc)
 
             range = node.loc.public_send(loc)
             next unless range

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def special_keyword?(node)
           # handle strings like __FILE__
-          (node.str_type? && !node.loc.respond_to?(:begin)) || node.source_range.is?('__LINE__')
+          (node.str_type? && !node.loc?(:begin)) || node.source_range.is?('__LINE__')
         end
 
         def array_in_regexp?(node)

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -59,7 +59,7 @@ module RuboCop
         return node.loc.name if node.casgn_type?
 
         if LSP.enabled?
-          end_range = node.loc.respond_to?(:name) ? node.loc.name : node.loc.begin
+          end_range = node.loc?(:name) ? node.loc.name : node.loc.begin
           node.source_range.begin.join(end_range)
         else
           node.source_range

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -13,7 +13,7 @@ module RuboCop
 
       DefNode = Struct.new(:node) do
         def selector
-          if node.loc.respond_to?(:selector)
+          if node.loc?(:selector)
             node.loc.selector
           else
             node.loc.keyword

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -73,7 +73,7 @@ module RuboCop
 
       def location(node)
         if LSP.enabled?
-          end_range = node.loc.respond_to?(:name) ? node.loc.name : node.loc.begin
+          end_range = node.loc?(:name) ? node.loc.name : node.loc.begin
           node.source_range.begin.join(end_range)
         else
           node.source_range

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -200,7 +200,7 @@ module RuboCop
       end
 
       def grouped_expression?(node)
-        node.begin_type? && node.loc.respond_to?(:begin) && node.loc.begin
+        node.begin_type? && node.loc?(:begin) && node.loc.begin
       end
 
       def inside_arg_list_parentheses?(node, ancestor)

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -127,7 +127,7 @@ module RuboCop
         parent ||= node
 
         if node.respond_to?(:loc) &&
-           node.loc.respond_to?(:heredoc_end) &&
+           node.loc?(:heredoc_end) &&
            node.loc.heredoc_end.last_line >= parent.last_line
           return true
         end

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -184,7 +184,7 @@ module RuboCop
 
       def heredoc?(node)
         return false unless node.is_a?(RuboCop::AST::Node)
-        return true if node.loc.respond_to?(:heredoc_body)
+        return true if node.loc?(:heredoc_body)
 
         return heredoc_send?(node) if node.send_type?
 

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -234,7 +234,7 @@ module RuboCop
         end
 
         def range_position(node)
-          if node.loc.respond_to?(:selector)
+          if node.loc?(:selector)
             selector_end_pos = node.loc.selector.end_pos + 1
             expr_end_pos = node.source_range.end_pos
 

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -41,8 +41,7 @@ module RuboCop
 
         def check(node)
           return if node.heredoc?
-          return unless node.loc.respond_to?(:begin)
-          return unless node.loc.begin
+          return unless node.loc?(:begin)
 
           source = node.loc.begin.source
           if requires_percent_q?(source)

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -223,7 +223,7 @@ module RuboCop
             # __FILE__ is treated as a StrNode but has no begin
             if node.str_type? && loc.respond_to?(:begin) && loc.begin.nil?
               "'#{node.source}'"
-            elsif node.sym_type? && loc.begin.nil?
+            elsif node.sym_type? && !node.loc?(:begin)
               ":#{node.source}"
             else
               node.source

--- a/lib/rubocop/cop/style/redundant_percent_q.rb
+++ b/lib/rubocop/cop/style/redundant_percent_q.rb
@@ -80,8 +80,7 @@ module RuboCop
         end
 
         def string_literal?(node)
-          node.loc.respond_to?(:begin) && node.loc.respond_to?(:end) &&
-            node.loc.begin && node.loc.end
+          node.loc?(:begin) && node.loc?(:end)
         end
 
         def start_with_percent_q_variant?(string)

--- a/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
@@ -1,222 +1,290 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::InternalAffairs::LocationExists, :config do
-  context 'code that can be replaced with `loc?`' do
-    it 'does not register an offense for `respond_to?` without `&&' do
-      expect_no_offenses(<<~RUBY)
-        node.loc.respond_to?(:begin)
-      RUBY
-    end
-
-    it 'does not register an offense when the receiver does not match' do
-      expect_no_offenses(<<~RUBY)
-        node.loc.respond_to?(:begin) && other_node.loc.begin
-      RUBY
-    end
-
-    it 'does not register an offense when the location does not match' do
-      expect_no_offenses(<<~RUBY)
-        node.loc.respond_to?(:begin) && node.loc.end
-      RUBY
-    end
-
-    context 'when there is no receiver' do
-      it 'registers an offense and corrects' do
+  context 'within an `and` node' do
+    context 'code that can be replaced with `loc?`' do
+      it 'registers an offense when the receiver does not match' do
         expect_offense(<<~RUBY)
-          loc.respond_to?(:begin) && loc.begin
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `loc?(:begin)` instead of [...]
+          node.loc.respond_to?(:begin) && other_node.loc.begin
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
         RUBY
 
         expect_correction(<<~RUBY)
-          loc?(:begin)
+          node.loc?(:begin) && other_node.loc.begin
         RUBY
       end
-    end
 
-    context 'when there is a single receiver' do
-      it 'registers an offense and corrects' do
+      it 'registers an offense when the location does not match' do
         expect_offense(<<~RUBY)
-          node.loc.respond_to?(:begin) && node.loc.begin
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of [...]
+          node.loc.respond_to?(:begin) && node.loc.end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
         RUBY
 
         expect_correction(<<~RUBY)
-          node.loc?(:begin)
-        RUBY
-      end
-    end
-
-    context 'when there is a single receiver with safe navigation' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          node&.loc&.respond_to?(:begin) && node&.loc&.begin
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc?(:begin)` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          node&.loc?(:begin)
-        RUBY
-      end
-    end
-
-    context 'when the receiver is a method chain' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          foo.bar.loc.respond_to?(:begin) && foo.bar.loc.begin
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo.bar.loc?(:begin)` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          foo.bar.loc?(:begin)
-        RUBY
-      end
-    end
-
-    context 'when the receiver is a method chain with safe navigation' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          foo&.bar&.loc&.respond_to?(:begin) && foo&.bar&.loc&.begin
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo&.bar&.loc?(:begin)` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          foo&.bar&.loc?(:begin)
-        RUBY
-      end
-    end
-
-    context 'when assigned' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          value = node.loc.respond_to?(:begin) && node.loc.begin
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc.begin if node.loc?(:begin)` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          value = node.loc.begin if node.loc?(:begin)
+          node.loc?(:begin) && node.loc.end
         RUBY
       end
 
-      context 'with safe navigation' do
+      context 'when there is no receiver' do
         it 'registers an offense and corrects' do
           expect_offense(<<~RUBY)
-            value = node&.loc&.respond_to?(:begin) && node&.loc&.begin
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc&.begin if node&.loc?(:begin)` instead of [...]
+            loc.respond_to?(:begin) && loc.begin
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `loc?(:begin)` instead of [...]
           RUBY
 
           expect_correction(<<~RUBY)
-            value = node&.loc&.begin if node&.loc?(:begin)
+            loc?(:begin)
+          RUBY
+        end
+      end
+
+      context 'when there is a single receiver' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            node.loc.respond_to?(:begin) && node.loc.begin
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node.loc?(:begin)
+          RUBY
+        end
+      end
+
+      context 'when there is a single receiver with safe navigation' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            node&.loc&.respond_to?(:begin) && node&.loc&.begin
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc?(:begin)` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node&.loc?(:begin)
+          RUBY
+        end
+      end
+
+      context 'when the receiver is a method chain' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            foo.bar.loc.respond_to?(:begin) && foo.bar.loc.begin
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo.bar.loc?(:begin)` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.bar.loc?(:begin)
+          RUBY
+        end
+      end
+
+      context 'when the receiver is a method chain with safe navigation' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            foo&.bar&.loc&.respond_to?(:begin) && foo&.bar&.loc&.begin
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo&.bar&.loc?(:begin)` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.bar&.loc?(:begin)
+          RUBY
+        end
+      end
+
+      context 'when assigned' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            value = node.loc.respond_to?(:begin) && node.loc.begin
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc.begin if node.loc?(:begin)` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            value = node.loc.begin if node.loc?(:begin)
+          RUBY
+        end
+
+        context 'with safe navigation' do
+          it 'registers an offense and corrects' do
+            expect_offense(<<~RUBY)
+              value = node&.loc&.respond_to?(:begin) && node&.loc&.begin
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc&.begin if node&.loc?(:begin)` instead of [...]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              value = node&.loc&.begin if node&.loc?(:begin)
+            RUBY
+          end
+        end
+      end
+    end
+
+    context 'code that can potentially be replaced with `loc_is?`' do
+      it 'registers an offense but does not replace with `loc_is?` when the receiver does not match' do
+        expect_offense(<<~RUBY)
+          node.loc.respond_to?(:begin) && other_node.loc.begin.is?('(')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          node.loc?(:begin) && other_node.loc.begin.is?('(')
+        RUBY
+      end
+
+      it 'registers an offense but does not replace with `loc_is?` when the location does not match' do
+        expect_offense(<<~RUBY)
+          node.loc.respond_to?(:begin) && node.loc.end.is?('(')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          node.loc?(:begin) && node.loc.end.is?('(')
+        RUBY
+      end
+
+      context 'when there is no receiver' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            loc.respond_to?(:begin) && loc.begin.is?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when there is a single receiver' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            node.loc.respond_to?(:begin) && node.loc.begin.is?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node.loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when there is a single receiver with safe navigation' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            node&.loc&.respond_to?(:begin) && node&.loc&.begin.is?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node&.loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when the receiver is a method chain' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            foo.bar.loc.respond_to?(:begin) && foo.bar.loc.begin.is?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo.bar.loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo.bar.loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when the receiver is a method chain with safe navigation' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            foo&.bar&.loc&.respond_to?(:begin) && foo&.bar&.loc&.begin.is?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo&.bar&.loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.bar&.loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when using `source ==`' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY)
+            node.loc.respond_to?(:begin) && node.loc.begin.source == '('
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc_is?(:begin, '(')` instead of [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node.loc_is?(:begin, '(')
+          RUBY
+        end
+      end
+
+      context 'when using `source !=`' do
+        it 'registers an offense but does not replace with `loc_is?`' do
+          expect_offense(<<~RUBY)
+            node.loc.respond_to?(:begin) && node.loc.begin.source != '('
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node.loc?(:begin) && node.loc.begin.source != '('
+          RUBY
+        end
+      end
+
+      context 'when using `source.start_with?`' do
+        it 'registers an offense but does not replace with `loc_is?`' do
+          expect_offense(<<~RUBY)
+            node.loc.respond_to?(:begin) && node.loc.begin.source.start_with?('(')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            node.loc?(:begin) && node.loc.begin.source.start_with?('(')
           RUBY
         end
       end
     end
   end
 
-  context 'code that can be replaced with `loc_is?`' do
-    it 'does not register an offense when the receiver does not match' do
-      expect_no_offenses(<<~RUBY)
-        node.loc.respond_to?(:begin) && other_node.loc.begin.is?('(')
+  context 'as a `send` node' do
+    it 'registers an offense on `node.loc.respond_to?`' do
+      expect_offense(<<~RUBY)
+        node.loc.respond_to?(:begin)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        node.loc?(:begin)
       RUBY
     end
 
-    it 'does not register an offense when the location does not match' do
-      expect_no_offenses(<<~RUBY)
-        node.loc.respond_to?(:begin) && node.loc.end.is?('(')
+    it 'registers an offense but does not correct on `loc.respond_to?` without receiver' do
+      expect_offense(<<~RUBY)
+        loc.respond_to?(:begin)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?` instead of `loc.respond_to?`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense within an `if` node' do
+      expect_offense(<<~RUBY)
+        foo if node.loc.respond_to?(:begin)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?(:begin)` instead of `node.loc.respond_to?(:begin)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo if node.loc?(:begin)
       RUBY
     end
 
-    context 'when there is no receiver' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          loc.respond_to?(:begin) && loc.begin.is?('(')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `loc_is?(:begin, '(')` instead of [...]
-        RUBY
+    it 'registers an offense within an `if` node without receiver' do
+      expect_offense(<<~RUBY)
+        foo if loc.respond_to?(:begin)
+               ^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?` instead of `loc.respond_to?`.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when there is a single receiver' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          node.loc.respond_to?(:begin) && node.loc.begin.is?('(')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc_is?(:begin, '(')` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          node.loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when there is a single receiver with safe navigation' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          node&.loc&.respond_to?(:begin) && node&.loc&.begin.is?('(')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node&.loc_is?(:begin, '(')` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          node&.loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when the receiver is a method chain' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          foo.bar.loc.respond_to?(:begin) && foo.bar.loc.begin.is?('(')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo.bar.loc_is?(:begin, '(')` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          foo.bar.loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when the receiver is a method chain with safe navigation' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          foo&.bar&.loc&.respond_to?(:begin) && foo&.bar&.loc&.begin.is?('(')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `foo&.bar&.loc_is?(:begin, '(')` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          foo&.bar&.loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when using `source ==`' do
-      it 'registers an offense and corrects' do
-        expect_offense(<<~RUBY)
-          node.loc.respond_to?(:begin) && node.loc.begin.source == '('
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc_is?(:begin, '(')` instead of [...]
-        RUBY
-
-        expect_correction(<<~RUBY)
-          node.loc_is?(:begin, '(')
-        RUBY
-      end
-    end
-
-    context 'when using `source !=`' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          node.loc.respond_to?(:begin) && node.loc.begin.source != '('
-        RUBY
-      end
-    end
-
-    context 'when using `source.start_with?`' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
-          node.loc.respond_to?(:begin) && node.loc.begin.source.start_with?('(')
-        RUBY
-      end
+      expect_no_corrections
     end
   end
 end


### PR DESCRIPTION
Expands the breadth of `InternalAffairs/LocationExists` to cover more cases where `loc.respond_to?` is used (no longer limited to part of an `and` node).

Follows rubocop/rubocop-ast#346 and #13581.