### PR TITLE
[Fix #14697] Allow non-method calls in `Categories` for `Layout/ClassStructure`

### DIFF
--- a/changelog/fix_allow_non_method_calls_in_categories_for_class_structure.md
+++ b/changelog/fix_allow_non_method_calls_in_categories_for_class_structure.md
@@ -1,0 +1,1 @@
+* [#14697](https://github.com/rubocop/rubocop/issues/14697): Allow non-method calls in `Categories` for `Layout/ClassStructure`. ([@fatkodima][])

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -568,4 +568,42 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       end
     end
   end
+
+  context 'when constants is in the Categories' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/ClassStructure' => {
+          'ExpectedOrder' => %w[
+            all_constants
+            attribute_macros
+          ],
+          'Categories' => {
+            'all_constants' => %w[
+              constants
+            ],
+            'attribute_macros' => %w[
+              attr_accessor
+            ]
+          }
+        }
+      )
+    end
+
+    it 'registers an offense and corrects when attribute macros after constant' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr_accessor :foo
+          CONST = 'wrong place'
+          ^^^^^^^^^^^^^^^^^^^^^ `all_constants` is supposed to appear before `attribute_macros`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          CONST = 'wrong place'
+          attr_accessor :foo
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #14697.

Previously, `Categories` configuration of `Layout/ClassStructure` cop allowed configuring only send nodes, now it allows any nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
