### PR TITLE
Handle `foo.~@` on prism for `Style/OperatorMethodCall`

### DIFF
--- a/spec/rubocop/cop/style/operator_method_call_spec.rb
+++ b/spec/rubocop/cop/style/operator_method_call_spec.rb
@@ -146,15 +146,13 @@ RSpec.describe RuboCop::Cop::Style::OperatorMethodCall, :config do
     RUBY
   end
 
-  # FIXME: Remove `broken_on: :prism` after https://github.com/ruby/prism/issues/3820 is resolved.
-  it 'does not register an offense when using `foo.!@bar`', broken_on: :prism do
+  it 'does not register an offense when using `foo.!@bar`' do
     expect_no_offenses(<<~RUBY)
       foo.!@ bar
     RUBY
   end
 
-  # FIXME: Remove `broken_on: :prism` after https://github.com/ruby/prism/issues/3820 is resolved.
-  it 'does not register an offense when using `foo.~@bar`', broken_on: :prism do
+  it 'does not register an offense when using `foo.~@bar`' do
     expect_no_offenses(<<~RUBY)
       foo.~@ bar
     RUBY


### PR DESCRIPTION
This currently works because of a bug in the `parser` gem:

```rb
foo = Object.new
def foo.singleton_method_added(name)
  puts "Added `#{name}`"
end

def foo.~@
  puts "called"
end

# Both call the same method
foo.~@
~foo
```

Also see:
* https://github.com/ruby/prism/issues/3820
* https://github.com/whitequark/parser/issues/1084
* https://github.com/whitequark/parser/issues/486

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
