### PR TITLE
Fix incorrect autocorrect for `Style/GuardClause`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_guard_clause.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_guard_clause.md
@@ -1,0 +1,1 @@
+* [#14819](https://github.com/rubocop/rubocop/pull/14819): Fix incorrect autocorrect for `Style/GuardClause` when using heredoc as an argument of method call in raise in `else` branch. ([@koic][])


### PR DESCRIPTION
This PR fixes the following incorrect autocorrect for `Style/GuardClause` when using heredoc as an argument of method call in raise in `else` branch.

```console
$ cat example.rb
def func
  if condition
    foo
  else
    raise do_something(<<~MESSAGE)
      text
    MESSAGE
  end
end

$ bundle exec rubocop -a --only Style/GuardClause
(snip)

$ cat example.rb
def func
  raise do_something(<<~MESSAGE) unless condition
    foo

      text
    MESSAGE

end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
