### PR TITLE
[Fix #14684] Allow regexp case equality in `Style/CaseEquality`

### DIFF
--- a/changelog/change_fmake_style_case_equality_cop_allow_regexp.md
+++ b/changelog/change_fmake_style_case_equality_cop_allow_regexp.md
@@ -1,0 +1,1 @@
+* [#14684](https://github.com/rubocop/rubocop/issues/14684): Make `Style/CaseEquality` allow regexp case equality where the receiver is a regexp literal. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3531,9 +3531,11 @@ Style/BlockDelimiters:
   BracesRequiredMethods: []
 
 Style/CaseEquality:
-  Description: 'Avoid explicit use of the case equality operator(===).'
+  Description: 'Avoid explicit use of the case equality operator (`===`).'
   StyleGuide: '#no-case-equality'
   Enabled: true
+  References:
+    - 'https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceregexpmatch'
   VersionAdded: '0.9'
   VersionChanged: '0.89'
   # If `AllowOnConstant` option is enabled, the cop will ignore violations when the receiver of

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -14,14 +14,11 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
       RUBY
     end
 
-    it 'registers an offense but does not correct for === when the receiver is a regexp' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for === when the receiver is a regexp' do
+      # This detection is expected to be supported by `Performance/RegexpMatch`.
+      expect_no_offenses(<<~RUBY)
         /OMG/ === var
-              ^^^ Avoid the use of the case equality operator `===`.
       RUBY
-
-      # This correction is expected to be supported by `Performance/Regexp`.
-      expect_no_corrections
     end
 
     it 'registers an offense and corrects for === when the receiver is a range' do


### PR DESCRIPTION
This PR makes `Style/CaseEquality` allow regexp case equality where the receiver is a regexp literal.

Regexp case equality (`/regexp/ === var`) is allowed because changing it to `/regexp/.match?(var)` needs to take `Regexp.last_match?`, `$~`, `$1`, etc. This potentially incompatible transformation is handled by `Performance/RegexpMatch` cop.

Fixes #14684.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
