### PR TITLE
Fix `Layout/LineLength` cop error if the cop is disabled and forced

### DIFF
--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -311,6 +311,7 @@ module RuboCop
         def max
           cop_config['Max']
         end
+        alias max_line_length max
 
         def allow_heredoc?
           allowed_heredoc

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -717,6 +717,30 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         end
       end
 
+      context 'when specifying disabled `Layout/LineLength` cop' do
+        let(:line) { "Object::#{'A' * 100}".inspect }
+
+        it 'enables the given cop' do
+          create_file('example.rb', [line])
+
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/LineLength:
+              Enabled: false
+              Max: 80
+          YAML
+
+          expect(cli.run(['--format', 'simple',
+                          '--only', 'Layout/LineLength',
+                          'example.rb'])).to be_zero
+          expect($stderr.string).to eq('')
+          expect($stdout.string)
+            .to eq(<<~RESULT)
+
+              1 file inspected, no offenses detected
+            RESULT
+        end
+      end
+
       context 'without using namespace' do
         it 'runs just one cop' do
           create_file('example.rb', ['if x== 0 ', "\ty", 'end'])


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14658

If `Layout/LineLength` is disabled but forced (via `--only`), it throws the same error as in https://github.com/rubocop/rubocop/pull/14719.

Looks like the easies way to fix that is to override `LineLength#max_line_length` method.

The error without the patch:

```shell
Failures:

  1) RuboCop::CLI options --only when one cop is given when specifying disabled `Layout/LineLength` cop enables the given cop
     Got 2 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:26:in 'block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:44:in 'block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:29:in 'block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:29:in 'Dir.chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:29:in 'block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:7:in 'block (2 levels) in <top (required)>'

     1.1) Failure/Error:
            expect(cli.run(['--format', 'simple',
                            '--only', 'Layout/LineLength',
                            'example.rb'])).to be_zero

            expected `1.zero?` to be truthy, got false
          # ./spec/rubocop/cli/options_spec.rb:735:in 'block (5 levels) in <top (required)>'

     1.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Layout/LineLength cop was inspecting /tmp/d20251219-51392-5a0566/work/exampl...Parser 3.3.10.0, rubocop-ast 1.48.0, analyzing as Ruby 2.7, running on ruby 3.4.7) [x86_64-linux]\n"

            (compared using ==)

            Diff:
            @@ -0,0 +1,11 @@
            +An error occurred while Layout/LineLength cop was inspecting /tmp/d20251219-51392-5a0566/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +
            +1 error occurred:
            +An error occurred while Layout/LineLength cop was inspecting /tmp/d20251219-51392-5a0566/work/example.rb.
            +Errors are usually caused by RuboCop bugs.
            +Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
            +https://github.com/rubocop/rubocop/issues
            +
            +Mention the following information in the issue report:
            +1.82.0 (using Parser 3.3.10.0, rubocop-ast 1.48.0, analyzing as Ruby 2.7, running on ruby 3.4.7) [x86_64-linux]

          # ./spec/rubocop/cli/options_spec.rb:736:in 'block (5 levels) in <top (required)>'

Finished in 0.10147 seconds (files took 0.77374 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/cli/options_spec.rb:723 # RuboCop::CLI options --only when one cop is given when specifying disabled `Layout/LineLength` cop enables the given cop

Randomized with seed 44805
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
