### PR TITLE
Add AllowedMethods configuration to Style/ModuleMemberExistenceCheck

### DIFF
--- a/changelog/change_style_module_member_existence_check_add_allowed_methods.md
+++ b/changelog/change_style_module_member_existence_check_add_allowed_methods.md
@@ -1,0 +1,1 @@
+* [#14795](https://github.com/rubocop/rubocop/pull/14795): Add `AllowedMethods` configuration to `Style/ModuleMemberExistenceCheck`. ([@lovro-bikic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4777,6 +4777,7 @@ Style/ModuleMemberExistenceCheck:
   Description: 'Checks for usage of `Module` methods returning arrays that can be replaced with equivalent predicates.'
   Enabled: pending
   VersionAdded: '1.82'
+  AllowedMethods: []
 
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'

--- a/lib/rubocop/cop/style/module_member_existence_check.rb
+++ b/lib/rubocop/cop/style/module_member_existence_check.rb
@@ -42,7 +42,13 @@ module RuboCop
       #   Array.public_method_defined?(:foo)
       #   Array.include?(:foo)
       #
+      #  @example AllowedMethods: [included_modules]
+      #
+      #   # good
+      #   Array.included_modules.include?(:foo)
+      #
       class ModuleMemberExistenceCheck < Base
+        include AllowedMethods
         extend AutoCorrector
 
         MSG = 'Use `%<replacement>s` instead.'
@@ -75,6 +81,7 @@ module RuboCop
           return unless (parent = node.parent)
           return unless module_member_inclusion?(parent)
           return unless simple_method_argument?(node) && simple_method_argument?(parent)
+          return if allowed_method?(node.method_name)
 
           offense_range = node.location.selector.join(parent.source_range.end)
           replacement = replacement_for(node, parent)

--- a/spec/rubocop/cop/style/module_member_existence_check_spec.rb
+++ b/spec/rubocop/cop/style/module_member_existence_check_spec.rb
@@ -133,6 +133,16 @@ RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
         x.#{array_returning_method}(*foo).include?(method)
       RUBY
     end
+
+    context "when #{array_returning_method} is in AllowedMethods" do
+      let(:cop_config) { { 'AllowedMethods' => [array_returning_method.to_s] } }
+
+      it "does not register an offense when using `.#{array_returning_method}.include?(method)`" do
+        expect_no_offenses(<<~RUBY)
+          x.#{array_returning_method}.include?(method)
+        RUBY
+      end
+    end
   end
 
   it_behaves_like 'module member inclusion', :class_variables, :class_variable_defined?, false


### PR DESCRIPTION
Follow-up on https://github.com/rubocop/rubocop/pull/14748#issuecomment-3775042592.

Adds support for `AllowedMethods` configuration to `Style/ModuleMemberExistenceCheck`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
