### PR TITLE
Add `Layout/IndentationWidth` `relative_to_receiver` style

### DIFF
--- a/changelog/fix_indentation_width_relative_to_receiver.md
+++ b/changelog/fix_indentation_width_relative_to_receiver.md
@@ -1,0 +1,1 @@
+* [#14747](https://github.com/rubocop/rubocop/issues/14747): Fix a regression in`Layout/IndentationWidth` by adding a new `EnforcedStyleAlignWith` style parameter. ([@MikeMcQuaid][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1037,6 +1037,15 @@ Layout/IndentationWidth:
   VersionAdded: '0.49'
   # Number of spaces for each indentation level.
   Width: 2
+  # Block body indentation for method chain blocks.
+  # The value `start_of_line` means that block bodies are indented
+  # relative to the start of the line where the block starts.
+  # The value `relative_to_receiver` means that block bodies are indented
+  # relative to the method call position in the chain.
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+    - start_of_line
+    - relative_to_receiver
   AllowedPatterns: []
 
 Layout/InitialIndentation:

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3787,6 +3787,60 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
       Layout/IndentationWidth:
         Width: 2
+        EnforcedStyleAlignWith: start_of_line
+    YAML
+
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      class Test
+        def foo
+        end
+
+        private
+
+        def example
+          Model
+            .some_scope
+            .find_each do |record|
+            record.do_something
+            record.do_something_else
+          end
+        end
+      end
+    RUBY
+
+    status = cli.run(%w[--autocorrect-all])
+    expect(status).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(source_file.read).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      class Test
+        def foo; end
+
+        private
+
+          def example
+            Model
+              .some_scope
+              .find_each do |record|
+              record.do_something
+              record.do_something_else
+            end
+          end
+      end
+    RUBY
+  end
+
+  it 'does not cause an infinite loop between `Layout/IndentationConsistency` and `Layout/IndentationWidth` ' \
+     'with EnforcedStyleAlignWith: relative_to_receiver' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/IndentationConsistency:
+        EnforcedStyle: indented_internal_methods
+
+      Layout/IndentationWidth:
+        Width: 2
+        EnforcedStyleAlignWith: relative_to_receiver
     YAML
 
     source_file = Pathname('example.rb')


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/14747 (and thanks to @dostapn for the great write-up that made it easier to implement this).

This behaviour changed in 1.82.1 so let's revert to the existing 1.82.0 behaviour and add an option for the new behaviour.

I defer to the maintainers whether it would be better for the default to be `relative_to_receiver`, the new behavior in 1.82.1, instead.

My first RuboCop PR (as Homebrew, a project I maintain, hit this) so apologies for any mistakes. Thanks for the great project, use it wherever I can! ❤️ 

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
