### PR TITLE
Add support for `squish` and `squish!` applied to heredoc to `Layout/HeredocIndentation`

### DIFF
--- a/changelog/change_layout_heredoc_indentation_squish_support.md
+++ b/changelog/change_layout_heredoc_indentation_squish_support.md
@@ -1,0 +1,1 @@
+* [#14753](https://github.com/rubocop/rubocop/pull/14753): Add support for `squish` and `squish!` applied to heredoc to `Layout/HeredocIndentation`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -268,6 +268,104 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
         RUBY
       end
     end
+
+    context 'when `AllCops/ActiveSupportExtensionsEnabled: true`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
+      end
+
+      it 'registers an offense for `squish` applied to heredoc' do
+        expect_offense(<<~RUBY)
+                    def foo
+                      <<-#{quote}RUBY2#{quote}.squish
+                      something
+          ^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+                      RUBY2
+                    end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          def foo
+            <<~#{quote}RUBY2#{quote}.squish
+              something
+            RUBY2
+          end
+        RUBY
+      end
+
+      it 'registers an offense for `squish` applied to heredoc when indentation is already good' do
+        expect_offense(<<~RUBY)
+                    def foo
+                      <<-#{quote}RUBY2#{quote}.squish
+                        something
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+                      RUBY2
+                    end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          def foo
+            <<~#{quote}RUBY2#{quote}.squish
+              something
+            RUBY2
+          end
+        RUBY
+      end
+
+      it "registers an offense for `squish` applied to heredoc when there's too much indentation" do
+        expect_offense(<<~RUBY)
+                    def foo
+                      <<-#{quote}RUBY2#{quote}.squish
+                          something
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+                      RUBY2
+                    end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          def foo
+            <<~#{quote}RUBY2#{quote}.squish
+              something
+            RUBY2
+          end
+        RUBY
+      end
+
+      it 'registers an offense for `squish!` applied to heredoc' do
+        expect_offense(<<~RUBY)
+                    def foo
+                      <<-#{quote}RUBY2#{quote}.squish!
+                      something
+          ^^^^^^^^^^^^^^^^^^^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+                      RUBY2
+                    end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          def foo
+            <<~#{quote}RUBY2#{quote}.squish!
+              something
+            RUBY2
+          end
+        RUBY
+      end
+    end
+
+    context 'when `AllCops/ActiveSupportExtensionsEnabled: false`' do
+      let(:config) do
+        RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => false })
+      end
+
+      it 'does not register an offense for `squish` applied to heredoc' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            <<-#{quote}RUBY2#{quote}.squish
+            something
+            RUBY2
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when Ruby >= 2.3', :ruby23 do


### PR DESCRIPTION
Adds support for `<<-HEREDOC.squish` and `<<-HEREDOC.squish!` pattern to `Layout/HeredocIndentation` when `AllCops/ActiveSupportExtensionsEnabled` is enabled. When [`squish`](https://api.rubyonrails.org/classes/String.html#method-i-squish) is applied, the original heredoc body's indentation doesn't really matter, so it's preferable to have it indented properly if it isn't already.

This is a common pattern according to [this Github search](https://github.com/search?q=%2F%3C%3C-%5Cw%2B%5C.squish!%3F%2F%20lang%3Aruby&type=code); there are ~18.8k results at the time of writing.

[Example from GitLab](https://github.com/gitlabhq/gitlabhq/blob/9ca0553b0025e1079c757cd6032b244cf2a297fa/lib/gitlab/database/load_balancing/load_balancer.rb#L330-L333) which would be caught as an offense with this patch:
```ruby
query = <<-SQL.squish
SELECT pg_wal_lsn_diff(#{lsn1}, #{lsn2})
  AS result
SQL
```
and autocorrected to:
```ruby
query = <<-SQL.squish
  SELECT pg_wal_lsn_diff(#{lsn1}, #{lsn2})
    AS result
SQL
```

In case the indentation is already as expected, `<<-` is just replaced with `<<~`, which I believe is the preferable option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
