### PR TITLE
Fix an error when running `rake rubocop:auto_correct`

### DIFF
--- a/changelog/fix_an_error_when_running_rake_rubocop_auto_correct.md
+++ b/changelog/fix_an_error_when_running_rake_rubocop_auto_correct.md
@@ -1,0 +1,1 @@
+* [#14678](https://github.com/rubocop/rubocop/pull/14678): Fix an error when running deprecated `rake rubocop:auto_correct` task. ([@koic][])

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -75,7 +75,7 @@ module RuboCop
     def setup_subtasks(name, *args, &task_block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace(name) do
         # rubocop:todo Naming/InclusiveLanguage
-        task(:auto_correct, *args) do
+        task(:auto_correct, *args) do |_, task_args|
           require 'rainbow'
           warn Rainbow(
             'rubocop:auto_correct task is deprecated; ' \


### PR DESCRIPTION
This PR fixes the following error when running deprecated `rake rubocop:auto_correct` task:

```console
$ cat Rakefile
require 'rubocop/rake_task'
RuboCop::RakeTask.new { |task| task.patterns = ['lib/'] }

$ rake rubocop:auto_correct
rubocop:auto_correct task is deprecated; use rubocop:autocorrect task or rubocop:autocorrect_all task instead.
rake aborted!
NameError: undefined local variable or method 'task_args' for an instance of RuboCop::RakeTask (NameError)

            yield(*[self, task_args].slice(0, task_block.arity)) if task_block
                          ^^^^^^^^^
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/rake_task.rb:85:in 'block (3 levels) in RuboCop::RakeTask#setup_subtasks'
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/rake_task.rb:84:in 'block (2 levels) in RuboCop::RakeTask#setup_subtasks'
/Users/koic/.rbenv/versions/3.5-dev/bin/bundle:25:in '<main>'
Tasks: TOP => rubocop:auto_correct
(See full trace by running task with --trace)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
