### PR TITLE
Do not autocorrect `Style/RedundantAssignment` offenses when there are comments between assignment and reference

### DIFF
--- a/changelog/change_style_redundant_assignment_skip_correction_for_comments.md
+++ b/changelog/change_style_redundant_assignment_skip_correction_for_comments.md
@@ -1,0 +1,1 @@
+* [#14809](https://github.com/rubocop/rubocop/pull/14809): Do not autocorrect `Style/RedundantAssignment` offenses when there are comments between assignment and reference. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/redundant_assignment_spec.rb
+++ b/spec/rubocop/cop/style/redundant_assignment_spec.rb
@@ -250,4 +250,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantAssignment, :config do
       end
     RUBY
   end
+
+  it 'reports an offense for def ending with assignment and returning with comment in between, but does not autocorrect' do
+    expect_offense(<<~RUBY)
+      def func
+        some_preceding_statements
+        x = something
+        ^^^^^^^^^^^^^ Redundant assignment before returning detected.
+        # something important about x
+        x
+      end
+    RUBY
+
+    expect_no_corrections
+  end
 end


### PR DESCRIPTION
Redo of https://github.com/rubocop/rubocop/pull/13911.

When there's a `Style/RedundantAssignment` offense and there are comments between assignment and reference:
```ruby
def foo
  x = something
  # TODO: disabled this because of an edge case bug, see ...
  # assert_bar!(x)
  x
end
```
the cop will currently autocorrect like so:
```ruby
def foo
  something
  # TODO: disabled this because of an edge case bug, see ...
  # assert_bar!(x)
end
```
which is not desired.

This PR makes the cop still register an offense, but it does not autocorrect, so that developers can decide manually what to do with the assignment and comments. These cases are rare enough anyway (based on my experience with this cop), so I believe that having to fix the offense manually won't be a nuisance to developers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
