### PR TITLE
Preserve source code's tabs when displaying offense highlight

### DIFF
--- a/changelog/fix_preserve_tabs_in_highlight.md
+++ b/changelog/fix_preserve_tabs_in_highlight.md
@@ -1,0 +1,1 @@
+* [#14801](https://github.com/rubocop/rubocop/pull/14801): Preserve source tabs in Clang and Tap formatters when displaying offense highlight. ([@lovro-bikic][])

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -47,8 +47,11 @@ module RuboCop
       def report_highlighted_area(highlighted_area)
         space_area  = highlighted_area.source_buffer.slice(0...highlighted_area.begin_pos)
         source_area = highlighted_area.source
-        output.puts("#{' ' * Unicode::DisplayWidth.of(space_area)}" \
-                    "#{'^' * Unicode::DisplayWidth.of(source_area)}")
+        output.puts("#{to_whitespace(space_area)}#{'^' * Unicode::DisplayWidth.of(source_area)}")
+      end
+
+      def to_whitespace(string)
+        "#{string.delete("^\t")}#{' ' * Unicode::DisplayWidth.of(string.delete("\t"))}"
       end
     end
   end

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -39,8 +39,11 @@ module RuboCop
       def report_highlighted_area(highlighted_area)
         space_area  = highlighted_area.source_buffer.slice(0...highlighted_area.begin_pos)
         source_area = highlighted_area.source
-        output.puts("# #{' ' * Unicode::DisplayWidth.of(space_area)}" \
-                    "#{'^' * Unicode::DisplayWidth.of(source_area)}")
+        output.puts("# #{to_whitespace(space_area)}#{'^' * Unicode::DisplayWidth.of(source_area)}")
+      end
+
+      def to_whitespace(string)
+        "#{string.delete("^\t")}#{' ' * Unicode::DisplayWidth.of(string.delete("\t"))}"
       end
 
       def report_offense(file, offense)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1703,7 +1703,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             'example2.rb:3:2: C: [Correctable] Layout/InitialIndentation: ' \
             'Indentation of first line in file detected.',
             "\tx",
-            ' ^',
+            "\t^",
             'example2.rb:4:1: C: [Correctable] Layout/IndentationConsistency: ' \
             'Inconsistent indentation detected.',
             'def a ...',

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -127,5 +127,27 @@ RSpec.describe RuboCop::Formatter::ClangStyleFormatter, :config do
         OUTPUT
       end
     end
+
+    context 'when the source contains tabs' do
+      let(:source) do
+        <<~RUBY
+          \t\t\tdo_something("[123]")
+        RUBY
+      end
+
+      it 'preserves tabs in highlighted area' do
+        range = source_range(source.index('[')..source.index(']'))
+
+        offenses = cop.add_offense(range, message: 'message 1')
+        formatter.report_file('test', offenses)
+
+        expect(output.string)
+          .to eq <<~OUTPUT
+            test:1:18: C: message 1
+            \t\t\tdo_something("[123]")
+            \t\t\t              ^^^^^
+        OUTPUT
+      end
+    end
   end
 end

--- a/spec/rubocop/formatter/tap_formatter_spec.rb
+++ b/spec/rubocop/formatter/tap_formatter_spec.rb
@@ -165,5 +165,27 @@ RSpec.describe RuboCop::Formatter::TapFormatter do
         OUTPUT
       end
     end
+
+    context 'when the source contains tabs' do
+      let(:source) do
+        <<~RUBY
+          \t\t\tdo_something("[123]")
+        RUBY
+      end
+
+      it 'preserves tabs in highlighted area' do
+        range = source_range(source.index('[')..source.index(']'))
+
+        offenses = cop.add_offense(range, message: 'message 1')
+        formatter.report_file('test', offenses)
+
+        expect(output.string)
+          .to eq <<~OUTPUT
+            # test:1:18: C: message 1
+            # \t\t\tdo_something("[123]")
+            # \t\t\t              ^^^^^
+        OUTPUT
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #10956.

Currently, when displaying offense highlight (i.e., `^^^^ Offense message`), all characters in the source before the highlighted area are converted to a space. This would result in misaligned source and highlighted area when the source contains tabs before the offending code.

For example, source (6 tabs before `vary`):
```ruby
						vary.map {  |key| headers[key] }
```

would report:
<img width="591" height="160" alt="image" src="https://github.com/user-attachments/assets/2a78f905-40d9-441d-874c-df951a7fa74f" />

This PR changes display logic in Clang and Tap formatters so they preserve tabs before the first `^` character. With the fix, the same file displays the highlight in the expected location (in the first run file is indented using spaces and in the second run it's indented using tabs):
<img width="596" height="316" alt="Screenshot 2026-01-25 at 13 30 44" src="https://github.com/user-attachments/assets/5089f935-9912-4348-b1fd-3a1870967bda" />

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
