### PR TITLE
Fix `Security/JSONLoad` false positive with multiple options

### DIFF
--- a/changelog/fix_security_json_load_with_multiple_options.md
+++ b/changelog/fix_security_json_load_with_multiple_options.md
@@ -1,0 +1,1 @@
+* [#14778](https://github.com/rubocop/rubocop/pull/14778): Fix a false positive for `Security/JSONLoad` when `create_additions` option is passed with other options in a hash. ([@wktk][])

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -52,7 +52,7 @@ module RuboCop
           (
             send (const {nil? cbase} :JSON) ${:load :restore}
             ...
-            !(hash `(sym $:create_additions))
+            !`(pair (sym :create_additions) _)
           )
         PATTERN
 

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
     expect_no_offenses(<<~RUBY)
       JSON.load(arg, create_additions: true)
       ::JSON.load(arg, create_additions: false)
+      JSON.load(arg, { allow_nan: false, create_additions: true })
+      ::JSON.load(arg, { allow_nan: false, create_additions: true })
+      JSON.load(arg, proc {}, create_additions: false, max_nesting: 19)
+      ::JSON.load(arg, proc {}, create_additions: false, max_nesting: 19)
+      JSON.load(arg, -> {}, { max_nesting: 19, create_additions: false, allow_nan: true })
+      ::JSON.load(arg, -> {}, { max_nesting: 19, create_additions: false, allow_nan: true })
     RUBY
   end
 


### PR DESCRIPTION
Fix false positive for `Security/JSONLoad` when `create_additions` option is passed with other options.

The `Security/JSONLoad` cop was not detecting the `create_additions` option when it was passed alongside other options in a hash. Changed the AST pattern to find the key anywhere in the arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
