### PR TITLE
[Fix #14711] Fix broken auto-correction in `Style/RedundantRegexpArgument` rule

### DIFF
--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -75,6 +75,11 @@ module RuboCop
             new_argument.gsub!('\"', '"')
             quote = "'"
           elsif new_argument.include?("\\'")
+            # Add a backslash before single quotes preceded by an even number of backslashes.
+            # An even number (including zero) of backslashes before a quote means the quote itself
+            # is not escaped.
+            # Otherwise an odd number means the quote is already escaped so this doesn't touch it.
+            new_argument.gsub!(/(?<!\\)((?:\\\\)*)'/) { "#{::Regexp.last_match(1)}\\'" }
             quote = "'"
           elsif new_argument.include?('\'')
             new_argument.gsub!("'", "\\\\'")

--- a/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_argument_spec.rb
@@ -69,6 +69,52 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpArgument, :config do
     RUBY
   end
 
+  context 'single quote with escape character(s)' do
+    it 'registers an offense and corrects when using single backslash and single quote' do
+      expect_offense(<<~'RUBY')
+        str.gsub!(/\\'/, "'")
+                  ^^^^^ Use string `'\\\''` as argument instead of regexp `/\\'/`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        str.gsub!('\\\'', "'")
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using single backslash and escaped single quote' do
+      expect_offense(<<~'RUBY')
+        str.gsub!(/\\\'/, "'")
+                  ^^^^^^ Use string `'\\\''` as argument instead of regexp `/\\\'/`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        str.gsub!('\\\'', "'")
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using double backslash and single quote' do
+      expect_offense(<<~'RUBY')
+        str.gsub!(/\\\\'/, "'")
+                  ^^^^^^^ Use string `'\\\\\''` as argument instead of regexp `/\\\\'/`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        str.gsub!('\\\\\'', "'")
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using double backslash and escaped single quote' do
+      expect_offense(<<~'RUBY')
+        str.gsub!(/\\\\\'/, "'")
+                  ^^^^^^^^ Use string `'\\\\\''` as argument instead of regexp `/\\\\\'/`.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        str.gsub!('\\\\\'', "'")
+      RUBY
+    end
+  end
+
   it 'registers an offense and corrects when using escaped double quote character' do
     expect_offense(<<~'RUBY')
       str.gsub(/\"/)


### PR DESCRIPTION
Fixes #14711

In some scenarios of the combination of single-quote characters and escape characters, it breaks the Ruby syntax.

For example,

```ruby
str.gsub!(/\\'/, "'")
```

RuboCop suggests rewriting the regexp literal with a string surrounded by single quotes, but that breaks the Ruby syntax due to unbalanced quotes with escaping, like:

```ruby
str.gsub!('\\'', "'")
```

This commit ensures that single quotes preceded by an even number of backslashes are properly escaped in the suggested replacement like the following:

```ruby
str.gsub!('\\\'', "'")
#            ^ appended
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
