### PR TITLE
Fix false negatives for `Layout/RescueEnsureAlignment`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_rescue_ensure_alignment.md
+++ b/changelog/fix_false_negatives_for_layout_rescue_ensure_alignment.md
@@ -1,0 +1,1 @@
+* [#14703](https://github.com/rubocop/rubocop/pull/14703): Fix false negatives for `Layout/RescueEnsureAlignment` when using self class definition. ([@koic][])

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -29,7 +29,7 @@ module RuboCop
         MSG = '`%<kw_loc>s` at %<kw_loc_line>d, %<kw_loc_column>d is not ' \
               'aligned with `%<beginning>s` at ' \
               '%<begin_loc_line>d, %<begin_loc_column>d.'
-        ANCESTOR_TYPES = %i[kwbegin any_def class module any_block].freeze
+        ANCESTOR_TYPES = %i[kwbegin any_def class module sclass any_block].freeze
         ALTERNATIVE_ACCESS_MODIFIERS = %i[public_class_method private_class_method].freeze
 
         def on_resbody(node)
@@ -91,7 +91,7 @@ module RuboCop
           )
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def alignment_source(node, starting_loc)
           ending_loc =
             case node.type
@@ -100,6 +100,8 @@ module RuboCop
             when :def, :defs, :class, :module,
                  :lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn
               node.loc.name
+            when :sclass
+              node.identifier.source_range
             when :masgn
               node.lhs.source_range
             else
@@ -109,7 +111,7 @@ module RuboCop
 
           range_between(starting_loc.begin_pos, ending_loc.end_pos).source
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         # We will use ancestor or wrapper with access modifier.
 

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -264,6 +264,27 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
     end
   end
 
+  context 'rescue with self class' do
+    it 'registers an offense when rescue used with class' do
+      expect_offense(<<~RUBY)
+        class << self
+          something
+            rescue
+            ^^^^^^ `rescue` at 3, 4 is not aligned with `class << self` at 1, 0.
+            error
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
+          something
+        rescue
+            error
+        end
+      RUBY
+    end
+  end
+
   context 'ensure with begin' do
     it 'registers an offense when ensure used with begin' do
       expect_offense(<<~RUBY)
@@ -361,6 +382,27 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
 
       expect_correction(<<~RUBY)
         module M
+          something
+        ensure
+            error
+        end
+      RUBY
+    end
+  end
+
+  context 'ensure with self class' do
+    it 'registers an offense when ensure used with self class' do
+      expect_offense(<<~RUBY)
+        class << self
+          something
+            ensure
+            ^^^^^^ `ensure` at 3, 4 is not aligned with `class << self` at 1, 0.
+            error
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
           something
         ensure
             error


### PR DESCRIPTION
This PR fixes false negatives for `Layout/RescueEnsureAlignment` when using self class definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
