### PR TITLE
[Fix #14559] Fix false positives for `Lint/UselessAssignment` when a variable is assigned in loop body and used in loop condition

### DIFF
--- a/changelog/fix_useless_assignment_in_method_defined_in_loop.md
+++ b/changelog/fix_useless_assignment_in_method_defined_in_loop.md
@@ -1,0 +1,1 @@
+* [#14559](https://github.com/rubocop/rubocop/issues/14559): Fix false positives for `Lint/UselessAssignment` when a variable is assigned in loop body and used in loop condition. ([@ydakuka][])

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2526,4 +2526,31 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
       end
     end
   end
+
+  context 'when a variable is assigned in loop body and used in loop condition' do
+    it 'does not register an offense when variable is used directly in condition' do
+      expect_no_offenses(<<~RUBY)
+        keep_going = true
+        while keep_going
+          keep_going = false
+          if rand < 0.5
+            keep_going = true
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when variable is used in condition expression' do
+      expect_no_offenses(<<~RUBY)
+        try = 0
+        while try < max_tries
+          try += 1
+          next if weak?
+          try = 0
+        end
+
+        raise(CombinationPoolExhaustedError)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix #14520, #14559

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
