### PR TITLE
Make Ruby 4.0 non-experimental

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', 'head']
 
     steps:
       - uses: actions/checkout@v6

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -36,7 +36,7 @@ The following table is the runtime support matrix.
 | 3.2 | -
 | 3.3 | -
 | 3.4 | -
-| 4.0 (experimental) | -
+| 4.0 | -
 |===
 
 RuboCop targets Ruby 2.0+ code analysis with Parser gem as a parser since RuboCop 1.30. It restored code analysis support that had been removed earlier by mistake, together with dropping runtime support for unsupported Ruby versions.


### PR DESCRIPTION
Ruby 4.0 has been released:
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/

Since development has already been moving forward on Ruby 4.0-dev, this seems like a good time to drop the experimental label and add it to the CI matrix.

Once Ruby 4.0 is supported by setup-ruby, the CI will pass: https://github.com/ruby/setup-ruby

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
