### PR TITLE
Recognize `Forwardable` methods in `Lint/DuplicateMethods`

### DIFF
--- a/changelog/change_lint_duplicate_methods_forwardable_support.md
+++ b/changelog/change_lint_duplicate_methods_forwardable_support.md
@@ -1,0 +1,1 @@
+* [#14798](https://github.com/rubocop/rubocop/pull/14798): Recognize `Forwardable` methods in `Lint/DuplicateMethods`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -717,6 +717,105 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         RUBY
       end
     end
+
+    it 'registers an offense for duplicate method when `def_delegator` is used' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_delegator :foo, :bar
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_delegator` is used with string arguments' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_delegator 'foo', 'bar'
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_instance_delegator` is used' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_instance_delegator :foo, :bar
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_delegator` is used with alias' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_delegator :foo, :bar, :baz
+
+          def bar; end
+
+          def baz; end
+          ^^^^^^^ Method `A#baz` is defined at both (string):2 and (string):6.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for duplicate method when `def_delegator` is used within a condition' do
+      expect_no_offenses(<<~RUBY)
+        #{opening_line}
+          def_delegator :foo, :bar if baz?
+
+          def bar; end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_delegators` is used' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_delegators :foo, :bar, :baz
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_delegators` is used with string arguments' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_delegators 'foo', 'bar', 'baz'
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for duplicate method when `def_instance_delegators` is used' do
+      expect_offense(<<~RUBY)
+        #{opening_line}
+          def_instance_delegators :foo, :bar, :baz
+
+          def bar; end
+          ^^^^^^^ Method `A#bar` is defined at both (string):2 and (string):4.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for duplicate method when `def_delegators` is used within a condition' do
+      expect_no_offenses(<<~RUBY)
+        #{opening_line}
+          def_delegators :foo, :bar, :baz if qux?
+
+          def bar; end
+        end
+      RUBY
+    end
   end
 
   it_behaves_like('in scope', 'class', 'class A')


### PR DESCRIPTION
Closes #14691.

Adds support for [`Forwardable`](https://docs.ruby-lang.org/en/4.0/Forwardable.html) methods to `Lint/DuplicateMethods`, namely: `def_delegator`, `def_instance_delegator`, `def_delegators` and `def_instance_delegators`.

With this patch, usage of any of the above methods will result in an offense:
```ruby
class MyClass
  attr_accessor :foo

  def bar; end

  def_delegator :foo, :bar # results in an offense; same with:
  def_instance_delegator :foo, :bar # same with:
  def_delegator :foo, :baz, :bar # same with:

  def_delegators :foo, :bar # same with:
  def_instance_delegators :foo, :bar
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
