### PR TITLE
Support `TargetRubyVersion 4.1`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
                elsif cop == RuboCop::Cop::Lint::NumberedParameterAssignment
                  Parser::Ruby27.new(RuboCop::AST::Builder.new)
                else
-                 Prism::Translation::Parser35.new(RuboCop::AST::BuilderPrism.new)
+                 Prism::Translation::Parser41.new(RuboCop::AST::BuilderPrism.new)
                end
       parser.diagnostics.all_errors_are_fatal = true
       parser.parse(buffer)

--- a/changelog/new_support_ruby_41.md
+++ b/changelog/new_support_ruby_41.md
@@ -1,0 +1,1 @@
+* [#14722](https://github.com/rubocop/rubocop/pull/14722): Support `TargetRubyVersion 4.1` (experimental). ([@koic][])

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -37,6 +37,7 @@ The following table is the runtime support matrix.
 | 3.3 | -
 | 3.4 | -
 | 4.0 | -
+| 4.1 (experimental) | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -269,3 +269,7 @@ end
 RSpec.shared_context 'ruby 4.0' do
   let(:ruby_version) { 4.0 }
 end
+
+RSpec.shared_context 'ruby 4.1' do
+  let(:ruby_version) { 4.1 }
+end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -31,4 +31,5 @@ RSpec.configure do |config|
   config.include_context 'ruby 3.3', :ruby33
   config.include_context 'ruby 3.4', :ruby34
   config.include_context 'ruby 4.0', :ruby40
+  config.include_context 'ruby 4.1', :ruby41
 end

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -4,7 +4,9 @@ module RuboCop
   # The kind of Ruby that code inspected by RuboCop is written in.
   # @api private
   class TargetRuby
-    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0].freeze
+    KNOWN_RUBIES = [
+      2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0, 4.1
+    ].freeze
     DEFAULT_VERSION = 2.7
 
     OBSOLETE_RUBIES = {

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')
-  s.add_dependency('rubocop-ast', '>= 1.48.0', '< 2.0')
+  s.add_dependency('rubocop-ast', '>= 1.49.0', '< 2.0')
   s.add_dependency('ruby-progressbar', '~> 1.7')
   s.add_dependency('unicode-display_width', '>= 2.4.0', '< 4.0')
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2044,7 +2044,12 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           'Error: RuboCop found unknown Ruby version 5.0 in `TargetRubyVersion`'
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0/
+          Regexp.new(<<~MESSAGE.chomp.tr("\n", ' '))
+            Supported versions:
+            2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7,
+            3.0, 3.1, 3.2, 3.3, 3.4,
+            4.0, 4.1
+          MESSAGE
         )
       end
     end


### PR DESCRIPTION
Follow-up https://github.com/rubocop/rubocop-ast/pull/394

This PR supports `TargetRubyVersion 4.1`.

IMPORTANT: Merging this PR requires https://github.com/rubocop/rubocop-ast/pull/394.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
