### PR TITLE
[Fix #12754] Fix infinite loop in Style/IfUnlessModifier with Layout cops

### DIFF
--- a/changelog/fix_infinite_loop_style_if_unless_modifier_with_layout_cops.md
+++ b/changelog/fix_infinite_loop_style_if_unless_modifier_with_layout_cops.md
@@ -1,0 +1,1 @@
+* [#12754](https://github.com/rubocop/rubocop/issues/12754): Fix an infinite loop for `Style/IfUnlessModifier` with `Layout/EndAlignment` and `Layout/IndentationWidth`. ([@rscq][])

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -1034,4 +1034,77 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       end
     end
   end
+
+  context 'when multiple if/unless modifiers are in an array literal' do
+    context 'when the line is too long' do
+      it 'registers an offense but does not correct' do
+        expect_offense(<<~RUBY)
+          [(fooooooooooo if condition_onnnnnnnnnnne), (baaaaaar if condition_twwwwwwwwwwo)]
+                         ^^ Modifier form of `if` makes the line too long.
+                                                                ^^ Modifier form of `if` makes the line too long.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    context 'when the normal form fits on single lines' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          [
+            (if condition1
+             ^^ Favor modifier `if` usage [...]
+               foo
+             end),
+            (if condition2
+             ^^ Favor modifier `if` usage [...]
+               bar
+             end)
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            (foo if condition1),
+            (bar if condition2)
+          ]
+        RUBY
+      end
+    end
+  end
+
+  context 'when multiple if/unless modifiers are in a hash literal' do
+    context 'when the line is too long' do
+      it 'registers an offense but does not correct' do
+        expect_offense(<<~RUBY)
+          { a: (fooooooooo if condition_onnnnnnnnnnne), b: (baaaaaaaar if condition_twwwo) }
+                           ^^ Modifier form of `if` makes the line too long.
+                                                                       ^^ Modifier form of `if` makes the line too long.
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+  end
+
+  context 'when single if modifier is in an array literal' do
+    context 'when the line is too long' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          [
+            (foooooooooooooooooooooooooooooooooooooooooooo if condition_onnnnnnnnnnnnnnnnne)
+                                                           ^^ Modifier form of `if` makes the line too long.
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            (if condition_onnnnnnnnnnnnnnnnne
+               foooooooooooooooooooooooooooooooooooooooooooo
+             end)
+          ]
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #12754

## Summary

Fix infinite autocorrect loop between `Style/IfUnlessModifier` and Layout cops (`Layout/EndAlignment`, `Layout/IndentationWidth`) when multiple parenthesized `if/unless` modifiers exist in array or hash literals.

## Problem

When code like `[(foo if cond1), (bar if cond2)]` triggers "line too long" offense, autocorrect converts to normal form. Layout cops then adjust indentation, changing the node's column position. On the next iteration, `length_in_modifier_form` recalculates with the new position and converts back to modifier form, creating an infinite loop.

## Solution

Skip autocorrect for modifier-to-normal conversion when the if/unless is inside an array or hash literal with multiple conditional siblings. The offense is still reported, but not autocorrected to prevent oscillation.

Normal-to-modifier conversion is always allowed since it doesn't cause the loop.

## Changes

- Add `inside_complex_structure?` method to detect problematic patterns
- Add documentation NOTE explaining non-autocorrect case
- Add tests for array/hash literals with multiple and single conditionals

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
