### PR TITLE
[Fix #14763] Fix an infinite loop error for `Layout/IndentationWidth` and `Layout/IndentationConsistency`

### DIFF
--- a/changelog/fix_infinite_loop_indentation_width_with_indented_internal_methods.md
+++ b/changelog/fix_infinite_loop_indentation_width_with_indented_internal_methods.md
@@ -1,0 +1,1 @@
+* [#14763](https://github.com/rubocop/rubocop/issues/14763): Fix an infinite loop error for `Layout/IndentationWidth` and `Layout/IndentationConsistency` when using `EnforcedStyle: indented_internal_methods` with method chain blocks. ([@ydakuka][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -89,6 +89,7 @@ module RuboCop
           check_indentation(base_loc, node.body)
 
           return unless indented_internal_methods_style?
+          return unless contains_access_modifier?(node.body)
 
           check_members(end_loc, [node.body])
         end
@@ -375,6 +376,12 @@ module RuboCop
           return false unless starting_node
 
           starting_node.send_type? && starting_node.bare_access_modifier?
+        end
+
+        def contains_access_modifier?(body_node)
+          return false unless body_node.begin_type?
+
+          body_node.children.any? { |child| child.send_type? && child.bare_access_modifier? }
         end
 
         def configured_indentation_width

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3780,6 +3780,57 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'does not cause an infinite loop between `Layout/IndentationConsistency` and `Layout/IndentationWidth`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/IndentationConsistency:
+        EnforcedStyle: indented_internal_methods
+
+      Layout/IndentationWidth:
+        Width: 2
+    YAML
+
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      class Test
+        def foo
+        end
+
+        private
+
+        def example
+          Model
+            .some_scope
+            .find_each do |record|
+            record.do_something
+            record.do_something_else
+          end
+        end
+      end
+    RUBY
+
+    status = cli.run(%w[--autocorrect-all])
+    expect(status).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(source_file.read).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      class Test
+        def foo; end
+
+        private
+
+          def example
+            Model
+              .some_scope
+              .find_each do |record|
+                record.do_something
+                record.do_something_else
+            end
+          end
+      end
+    RUBY
+  end
+
   it 'does not trigger `Style/SingleArgumentDig` when `Style/DigChain` is enabled and will correct' do
     source_file = Pathname('example.rb')
     create_file(source_file, <<~RUBY)


### PR DESCRIPTION
Fixes #14763

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
