### PR TITLE
Fix crash when Layout/LineLength is disabled

### DIFF
--- a/changelog/fix_crash_when_layout_line_length_is_20251218091719.md
+++ b/changelog/fix_crash_when_layout_line_length_is_20251218091719.md
@@ -1,0 +1,1 @@
+* [#14719](https://github.com/rubocop/rubocop/pull/14719): Fix crash on long lines when `Layout/LineLength` is disabled. ([@floriandejonckheere][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -90,6 +90,8 @@ module RuboCop
       end
 
       def line_with_eol_comment_too_long?(range)
+        return false unless max_line_length
+
         (range.source_line + eol_comment).length > max_line_length
       end
 

--- a/lib/rubocop/cop/layout/heredoc_indentation.rb
+++ b/lib/rubocop/cop/layout/heredoc_indentation.rb
@@ -89,6 +89,7 @@ module RuboCop
         end
 
         def line_too_long?(node)
+          return false unless max_line_length
           return false if unlimited_heredoc_length?
 
           body = heredoc_body(node)

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -78,6 +78,8 @@ module RuboCop
         end
 
         def line_break_necessary_in_args?(node)
+          return false unless max_line_length
+
           needed_length_for_args(node) > max_line_length
         end
 

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -75,6 +75,8 @@ module RuboCop
         end
 
         def correction_exceeds_max_line_length?(node)
+          return false unless max_line_length
+
           indentation_width(node) + definition_width(node) > max_line_length
         end
 

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -249,6 +249,25 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
         RUBY
       end
     end
+
+    context 'when `Layout/LineLength` is disabled' do
+      let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          <<~#{quote}RUBY2#{quote}
+          something
+          ^^^^^^^^^ Use 2 spaces for indentation in a heredoc.
+          RUBY2
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~#{quote}RUBY2#{quote}
+            something
+          RUBY2
+        RUBY
+      end
+    end
   end
 
   context 'when Ruby >= 2.3', :ruby23 do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -349,6 +349,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineBlockLayout, :config do
     RUBY
   end
 
+  context 'when `Layout/LineLength` is disabled' do
+    let(:config) do
+      RuboCop::Config.new('Layout/LineLength' => { 'Enabled' => false })
+    end
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        test do
+        |(x, y)|
+        ^^^^^^^^ Block argument expression is not on the same line as the block start.
+          play_with(x, y)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        test do |(x, y)|
+          play_with(x, y)
+        end
+      RUBY
+    end
+  end
+
   context 'Ruby 2.7', :ruby27 do
     it 'registers an offense and corrects for missing newline in {} block w/o params' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -248,4 +248,22 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
       end
     end
   end
+
+  context 'when `Layout/LineLength` is disabled' do
+    let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        def foo(bar
+        ^^^^^^^^^^^ Avoid multi-line method signatures.
+            )
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(bar)
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -123,6 +123,23 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
     RUBY
   end
 
+  context 'when `Layout/LineLength` is disabled' do
+    let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
+
+    it 'registers an offense when using single line `do`...`end`' do
+      expect_offense(<<~RUBY)
+        foo do bar end
+        ^^^^^^^^^^^^^^ Prefer multiline `do`...`end` block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo do
+         bar#{' '}
+        end
+      RUBY
+    end
+  end
+
   context 'when `Layout/RedundantLineBreak` is enabled with `InspectBlocks: true`' do
     let(:other_cops) do
       {


### PR DESCRIPTION
Fix a crash in the code that manifests when `Layout/LineLength` is disabled, caused by a comparison of Integer with `nil`. The `nil` value is returned from the `max_line_length` helper that returns `nil` instead of a default max value (120) since #14658.

Added a guard statement where applicable, and regression tests.

```
An error occurred while Layout/MultilineBlockLayout cop was inspecting myfile.rb:99:10.
/usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/layout/multiline_block_layout.rb:81:in 'Integer#>': comparison of Integer with nil failed (ArgumentError)

          needed_length_for_args(node) > max_line_length
                                         ^^^^^^^^^^^^^^^
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/layout/multiline_block_layout.rb:81:in 'RuboCop::Cop::Layout::MultilineBlockLayout#line_break_necessary_in_args?'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/layout/multiline_block_layout.rb:62:in 'RuboCop::Cop::Layout::MultilineBlockLayout#on_block'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:107:in 'Kernel#public_send'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:107:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:171:in 'RuboCop::Cop::Commissioner#with_cop_error_handling'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:106:in 'block in RuboCop::Cop::Commissioner#trigger_responding_cops'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:105:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:105:in 'RuboCop::Cop::Commissioner#trigger_responding_cops'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:69:in 'RuboCop::Cop::Commissioner#on_block'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'block in RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:164:in 'RuboCop::AST::Traversal#on_def'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_def'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'block in RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:164:in 'RuboCop::AST::Traversal#on_class'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_class'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'block in RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:147:in 'RuboCop::AST::Traversal#on_dstr'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_begin'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:148:in 'RuboCop::AST::Traversal#on_while'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_module'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:148:in 'RuboCop::AST::Traversal#on_while'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_module'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:148:in 'RuboCop::AST::Traversal#on_while'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_module'
	from /usr/local/bundle/gems/rubocop-ast-1.48.0/lib/rubocop/ast/traversal.rb:20:in 'RuboCop::AST::Traversal#walk'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/commissioner.rb:87:in 'RuboCop::Cop::Commissioner#investigate'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/team.rb:174:in 'RuboCop::Cop::Team#investigate_partial'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cop/team.rb:108:in 'RuboCop::Cop::Team#investigate'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:350:in 'block in RuboCop::Runner#inspect_file'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:349:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:349:in 'Enumerable#flat_map'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:349:in 'RuboCop::Runner#inspect_file'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:291:in 'block in RuboCop::Runner#do_inspection_loop'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:326:in 'block in RuboCop::Runner#iterate_until_no_changes'
	from <internal:kernel>:168:in 'Kernel#loop'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:319:in 'RuboCop::Runner#iterate_until_no_changes'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:287:in 'RuboCop::Runner#do_inspection_loop'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:167:in 'block in RuboCop::Runner#file_offenses'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:192:in 'RuboCop::Runner#file_offense_cache'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:166:in 'RuboCop::Runner#file_offenses'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:154:in 'RuboCop::Runner#process_file'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:135:in 'block in RuboCop::Runner#each_inspected_file'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:134:in 'Array#each'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:134:in 'Enumerable#reduce'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:134:in 'RuboCop::Runner#each_inspected_file'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:120:in 'RuboCop::Runner#inspect_files'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/runner.rb:73:in 'RuboCop::Runner#run'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/command/execute_runner.rb:26:in 'block in RuboCop::CLI::Command::ExecuteRunner#execute_runner'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/command/execute_runner.rb:52:in 'RuboCop::CLI::Command::ExecuteRunner#with_redirect'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/command/execute_runner.rb:25:in 'RuboCop::CLI::Command::ExecuteRunner#execute_runner'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/command/execute_runner.rb:17:in 'RuboCop::CLI::Command::ExecuteRunner#run'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/command.rb:11:in 'RuboCop::CLI::Command.run'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli/environment.rb:18:in 'RuboCop::CLI::Environment#run'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli.rb:128:in 'RuboCop::CLI#run_command'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli.rb:135:in 'RuboCop::CLI#execute_runners'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli.rb:54:in 'block in RuboCop::CLI#run'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli.rb:87:in 'RuboCop::CLI#profile_if_needed'
	from /usr/local/bundle/gems/rubocop-1.82.0/lib/rubocop/cli.rb:45:in 'RuboCop::CLI#run'
	from /usr/local/bundle/gems/rubocop-1.82.0/exe/rubocop:15:in '<top (required)>'
	from /usr/local/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Kernel#load'
	from /usr/local/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Gem.activate_and_load_bin_path'
	from /usr/local/bundle/bin/rubocop:25:in '<top (required)>'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli.rb:456:in 'Bundler::CLI#exec'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
	from /usr/local/bundle/gems/bundler-2.7.2/exe/bundle:28:in 'block in <top (required)>'
	from /usr/local/bundle/gems/bundler-2.7.2/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
	from /usr/local/bundle/gems/bundler-2.7.2/exe/bundle:20:in '<top (required)>'
	from /usr/local/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Kernel#load'
	from /usr/local/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Gem.activate_and_load_bin_path'
	from /usr/local/bundle/bin/bundle:25:in '<main>'
```
