### PR TITLE
Improved the remote configuration file name on the cache location.

### DIFF
--- a/fix_remote_config_cache_filename.md
+++ b/fix_remote_config_cache_filename.md
@@ -1,0 +1,1 @@
+* [#14761](https://github.com/rubocop/rubocop/issues/14761): Improved the remote configuration file name on the cache location. ([@Jack12816][])

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -81,7 +81,7 @@ module RuboCop
     end
 
     def cache_path
-      @cache_path ||= File.expand_path(".rubocop-remote-#{cache_name_from_uri}", @cache_root)
+      @cache_path ||= File.expand_path(cache_name_from_uri, @cache_root)
     end
 
     def cache_path_exists?
@@ -98,7 +98,10 @@ module RuboCop
     end
 
     def cache_name_from_uri
-      "#{Digest::MD5.hexdigest(@uri.to_s)}.yml"
+      # The md5 checksum suffix is 37 bytes, so we play it save and
+      # allow 254 bytes total - this should be safe on Linux/macOS/Windows
+      filename = File.basename(@uri.path).gsub(/\.ya?ml\z/i, '').byteslice(0, 217).scrub('')
+      "#{filename}-#{Digest::MD5.hexdigest(@uri.to_s)}.yml"
     end
 
     def cloned_url

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1436,7 +1436,7 @@ RSpec.describe RuboCop::ConfigLoader do
 
     context 'when a file inherits from a url' do
       let(:file_path) { '.rubocop.yml' }
-      let(:cache_file) { '.rubocop-remote-e32e465e27910f2bc7262515eebe6b63.yml' }
+      let(:cache_file) { 'rubocop-e32e465e27910f2bc7262515eebe6b63.yml' }
 
       before do
         described_class.cache_root = Dir.pwd
@@ -1468,8 +1468,8 @@ RSpec.describe RuboCop::ConfigLoader do
 
     context 'when a file inherits from a url inheriting from another file' do
       let(:file_path) { '.rubocop.yml' }
-      let(:cache_file) { '.rubocop-remote-1e2eaf67d5bc989f4bc3c5a900039224.yml' }
-      let(:cache_file2) { '.rubocop-remote-e32e465e27910f2bc7262515eebe6b63.yml' }
+      let(:cache_file) { 'inherit-1e2eaf67d5bc989f4bc3c5a900039224.yml' }
+      let(:cache_file2) { 'rubocop-e32e465e27910f2bc7262515eebe6b63.yml' }
 
       before do
         described_class.cache_root = Dir.pwd


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/14625.

---

When I reworked the `inherit_from` remote cache location, I missed the implications of the already fixed file name prefix (`.rubocop`) in conjunction to the previous cache file location (always next to the project `.rubocop.yml`). 

This renders the [path relativity feature](https://docs.rubocop.org/rubocop/configuration.html#path-relativity) useless:

> In `.rubocop.yml` and any other configuration file beginning with `.rubocop`, files, and directories are specified relative to the directory where the configuration file is. **In configuration files that don't begin with `.rubocop`, e.g. `our_company_defaults.yml`, paths are relative to the directory where `rubocop` is run.**

So users cannot control this behavior with remote configurations. Relative paths are always prefixed with the configured cache location.

Consider this shared configuration:

```yaml
AllCops:
  Exclude:
    - app/models/**/*
```

### Example: `http://example.com/rubocop-shared.yml`

* Current working directory: `/home/jack/example-app`
* `RUBOCOP_CACHE_ROOT=/home/jack/.cache/rubocop`

Before: `/home/jack/.cache/rubocop/rubocop_cache/app/models/**/*`
After: `/home/jack/example-app/app/models/**/*`

### Example: `http://example.com/.rubocop-shared.yml`

* Current working directory: `/home/jack/example-app`
* `RUBOCOP_CACHE_ROOT=/home/jack/.cache/rubocop`

Before: `/home/jack/.cache/rubocop/rubocop_cache/app/models/**/*`
After: `/home/jack/.cache/rubocop/rubocop_cache/app/models/**/*`

---

With this patch the path relativity feature in conjunction with a custom cache location, works as documented.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
