### PR TITLE
[Fix #12527] Fix `Offense#highlighted_area` to return a valid `Parser::Source::Range`

### DIFF
--- a/changelog/fix_offense_highlighted_area.md
+++ b/changelog/fix_offense_highlighted_area.md
@@ -1,0 +1,1 @@
+* [#12527](https://github.com/rubocop/rubocop/issues/12527): Fix `Offense#highlighted_area` to return a valid `Parser::Source::Range`. ([@ydakuka][])

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -139,7 +139,8 @@ module RuboCop
       # @return [Parser::Source::Range]
       #   the range of the code that is highlighted
       def highlighted_area
-        Parser::Source::Range.new(source_line, column, column + column_length)
+        source_buffer = Parser::Source::Buffer.new(location.source_buffer.name, source: source_line)
+        Parser::Source::Range.new(source_buffer, column, column + column_length)
       end
 
       # @api private

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe RuboCop::Cop::Offense do
     end
   end
 
+  describe '#highlighted_area' do
+    subject(:highlighted_area) { offense.highlighted_area }
+
+    it 'returns a range with correct column and length' do
+      expect(highlighted_area).to be_a Parser::Source::Range
+      expect(highlighted_area.column).to eq(0)
+      expect(highlighted_area.length).to eq(1)
+    end
+  end
+
   describe '#severity_level' do
     subject(:severity_level) do
       described_class.new(severity, location, 'message', 'CopName').severity.level


### PR DESCRIPTION
Fixes #12527 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
