### PR TITLE
[Fix #14695] Make `Layout/EmptyLineAfterMagicComment` aware of `# rbs_inline` magic comment

### DIFF
--- a/changelog/change_make_layout_empty_line_after_magic_comment_aware_of_rbs_inline_magic_comment.md
+++ b/changelog/change_make_layout_empty_line_after_magic_comment_aware_of_rbs_inline_magic_comment.md
@@ -1,0 +1,1 @@
+* [#14695](https://github.com/rubocop/rubocop/issues/14695): Make `Layout/EmptyLineAfterMagicComment` aware of `# rbs_inline` magic comment. ([@koic][])

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -11,6 +11,7 @@ module RuboCop
     KEYWORDS = {
       encoding: '(?:en)?coding',
       frozen_string_literal: 'frozen[_-]string[_-]literal',
+      rbs_inline: 'rbs_inline',
       shareable_constant_value: 'shareable[_-]constant[_-]value',
       typed: 'typed'
     }.freeze
@@ -36,6 +37,7 @@ module RuboCop
     def any?
       frozen_string_literal_specified? ||
         encoding_specified? ||
+        rbs_inline_specified? ||
         shareable_constant_value_specified? ||
         typed_specified?
     end
@@ -58,6 +60,10 @@ module RuboCop
 
     def valid_literal_value?
       [true, false].include?(frozen_string_literal)
+    end
+
+    def valid_rbs_inline_value?
+      %w[enabled disabled].include?(extract_rbs_inline_value)
     end
 
     def valid_shareable_constant_value?
@@ -103,6 +109,10 @@ module RuboCop
 
     def encoding_specified?
       specified?(encoding)
+    end
+
+    def rbs_inline_specified?
+      valid_rbs_inline_value?
     end
 
     # Was the Sorbet `typed` sigil specified?
@@ -203,6 +213,9 @@ module RuboCop
         match(KEYWORDS[:frozen_string_literal])
       end
 
+      # Emacs comments cannot specify RBS::inline behavior.
+      def extract_rbs_inline_value; end
+
       def extract_shareable_constant_value
         match(KEYWORDS[:shareable_constant_value])
       end
@@ -241,6 +254,9 @@ module RuboCop
 
       # Vim comments cannot specify frozen string literal behavior.
       def frozen_string_literal; end
+
+      # Vim comments cannot specify RBS::inline behavior.
+      def extract_rbs_inline_value; end
 
       # Vim comments cannot specify shareable constant values behavior.
       def shareable_constant_value; end
@@ -294,6 +310,10 @@ module RuboCop
       # @see https://github.com/ruby/ruby/blob/78b95b49f8/parse.y#L7134-L7138
       def extract_frozen_string_literal
         extract(/\A\s*#\s*#{KEYWORDS[:frozen_string_literal]}:\s*#{TOKEN}\s*\z/io)
+      end
+
+      def extract_rbs_inline_value
+        extract(/\A\s*#\s*#{KEYWORDS[:rbs_inline]}:\s*#{TOKEN}\s*\z/io)
       end
 
       def extract_shareable_constant_value

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -15,6 +15,41 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     RUBY
   end
 
+  it 'registers an offense when code that immediately follows `rbs_inline: enabled` comment' do
+    expect_offense(<<~RUBY)
+      # rbs_inline: enabled
+      class Foo; end
+      ^ Add an empty line after magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rbs_inline: enabled
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'registers an offense when code that immediately follows `rbs_inline: disabled` comment' do
+    expect_offense(<<~RUBY)
+      # rbs_inline: disabled
+      class Foo; end
+      ^ Add an empty line after magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rbs_inline: disabled
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'does not register an offense when code that immediately follows `rbs_inline: invalid_value` comment' do
+    expect_no_offenses(<<~RUBY)
+      # rbs_inline: invalid_value
+      class Foo; end
+    RUBY
+  end
+
   it 'registers an offense when code that immediately follows typed comment' do
     expect_offense(<<~RUBY)
       # typed: true
@@ -80,6 +115,38 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
 
     expect_no_offenses(<<~RUBY)
       # shareable_constant_value: experimental_everything
+      # frozen_string_literal: true
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'accepts magic comment with `rbs_inline: enabled`' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # rbs_inline: enabled
+
+      class Foo; end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      # rbs_inline: enabled
+      # frozen_string_literal: true
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'accepts magic comment with `rbs_inline: disabled`' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # rbs_inline: disabled
+
+      class Foo; end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      # rbs_inline: disabled
       # frozen_string_literal: true
 
       class Foo; end

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -214,6 +214,28 @@ RSpec.describe RuboCop::MagicComment do
     end
   end
 
+  describe '#valid_rbs_inline_value?' do
+    subject { described_class.parse(comment).valid_rbs_inline_value? }
+
+    context 'when given comment specified as `enabled`' do
+      let(:comment) { '# rbs_inline: enabled' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when given comment specified as `disabled`' do
+      let(:comment) { '# rbs_inline: disabled' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when given comment specified as an invalid value`' do
+      let(:comment) { '# rbs_inline: invalid' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe '#valid_shareable_constant_value?' do
     subject { described_class.parse(comment).valid_shareable_constant_value? }
 


### PR DESCRIPTION
This PR makes `Layout/EmptyLineAfterMagicComment` aware of `# rbs_inline` magic comment.

Fixes #14695.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
