### PR TITLE
Optimize Layout/SpaceAfterComma

### DIFF
--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -32,7 +32,7 @@ module RuboCop
         def before_semicolon?(token)
           tokens = processed_source.tokens
 
-          tokens[tokens.index(token) + 1].semicolon?
+          tokens[processed_source.token_index(token) + 1].semicolon?
         end
       end
     end


### PR DESCRIPTION
Profiling of rubocop on our codebase revealed ~23% of the time spent in that cop calling Array#index.

https://share.firefox.dev/4aIne95

By using the `token_index` provided in https://github.com/rubocop/rubocop-ast/pull/396 this cop become fast enough that it's no longer visible in the profile.

