### PR TITLE
Compute the `source_checksum` before spawning workers.

### DIFF
--- a/changelog/fix_source_checksum_consistency.md
+++ b/changelog/fix_source_checksum_consistency.md
@@ -1,0 +1,1 @@
+* [#14730](https://github.com/rubocop/rubocop/pull/14730): Fix the cache implementation to use consistent cache keys across workers. ([@byroot][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -65,6 +65,10 @@ module RuboCop
     end
 
     def run(paths)
+      # Compute the cache source checksum once to avoid potential
+      # inconsistencies between workers.
+      ResultCache.source_checksum
+
       target_files = find_target_files(paths)
       if @options[:list_target_files]
         list_files(target_files)


### PR DESCRIPTION
While profiling rubocop with a warm cache, I noticed workers were spending a lot of time parsing code and running cops.

After a deeper investigation I found that some workers had an extra file from the `parser` gem (`parser_32.rb`) in `$LOADED_FEATURES`.

My understanding is the parser is lazy loaded, so depending on what the worker does first, it may load some more source compared to others.

By computing the checksum only once in the parent, we guarantee the parent and all workers share the same checksum, hence share their caches.
