### PR TITLE
[Fix #14706] Fix false negatives for `Lint/NoReturnInBeginEndBlocks`

### DIFF
--- a/changelog/fix_false_negatives_for_lint_no_return_in_begin_end_blocks.md
+++ b/changelog/fix_false_negatives_for_lint_no_return_in_begin_end_blocks.md
@@ -1,0 +1,1 @@
+* [#14706](https://github.com/rubocop/rubocop/issues/14706): Fix false negatives for `Lint/NoReturnInBeginEndBlocks` when assigning instance variable, class variable, global variable, or constant. ([@koic][])

--- a/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
+++ b/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
@@ -45,6 +45,10 @@ module RuboCop
             end
           end
         end
+        alias on_ivasgn on_lvasgn
+        alias on_cvasgn on_lvasgn
+        alias on_gvasgn on_lvasgn
+        alias on_casgn on_lvasgn
         alias on_or_asgn on_lvasgn
         alias on_op_asgn on_lvasgn
       end

--- a/spec/rubocop/cop/lint/no_return_in_begin_end_blocks_spec.rb
+++ b/spec/rubocop/cop/lint/no_return_in_begin_end_blocks_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Lint::NoReturnInBeginEndBlocks, :config do
   shared_examples 'rejects return inside a block' do |operator|
-    it "rejects a return statement inside a block when using #{operator}" do
+    it "rejects a return statement inside a block when using #{operator} for local variable" do
       expect_offense(<<~RUBY)
         some_value = 10
 
@@ -13,12 +13,100 @@ RSpec.describe RuboCop::Cop::Lint::NoReturnInBeginEndBlocks, :config do
         end
       RUBY
     end
+
+    it "rejects a return statement inside a block when using #{operator} for instance variable" do
+      expect_offense(<<~RUBY)
+        @some_value #{operator} begin
+          return 1 if rand(1..2).odd?
+          ^^^^^^^^ Do not `return` in `begin..end` blocks in assignment contexts.
+          2
+        end
+      RUBY
+    end
+
+    it "rejects a return statement inside a block when using #{operator} for class variable" do
+      expect_offense(<<~RUBY)
+        @@some_value #{operator} begin
+          return 1 if rand(1..2).odd?
+          ^^^^^^^^ Do not `return` in `begin..end` blocks in assignment contexts.
+          2
+        end
+      RUBY
+    end
+
+    it "rejects a return statement inside a block when using #{operator} for global variable" do
+      expect_offense(<<~RUBY)
+        $some_value #{operator} begin
+          return 1 if rand(1..2).odd?
+          ^^^^^^^^ Do not `return` in `begin..end` blocks in assignment contexts.
+          2
+        end
+      RUBY
+    end
+
+    it "rejects a return statement inside a block when using #{operator} for constant" do
+      expect_offense(<<~RUBY)
+        CONST #{operator} begin
+          return 1 if rand(1..2).odd?
+          ^^^^^^^^ Do not `return` in `begin..end` blocks in assignment contexts.
+          2
+        end
+      RUBY
+    end
   end
 
   shared_examples 'accepts a block with no return' do |operator|
-    it "accepts a block with no return when using #{operator}" do
+    it "accepts a block with no return when using #{operator} for local variable" do
       expect_no_offenses(<<~RUBY)
-        @good_method #{operator} begin
+        some_value #{operator} begin
+          if rand(1..2).odd?
+            "odd number"
+          else
+            "even number"
+          end
+        end
+      RUBY
+    end
+
+    it "accepts a block with no return when using #{operator} for instance variable" do
+      expect_no_offenses(<<~RUBY)
+        @some_value #{operator} begin
+          if rand(1..2).odd?
+            "odd number"
+          else
+            "even number"
+          end
+        end
+      RUBY
+    end
+
+    it "accepts a block with no return when using #{operator} for class variable" do
+      expect_no_offenses(<<~RUBY)
+        @@some_value #{operator} begin
+          if rand(1..2).odd?
+            "odd number"
+          else
+            "even number"
+          end
+        end
+      RUBY
+    end
+
+    it "accepts a block with no return when using #{operator} for global variable" do
+      expect_no_offenses(<<~RUBY)
+        $some_value #{operator} begin
+          if rand(1..2).odd?
+            "odd number"
+          else
+            "even number"
+          end
+        end
+      RUBY
+    end
+
+    it "accepts a block with no return when using #{operator} for constant" do
+      expect_no_offenses(<<~RUBY)
+        CONST #{operator} begin
           if rand(1..2).odd?
             "odd number"
           else


### PR DESCRIPTION
This PR fixes false negatives for `Lint/NoReturnInBeginEndBlocks` when assigning instance variable, class variable, global variable, or constant.

Fixes #14706.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
