### PR TITLE
[Fix #14281] Update `Layout/EndAlignment` with `EnforcedStyleAlignWith: variable` to handle conditionals inside `begin` nodes properly

### DIFF
--- a/changelog/fix_update_layout_end_alignment_with_20251203155653.md
+++ b/changelog/fix_update_layout_end_alignment_with_20251203155653.md
@@ -1,0 +1,1 @@
+* [#14281](https://github.com/rubocop/rubocop/issues/14281): Update `Layout/EndAlignment` with `EnforcedStyleAlignWith: variable` to handle conditionals inside `begin` nodes properly. ([@dvandersluis][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -128,6 +128,10 @@ module RuboCop
           # assignment, we let rhs be the receiver of those method calls before
           # we check if it's an if/unless/while/until.
           return unless (rhs = first_part_of_call_chain(rhs))
+
+          # If `rhs` is a `begin` node, find the first non-`begin` child.
+          rhs = rhs.child_nodes.first while rhs.begin_type?
+
           return unless rhs.conditional?
           return if rhs.if_type? && rhs.ternary?
 

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -413,6 +413,36 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       RUBY
     end
 
+    it 'registers an offense when using `+` operator method with `if` inside `begin` and `end` is not aligned' do
+      expect_offense(<<~RUBY)
+        variable + (if bar
+                      baz
+                    end)
+                    ^^^ `end` at 3, 12 is not aligned with `variable + (if` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        variable + (if bar
+                      baz
+        end)
+      RUBY
+    end
+
+    it 'registers an offense when using `+` operator method with `if` inside multiple `begin`s and `end` is not aligned' do
+      expect_offense(<<~RUBY)
+        variable + ((if bar
+                      baz
+                    end))
+                    ^^^ `end` at 3, 12 is not aligned with `variable + ((if` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        variable + ((if bar
+                      baz
+        end))
+      RUBY
+    end
+
     it 'registers an offense when using a conditional statement in a method argument and `end` is not aligned' do
       expect_offense(<<~RUBY)
         format(


### PR DESCRIPTION
When the `EnforcedStyleAlignWith` mode is `variable`, the alignment should be the same whether the node after an operator is wrapped in parentheses or not. This change fixes a discrepancy due to the inner conditional node not being considered properly when inside a `begin` node.

Fixes #14281.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
