### PR TITLE
Fix an error for `Style/GuardClause`

### DIFF
--- a/changelog/fix_an_error_for_style_guard_clause.md
+++ b/changelog/fix_an_error_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#14784](https://github.com/rubocop/rubocop/pull/14784): Fix an error for `Style/GuardClause` when using heredoc as an argument of raise in `else` branch and `if` branch is empty. ([@koic][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -227,12 +227,15 @@ module RuboCop
           remove_whole_lines(corrector, node.loc.end)
           return unless node.else?
 
-          remove_whole_lines(corrector, leave_branch.source_range)
+          if leave_branch
+            remove_whole_lines(corrector, leave_branch.source_range)
+            corrector.insert_after(
+              heredoc_branch.last_argument.loc.heredoc_end, "\n#{leave_branch.source}"
+            )
+          end
+
           remove_whole_lines(corrector, node.loc.else)
           remove_whole_lines(corrector, range_of_branch_to_remove(node, guard))
-          corrector.insert_after(
-            heredoc_branch.last_argument.loc.heredoc_end, "\n#{leave_branch.source}"
-          )
         end
 
         def range_of_branch_to_remove(node, guard)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -514,6 +514,30 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
+  it 'registers an offense when using heredoc as an argument of raise in `else` branch and `if` branch is empty' do
+    expect_offense(<<~RUBY)
+      def func
+        if condition
+        ^^ Use a guard clause (`raise <<~MESSAGE unless condition`) instead of wrapping the code inside a conditional expression.
+        else
+          raise <<~MESSAGE
+            oops
+          MESSAGE
+        end
+      end
+    RUBY
+
+    # NOTE: Let `Layout/HeredocIndentation`, `Layout/ClosingHeredocIndentation`, and
+    #       `Layout/IndentationConsistency` cops autocorrect inconsistent indentations.
+    expect_correction(<<~RUBY)
+      def func
+        raise <<~MESSAGE unless condition
+            oops
+          MESSAGE
+      end
+    RUBY
+  end
+
   it 'registers an offense when using heredoc as an argument of raise in `then` branch and it does not have `else` branch' do
     expect_offense(<<~RUBY)
       def func


### PR DESCRIPTION
This PR fixes the following error for `Style/GuardClause` when using heredoc as an argument of raise in `else` branch and `if` branch is empty.

```console
$ cat example.rb
def func
  if condition
  else
    raise <<~MESSAGE
      text
    MESSAGE
  end
end

$ bundle exec rubocop -a --only Style/GuardClause -d
(snip)

/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/guard_clause.rb:230:
in 'RuboCop::Cop::Style::GuardClause#autocorrect_heredoc_argument': undefined method 'source_range' for nil (NoMethodError)

          remove_whole_lines(corrector, leave_branch.source_range)
                                                    ^^^^^^^^^^^^^
        from /Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/style/guard_clause.rb:211:
        in 'RuboCop::Cop::Style::GuardClause#autocorrect'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
