### PR TITLE
[Fix #14743] Fix false positives for `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_false_positives_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_positives_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#14743](https://github.com/rubocop/rubocop/issues/14743): Fix false positives for `Layout/MultilineMethodCallIndentation` when multiline method chain with block has expected indent width and the method is preceded by splat or double splat. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -84,19 +84,23 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def offending_range(node, lhs, rhs, given_style)
           return false unless begins_its_line?(rhs)
           return false if not_for_this_cop?(node)
 
           @base = alignment_base(node, rhs, given_style)
           correct_column = if @base
-                             @base.column + extra_indentation(given_style, node.parent)
+                             parent = node.parent
+                             parent = parent.parent if parent&.any_block_type?
+                             @base.column + extra_indentation(given_style, parent)
                            else
                              indentation(lhs) + correct_indentation(node)
                            end
           @column_delta = correct_column - rhs.column
           rhs if @column_delta.nonzero?
         end
+        # rubocop:enable Metrics/AbcSize
 
         def extra_indentation(given_style, parent)
           if given_style == :indented_relative_to_receiver

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -938,6 +938,36 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'does not register an offense when multiline method chain with block has expected indent width and ' \
+       'the method is preceded by splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          *foo
+            .bar { |arg| baz(arg) }
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain with numbered block has expected indent width and ' \
+       'the method is preceded by splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          *foo
+            .bar { baz(_1) }
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain with `it` block has expected indent width and ' \
+       'the method is preceded by splat', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        [
+          *foo
+            .bar { baz(it) }
+        ]
+      RUBY
+    end
+
     it 'does not register an offense when multiline method chain has expected indent width and ' \
        'the method is preceded by double splat' do
       expect_no_offenses(<<~RUBY)
@@ -945,6 +975,36 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           **foo
             .bar(
               arg)
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain with block has expected indent width and ' \
+       'the method is preceded by double splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          **foo
+            .bar { |arg| baz(arg) }
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain with numbered block has expected indent width and ' \
+       'the method is preceded by double splat' do
+      expect_no_offenses(<<~RUBY)
+        [
+          **foo
+            .bar { baz(_1) }
+        ]
+      RUBY
+    end
+
+    it 'does not register an offense when multiline method chain with `it` block has expected indent width and ' \
+       'the method is preceded by double splat', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        [
+          **foo
+            .bar { baz(it) }
         ]
       RUBY
     end


### PR DESCRIPTION
This PR fixes false positives for `Layout/MultilineMethodCallIndentation` when multiline method chain with block has expected indent width and the method is preceded by splat or double splat.

Fixes #14743.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
