### PR TITLE
[Fix #14779] Fix autocorrect crash with `ruby_extractor` when using `offset: 0` and different source buffers

### DIFF
--- a/changelog/fix_autocorrect_with_ruby_extractor_offset_zero.md
+++ b/changelog/fix_autocorrect_with_ruby_extractor_offset_zero.md
@@ -1,0 +1,1 @@
+* [#14779](https://github.com/rubocop/rubocop/issues/14779): Fix autocorrect crash with `ruby_extractor` when using `offset: 0` and different source buffers. ([@ydakuka][])

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -211,10 +211,10 @@ module RuboCop
 
         each_corrector(report) do |to_merge|
           suppress_clobbering do
-            if offset.positive?
-              corrector.import!(to_merge, offset: offset)
-            else
+            if corrector.source_buffer == to_merge.source_buffer
               corrector.merge!(to_merge)
+            else
+              corrector.import!(to_merge, offset: offset)
             end
           end
         end


### PR DESCRIPTION
Fixes #14779

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
