### PR TITLE
Allow disabling cache cleanup

### DIFF
--- a/changelog/change_allow_disabling_cache_pruning.md
+++ b/changelog/change_allow_disabling_cache_pruning.md
@@ -1,0 +1,1 @@
+* [#14718](https://github.com/rubocop/rubocop/pull/14718): Allow setting `MaxFilesInCache` to `false` to entirely disable cache pruning. ([@byroot][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -27,6 +27,7 @@ module RuboCop
     # there's parallel execution and the cache is shared.
     def self.cleanup(config_store, verbose, cache_root_override = nil)
       return if inhibit_cleanup # OPTIMIZE: For faster testing
+      return unless config_store.for_pwd.for_all_cops['MaxFilesInCache']
 
       rubocop_cache_dir = cache_root(config_store, cache_root_override)
       return unless File.exist?(rubocop_cache_dir)


### PR DESCRIPTION
In our use case, we have CI nodes that are recycled frequently, none live more than a say, so cleaning up the cache directory is just a waste of time.

I could set the limit to a very large number, but that is worse because then rubocop will keep getting slower counting cache entries just to realize there's nothing to cleanup.
