### PR TITLE
[Fix #12297] Fix a false negative in `Layout/IndentationWidth` for method chain blocks

### DIFF
--- a/changelog/fix_indentation_width_method_chain_blocks.md
+++ b/changelog/fix_indentation_width_method_chain_blocks.md
@@ -1,0 +1,1 @@
+* [#12297](https://github.com/rubocop/rubocop/issues/12297): Fix false negative in `Layout/IndentationWidth` for multiline method chain blocks. ([@rscq][])

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -43,8 +43,7 @@ module RuboCop
         def on_new_investigation
           return if processed_source.blank?
 
-          gem_declarations(processed_source.ast)
-            .each_cons(2) do |previous, current|
+          gem_declarations(processed_source.ast).each_cons(2) do |previous, current|
             next unless consecutive_lines?(previous, current)
             next unless case_insensitive_out_of_order?(gem_name(current), gem_name(previous))
 

--- a/lib/rubocop/cop/gemspec/ordered_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/ordered_dependencies.rb
@@ -69,8 +69,7 @@ module RuboCop
         def on_new_investigation
           return if processed_source.blank?
 
-          dependency_declarations(processed_source.ast)
-            .each_cons(2) do |previous, current|
+          dependency_declarations(processed_source.ast).each_cons(2) do |previous, current|
             next unless consecutive_lines?(previous, current)
             next unless case_insensitive_out_of_order?(gem_name(current), gem_name(previous))
             next unless get_dependency_name(previous) == get_dependency_name(current)

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -83,7 +83,10 @@ module RuboCop
 
           return unless begins_its_line?(end_loc)
 
-          check_indentation(end_loc, node.body)
+          # For blocks where the dot is on a new line, use the dot position as the base.
+          # Otherwise, use the end keyword position as the base.
+          base_loc = dot_on_new_line?(node) ? node.send_node.loc.dot : end_loc
+          check_indentation(base_loc, node.body)
 
           return unless indented_internal_methods_style?
 
@@ -382,6 +385,14 @@ module RuboCop
           return node unless node.parent&.send_type?
 
           leftmost_modifier_of(node.parent)
+        end
+
+        def dot_on_new_line?(node)
+          send_node = node.send_node
+          return false unless send_node.loc?(:dot)
+
+          receiver = send_node.receiver
+          receiver && receiver.last_line < send_node.loc.dot.line
         end
       end
     end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1659,6 +1659,53 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
     end
+
+    context 'with method chain blocks' do
+      it 'registers an offense for bad indentation in chained block' do
+        expect_offense(<<~RUBY)
+          foo
+            .bar do |x|
+            x
+            ^{} Use 2 (not 0) spaces for indentation.
+          end
+        RUBY
+      end
+
+      it 'accepts correct indentation in chained block' do
+        expect_no_offenses(<<~RUBY)
+          foo
+            .bar do |x|
+              x
+            end
+        RUBY
+      end
+
+      it 'accepts correct indentation for block without method chain' do
+        expect_no_offenses(<<~RUBY)
+          foo bar do
+            baz
+          end
+        RUBY
+      end
+
+      it 'accepts correct indentation when dot is on the same line as receiver' do
+        expect_no_offenses(<<~RUBY)
+          foo.bar do |x|
+            x
+          end
+        RUBY
+      end
+
+      it 'does not raise error for block without dot (e.g., super)' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            super do |x|
+              x
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   it 'does not register an offense for blocks with a very large offset' do

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -477,8 +477,7 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'registers an offense for a non-empty block with multiple unused args' do
-      (arg1_message, arg2_message, others_message) = %w[arg1 arg2 others]
-                                                     .map do |arg|
+      (arg1_msg, arg2_msg, others_msg) = %w[arg1 arg2 others].map do |arg|
         "Unused block argument - `#{arg}`. If it's necessary, use `_` or " \
           "`_#{arg}` as an argument name to indicate that it won't be used. " \
           'Also consider using a proc without arguments instead of a lambda ' \
@@ -487,9 +486,9 @@ RSpec.describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
       expect_offense(<<~RUBY)
         ->(arg1, arg2, *others) { 1 }
-                        ^^^^^^ #{others_message}
-                 ^^^^ #{arg2_message}
-           ^^^^ #{arg1_message}
+                        ^^^^^^ #{others_msg}
+                 ^^^^ #{arg2_msg}
+           ^^^^ #{arg1_msg}
       RUBY
 
       expect_correction(<<~RUBY)

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
     describe 'invocation order' do
       let(:formatter) do
         formatter = instance_spy(RuboCop::Formatter::BaseFormatter)
-        %i[started file_started file_finished finished output]
-          .each do |message|
+        %i[started file_started file_finished finished output].each do |message|
           allow(formatter).to receive(message) do
             puts message unless message == :output
           end


### PR DESCRIPTION
## Summary

Fix a false negative in `Layout/IndentationWidth` when checking indentation inside `do...end` blocks that are part of multiline method chains.

Fixes #12297

## Problem

`Layout/IndentationWidth` did not detect incorrect indentation inside blocks when the block was part of a multiline method chain. This was because the cop used the `end` keyword position as the base for indentation checking, but in method chains, `end` aligns with the method chain start (the dot), not the `do` keyword.

## Solution

Use the dot position (`.method`) as the base for indentation checking when the block is part of a multiline method chain.

## Example

```ruby
# Before: No offense detected (false negative)
foo
  .bar do |x|
  x  # should be indented 2 more spaces
end

# After: Offense detected
foo
  .bar do |x|
  x  # Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.
end

# Correct code
foo
  .bar do |x|
    x
  end
```

## Note

Unrelated style fixes in `unused_block_argument_spec.rb`, `runner_formatter_invocation_spec.rb`,  `ordered_gems.rb` and `ordered_dependencies.rb` were included to pass CI.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
