### PR TITLE
[Fix #14476] Skip nested style check inside another class/module

### DIFF
--- a/changelog/fix_style_class_and_module_children_nested_scope.md
+++ b/changelog/fix_style_class_and_module_children_nested_scope.md
@@ -1,0 +1,1 @@
+* [#14476](https://github.com/rubocop/rubocop/issues/14476): Fix `Style/ClassAndModuleChildren` to skip compact style definitions inside another class or module when `EnforcedStyle: nested`. ([@rscq][])

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1847,6 +1847,30 @@ verification that the outer parent is defined elsewhere. RuboCop does not
 have the knowledge to perform either operation safely and thus requires
 manual oversight.
 
+NOTE: When using `nested` style, this cop does not register an offense for
+compact style definitions inside another class or module (e.g., `class Foo::Bar`
+inside `module Baz`), because autocorrection would change semantics:
+
+[source,ruby]
+----
+module Baz
+  class Foo::Bar  # References top-level ::Foo, not Baz::Foo
+  end
+end
+----
+
+If this were autocorrected to nested style, it would become:
+
+[source,ruby]
+----
+module Baz
+  class Foo       # Creates Baz::Foo, not ::Foo
+    class Bar
+    end
+  end
+end
+----
+
 [#examples-styleclassandmodulechildren]
 === Examples
 

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -183,6 +183,7 @@ module RuboCop
 
         def check_nested_style(node)
           return unless compact_node_name?(node)
+          return if node.parent&.type?(:class, :module)
 
           add_offense(node.loc.name, message: NESTED_MSG) do |corrector|
             autocorrect(corrector, node)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -185,6 +185,24 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         end
       RUBY
     end
+
+    it 'accepts compact style when inside another module' do
+      expect_no_offenses(<<~RUBY)
+        module Z
+          module X::Y
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts compact style when inside another class' do
+      expect_no_offenses(<<~RUBY)
+        class Z
+          module X::Y
+          end
+        end
+      RUBY
+    end
   end
 
   context 'compact style' do


### PR DESCRIPTION
Fixes #14476

## Summary

When `Style/ClassAndModuleChildren` enforces `nested` style, it now skips offense detection for compact style definitions (e.g., `X::Y`) that are inside another class or module.

## Problem

Previously, the cop would register an offense and autocorrect the following code:

```ruby
# Before autocorrection
module Z
  module X::Y
    puts X::Y.object_id  # References top-level ::X::Y
  end
end

# After autocorrection (incorrect semantics!)
module Z
  module X
    module Y
      puts X::Y.object_id  # Now references Z::X::Y (different module!)
    end
  end
end
```

This changes the semantics of the code because `X::Y` inside a nested scope refers to the top-level constant, but after autocorrection it would refer to a newly created nested module.

Solution

Added a check in `check_nested_style` to skip offense detection when the node's parent is a class or module. This matches the existing behavior  in `check_compact_style`.

Test

Added two test cases to verify that compact style is accepted when inside another module or class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
