### PR TITLE
Make `Style/AccessModifierDeclarations` aware of self class

### DIFF
--- a/changelog/change_make_style_access_modifier_declarations_aware_of_sclass.md
+++ b/changelog/change_make_style_access_modifier_declarations_aware_of_sclass.md
@@ -1,0 +1,1 @@
+* [#14770](https://github.com/rubocop/rubocop/pull/14770): Make `Style/AccessModifierDeclarations` aware of self class. ([@koic][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -326,8 +326,7 @@ module RuboCop
           argument_less_modifier_node = find_argument_less_modifier_node(node)
           if argument_less_modifier_node
             corrector.insert_after(argument_less_modifier_node, "\n\n#{source}")
-          elsif (ancestor = node.each_ancestor(:class, :module).first)
-
+          elsif (ancestor = node.each_ancestor(:class, :module, :sclass).first)
             corrector.insert_before(ancestor.loc.end, "#{node.method_name}\n\n#{source}\n")
           else
             corrector.replace(node, "#{node.method_name}\n\n#{source}")

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -179,6 +179,92 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
 
           expect_no_corrections
         end
+
+        it 'registers an offense and autocorrects when methods are all defined in self class' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class << self
+              def bar; end
+              def baz; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class << self
+
+            #{access_modifier}
+
+            def bar; end
+            def baz; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when methods are all defined in self class and there is a comment' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class << self
+              def bar; end
+              def baz; end
+
+              # comment
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class << self
+
+            #{access_modifier}
+
+            # comment
+            def bar; end
+            def baz; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense and autocorrects when methods are all defined in self class and there is already a bare access modifier' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class << self
+              def bar; end
+              def baz; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+
+              %{access_modifier}
+              def quux; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class << self
+
+
+              #{access_modifier}
+
+            def bar; end
+            def baz; end
+              def quux; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense but does not correct when not all methods are defined in self class' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class << self
+              def bar; end
+
+              %{access_modifier} :bar, :baz
+              ^{access_modifier} `#{access_modifier}` should not be inlined in method definitions.
+            end
+          RUBY
+
+          expect_no_corrections
+        end
       end
 
       it "registers an offense when argument to #{access_modifier} is splat with a `%i` array literal" do


### PR DESCRIPTION
This PR makes `Style/AccessModifierDeclarations` aware of self class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
