### PR TITLE
[Fix #14737] Fix crash in `Layout/RedundantLineBreak` when `Layout/LineLength` is disabled

### DIFF
--- a/changelog/fix_crash_in_layout_redundant_line_break_when_layout_line_length_is_disabled.md
+++ b/changelog/fix_crash_in_layout_redundant_line_break_when_layout_line_length_is_disabled.md
@@ -1,0 +1,1 @@
+* [#14737](https://github.com/rubocop/rubocop/issues/14737): Fix crash in `Layout/RedundantLineBreak` when `Layout/LineLength` is disabled. ([@ydakuka][])

--- a/lib/rubocop/cop/mixin/check_single_line_suitability.rb
+++ b/lib/rubocop/cop/mixin/check_single_line_suitability.rb
@@ -14,6 +14,8 @@ module RuboCop
       private
 
       def too_long?(node)
+        return false unless max_line_length
+
         lines = processed_source.lines[(node.first_line - 1)...node.last_line]
         to_single_line(lines.join("\n")).length > max_line_length
       end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -2,13 +2,17 @@
 
 RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
   let(:config) do
-    RuboCop::Config.new('Layout/LineLength' => { 'Max' => max_line_length },
+    RuboCop::Config.new('Layout/LineLength' => {
+                          'Enabled' => line_length_enabled, 'Max' => max_line_length
+                        },
                         'Layout/RedundantLineBreak' => { 'InspectBlocks' => inspect_blocks },
                         'Layout/SingleLineBlockChain' => {
                           'Enabled' => single_line_block_chain_enabled
                         })
   end
+  let(:line_length_enabled) { true }
   let(:max_line_length) { 31 }
+  let(:inspect_blocks) { false }
   let(:single_line_block_chain_enabled) { true }
 
   shared_examples 'common behavior' do
@@ -772,6 +776,23 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
           RUBY
         end
       end
+    end
+  end
+
+  context 'when `Layout/LineLength` is disabled' do
+    let(:line_length_enabled) { false }
+
+    it 'registers an offense for a method call on multiple lines' do
+      expect_offense(<<~RUBY)
+        my_method(1,
+        ^^^^^^^^^^^^ Redundant line break detected.
+                  2,
+                  "x")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        my_method(1, 2, "x")
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Fixes #14737

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
