### PR TITLE
Make `Style/RedundantArgument` aware of `to_i`

### DIFF
--- a/changelog/change_make_style_redundant_argument_aware_of_to_i.md
+++ b/changelog/change_make_style_redundant_argument_aware_of_to_i.md
@@ -1,0 +1,1 @@
+* [#14677](https://github.com/rubocop/rubocop/pull/14677): Make `Style/RedundantArgument` aware of `to_i`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5228,6 +5228,8 @@ Style/RedundantArgument:
     exit: true
     # Kernel.#exit!
     exit!: false
+    # String#to_i
+    to_i: 10
     # String#split
     split: ' '
     # String#chomp

--- a/lib/rubocop/cop/style/redundant_argument.rb
+++ b/lib/rubocop/cop/style/redundant_argument.rb
@@ -37,6 +37,7 @@ module RuboCop
       #   array.sum(0)
       #   exit(true)
       #   exit!(false)
+      #   string.to_i(10)
       #   string.split(" ")
       #   "first\nsecond".split(" ")
       #   string.chomp("\n")
@@ -49,6 +50,7 @@ module RuboCop
       #   array.sum
       #   exit
       #   exit!
+      #   string.to_i
       #   string.split
       #   "first second".split
       #   string.chomp

--- a/spec/rubocop/cop/style/redundant_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_argument_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
     {
       'Methods' => {
         'join' => '', 'sum' => 0, 'exit' => true, 'exit!' => false,
-        'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n"
+        'to_i' => 10, 'split' => ' ', 'chomp' => "\n", 'chomp!' => "\n"
       }
     }
   end
@@ -20,6 +20,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
           ^^^^^^ Argument true is redundant because it is implied by default.
       exit!(false)
            ^^^^^^^ Argument false is redundant because it is implied by default.
+      foo.to_i(10)
+              ^^^^ Argument 10 is redundant because it is implied by default.
       foo.split(' ')
                ^^^^^ Argument ' ' is redundant because it is implied by default.
       foo.chomp("\n")
@@ -33,6 +35,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantArgument, :config do
       foo.sum
       exit
       exit!
+      foo.to_i
       foo.split
       foo.chomp
       foo.chomp!


### PR DESCRIPTION
This PR makes `Style/RedundantArgument` aware of `to_i`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
