### PR TITLE
Fix an error for `Layout/IndentationWidth` cop

### DIFF
--- a/changelog/fix_an_error_for_layout_indentation_width_cop_20260127141205.md
+++ b/changelog/fix_an_error_for_layout_indentation_width_cop_20260127141205.md
@@ -1,0 +1,1 @@
+* [#14803](https://github.com/rubocop/rubocop/pull/14803): Fix an error for `Layout/IndentationWidth` cop. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -424,7 +424,7 @@ module RuboCop
         end
 
         def contains_access_modifier?(body_node)
-          return false unless body_node.begin_type?
+          return false unless body_node&.begin_type?
 
           body_node.children.any? { |child| child.send_type? && child.bare_access_modifier? }
         end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1598,6 +1598,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             end
           RUBY
         end
+
+        it 'does not register an offense for an empty block body' do
+          expect_no_offenses(<<~RUBY)
+            some_block do
+              # intentionally left empty
+            end
+          RUBY
+        end
       end
 
       it 'registers an offense for bad indentation of a do/end body' do


### PR DESCRIPTION
Fixup https://github.com/rubocop/rubocop/commit/9eb0b40d54362e713f20e6c17621104d115854bb

Without the patch applied:

```shell
Failures:

  1) RuboCop::Cop::Layout::IndentationWidth with Width set to 2 with block when consistency style is indented_internal_methods does not register an offense for an empty block body
     Failure/Error: return false unless body_node.begin_type?

     NoMethodError:
       undefined method 'begin_type?' for nil
     # ./lib/rubocop/cop/layout/indentation_width.rb:427:in 'RuboCop::Cop::Layout::IndentationWidth#contains_access_modifier?'
     # ./lib/rubocop/cop/layout/indentation_width.rb:107:in 'RuboCop::Cop::Layout::IndentationWidth#on_block'
     # ./lib/rubocop/cop/commissioner.rb:107:in 'Kernel#public_send'
     # ./lib/rubocop/cop/commissioner.rb:107:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:171:in 'RuboCop::Cop::Commissioner#with_cop_error_handling'
     # ./lib/rubocop/cop/commissioner.rb:106:in 'block in RuboCop::Cop::Commissioner#trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:105:in 'Array#each'
     # ./lib/rubocop/cop/commissioner.rb:105:in 'RuboCop::Cop::Commissioner#trigger_responding_cops'
     # ./lib/rubocop/cop/commissioner.rb:69:in 'RuboCop::Cop::Commissioner#on_block'
     # ./lib/rubocop/cop/commissioner.rb:87:in 'RuboCop::Cop::Commissioner#investigate'
     # ./lib/rubocop/cop/team.rb:174:in 'RuboCop::Cop::Team#investigate_partial'
     # ./lib/rubocop/cop/team.rb:108:in 'RuboCop::Cop::Team#investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:91:in 'CopHelper#_investigate'
     # ./lib/rubocop/rspec/cop_helper.rb:37:in 'CopHelper#inspect_source'
     # ./lib/rubocop/rspec/expect_offense.rb:197:in 'RuboCop::RSpec::ExpectOffense#expect_no_offenses'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
