### PR TITLE
[Fix #12295] Fix `Layout/FirstArgumentIndentation` to correct entire method calls and chains for nested calls

### DIFF
--- a/changelog/fix_layout_first_argument_indentation_to_correct_entire_method_calls_and_chains_for_nested_calls.md
+++ b/changelog/fix_layout_first_argument_indentation_to_correct_entire_method_calls_and_chains_for_nested_calls.md
@@ -1,0 +1,1 @@
+* [#12295](https://github.com/rubocop/rubocop/issues/12295): Fix `Layout/FirstArgumentIndentation` to correct entire method calls and chains for nested calls. ([@ydakuka][])

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -441,6 +441,77 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                                a))
           RUBY
         end
+
+        it 'corrects the entire method call when closing parenthesis is on a separate line' do
+          expect_offense(<<~RUBY)
+            instance_variable_set(
+              "@diagnostics",
+              Diagnostic.where(
+                          'limit >= 10 and limit < 100',
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than `Diagnostic.where(`.
+                        )
+            )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            instance_variable_set(
+              "@diagnostics",
+              Diagnostic.where(
+                'limit >= 10 and limit < 100',
+              )
+            )
+          RUBY
+        end
+
+        it 'corrects the entire method call with multiple arguments' do
+          expect_offense(<<~RUBY)
+            instance_variable_set(
+              "@diagnostics",
+              Diagnostic.where(
+                    'limit >= ? and limit < ?',
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than `Diagnostic.where(`.
+                    LIMITS[:lowest_value], LIMITS[:highest_value]
+                  )
+            )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            instance_variable_set(
+              "@diagnostics",
+              Diagnostic.where(
+                'limit >= ? and limit < ?',
+                LIMITS[:lowest_value], LIMITS[:highest_value]
+              )
+            )
+          RUBY
+        end
+
+        it 'corrects the entire method call chain' do
+          expect_offense(<<~RUBY)
+            instance_variable_set(
+              "@diagnostic_ids",
+              Diagnostic.where(
+                    'limit >= ? and limit < ?',
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                    LIMITS[:lowest_value], LIMITS[:highest_value]
+                  )
+                  .where(id: 1)
+                  .ids,
+            )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            instance_variable_set(
+              "@diagnostic_ids",
+              Diagnostic.where(
+                'limit >= ? and limit < ?',
+                LIMITS[:lowest_value], LIMITS[:highest_value]
+              )
+              .where(id: 1)
+              .ids,
+            )
+          RUBY
+        end
       end
 
       context 'without outer parentheses' do


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/12295 , https://github.com/rubocop/rubocop/issues/13790

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
