### PR TITLE
Fix false positives for `Layout/EndAlignment`

### DIFF
--- a/changelog/fix_false_positives_for_layout_end_alignment_cop.md
+++ b/changelog/fix_false_positives_for_layout_end_alignment_cop.md
@@ -1,0 +1,1 @@
+* [#14688](https://github.com/rubocop/rubocop/pull/14688): Fix false positives for `Layout/EndAlignment` when a conditional assignment is used on the same line and the `end` with a numbered block or `it` block method call is aligned. ([@koic][])

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -117,10 +117,9 @@ module RuboCop
       # with calls chained to the end of it.
       def first_part_of_call_chain(node)
         while node
-          case node.type
-          when :send, :csend
+          if node.call_type?
             node = node.receiver
-          when :block
+          elsif node.any_block_type?
             node = node.send_node
           else
             break

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -678,6 +678,11 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       it_behaves_like 'aligned', 'var = until',  'test',     'end'
       it_behaves_like 'aligned', 'var = until',  'test',     'end.ab.join("")'
       it_behaves_like 'aligned', 'var = until',  'test',     'end.ab.tap {}'
+      it_behaves_like 'aligned', 'var = until', 'test', 'end.ab.tap { _1 }'
+      context 'Ruby >= 3.4', :ruby34 do
+        it_behaves_like 'aligned', 'var = until', 'test', 'end.ab.tap { it }'
+      end
+
       it_behaves_like 'aligned', 'var = case',   'a when b', 'end'
       it_behaves_like 'aligned', "var =\n  if",  'test', '  end'
       context 'Ruby >= 2.7', :ruby27 do


### PR DESCRIPTION
This PR fixes false positives for `Layout/EndAlignment` when a conditional assignment is used on the same line and the `end` with a numbered block or `it` block method call is aligned.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
