### PR TITLE
[Fix #14806] Fix an error in `Style/NegativeArrayIndex`

### DIFF
--- a/changelog/fix_an_error_in_style_negative_array_index.md
+++ b/changelog/fix_an_error_in_style_negative_array_index.md
@@ -1,0 +1,1 @@
+* [#14806](https://github.com/rubocop/rubocop/issues/14806): Fix an error in `Style/NegativeArrayIndex` when using `self` as array with implicit `self` receiver. ([@koic][])

--- a/lib/rubocop/cop/style/negative_array_index.rb
+++ b/lib/rubocop/cop/style/negative_array_index.rb
@@ -182,6 +182,8 @@ module RuboCop
         end
 
         def receivers_match?(length_receiver, array_receiver)
+          return array_receiver.self_type? unless length_receiver
+
           unless preserving_method?(array_receiver) && preserving_method?(length_receiver)
             return false
           end


### PR DESCRIPTION
This PR fixes an error in `Style/NegativeArrayIndex` when using `self` as array with implicit `self` receiver.

Fixes #14806.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
