### PR TITLE
Handle logical and operator assignment nodes in variable branch handling

### DIFF
--- a/changelog/fix_useless_assignment_add_branches_for_assignment_nodes.md
+++ b/changelog/fix_useless_assignment_add_branches_for_assignment_nodes.md
@@ -1,0 +1,1 @@
+* [#14796](https://github.com/rubocop/rubocop/pull/14796): Handle logical and operator assignment nodes in variable branch handling. ([@lovro-bikic][])

--- a/lib/rubocop/cop/variable_force/branch.rb
+++ b/lib/rubocop/cop/variable_force/branch.rb
@@ -254,8 +254,8 @@ module RuboCop
           end
         end
 
-        # Mix-in module for logical operator control structures.
-        module LogicalOperator
+        # Mix-in module for operator control structures.
+        module Operator
           def always_run?
             left_body?
           end
@@ -263,7 +263,15 @@ module RuboCop
 
         # left_body && right_body
         class And < Base
-          include LogicalOperator
+          include Operator
+
+          define_predicate :left_body?,  child_index: 0
+          define_predicate :right_body?, child_index: 1
+        end
+
+        # left_body &&= right_body
+        class AndAsgn < Base
+          include Operator
 
           define_predicate :left_body?,  child_index: 0
           define_predicate :right_body?, child_index: 1
@@ -271,7 +279,23 @@ module RuboCop
 
         # left_body || right_body
         class Or < Base
-          include LogicalOperator
+          include Operator
+
+          define_predicate :left_body?,  child_index: 0
+          define_predicate :right_body?, child_index: 1
+        end
+
+        # left_body ||= right_body
+        class OrAsgn < Base
+          include Operator
+
+          define_predicate :left_body?,  child_index: 0
+          define_predicate :right_body?, child_index: 1
+        end
+
+        # e.g. left_body += right_body
+        class OpAsgn < Base
+          include Operator
 
           define_predicate :left_body?,  child_index: 0
           define_predicate :right_body?, child_index: 1

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1205,6 +1205,45 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when an unreferenced variable is reassigned ' \
+          'on the right side of &&= and referenced after the &&=' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method(bar)
+          foo = 1
+          bar &&= (foo = 2)
+          [foo, bar]
+        end
+      RUBY
+    end
+  end
+
+  context 'when an unreferenced variable is reassigned ' \
+          'on the right side of ||= and referenced after the ||=' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method(bar)
+          foo = 1
+          bar ||= (foo = 2)
+          [foo, bar]
+        end
+      RUBY
+    end
+  end
+
+  context 'when an unreferenced variable is reassigned ' \
+          'on the right side of += and referenced after the +=' do
+    it 'accepts' do
+      expect_no_offenses(<<~RUBY)
+        def some_method(bar)
+          foo = 1
+          bar += (foo = 2)
+          [foo, bar]
+        end
+      RUBY
+    end
+  end
+
   context 'when a variable is reassigned while referencing itself in rhs and referenced' do
     it 'accepts' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/14788.

Currently, code such as:
```ruby
def some_method(bar)
  foo = 1
  bar &&= (foo = 2)
  [foo, bar]
end
```
will result in an `Lint/UselessAssignment` offense on `foo = 1` line. This assignment isn't useless if `bar` is falsey.

This PR adds Branch classes for `AndAsgn`, `OrAsgn` and `OpAsgn` nodes. Adding `AndAsgn` fixes the reported issue, but I figured other nodes should be supported as well.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
