### PR TITLE
Add option to ignore cops for RedundantCopDisableDirective

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2259,6 +2259,7 @@ Lint/RedundantCopDisableDirective:
                  It must be explicitly disabled.
   Enabled: true
   VersionAdded: '0.76'
+  CopsToIgnore: []
 
 Lint/RedundantCopEnableDirective:
   Description: Checks for rubocop:enable comments that can be removed.

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -230,7 +230,14 @@ module RuboCop
           DirectiveComment.new(comment).directive_count
         end
 
+        def cops_to_ignore
+          @cops_to_ignore ||= Set.new(Array(cop_config['CopsToIgnore']))
+        end
+
         def add_offenses(redundant_cops)
+          redundant_cops.reject! do |_comment, cops|
+            cops_to_ignore.intersect?(cops)
+          end
           redundant_cops.each do |comment, cops|
             if all_disabled?(comment) || directive_count(comment) == cops.size
               add_offense_for_entire_comment(comment, cops)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
 
               expect_correction('')
             end
+
+            context 'when that cop is configured in CopsToIgnore' do
+              let(:cop_config) { { 'CopsToIgnore' => ['Metrics/MethodLength'] } }
+
+              it 'returns no offense' do
+                expect_no_offenses(<<~RUBY)
+                  # rubocop:disable Metrics/MethodLength
+                RUBY
+              end
+            end
           end
 
           context 'an unknown cop' do


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
