### PR TITLE
Disallow directory paths in ConfigLoader.inject_defaults!

### DIFF
--- a/changelog/change_remove_deprecated_inject_defaults.md
+++ b/changelog/change_remove_deprecated_inject_defaults.md
@@ -1,0 +1,1 @@
+* [#14735](https://github.com/rubocop/rubocop/pull/14735): Remove deprecated InjectDefaults handling. ([@afurm][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -151,31 +151,22 @@ module RuboCop
       # When testing a plugin using `rubocop/rspec/support`, the plugin is loaded automatically,
       # so this API is usually not needed. It is intended to be used only when implementing tests
       # that do not use `rubocop/rspec/support`.
-      # rubocop:disable Metrics/MethodLength
       def inject_defaults!(config_yml_path)
         if Pathname(config_yml_path).directory?
-          # TODO: Since the warning noise is expected to be high until some time after the release,
-          # warnings will only be issued when `RUBYOPT=-w` is specified.
-          # To proceed step by step, the next step is to remove `$VERBOSE` and always issue warning.
-          # Eventually, `project_root` will no longer be accepted.
-          if $VERBOSE
-            warn Rainbow(<<~MESSAGE).yellow, uplevel: 1
-              Use config YAML file path instead of project root directory.
-              e.g., `path/to/config/default.yml`
-            MESSAGE
-          end
-          # NOTE: For compatibility.
-          project_root = config_yml_path
-          path = File.join(project_root, 'config', 'default.yml')
-          config = load_file(path)
-        else
-          hash = ConfigLoader.load_yaml_configuration(config_yml_path.to_s)
-          config = Config.new(hash, config_yml_path).tap(&:make_excludes_absolute)
+          warn Rainbow(<<~MESSAGE).yellow, uplevel: 1
+            Use config YAML file path instead of project root directory.
+            e.g., `path/to/config/default.yml`
+          MESSAGE
+          raise ArgumentError,
+                'Passing a project root directory to `inject_defaults!` is no longer supported.'
         end
+
+        path = config_yml_path.to_s
+        hash = ConfigLoader.load_yaml_configuration(path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
 
         @default_configuration = ConfigLoader.merge_with_default(config, path)
       end
-      # rubocop:enable Metrics/MethodLength
 
       # Returns the path RuboCop inferred as the root of the project. No file
       # searches will go past this directory.

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -2120,6 +2120,18 @@ RSpec.describe RuboCop::ConfigLoader do
 
       it { expect { rubocop_config }.not_to raise_error }
     end
+
+    context 'when config path is a directory' do
+      let(:config_path) { 'config' }
+
+      before do
+        FileUtils.mkdir_p(config_path)
+      end
+
+      it 'raises an ArgumentError' do
+        expect { rubocop_config }.to raise_error(ArgumentError, /project root directory/)
+      end
+    end
   end
 
   describe 'configuration for CharacterLiteral', :isolated_environment do


### PR DESCRIPTION
## Goal
Remove the deprecated InjectDefaults handling path so RuboCop relies only on the supported configuration flow, reducing maintenance overhead and eliminating a legacy code path slated for removal.

## Motivation
InjectDefaults has been deprecated for some time. Keeping the legacy path makes the config loader harder to reason about and maintain, while providing no benefit for supported configurations.

## Changes
- Remove deprecated InjectDefaults handling in config loading.
- Update specs to match the supported behavior.