### PR TITLE
Fix false negatives for `Style/RedundantCondition`

### DIFF
--- a/changelog/fix_false_negative_for_style_redundant_condition_cop.md
+++ b/changelog/fix_false_negative_for_style_redundant_condition_cop.md
@@ -1,0 +1,1 @@
+* [#14762](https://github.com/rubocop/rubocop/pull/14762): Fix false negatives for `Style/RedundantCondition` when the branches contains constant assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -200,7 +200,7 @@ module RuboCop
         end
 
         def asgn_type?(node)
-          node.type?(:lvasgn, :ivasgn, :cvasgn, :gvasgn)
+          node.type?(:lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn)
         end
 
         def branches_have_method?(node)

--- a/spec/rubocop/cop/style/redundant_condition_spec.rb
+++ b/spec/rubocop/cop/style/redundant_condition_spec.rb
@@ -366,6 +366,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantCondition, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects when the branches contains constant assignment' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^^^^^ Use double pipes `||` instead.
+            CONST = foo
+          else
+            CONST = 'bar'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          CONST = foo || 'bar'
+        RUBY
+      end
+
       it 'registers an offense and corrects when the branches contains assignment method' do
         expect_offense(<<~RUBY)
           if foo


### PR DESCRIPTION
This PR fixes false negatives for `Style/RedundantCondition` when the branches contains constant assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
