### PR TITLE
Handle all `OptionParser` errors when running `rubocop` with input that causes an error

### DIFF
--- a/changelog/fix_handle_option_parser__ambiguous_option_20251124121925.md
+++ b/changelog/fix_handle_option_parser__ambiguous_option_20251124121925.md
@@ -1,0 +1,1 @@
+* [#14680](https://github.com/rubocop/rubocop/pull/14680): Handle all `OptionParser` errors when running `rubocop` with input that causes an error. ([@dvandersluis][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -66,7 +66,7 @@ module RuboCop
       STATUS_INTERRUPTED
     rescue Finished
       STATUS_SUCCESS
-    rescue OptionParser::InvalidOption => e
+    rescue OptionParser::ParseError => e
       warn e.message
       warn 'For usage information, use --help'
       STATUS_ERROR

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2440,4 +2440,52 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       RESULT
     end
   end
+
+  describe 'option is ambiguous' do
+    it 'suggests to use the --help flag' do
+      ambiguous_option = '--no'
+
+      expect(cli.run([ambiguous_option])).to eq(2)
+      expect($stderr.string).to eq(<<~RESULT)
+        ambiguous option: #{ambiguous_option}
+        For usage information, use --help
+      RESULT
+    end
+  end
+
+  describe 'argument is needless' do
+    it 'suggests to use the --help flag' do
+      option = '--help=yes'
+
+      expect(cli.run([option])).to eq(2)
+      expect($stderr.string).to eq(<<~RESULT)
+        needless argument: #{option}
+        For usage information, use --help
+      RESULT
+    end
+  end
+
+  describe 'argument is missing' do
+    it 'suggests to use the --help flag' do
+      option = '--exclude-limit'
+
+      expect(cli.run([option])).to eq(2)
+      expect($stderr.string).to eq(<<~RESULT)
+        missing argument: #{option}
+        For usage information, use --help
+      RESULT
+    end
+  end
+
+  describe 'argument is invalid' do
+    it 'suggests to use the --help flag' do
+      option = '--fail-level=Z'
+
+      expect(cli.run([option])).to eq(2)
+      expect($stderr.string).to eq(<<~RESULT)
+        invalid argument: #{option}
+        For usage information, use --help
+      RESULT
+    end
+  end
 end


### PR DESCRIPTION
`OptionParser` is configured by default to accept partial option names and does completion. When a partial name is given and it matches multiple options, `OptionParser` raises `AmbiguousOption`.

Furthermore, `OptionParser` can raise errors for invalid, missing and extra arguments.

We were not handling these exceptions, which means that a backtrace was being outputted rather than an error mesasge. This change updates rubocop to treat all `OptionParser` errors the same as invalid options and directs users to use `--help`.

Follows #12280.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
