### PR TITLE
Add support for other Module member existence methods to `Style/ModuleMemberExistenceCheck`

### DIFF
--- a/changelog/change_module_member_existence_check_expansion.md
+++ b/changelog/change_module_member_existence_check_expansion.md
@@ -1,0 +1,1 @@
+* [#14748](https://github.com/rubocop/rubocop/pull/14748): Add support for other `Module` member existence methods to `Style/ModuleMemberExistenceCheck`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/module_member_existence_check_spec.rb
+++ b/spec/rubocop/cop/style/module_member_existence_check_spec.rb
@@ -1,127 +1,145 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
-  it 'registers an offense when using `.instance_methods.include?(method)`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods.include?(method)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
+  shared_examples 'module member inclusion' do |array_returning_method, predicate_method, has_inherit_param = true|
+    it "registers an offense when using `.#{array_returning_method}.include?(method)`" do
+      expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+        x.#{array_returning_method}.include?(method)
+          ^{array_returning_method}^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      x.method_defined?(method)
-    RUBY
+      expect_correction(<<~RUBY)
+        x.#{predicate_method}(method)
+      RUBY
+    end
+
+    it "registers an offense when using `.#{array_returning_method}.include? method`" do
+      expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+        x.#{array_returning_method}.include? method
+          ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.#{predicate_method}(method)
+      RUBY
+    end
+
+    it "registers an offense when using `.#{array_returning_method}.member?(method)`" do
+      expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+        x.#{array_returning_method}.member?(method)
+          ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.#{predicate_method}(method)
+      RUBY
+    end
+
+    it "registers an offense when using `&.#{array_returning_method}&.include?(method)`" do
+      expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+        x&.#{array_returning_method}&.include?(method)
+           ^{array_returning_method}^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.#{predicate_method}(method)
+      RUBY
+    end
+
+    it "registers an offense when using `#{array_returning_method}.include?(method)`" do
+      expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+        #{array_returning_method}.include?(method)
+        ^{array_returning_method}^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{predicate_method}(method)
+      RUBY
+    end
+
+    if has_inherit_param
+      it "registers an offense when using `.#{array_returning_method}(false).include?(method)`" do
+        expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+          x.#{array_returning_method}(false).include?(method)
+            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, false)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.#{predicate_method}(method, false)
+        RUBY
+      end
+
+      it "registers an offense when using `.#{array_returning_method}(true).include?(method)`" do
+        expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+          x.#{array_returning_method}(true).include?(method)
+            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.#{predicate_method}(method)
+        RUBY
+      end
+
+      it "registers an offense when using `.#{array_returning_method}(inherit).include?(method)`" do
+        expect_offense(<<~RUBY, array_returning_method: array_returning_method)
+          x.#{array_returning_method}(inherit).include?(method)
+            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, inherit)` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x.#{predicate_method}(method, inherit)
+        RUBY
+      end
+    else
+      it "does not register an offense when using `.#{array_returning_method}(inherit).include?(method)`" do
+        expect_no_offenses(<<~RUBY)
+          x.#{array_returning_method}(inherit).include?(method)
+        RUBY
+      end
+    end
+
+    it "does not register an offense when passing more than one argument to `#{array_returning_method}`" do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}(true, false).include?(method)
+      RUBY
+    end
+
+    it 'does not register an offense when passing more than one argument to `include?`' do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}.include?(foo, bar)
+      RUBY
+    end
+
+    it 'does not register an offense when passing a splat argument to `include?`' do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}.include?(*foo)
+      RUBY
+    end
+
+    it 'does not register an offense when passing a kwargs argument to `include?`' do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}.include?(**foo)
+      RUBY
+    end
+
+    it 'does not register an offense when passing a block argument to `include?`' do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}.include?(&foo)
+      RUBY
+    end
+
+    it "does not register an offense when passing a splat argument to `#{array_returning_method}`" do
+      expect_no_offenses(<<~RUBY)
+        x.#{array_returning_method}(*foo).include?(method)
+      RUBY
+    end
   end
 
-  it 'registers an offense when using `.instance_methods.include? method`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods.include? method
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x.method_defined?(method)
-    RUBY
-  end
-
-  it 'registers an offense when using `.instance_methods.member?(method)`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods.member?(method)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x.method_defined?(method)
-    RUBY
-  end
-
-  it 'registers an offense when using `&.instance_methods&.include?(method)`' do
-    expect_offense(<<~RUBY)
-      x&.instance_methods&.include?(method)
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x&.method_defined?(method)
-    RUBY
-  end
-
-  it 'registers an offense when using `instance_methods.include?(method)`' do
-    expect_offense(<<~RUBY)
-      instance_methods.include?(method)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      method_defined?(method)
-    RUBY
-  end
-
-  it 'registers an offense when using `.instance_methods(false).include?(method)`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods(false).include?(method)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method, false)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x.method_defined?(method, false)
-    RUBY
-  end
-
-  it 'registers an offense when using `.instance_methods(true).include?(method)`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods(true).include?(method)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x.method_defined?(method)
-    RUBY
-  end
-
-  it 'registers an offense when using `.instance_methods(inherit).include?(method)`' do
-    expect_offense(<<~RUBY)
-      x.instance_methods(inherit).include?(method)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `method_defined?(method, inherit)` instead.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      x.method_defined?(method, inherit)
-    RUBY
-  end
-
-  it 'does not register an offense when passing more than one argument to `instance_methods`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods(true, false).include?(method)
-    RUBY
-  end
-
-  it 'does not register an offense when passing more than one argument to `include?`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods.include?(foo, bar)
-    RUBY
-  end
-
-  it 'does not register an offense when passing a splat argument to `include?`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods.include?(*foo)
-    RUBY
-  end
-
-  it 'does not register an offense when passing a kwargs argument to `include?`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods.include?(**foo)
-    RUBY
-  end
-
-  it 'does not register an offense when passing a block argument to `include?`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods.include?(&foo)
-    RUBY
-  end
-
-  it 'does not register an offense when passing a splat argument to `instance_methods`' do
-    expect_no_offenses(<<~RUBY)
-      x.instance_methods(*foo).include?(method)
-    RUBY
-  end
+  it_behaves_like 'module member inclusion', :class_variables, :class_variable_defined?, false
+  it_behaves_like 'module member inclusion', :constants, :const_defined?
+  it_behaves_like 'module member inclusion', :included_modules, :include?, false
+  it_behaves_like 'module member inclusion', :instance_methods, :method_defined?
+  it_behaves_like 'module member inclusion', :private_instance_methods, :private_method_defined?
+  it_behaves_like 'module member inclusion', :protected_instance_methods, :protected_method_defined?
+  it_behaves_like 'module member inclusion', :public_instance_methods, :public_method_defined?
 end


### PR DESCRIPTION
Follow-up on https://github.com/rubocop/rubocop/pull/14670#discussion_r2545779148.

Expands `Style/ModuleMemberExistenceCheck` so it registers offenses for the following code:
```ruby
Array.class_variables.include?(:foo)
Array.constants.include?(:foo)
Array.private_instance_methods.include?(:foo)
Array.protected_instance_methods.include?(:foo)
Array.public_instance_methods.include?(:foo)
Array.included_modules.include?(:foo)
```
and autocorrects it to:
```ruby
Array.class_variable_defined?(:foo)
Array.const_defined?(:foo)
Array.private_method_defined?(:foo)
Array.protected_method_defined?(:foo)
Array.public_method_defined?(:foo)
Array.include?(:foo)
```

[`Module#class_variable_defined?`](https://docs.ruby-lang.org/en/master/Module.html#method-i-class_variable_defined-3F) and [`Module#include?`](https://docs.ruby-lang.org/en/master/Module.html#method-i-include-3F) don't support the `inherit` param as other methods do, so special cases have been added for them.

Here's the [`real-world-ruby-apps`](https://github.com/jeromedalbert/real-world-ruby-apps) report:
<details>
<summary>Report</summary>

```ruby
# https://github.com/presidentbeef/brakeman/blob/7f673cda24185d868ad65c01843bb70fe6f095fe/test/test.rb#L145
unless Brakeman::Rescanner.instance_methods.include? :reindex

# https://github.com/chef/chef/blob/8af961bee34c587aabf10d39eb56a6c186abb691/lib/chef/property.rb#L701
return false unless declared_in.instance_methods.include?(name)

# https://github.com/chef/chef/blob/8af961bee34c587aabf10d39eb56a6c186abb691/spec/unit/dsl/platform_introspection_spec.rb#L137
expect(Chef::Resource.instance_methods.include?(method)).to be true

# https://github.com/chef/chef/blob/8af961bee34c587aabf10d39eb56a6c186abb691/spec/unit/dsl/platform_introspection_spec.rb#L145
expect(Chef::Provider.instance_methods.include?(method)).to be true

# https://github.com/chef/chef/blob/8af961bee34c587aabf10d39eb56a6c186abb691/spec/unit/dsl/platform_introspection_spec.rb#L153
expect(Chef::Recipe.instance_methods.include?(method)).to be true

# https://github.com/chef/chef/blob/8af961bee34c587aabf10d39eb56a6c186abb691/spec/unit/dsl/platform_introspection_spec.rb#L157
expect(Chef::Recipe.instance_methods.include?(method)).to be true

# https://github.com/rubychan/coderay/blob/f71b25d3112ac7fcc43ca48055030319ecc7a840/lib/coderay/tokens.rb#L44
undef_method :filter if instance_methods.include?(:filter)

# https://github.com/jordansissel/fpm/blob/9d3d96a93d6fd667ac21fecf2f91004bfaa77142/lib/fpm/util/tar_writer.rb#L24
return !::Gem::Package::TarWriter.public_instance_methods.include?(:add_symlink)

# https://github.com/alexreisner/geocoder/blob/7467752a085da19656c3fe928ea750155c05d7d3/lib/geocoder/models/mongo_base.rb#L55
included_modules.include? Geocoder::Store.const_get(geocoder_module_name)

# https://github.com/Homebrew/brew/blob/8c4c7319fc6ba3a69b1ba65659b03d418ebbfb2f/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11471/lib/types/private/abstract/validate.rb#L31
if ancestor.instance_methods.include?(abstract_method.name)

# https://github.com/nahi/httpclient/blob/d57cc6d5ffee1b566b5c189fe6dc8cc89570b812/lib/httpclient/util.rb#L60
unless Addressable::URI.instance_methods.include?(:default_port) # 1.9 only

# https://github.com/jekyll/jekyll/blob/60a9cd73569552b858e807cbd3c0e23455023cbc/lib/jekyll/converters/markdown.rb#L109
parser_name !~ %r![^A-Za-z0-9_]! && self.class.constants.include?(parser_name.to_sym)

# https://github.com/adamcooke/procodile/blob/6b86419edacdc49c2cbb53812ef6a1c276760912/lib/procodile/control_session.rb#L15
if self.class.instance_methods(false).include?(command.to_sym) && command != 'receive_data'

# https://github.com/puma/puma/blob/a7e3d944fa66bbba355abb9efed8ce53048c7e7c/lib/puma/detect.rb#L11
HAS_NATIVE_IO_WAIT = ::IO.public_instance_methods(false).include? :wait_readable

# https://github.com/puma/puma/blob/a7e3d944fa66bbba355abb9efed8ce53048c7e7c/test/test_puma_server_ssl.rb#L34
OpenSSL::SSL::SSLContext.private_instance_methods(false).include?(:set_minmax_proto_version)

# https://github.com/puma/puma/blob/a7e3d944fa66bbba355abb9efed8ce53048c7e7c/test/test_puma_server_ssl.rb#L169
skip("TLSv1.3 protocol can not be set") unless OpenSSL::SSL::SSLContext.instance_methods(false).include?(:min_version=)

# https://github.com/puma/puma/blob/a7e3d944fa66bbba355abb9efed8ce53048c7e7c/test/test_puma_server_ssl.rb#L541
USE_TO_UTFT8 = OpenSSL::X509::Name.instance_methods(false).include? :to_utf8

# https://github.com/puppetlabs/puppet/blob/7739378f6fa840d6dbee237132754c64f94cc38a/lib/puppet/property.rb#L171
if instance_methods(false).include?(method)

# https://github.com/puppetlabs/puppet/blob/7739378f6fa840d6dbee237132754c64f94cc38a/lib/puppet/util/monkey_patches.rb#L105
unless OpenSSL::X509::Name.instance_methods.include?(:to_utf8)

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/actionscript.rb#L141
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/apex.rb#L70
elsif self.class.constants.include? lowercased

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/awk.rb#L130
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/coffeescript.rb#L132
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/css.rb#L210
if self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/groovy.rb#L84
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/haxe.rb#L174
elsif self.class.constants.include?(match)

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/hcl.rb#L84
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/io.rb#L47
if self.class.constants.include? name

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/isbl.rb#L46
if self.class.constants.include? name.downcase

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/isbl.rb#L83
elsif self.class.constants.include? name.downcase

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/javascript.rb#L213
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/jsonnet.rb#L117
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/livescript.rb#L117
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/puppet.rb#L89
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/rego.rb#L49
if self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/sass/common.rb#L70
elsif CSS.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/sqf.rb#L92
elsif self.class.constants.include? name

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/stan.rb#L429
elsif self.class.constants.include? name

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/supercollider.rb#L92
elsif self.class.constants.include? m[0]

# https://github.com/rouge-ruby/rouge/blob/93e2bae74fe6a99c79add1ed4dc6482c8eef0855/lib/rouge/lexers/terraform.rb#L109
elsif self.class.constants.include? m[0]

# https://github.com/rubygems/rubygems/blob/238eedc5376240954676a893b631f7def7ed1efd/bundler/lib/bundler/rubygems_gem_installer.rb#L70
return unless Gem::Installer.instance_methods(false).include?(:generate_plugins)

# https://github.com/rubygems/rubygems/blob/238eedc5376240954676a893b631f7def7ed1efd/test/rubygems/test_gem_ext_cargo_builder_link_flag_converter.rb#L28
raise "duplicate test name" if instance_methods.include?(test_name)

# https://github.com/shugo/textbringer/blob/60656a9719df9f290a5c7050e4108bca4becf4fe/lib/textbringer/buffer.rb#L65
HAS_BYTEINDEX = String.instance_methods.include?(:byteindex)

# https://github.com/shugo/textbringer/blob/60656a9719df9f290a5c7050e4108bca4becf4fe/lib/textbringer/buffer.rb#L66
HAS_BYTESPLICE = String.instance_methods.include?(:bytesplice)

# https://github.com/macournoyer/thin/blob/3f375389d29deae252e03080b07a1f10aa60d957/spec/request/processing_spec.rb#L60
pending("Ruby 1.9 compatible implementations only") unless StringIO.instance_methods.include? :external_encoding

# https://github.com/hashicorp/vagrant/blob/26a1ff10a5a279ceb48ff629e9376140f90c4990/lib/vagrant/bundler.rb#L929
if defined?(::Bundler) && !::Bundler::SpecSet.instance_methods.include?(:delete)

# https://github.com/lsegal/yard/blob/e833aac7a01510245dd4ae1d1d18b046c8293c2d/benchmarks/generation.rb#L5
unless YARD::CodeObjects::Proxy.private_instance_methods.include?('to_obj')
```
</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
