### PR TITLE
Fix an error for `Style/HashLookupMethod` cop

### DIFF
--- a/changelog/fix_an_error_for_style_hash_lookup_method_cop_20260117121646.md
+++ b/changelog/fix_an_error_for_style_hash_lookup_method_cop_20260117121646.md
@@ -1,0 +1,1 @@
+* [#14790](https://github.com/rubocop/rubocop/pull/14790): Fix an error for `Style/HashLookupMethod` cop when there's no receiver. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -66,7 +66,8 @@ module RuboCop
         private
 
         def offense_for_brackets?(node)
-          style == :brackets && node.method?(:fetch) && node.arguments.one? && !node.block_literal?
+          style == :brackets && node.receiver && node.method?(:fetch) && node.arguments.one? &&
+            !node.block_literal?
         end
 
         def offense_for_fetch?(node)

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
       expect_no_offenses('hash.fetch(key) { default }')
     end
 
+    it 'accepts `fetch` without receiver' do
+      expect_no_offenses('fetch(key)')
+    end
+
+    it 'accepts `fetch` without receiver and with block' do
+      expect_no_offenses('fetch(key) { default }')
+    end
+
     context 'when using safe navigation operator' do
       it 'registers an offense for fetch with one argument' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
When configured style is `brackets` (default) and there's no receiver for the `fetch` call, the following error happens:

```bash
echo 'fetch(key)' | bundle exec rubocop --only Style/HashLookupMethod -d --stdin bug.rb
An error occurred while Style/HashLookupMethod cop was inspecting bug.rb:1:0.
lib/rubocop/cop/style/hash_lookup_method.rb:78:in 'RuboCop::Cop::Style::HashLookupMethod#correct_fetch_to_brackets': undefined method 'source' for nil (NoMethodError)

          receiver = node.receiver.source
                                  ^^^^^^^
	from lib/rubocop/cop/style/hash_lookup_method.rb:56:in 'block in RuboCop::Cop::Style::HashLookupMethod#on_send'
	from lib/rubocop/cop/base.rb:426:in 'RuboCop::Cop::Base#correct'
	from lib/rubocop/cop/base.rb:210:in 'RuboCop::Cop::Base#add_offense'

```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
