### PR TITLE
Extend autocorrection for `InternalAffairs/LocationExists`

### DIFF
--- a/lib/rubocop/cop/internal_affairs/location_exists.rb
+++ b/lib/rubocop/cop/internal_affairs/location_exists.rb
@@ -83,11 +83,7 @@ module RuboCop
           return if ignored_node?(node.parent)
 
           loc_respond_to?(node) do |receiver, location|
-            if receiver
-              register_correctable_offense(node, replacement(receiver, "loc?(#{location.source})"))
-            else
-              add_offense(node)
-            end
+            register_offense(node, replacement(receiver, "loc?(#{location.source})"))
           end
         end
         alias on_csend on_send
@@ -97,9 +93,9 @@ module RuboCop
         def replace_with_loc(node)
           replaceable_with_loc(node) do |receiver, location|
             if node.parent&.assignment?
-              register_correctable_offense(node, replace_assignment(receiver, location))
+              register_offense(node, replace_assignment(receiver, location))
             else
-              register_correctable_offense(node, replacement(receiver, "loc?(#{location.source})"))
+              register_offense(node, replacement(receiver, "loc?(#{location.source})"))
             end
           end
         end
@@ -107,11 +103,11 @@ module RuboCop
         def replace_with_loc_is(node)
           replaceable_with_loc_is(node) do |receiver, location, value|
             replacement = replacement(receiver, "loc_is?(#{location.source}, #{value.source})")
-            register_correctable_offense(node, replacement)
+            register_offense(node, replacement)
           end
         end
 
-        def register_correctable_offense(node, replacement)
+        def register_offense(node, replacement)
           message = format(MSG_CORRECTABLE, replacement: replacement, source: node.source)
 
           add_offense(node, message: message) do |corrector|

--- a/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
@@ -258,13 +258,15 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExists, :config do
       RUBY
     end
 
-    it 'registers an offense but does not correct on `loc.respond_to?` without receiver' do
+    it 'registers an offense and autocorrects on `loc.respond_to?` without receiver' do
       expect_offense(<<~RUBY)
         loc.respond_to?(:begin)
-        ^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?` instead of `loc.respond_to?`.
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `loc?(:begin)` instead of `loc.respond_to?(:begin)`.
       RUBY
 
-      expect_no_corrections
+      expect_correction(<<~RUBY)
+        loc?(:begin)
+      RUBY
     end
 
     it 'registers an offense within an `if` node' do
@@ -281,10 +283,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExists, :config do
     it 'registers an offense within an `if` node without receiver' do
       expect_offense(<<~RUBY)
         foo if loc.respond_to?(:begin)
-               ^^^^^^^^^^^^^^^^^^^^^^^ Use `node.loc?` instead of `loc.respond_to?`.
+               ^^^^^^^^^^^^^^^^^^^^^^^ Use `loc?(:begin)` instead of `loc.respond_to?(:begin)`.
       RUBY
 
-      expect_no_corrections
+      expect_correction(<<~RUBY)
+        foo if loc?(:begin)
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop-ast/commit/86a698b.

This PR extends autocorrection for `InternalAffairs/LocationExists`. In this case, once the offense is detected, it should reasonably support autocorrection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
