### PR TITLE
Use RuboCop RSpec 3.9 for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.26.0'
 gem 'rubocop-rake', '~> 0.7.0'
-gem 'rubocop-rspec', '~> 3.8.0'
+gem 'rubocop-rspec', '~> 3.9.0'
 # Ruby LSP supports Ruby 3.0+.
 gem 'ruby-lsp', '~> 0.24', platform: :mri if RUBY_VERSION >= '3.0'
 gem 'simplecov', '~> 0.20'

--- a/spec/rubocop/runner_formatter_invocation_spec.rb
+++ b/spec/rubocop/runner_formatter_invocation_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
     include_context 'cli spec behavior'
 
     let(:formatter) { instance_double(RuboCop::Formatter::BaseFormatter).as_null_object }
-    let(:output) { $stdout.string }
 
     before do
       create_file('2_offense.rb', '#' * 130)
@@ -25,11 +24,12 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
     end
 
     describe 'invocation order' do
+      let(:invocation_order) { [] }
       let(:formatter) do
         formatter = instance_spy(RuboCop::Formatter::BaseFormatter)
         %i[started file_started file_finished finished output].each do |message|
           allow(formatter).to receive(message) do
-            puts message unless message == :output
+            invocation_order << message unless message == :output
           end
         end
         formatter
@@ -37,16 +37,18 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
 
       it 'is called in the proper sequence' do
         run
-        expect(output).to eq(<<~OUTPUT)
-          started
-          file_started
-          file_finished
-          file_started
-          file_finished
-          file_started
-          file_finished
-          finished
-        OUTPUT
+        expect(invocation_order).to eq(
+          %i[
+            started
+            file_started
+            file_finished
+            file_started
+            file_finished
+            file_started
+            file_finished
+            finished
+          ]
+        )
       end
     end
 


### PR DESCRIPTION
This PR fixes the following build error:
https://github.com/rubocop/rubocop/actions/runs/20812089824/job/59778571865

RuboCop RSpec 3.9.0 was released:
https://github.com/rubocop/rubocop-rspec/releases/tag/v3.9.0

This PR fixes the following new RuboCop RSpec's offense:

```console
$ bundle exec rake
(snip)

Offenses:

spec/rubocop/runner_formatter_invocation_spec.rb:32:13:
C: [Correctable] RSpec/Output: Do not write to stdout in specs.
            puts message unless message == :output
            ^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
