### PR TITLE
Make `Lint/UnreachableCode` aware of singleton method redefinition

### DIFF
--- a/changelog/change_make_lint_unreachable_code_aware_of_defs.md
+++ b/changelog/change_make_lint_unreachable_code_aware_of_defs.md
@@ -1,0 +1,1 @@
+* [#14698](https://github.com/rubocop/rubocop/pull/14698): Make `Lint/UnreachableCode` aware of singleton method redefinition. ([@koic][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -90,7 +90,7 @@ module RuboCop
             check_if(node)
           when :case, :case_match
             check_case(node)
-          when :def
+          when :def, :defs
             register_redefinition(node)
             false
           else

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -268,6 +268,38 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
       RUBY
     end
 
+    it "registers an offense for `self.#{t}` with nested redefinition" do
+      expect_offense <<~RUBY
+        def foo
+          def self.#{t}; end
+        end
+
+        #{t}
+        bar
+        ^^^ Unreachable code detected.
+      RUBY
+    end
+
+    it "accepts `self.#{t}` if redefined" do
+      expect_no_offenses(wrap(<<~RUBY))
+        def self.#{t}; end
+        #{t}
+        bar
+      RUBY
+    end
+
+    it "accepts `self.#{t}` if redefined even if it's called recursively" do
+      expect_no_offenses(wrap(<<~RUBY))
+        def self.#{t}
+          #{t}
+          bar
+        end
+
+        #{t}
+        bar
+      RUBY
+    end
+
     it "accepts `#{t}` if called in `instance_eval`" do
       expect_no_offenses <<~RUBY
         class Dummy


### PR DESCRIPTION
This PR makes `Lint/UnreachableCode` aware of singleton method redefinition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
