### PR TITLE
[Doc] Update basic_usage.adoc to document that unambiguous prefixes of command line flags are acceptable

### DIFF
--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -128,6 +128,7 @@ To specify multiple cops for one flag, separate cops with commas and no spaces:
 $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 ----
 
+NOTE: Prefixes are accepted for the long form (starting with `--`) flags. For example, `--regen` could be used rather than `--regenerate-todo`. If the prefix is ambiguous, `rubocop` will fail with an error.
 
 |===
 | Command flag | Description


### PR DESCRIPTION
Although it is possible to restrict `OptionParser` to exact matches only, I think it's more valuable to just document the behaviour and keep it as-is.

Resolves #12280.

