### PR TITLE
Fix false positives for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_for_lint_redundant_safe_navigation.md
+++ b/changelog/fix_false_positives_for_lint_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#14699](https://github.com/rubocop/rubocop/pull/14699): Fix false positives for `Lint/RedundantSafeNavigation` when the receiver is used outside the singleton method definition scope. ([@koic][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -31,7 +31,7 @@ module RuboCop
             @checked_nodes[node] = true
 
             case node.type
-            when :def, :class, :module, :sclass
+            when :def, :defs, :class, :module, :sclass
               return false
             when :send
               return non_nil_method?(node.method_name) if node.receiver == receiver

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -662,11 +662,21 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
 
-    it 'ignores offenses outside of the scope' do
+    it 'ignores offenses outside of the method definition scope' do
       expect_no_offenses(<<~RUBY)
         foo.bar
 
         def x
+          foo&.bar
+        end
+      RUBY
+    end
+
+    it 'ignores offenses outside of the singleton method definition scope' do
+      expect_no_offenses(<<~RUBY)
+        foo.bar
+
+        def self.x
           foo&.bar
         end
       RUBY


### PR DESCRIPTION
This PR fixes false positives for `Lint/RedundantSafeNavigation` when the receiver is used outside the singleton method definition scope.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
