### PR TITLE
Fix push/pop directives to properly handle nested scopes and state re…

### DIFF
--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -300,8 +300,7 @@ RSpec.describe RuboCop::CommentConfig do
         <<~RUBY
           def process_data(input)
             result = input.upcase
-            # rubocop:push
-            # rubocop:disable Style/GuardClause
+            # rubocop:push -Style/GuardClause
             if result.present?
               return result.strip
             end
@@ -315,9 +314,9 @@ RSpec.describe RuboCop::CommentConfig do
         disabled = disabled_lines_of_cop('Style/GuardClause')
 
         # Lines 4-7 should be disabled (push to pop)
-        expect(disabled).to include(4, 5, 6, 7)
+        expect(disabled).to include(4, 5, 6)
         # Lines outside push/pop should be enabled
-        expect(disabled).not_to include(1, 2, 3, 8, 9, 10)
+        expect(disabled).not_to include(1, 2, 7, 8, 9, 10)
       end
     end
 
@@ -328,8 +327,7 @@ RSpec.describe RuboCop::CommentConfig do
           def long_method
             line1
             line2
-            # rubocop:push
-            # rubocop:enable Metrics/MethodLength
+            # rubocop:push +Metrics/MethodLength
             def short_method
               line3
             end
@@ -344,11 +342,11 @@ RSpec.describe RuboCop::CommentConfig do
         disabled = disabled_lines_of_cop('Metrics/MethodLength')
 
         # Lines 1-6 should be disabled (before and including enable)
-        expect(disabled).to include(1, 2, 3, 4, 5, 6)
+        expect(disabled).to include(1, 2, 3, 4, 5)
         # Lines 7-9 should be enabled (after enable, inside push/pop)
-        expect(disabled).not_to include(7, 8, 9)
+        expect(disabled).not_to include(6, 7, 8)
         # Lines 10-13 should be disabled (after pop restores state)
-        expect(disabled).to include(10, 11, 12, 13)
+        expect(disabled).to include(9, 10, 11, 12, 13)
       end
     end
 
@@ -359,8 +357,7 @@ RSpec.describe RuboCop::CommentConfig do
           for x in [1, 2, 3]
             not x.nil?
           end
-          # rubocop:push
-          # rubocop:enable Style/For
+          # rubocop:push +Style/For
           for y in [4, 5, 6]
             not y.nil?
           end
@@ -376,9 +373,9 @@ RSpec.describe RuboCop::CommentConfig do
         not_disabled = disabled_lines_of_cop('Style/Not')
 
         # Style/For: disabled 1-6 (including enable line), enabled 7-9, disabled 10-13
-        expect(for_disabled).to include(1, 2, 3, 4, 5, 6)
-        expect(for_disabled).not_to include(7, 8, 9)
-        expect(for_disabled).to include(10, 11, 12, 13)
+        expect(for_disabled).to include(1, 2, 3, 4, 5)
+        expect(for_disabled).not_to include(6, 7, 8)
+        expect(for_disabled).to include(9, 10, 11, 12, 13)
 
         # Style/Not: disabled everywhere (never enabled)
         expect(not_disabled).to include(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
@@ -391,8 +388,7 @@ RSpec.describe RuboCop::CommentConfig do
           def process
             x = 1
             y = 2
-            # rubocop:push
-            # rubocop:disable Style/NumericPredicate
+            # rubocop:push -Style/NumericPredicate
             if x.size == 0
               puts 'empty'
             end
@@ -408,9 +404,9 @@ RSpec.describe RuboCop::CommentConfig do
         disabled = disabled_lines_of_cop('Style/NumericPredicate')
 
         # Lines 5-8 should be disabled (inside push/pop)
-        expect(disabled).to include(5, 6, 7, 8)
+        expect(disabled).to include(5, 6, 7)
         # Lines outside should be enabled
-        expect(disabled).not_to include(1, 2, 3, 4, 9, 10, 11, 12)
+        expect(disabled).not_to include(1, 2, 3, 8, 9, 10, 11, 12)
       end
     end
 
@@ -420,12 +416,9 @@ RSpec.describe RuboCop::CommentConfig do
           # rubocop:disable Metrics/MethodLength
           def complex_method
             step1
-            # rubocop:push
-            # rubocop:enable Metrics/MethodLength
-            # rubocop:disable Style/GuardClause
+            # rubocop:push +Metrics/MethodLength -Style/GuardClause
             def helper_method
-              # rubocop:push
-              # rubocop:enable Style/GuardClause
+              # rubocop:push +Style/GuardClause
               if condition
                 return value
               end
@@ -442,19 +435,17 @@ RSpec.describe RuboCop::CommentConfig do
         method_length_disabled = disabled_lines_of_cop('Metrics/MethodLength')
         guard_clause_disabled = disabled_lines_of_cop('Style/GuardClause')
 
-        # Metrics/MethodLength: disabled 1-5 (including enable line),
-        # enabled 6-15 (after enable), disabled 16-18 (after pop)
-        expect(method_length_disabled).to include(1, 2, 3, 4, 5)
-        expect(method_length_disabled).not_to include(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-        expect(method_length_disabled).to include(16, 17, 18)
+        # Metrics/MethodLength: disabled 1-4, enabled 5-12, disabled 13+
+        expect(method_length_disabled).to include(1, 2, 3, 4)
+        expect(method_length_disabled).not_to include(5, 6, 7, 8, 9, 10, 11, 12)
+        expect(method_length_disabled).to include(13, 14, 15)
 
-        # Style/GuardClause: enabled 1-5, disabled 6-9 (including enable line),
-        # enabled 10-12, disabled 13-15 (after nested pop), enabled 16-18
-        expect(guard_clause_disabled).not_to include(1, 2, 3, 4, 5)
-        expect(guard_clause_disabled).to include(6, 7, 8, 9)
-        expect(guard_clause_disabled).not_to include(10, 11, 12)
-        expect(guard_clause_disabled).to include(13, 14, 15)
-        expect(guard_clause_disabled).not_to include(16, 17, 18)
+        # Style/GuardClause: enabled 1-3, disabled 4-6, enabled 7-9, disabled 10-12, enabled 13+
+        expect(guard_clause_disabled).not_to include(1, 2, 3)
+        expect(guard_clause_disabled).to include(4, 5, 6)
+        expect(guard_clause_disabled).not_to include(7, 8, 9)
+        expect(guard_clause_disabled).to include(10, 11, 12)
+        expect(guard_clause_disabled).not_to include(13, 14, 15)
       end
     end
 
@@ -462,8 +453,7 @@ RSpec.describe RuboCop::CommentConfig do
       let(:source) do
         <<~RUBY
           def configure(stage)
-            # rubocop:push
-            # rubocop:disable Layout/SpaceAroundMethodCallOperator
+            # rubocop:push -Layout/SpaceAroundMethodCallOperator
             self.stage =
               if    'macro'  .start_with? stage; Langeod::MACRO
               elsif 'dynamic'.start_with? stage; Langeod::DYNAMIC
@@ -480,9 +470,9 @@ RSpec.describe RuboCop::CommentConfig do
         disabled = disabled_lines_of_cop('Layout/SpaceAroundMethodCallOperator')
 
         # Lines 3-9 should be disabled (from disable to before pop)
-        expect(disabled).to include(3, 4, 5, 6, 7, 8, 9)
+        expect(disabled).to include(2, 3, 4, 5, 6, 7, 8)
         # Lines outside push/pop should be enabled
-        expect(disabled).not_to include(1, 2, 10, 11, 12)
+        expect(disabled).not_to include(1, 10, 11, 12)
       end
     end
 
@@ -612,6 +602,160 @@ RSpec.describe RuboCop::CommentConfig do
 
         # Metrics/MethodLength: enabled 4-10
         expect(method_disabled).not_to include(4, 5, 6, 7, 8, 9, 10)
+      end
+    end
+
+    context 'push/pop with departments' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable Style
+          def method_one
+            x = 1
+            # rubocop:push +Style
+            if condition
+              y = 2
+            end
+            # rubocop:pop
+            z = 3
+          end
+        RUBY
+      end
+
+      it 'enables all cops in a department temporarily' do
+        guard_clause_disabled = disabled_lines_of_cop('Style/GuardClause')
+        string_literals_disabled = disabled_lines_of_cop('Style/StringLiterals')
+
+        # Both Style cops should be disabled on lines 1-4
+        expect(guard_clause_disabled).to include(1, 2, 3, 4)
+        expect(string_literals_disabled).to include(1, 2, 3, 4)
+
+        # Both should be enabled on lines 5-7 (inside push/pop)
+        expect(guard_clause_disabled).not_to include(5, 6, 7)
+        expect(string_literals_disabled).not_to include(5, 6, 7)
+
+        # Both should be disabled again on lines 8-9 (after pop)
+        expect(guard_clause_disabled).to include(8, 9)
+        expect(string_literals_disabled).to include(8, 9)
+      end
+    end
+
+    context 'push/pop disabling a department' do
+      let(:source) do
+        <<~RUBY
+          def method_one
+            x = 1
+            # rubocop:push -Metrics
+            def long_method
+              line1
+              line2
+              line3
+            end
+            # rubocop:pop
+            y = 2
+          end
+        RUBY
+      end
+
+      it 'disables all cops in a department temporarily' do
+        method_length_disabled = disabled_lines_of_cop('Metrics/MethodLength')
+        abc_size_disabled = disabled_lines_of_cop('Metrics/AbcSize')
+
+        # Both Metrics cops should be enabled on lines 1-3
+        expect(method_length_disabled).not_to include(1, 2)
+        expect(abc_size_disabled).not_to include(1, 2)
+
+        # Both should be disabled on lines 4-8 (inside push/pop)
+        expect(method_length_disabled).to include(4, 5, 6, 7, 8)
+        expect(abc_size_disabled).to include(4, 5, 6, 7, 8)
+
+        # Both should be enabled again on lines 9-10 (after pop)
+        expect(method_length_disabled).not_to include(9, 10)
+        expect(abc_size_disabled).not_to include(9, 10)
+      end
+    end
+
+    context 'nested push/pop with mixed departments and cops' do
+      let(:source) do
+        <<~RUBY
+          def outer_method
+            # rubocop:push -Metrics
+            def middle_method
+              # rubocop:push +Metrics/MethodLength -Style/GuardClause
+              def inner_method
+                if condition
+                  return value
+                end
+              end
+              # rubocop:pop
+              code
+            end
+            # rubocop:pop
+            final
+          end
+        RUBY
+      end
+
+      it 'handles complex nested department and cop directives' do
+        method_length_disabled = disabled_lines_of_cop('Metrics/MethodLength')
+        abc_size_disabled = disabled_lines_of_cop('Metrics/AbcSize')
+        guard_clause_disabled = disabled_lines_of_cop('Style/GuardClause')
+
+        # Lines 1-2: all enabled
+        expect(method_length_disabled).not_to include(1)
+        expect(abc_size_disabled).not_to include(1)
+        expect(guard_clause_disabled).not_to include(1)
+
+        # Lines 3-4: Metrics department disabled
+        expect(method_length_disabled).to include(3, 4)
+        expect(abc_size_disabled).to include(3, 4)
+        expect(guard_clause_disabled).not_to include(3)
+
+        # Lines 5-9: MethodLength re-enabled, AbcSize remains disabled, GuardClause disabled
+        expect(method_length_disabled).not_to include(5, 6, 7, 8, 9)
+        expect(abc_size_disabled).to include(5, 6, 7, 8, 9)
+        expect(guard_clause_disabled).to include(5, 6, 7, 8, 9)
+
+        # Lines 10-11: back to Metrics department disabled, GuardClause enabled
+        expect(method_length_disabled).to include(10, 11)
+        expect(abc_size_disabled).to include(10, 11)
+        expect(guard_clause_disabled).not_to include(10, 11)
+
+        # Lines 12+: all enabled
+        expect(method_length_disabled).not_to include(13, 14)
+        expect(abc_size_disabled).not_to include(13, 14)
+        expect(guard_clause_disabled).not_to include(13, 14)
+      end
+    end
+
+    context 'push/pop with multiple departments' do
+      let(:source) do
+        <<~RUBY
+          def method_one
+            # rubocop:push -Metrics -Style
+            def method_two
+              code
+            end
+            # rubocop:pop
+            final
+          end
+        RUBY
+      end
+
+      it 'disables multiple departments at once' do
+        method_length_disabled = disabled_lines_of_cop('Metrics/MethodLength')
+        guard_clause_disabled = disabled_lines_of_cop('Style/GuardClause')
+
+        # Lines 1-2: both enabled
+        expect(method_length_disabled).not_to include(1)
+        expect(guard_clause_disabled).not_to include(1)
+
+        # Lines 3-5: both disabled
+        expect(method_length_disabled).to include(3, 4, 5)
+        expect(guard_clause_disabled).to include(3, 4, 5)
+
+        # Lines 6-7: both enabled again
+        expect(method_length_disabled).not_to include(6, 7)
+        expect(guard_clause_disabled).not_to include(6, 7)
       end
     end
   end


### PR DESCRIPTION
 # Commit message
Refactor the push/pop directive implementation to fix bugs in state management and scope handling. The previous implementation had issues with nested push/pop blocks and incorrect state restoration.

Key fixes:

* Fix `snapshot_cops` to only save affected cops instead of entire analysis
* Fix `resolve_push_cops` to properly expand department names
* Fix `apply_cop_op` to correctly start/stop disabled ranges at push line
* Fix `pop_state` to properly restore saved state and resume disabled ranges
  - When popping back to a disabled state, start new range from pop line
  - Correctly close any active disabled range before restoring

Bugs fixed:
- Nested push/pop blocks now properly restore intermediate states
- Department-level operations (+Metrics, -Style) now work correctly
- Mixed department and individual cop directives no longer conflict
- Pop correctly resumes disabled state from the pop line, not old line

Changes to directive behavior:
- Push directive line itself is included in the new state
- Pop line is where the old state resumes
- Multiple cops/departments in single directive are properly handled
- State stack only contains cops affected by that specific push

Updated tests to reflect correct line-by-line cop states across all push/pop scenarios including nested blocks and departments.

# Actual behavior

Push/pop directives had several bugs:

1. **Nested push/pop blocks did not restore state correctly**
```ruby
   # rubocop:disable Metrics/MethodLength
   def method
     # rubocop:push +Metrics/MethodLength
     code_here  # Still disabled (should be enabled)
     # rubocop:pop
   end
```

2. **Department-level operations were not supported**
```ruby
   # rubocop:push -Metrics
   def method
     # Metrics cops were not disabled
   end
   # rubocop:pop
```

3. **Pop reused old line numbers instead of starting new disabled ranges from pop line**

## Root cause

1. **Missing department expansion** - No logic to convert departments (e.g., "Metrics") into individual cop names
2. **Incorrect pop restoration** - Restored old `start_line_number` instead of creating new range from pop line  
3. **Wrong range boundaries** - Used exclusive range (`...`) instead of inclusive, causing off-by-one errors

Additionally, the `extra_enabled_comments_with_names` method did not filter out push/pop directives. When it encountered `# rubocop:push -CopName`, the `-CopName` part was passed to `handle_switch`, which incorrectly interpreted it as an enable directive.

## Fix

1. Added `expand_cop_name` to convert departments into individual cop names
2. Fixed `pop_state` to start new disabled ranges from pop line when restoring disabled state
3. Simplified `apply_cop_op` to properly handle `+`/`-` operations with inclusive ranges
4. Added guard `next if directive.push? || directive.pop?` in `extra_enabled_comments_with_names` to filter out push/pop directives before `handle_switch` processing

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
