### PR TITLE
Fix cop exclusion precedence to favor configuration

### DIFF
--- a/changelog/fix_exclude_pattern_precedence_over_opt_in_comments.md
+++ b/changelog/fix_exclude_pattern_precedence_over_opt_in_comments.md
@@ -1,0 +1,1 @@
+* [#14813](https://github.com/rubocop/rubocop/pull/14813): Fix opt-in cop comments taking precedence over configuration file exclude patterns. ([@afrase][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -908,6 +908,10 @@ class Ingredient
 end
 ----
 
+NOTE: If a file is excluded via configuration (e.g., in `.rubocop.yml` or `.rubocop_todo.yml`),
+`rubocop:enable` comments within that file will have no effect. Configuration-based exclusions take
+precedence over in-source opt-in directives.
+
 == Scoped disabling with push/pop directives
 
 When you want to temporarily change cop settings for a specific section of code

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -177,8 +177,8 @@ module RuboCop
       # @return [Array<cop>]
       def roundup_relevant_cops(processed_source)
         cops.select do |cop|
-          next true if processed_source.comment_config.cop_opted_in?(cop)
           next false if cop.excluded_file?(processed_source.file_path)
+          next true if processed_source.comment_config.cop_opted_in?(cop)
           next false unless @registry.enabled?(cop, @config)
 
           support_target_ruby_version?(cop) && support_target_rails_version?(cop)

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -128,6 +128,20 @@ RSpec.describe RuboCop::Cop::Team do
           expect(cop_names).not_to include('Layout/LineLength')
         end
       end
+
+      context 'when a cop is excluded but has an opt-in comment' do
+        before do
+          create_file(file_path, ['# rubocop:enable Layout/LineLength', '#' * 130, 'puts *test'])
+        end
+
+        it 'still excludes the cop (exclude pattern takes precedence over opt-in)' do
+          allow_any_instance_of(RuboCop::Cop::Layout::LineLength)
+            .to receive(:excluded_file?).and_return(true)
+
+          expect(cop_names).to include('Lint/AmbiguousOperator')
+          expect(cop_names).not_to include('Layout/LineLength')
+        end
+      end
     end
 
     context 'when autocorrection is enabled' do


### PR DESCRIPTION
Currently, if you excluded a file in the config (`.rubocop.yml`/`.rubocop_todo.yml`) but the file contained an opt-in comment (`rubocop:enable`), it would take precedent and include the file anyway. This caused issues with generating todo files since it would exclude the file in the todo but then get included by the comment, thus failing the run.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
