### PR TITLE
Fix: Unnecessary enabling with rubocop:push/pop

### DIFF
--- a/changelog/new_push_pop_system_for_local_disable_enable_cops.md
+++ b/changelog/new_push_pop_system_for_local_disable_enable_cops.md
@@ -1,0 +1,1 @@
+* [#14633](https://github.com/rubocop/rubocop/pull/14633): Make a new system to handle push and pop locally. ([@Magikdidi24][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -70,6 +70,7 @@ module RuboCop
     def extra_enabled_comments_with_names(extras:, names:)
       each_directive do |directive|
         next unless comment_only_line?(directive.line_number)
+        next if directive.push? || directive.pop?
 
         if directive.enabled_all?
           handle_enable_all(directive, names, extras)

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -217,6 +217,27 @@ RSpec.describe RuboCop::CommentConfig do
     it 'has values as arrays of extra enabled cops' do
       expect(extra.values.first).to eq ['Metrics/MethodLength', 'Security/Eval']
     end
+
+    context 'with push directive disabling Style/GuardClause' do
+      let(:source) do
+        <<~RUBY
+          def process
+            # rubocop:push -Style/GuardClause
+            if condition
+              return value
+            end
+            # rubocop:pop
+          end
+        RUBY
+      end
+
+      it 'does not treat push with -CopName as an extra enable comment' do
+        # This test reproduces the bug where "# rubocop:push -..."
+        # was incorrectly interpreted as an enable directive, causing:
+        # "Unnecessary enabling of -Style/GuardClause. (error:Lint/RedundantCopEnableDirective)"
+        expect(extra).to be_empty
+      end
+    end
   end
 
   describe 'comment_only_line?' do


### PR DESCRIPTION
# Actual behavior
Unnecessary enabling of -Layout/SpaceAroundMethodCallOperator. (error:Lint/RedundantCopEnableDirective)

# Root cause
The extra_enabled_comments_with_names method in lib/rubocop/comment_config.rb does not filter out push/pop directives. When it encounters # rubocop:push -CopName, the -CopName part is passed to handle_switch, which incorrectly interprets it as an enable directive.

# Fix
The fix adds a simple guard 
next if directive.push? || directive.pop?
This line explicitly filters out push and pop directives before they can be processed by handle_switch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
