### PR TITLE
[Fix #14751] Fix --force-default-config regression

### DIFF
--- a/changelog/fix_force_default_config_regression.md
+++ b/changelog/fix_force_default_config_regression.md
@@ -1,0 +1,1 @@
+* [#14751](https://github.com/rubocop/rubocop/issues/14751): Fix `--force-default-config` not preventing project config loading when used with options that access configuration. ([@sakuro][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -165,6 +165,8 @@ module RuboCop
       handle_editor_mode
 
       @config_store.apply_options!(@options)
+      # Set cache root after apply_options! to ensure force_default_config is applied first.
+      ConfigLoader.cache_root = ResultCache.cache_root(@config_store, @options[:cache_root])
 
       handle_exiting_options
 
@@ -183,7 +185,6 @@ module RuboCop
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
       ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
-      ConfigLoader.cache_root = ResultCache.cache_root(@config_store, @options[:cache_root])
     end
 
     def set_options_to_pending_cops_reporter

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           create_file('test.rb', 'puts 1')
         end
 
-        it 'does parse local configuration' do
+        it 'does not parse local configuration' do
           cli.run ['--parallel', '--force-default-config']
-          expect($stderr.string).to match(/unrecognized cop or department ALLCOPS/)
+          expect($stdout.string).to match(/Inspecting 1 file/)
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1112,6 +1112,18 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
 
         it_behaves_like 'ignores config file'
       end
+
+      context 'when config file has invalid inherit_from' do
+        it 'ignores config file with invalid inherit_from' do
+          create_file('example.rb', ['# frozen_string_literal: true', '', 'x = 0', 'puts x'])
+          create_file('.rubocop.yml', <<~YAML)
+            inherit_from: config/nonexistent.yml
+          YAML
+
+          expect(cli.run(%w[--format simple --force-default-config])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
     end
 
     it 'displays cop names if DisplayCopNames is false' do


### PR DESCRIPTION
## Summary

Fix a regression introduced by #14625 where `--force-default-config` flag fails to prevent loading of project `.rubocop.yml` files.

The issue was caused by `ResultCache.cache_root` being called before `@config_store.apply_options!`, which meant the `force_default_config` option was not yet applied when `config_store.for_pwd` was invoked.

This PR:
- Moves the cache root configuration to run after `apply_options!`
- Reverts the incorrect test expectation change that was made in #14625
- Adds a test case for invalid `inherit_from` with `--force-default-config`

Fixes #14751

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
