### PR TITLE
[Fix #14736] Fix an error for `Style/TrailingCommaInArguments`

### DIFF
--- a/changelog/fix_an_error_for_style_trailing_comma_in_arguments.md
+++ b/changelog/fix_an_error_for_style_trailing_comma_in_arguments.md
@@ -1,0 +1,1 @@
+* [#14736](https://github.com/rubocop/rubocop/issues/14736): Fix an error for `Style/TrailingCommaInArguments` when `EnforcedStyleForMultiline` is `consistent_comma` and keyword arguments use a trailing comma. ([@koic][])

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -95,12 +95,16 @@ module RuboCop
         node.multiline? && !allowed_multiline_argument?(node)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def method_name_and_arguments_on_same_line?(node)
         return false if !node.call_type? || node.last_line != node.last_argument.last_line
         return true if node.last_argument.hash_type? && node.last_argument.braces?
 
-        node.loc.selector.line == node.last_argument.last_line
+        line = node.loc.selector&.line || node.loc.line
+
+        line == node.last_argument.last_line
       end
+      # rubocop:enable Metrics/AbcSize
 
       # A single argument with the closing bracket on the same line as the end
       # of the argument is not considered multiline, even if the argument

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -168,17 +168,24 @@ RSpec.describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
   end
 
-  context 'with a single argument of anonymous function spanning multiple lines' do
+  context 'with multiple arguments of anonymous function spanning multiple lines' do
     context 'when EnforcedStyleForMultiline is consistent_comma' do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'consistent_comma' } }
 
-      it 'accepts a single argument with no trailing comma' do
+      it 'accepts multiple arguments with trailing comma' do
         expect_no_offenses(<<~RUBY)
           func.(
             'foo',
             'bar',
             'baz',
           )
+        RUBY
+      end
+
+      it 'accepts keyword arguments with trailing comma' do
+        expect_no_offenses(<<~RUBY)
+          func.(foo: 1,
+                bar: 2,)
         RUBY
       end
     end


### PR DESCRIPTION
This PR fixes an error for `Style/TrailingCommaInArguments` when `EnforcedStyleForMultiline` is `consistent_comma` and keyword arguments use a trailing comma.

Fixes #14736.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
