### PR TITLE
Add option to ignore cops for RedundantCopDisableDirective

### DIFF
--- a/changelog/change_add_option_to_ignore_cops_for_20251226171851.md
+++ b/changelog/change_add_option_to_ignore_cops_for_20251226171851.md
@@ -1,0 +1,1 @@
+* [#14755](https://github.com/rubocop/rubocop/pull/14755): Add option to ignore cops for RedundantCopDisableDirective. ([@vjlira][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2259,6 +2259,7 @@ Lint/RedundantCopDisableDirective:
                  It must be explicitly disabled.
   Enabled: true
   VersionAdded: '0.76'
+  CopsToIgnore: []
 
 Lint/RedundantCopEnableDirective:
   Description: Checks for rubocop:enable comments that can be removed.

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -230,7 +230,14 @@ module RuboCop
           DirectiveComment.new(comment).directive_count
         end
 
+        def cops_to_ignore
+          @cops_to_ignore ||= Set.new(Array(cop_config['CopsToIgnore']))
+        end
+
         def add_offenses(redundant_cops)
+          redundant_cops.reject! do |_comment, cops|
+            cops_to_ignore.intersect?(cops)
+          end
           redundant_cops.each do |comment, cops|
             if all_disabled?(comment) || directive_count(comment) == cops.size
               add_offense_for_entire_comment(comment, cops)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
 
               expect_correction('')
             end
+
+            context 'when that cop is configured in CopsToIgnore' do
+              let(:cop_config) { { 'CopsToIgnore' => ['Metrics/MethodLength'] } }
+
+              it 'returns no offense' do
+                expect_no_offenses(<<~RUBY)
+                  # rubocop:disable Metrics/MethodLength
+                RUBY
+              end
+            end
           end
 
           context 'an unknown cop' do


### PR DESCRIPTION
## Why
Sometimes we need to disable a specific cop immediately (e.g., after enabling a new cop or when a cop starts producing unexpected offenses). However, Lint/RedundantCopDisableDirective might raise errors/alerts, creating churn and potential pipeline failures. Depending on the case, erasing all the redundant todo/disables of cops could be hard, delaying the disabling of the cop.

This PR introduces a way to temporarily tolerate these disable directives for selected cops so teams can:

Apply a quick “stop the bleeding” change without CI issues.
Follow up in a separate PR to safely remove disable comments once the underlying issues are addressed.
Reduce risk of concurrent changes (multiple PRs touching disable directives / autocorrecting them) causing conflicts or noisy diffs.

## What changed
New configuration option for Lint/RedundantCopDisableDirective: CopsToIgnore
When a redundant disable is detected for a cop listed in CopsToIgnore, the cop will not register an offense.
Added CopsToIgnore to the cop’s default configuration (config/default.yml) so RuboCop recognizes it as a valid parameter.
Added spec coverage ensuring the new behavior works as intended.


## Usage

```
yaml
Lint/RedundantCopDisableDirective:
  CopsToIgnore:
    - Layout/LineLength
    - Metrics/MethodLength
```

## Tests
Added a cop spec verifying that redundant # rubocop:disable Metrics/MethodLength is not reported when Metrics/MethodLength is included in CopsToIgnore.


## Follow-up
Once the project is stable again, a follow-up PR can remove the temporary disable directives (and optionally remove entries from CopsToIgnore) with minimal risk and reduced merge/conflict noise.