### PR TITLE
[Fix #14783] Fix incorrect autocorrect for `Style/HashSyntax` when shorthand syntax is used in condition of `if`/`unless`/`while`/`until`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_syntax.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_syntax.md
@@ -1,0 +1,1 @@
+* [#14783](https://github.com/rubocop/rubocop/issues/14783): Fix incorrect autocorrect for `Style/HashSyntax` when shorthand syntax is used in condition of `if`/`unless`/`while`/`until`. ([@ydakuka][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -125,7 +125,7 @@ module RuboCop
         return if dispatch_node.assignment_method?
         return if dispatch_node.parenthesized?
         return if dispatch_node.parent && parentheses?(dispatch_node.parent)
-        return if last_expression?(dispatch_node) && !method_dispatch_as_argument?(dispatch_node)
+        return if last_expression?(dispatch_node) && !requires_parentheses_context?(dispatch_node)
 
         def_node = node.each_ancestor(:call, :super, :yield).first
 
@@ -164,11 +164,11 @@ module RuboCop
         !assignment_node.right_sibling
       end
 
-      def method_dispatch_as_argument?(method_dispatch_node)
-        parent = method_dispatch_node.parent
+      def requires_parentheses_context?(node)
+        parent = node.parent
         return false unless parent
 
-        parent.type?(:call, :super, :yield)
+        parent.type?(:call, :if, :super, :until, :while, :yield)
       end
 
       def breakdown_value_types_of_hash(hash_node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -219,6 +219,74 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
           method(:puts).(key: value)
         RUBY
       end
+
+      context 'Ruby >= 3.1', :ruby31 do
+        it 'registers an offense and adds parentheses for `if` condition' do
+          expect_offense(<<~RUBY)
+            if foo bar: bar
+                        ^^^ Omit the hash value.
+              baz
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if foo(bar:)
+              baz
+            end
+          RUBY
+        end
+
+        it 'registers an offense and adds parentheses for `unless` condition' do
+          expect_offense(<<~RUBY)
+            unless foo bar: bar
+                            ^^^ Omit the hash value.
+              baz
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            unless foo(bar:)
+              baz
+            end
+          RUBY
+        end
+
+        it 'registers an offense and adds parentheses for `while` condition' do
+          expect_offense(<<~RUBY)
+            while foo bar: bar
+                           ^^^ Omit the hash value.
+              baz
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            while foo(bar:)
+              baz
+            end
+          RUBY
+        end
+
+        it 'registers an offense and adds parentheses for `until` condition' do
+          expect_offense(<<~RUBY)
+            until foo bar: bar
+                           ^^^ Omit the hash value.
+              baz
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            until foo(bar:)
+              baz
+            end
+          RUBY
+        end
+
+        it 'does not register an offense for modifier form' do
+          expect_no_offenses(<<~RUBY)
+            baz if foo bar: bar
+          RUBY
+        end
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do
@@ -1520,6 +1588,72 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
         RUBY
       end
 
+      it 'registers an offense and adds parentheses for `if` condition' do
+        expect_offense(<<~RUBY)
+          if foo bar: bar
+                      ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `unless` condition' do
+        expect_offense(<<~RUBY)
+          unless foo bar: bar
+                          ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          unless foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `while` condition' do
+        expect_offense(<<~RUBY)
+          while foo bar: bar
+                         ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          while foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `until` condition' do
+        expect_offense(<<~RUBY)
+          until foo bar: bar
+                         ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          until foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for modifier form' do
+        expect_no_offenses(<<~RUBY)
+          baz if foo bar: bar
+        RUBY
+      end
+
       context 'when hash rocket syntax' do
         let(:enforced_style) { 'hash_rockets' }
 
@@ -1698,6 +1832,72 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
         expect_correction(<<~RUBY)
           {foo:, bar:}
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `if` condition' do
+        expect_offense(<<~RUBY)
+          if foo bar: bar
+                      ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `unless` condition' do
+        expect_offense(<<~RUBY)
+          unless foo bar: bar
+                          ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          unless foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `while` condition' do
+        expect_offense(<<~RUBY)
+          while foo bar: bar
+                         ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          while foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and adds parentheses for `until` condition' do
+        expect_offense(<<~RUBY)
+          until foo bar: bar
+                         ^^^ Omit the hash value.
+            baz
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          until foo(bar:)
+            baz
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for modifier form' do
+        expect_no_offenses(<<~RUBY)
+          baz if foo bar: bar
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #14783 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
