### PR TITLE
Remove prism test skip for `Layout/MultilineOperationIndentation`

### DIFF
--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
       RUBY
     end
 
-    it 'accepts `[]=` operator without arguments', broken_on: :prism do
+    it 'accepts `[]=` operator without arguments' do
       expect_no_offenses(<<~RUBY)
         begin
         rescue =>


### PR DESCRIPTION
The fix for this has already been released.

