### PR TITLE
[Fix #14716] Fix infinite loop for Layout/LineLength with SplitStrings

### DIFF
--- a/changelog/fix_infinite_loop_for_layout_line_length_with_split_strings.md
+++ b/changelog/fix_infinite_loop_for_layout_line_length_with_split_strings.md
@@ -1,0 +1,1 @@
+* [#14716](https://github.com/rubocop/rubocop/issues/14716): Fix an infinite loop error for `Layout/LineLength` when `SplitStrings` option is enabled and strings span multiple lines. ([@HariprasanthMSH][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -418,8 +418,11 @@ module RuboCop
           # The maximum allowed length of a string value is:
           # `Max` - end delimiter (quote) - continuation characters (space and slash)
           max_length = max - 3
-          # If the string doesn't start at the beginning of the line, the max length is offset
-          max_length -= column_offset_between(node.loc, node.parent.loc) if node.parent
+          # If the string is on the same line as its parent, offset by the column difference
+          # (Only apply when on same line to avoid negative offsets for multi-line dstr)
+          if same_line?(node, node.parent)
+            max_length -= column_offset_between(node.loc, node.parent.loc)
+          end
           node.source[0...(max_length)]
         end
       end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1058,6 +1058,24 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
               end
             end
           end
+
+          context 'when the string has no spaces and spans multiple words with `Max` set to 30' do
+            let(:cop_config) { super().merge('Max' => 30) }
+
+            it 'registers an offense and corrects by splitting the string' do
+              expect_offense(<<~RUBY)
+                _const = '000000000000000 0000000000000000000000000000 000000000000000000000000000'
+                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [83/30]
+              RUBY
+
+              expect_correction(<<~'RUBY')
+                _const = '000000000000000 ' \
+                '00000000000000000000000000' \
+                '00 ' \
+                '000000000000000000000000000'
+              RUBY
+            end
+          end
         end
 
         context 'when SplitStrings: false' do


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/14716

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
