### PR TITLE
Expand method names in `Lint/StructNewOverride`

### DIFF
--- a/lib/rubocop/cop/lint/struct_new_override.rb
+++ b/lib/rubocop/cop/lint/struct_new_override.rb
@@ -26,7 +26,23 @@ module RuboCop
               'and it may be unexpected.'
         RESTRICT_ON_SEND = %i[new].freeze
 
-        STRUCT_METHOD_NAMES = Struct.instance_methods
+        # This is based on `Struct.instance_methods.sort` in Ruby 4.0.0.
+        STRUCT_METHOD_NAMES = %i[
+          ! != !~ <=> == === [] []= __id__ __send__ all? any? chain chunk chunk_while class clone
+          collect collect_concat compact count cycle deconstruct deconstruct_keys
+          define_singleton_method detect dig display drop drop_while dup each each_cons each_entry
+          each_pair each_slice each_with_index each_with_object entries enum_for eql? equal? extend
+          filter filter_map find find_all find_index first flat_map freeze frozen? grep grep_v
+          group_by hash include? inject inspect instance_eval instance_exec instance_of?
+          instance_variable_defined? instance_variable_get instance_variable_set instance_variables
+          is_a? itself kind_of? lazy length map max max_by member? members method methods
+          min min_by minmax minmax_by nil? none? object_id one? partition private_methods
+          protected_methods public_method public_methods public_send reduce reject
+          remove_instance_variable respond_to? reverse_each select send singleton_class
+          singleton_method singleton_methods size slice_after slice_before slice_when sort sort_by
+          sum take take_while tally tap then to_a to_enum to_h to_s to_set uniq values values_at
+          yield_self zip
+        ].freeze
         STRUCT_MEMBER_NAME_TYPES = %i[sym str].freeze
 
         # @!method struct_new(node)


### PR DESCRIPTION
RuboCop is a static analysis tool and does not rely on runtime information. This reduces the risk of differences in behavior across Ruby implementations. Although this is based on `Struct.instance_methods.sort` in Ruby 4.0, the API is not expected to change significantly, so the risk of incorrect detection is considered low.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
