### PR TITLE
Make `Lint/RedundantSplatExpansion` aware of constant assignment

### DIFF
--- a/changelog/change_make_lint_redundant_splat_expansion_aware_of_constant_assignment.md
+++ b/changelog/change_make_lint_redundant_splat_expansion_aware_of_constant_assignment.md
@@ -1,0 +1,1 @@
+* [#14793](https://github.com/rubocop/rubocop/pull/14793): Make `Lint/RedundantSplatExpansion` aware of constant assignment. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -77,7 +77,7 @@ module RuboCop
         PERCENT_CAPITAL_W = '%W'
         PERCENT_I = '%i'
         PERCENT_CAPITAL_I = '%I'
-        ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
+        ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn casgn].freeze
 
         # @!method array_new?(node)
         def_node_matcher :array_new?, <<~PATTERN

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects an array constructor in a constant assignment' do
+      expect_offense(<<~RUBY)
+        A = *Array.new(3) { 42 }
+            ^^^^^^^^^^^^^^^^^^^^ Replace splat expansion with comma separated values.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        A = Array.new(3) { 42 }
+      RUBY
+    end
+
     it 'registers and corrects an array using top-level const' do
       expect_offense(<<~RUBY)
         a = *::Array.new(3) { 42 }


### PR DESCRIPTION
This PR makes `Lint/RedundantSplatExpansion` aware of constant assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
