### PR TITLE
[Doc] Remove documentation for ambiguous command line options

### DIFF
--- a/docs/modules/ROOT/pages/usage/basic_usage.adoc
+++ b/docs/modules/ROOT/pages/usage/basic_usage.adoc
@@ -128,8 +128,6 @@ To specify multiple cops for one flag, separate cops with commas and no spaces:
 $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 ----
 
-NOTE: Prefixes are accepted for the long form (starting with `--`) flags. For example, `--regen` could be used rather than `--regenerate-todo`. If the prefix is ambiguous, `rubocop` will fail with an error.
-
 |===
 | Command flag | Description
 


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14683#issuecomment-3584320842.

The behavior of accepting abbreviated long options (e.g., `--regen` for `--regenerate-todo`) was unintentional. This behavior will be updated in https://github.com/rubocop/rubocop/pull/12282.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
