### PR TITLE
Fix bad indentation introduce in #14709

### DIFF
--- a/changelog/fix_indentation_in_1.84.0.md
+++ b/changelog/fix_indentation_in_1.84.0.md
@@ -1,0 +1,1 @@
+* [#14805](https://github.com/rubocop/rubocop/issues/14805): Bring back the original indentation from before version 1.84.0. ([@Magikdidi24][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -473,10 +473,10 @@ module RuboCop
         end
 
         def block_body_indentation_base(node, end_loc)
-          if style != :relative_to_receiver || !dot_on_new_line?(node)
-            end_loc
-          else
+          if dot_on_new_line?(node)
             node.send_node.loc.dot
+          else
+            end_loc
           end
         end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3824,8 +3824,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
             Model
               .some_scope
               .find_each do |record|
-              record.do_something
-              record.do_something_else
+                record.do_something
+                record.do_something_else
             end
           end
       end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1739,7 +1739,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           foo
             .bar do |x|
           x
-          ^{} Use 2 (not 0) spaces for indentation.
+          ^ Use 2 (not -2) spaces for indentation.
           end
         RUBY
       end
@@ -1753,12 +1753,42 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'accepts block body indented relative to dot when end is at different column' do
+        expect_no_offenses(<<~RUBY)
+          out
+            .break
+            .sep_with_breaks(inner) { |v|
+              simplified_process(v)
+          }
+        RUBY
+      end
+
+      it 'accepts block body indented relative to dot with do...end' do
+        expect_no_offenses(<<~RUBY)
+          out
+            .break
+            .sep_with_breaks(inner) do |v|
+              simplified_process(v)
+          end
+        RUBY
+      end
+
+      it 'registers an offense when the chain receiver is long and body not indented relative to dot' do
+        expect_offense(<<~RUBY)
+          ::Some::Very::Long::Module::Name.active
+                                          .in_batches do |batch|
+            process(batch)
+            ^^^^^^^^^^^^^^ Use 2 (not -30) spaces for indentation.
+          end
+        RUBY
+      end
+
       it 'accepts correct indentation when the chain receiver is long' do
         expect_no_offenses(<<~RUBY)
           ::Some::Very::Long::Module::Name.active
                                           .in_batches do |batch|
-            process(batch)
-          end
+                                            process(batch)
+                                          end
         RUBY
       end
 


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced in #14709 where Layout/IndentationWidth incorrectly reports offenses for block bodies in method chains when the dot is on a new line.

Problem
When a method chain has the dot on a new line, the block body should be indented 2 spaces relative to the dot position, not relative to the closing } or end.

Before this fix, the following correct code was flagged as an offense:

```ruby
constrs
  .flat_map { |constr|
    case constr.sid  # Offense: "Use 2 (not 4) spaces for indentation"
    in :cconj
      constr
    end
  }
```
RuboCop was using the } position (column 2) as the base, expecting the body at column 4, but finding it at column 6.

## Solution
Changed block_body_indentation_base to always use the dot position as the indentation base when the dot is on a new line, regardless of the EnforcedStyleAlignWith setting.

```diff
 def block_body_indentation_base(node, end_loc)
-  if style != :relative_to_receiver || !dot_on_new_line?(node)
-    end_loc
-  else
+  if dot_on_new_line?(node)
     node.send_node.loc.dot
+  else
+    end_loc
   end
 end
```

## Correct - no offense

```ruby
out
  .method { |v|
    body  # indented 2 spaces relative to the dot
  }

# Offense - body not indented relative to dot
out
  .method { |v|
  body  # should be indented 2 more spaces
  }
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
