### PR TITLE
Drop `prism_spec` from the default Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,10 +24,11 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation)
 
-# The `ascii_spec` task has not been failing for a while, so it will not be run by default.
-# However, `ascii_spec` task will continue to be checked in CI. If there are any failures
-# originating from `ascii_spec` in CI, please run `bundle exec ascii_spec` to investigate.
-task default: %i[codespell documentation_syntax_check spec prism_spec internal_investigation]
+# The `ascii_spec` and `prism_spec` tasks have not been failing for a while,
+# so they are not run by default. However, these tasks will continue to be checked in CI.
+# If there are any failures originating from these tasks in CI,
+# please run `bundle exec ascii_spec` or `bundle exec prism_spec` to investigate.
+task default: %i[codespell documentation_syntax_check spec internal_investigation]
 
 require 'yard'
 YARD::Rake::YardocTask.new


### PR DESCRIPTION
`rake prism_spec`, like `rake ascii_spec`, has not failed on its own for quite some time. Since it is always checked in CI, it seems like a good time to remove it from the default local execution.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
