### PR TITLE
Fix false positives for `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_false_positives_for_layout_empty_line_after_guard_clause.md
+++ b/changelog/fix_false_positives_for_layout_empty_line_after_guard_clause.md
@@ -1,0 +1,1 @@
+* [#14715](https://github.com/rubocop/rubocop/pull/14715): Fix false positives for `Layout/EmptyLineAfterGuardClause` when a guard clause follows a multiline heredoc in a parenthesized method call. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -145,8 +145,10 @@ module RuboCop
           next_sibling.if_type? && contains_guard_clause?(next_sibling)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def last_heredoc_argument(node)
           n = last_heredoc_argument_node(node)
+          n = n.children.first while n.respond_to?(:begin_type?) && n.begin_type?
 
           return n if heredoc?(n)
           return unless n.respond_to?(:arguments)
@@ -158,6 +160,7 @@ module RuboCop
 
           last_heredoc_argument(n.receiver) if n.respond_to?(:receiver)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def last_heredoc_argument_node(node)
           return node unless node.respond_to?(:if_branch)

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -521,6 +521,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'accepts a guard clause that is after a multiline heredoc with parenthesized method call' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        raise ArgumentError, (<<~END.squish) unless guard
+          A multiline message
+          that will be squished.
+        END
+
+        return_value
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `return` before guard condition with heredoc' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes false positives for `Layout/EmptyLineAfterGuardClause` when a guard clause follows a multiline heredoc in a parenthesized method call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
