### PR TITLE
Fix incorrect Position character value in LSP

### DIFF
--- a/changelog/fix_incorrect_position_character_value_in_lsp_20251211233711.md
+++ b/changelog/fix_incorrect_position_character_value_in_lsp_20251211233711.md
@@ -1,0 +1,1 @@
+* [#14704](https://github.com/rubocop/rubocop/pull/14704): Fix incorrect Position character value in LSP. ([@tmtm][])


### PR DESCRIPTION
For utf-16 positionEncoding, characters above U+FFFF must be counted as 2, but they were incorrectly counted as 1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
