### PR TITLE
[Fix #14817] Fix an infinite loop between `Layout/FirstArgumentIndentation` and `Layout/LineLength` when correcting method chains

### DIFF
--- a/changelog/fix_infinite_loop_with_layout_first_argument_indentation_and_layout_line_length.md
+++ b/changelog/fix_infinite_loop_with_layout_first_argument_indentation_and_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#14817](https://github.com/rubocop/rubocop/issues/14817): Fix an infinite loop between `Layout/FirstArgumentIndentation` and `Layout/LineLength` when correcting method chains. ([@ydakuka][])

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -374,6 +374,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                         bar: 3))
           RUBY
         end
+
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run(:foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                        )
+                        .ids)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, Diagnostic.where(
+              'limit >= 10',
+                        )
+                        .ids)
+          RUBY
+        end
       end
 
       context 'without outer parentheses' do
@@ -383,6 +400,79 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                         bar: 3)
           RUBY
         end
+
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run :foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                        )
+                        .ids
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run :foo, Diagnostic.where(
+              'limit >= 10',
+                        )
+                        .ids
+          RUBY
+        end
+      end
+    end
+
+    context 'for method chains' do
+      it 'corrects only the first argument, not the entire method chain' do
+        expect_offense(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+                course_sequence_memberships: {
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                  course: :course_components
+                }
+              )
+            .joins(:courses)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+              )
+            .joins(:courses)
+        RUBY
+      end
+
+      it 'corrects an under-indented first argument in a method chain' do
+        expect_offense(<<~RUBY)
+          result = Foo
+            .bar(
+          x: 1
+          ^^^^ Indent the first argument one step more than the start of the previous line.
+            )
+            .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          result = Foo
+            .bar(
+              x: 1
+            )
+            .baz
+        RUBY
+      end
+
+      it 'accepts properly indented first argument in a method chain' do
+        expect_no_offenses(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+            )
+            .joins(:courses)
+        RUBY
       end
     end
   end
@@ -521,6 +611,60 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               bar: 3)
           RUBY
         end
+
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run :foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                        )
+                        .ids
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run :foo, Diagnostic.where(
+              'limit >= 10',
+                        )
+                        .ids
+          RUBY
+        end
+      end
+    end
+
+    context 'for method chains' do
+      it 'corrects only the first argument when not inside a parenthesized call' do
+        expect_offense(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+                course_sequence_memberships: {
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                  course: :course_components
+                }
+              )
+            .joins(:courses)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+              )
+            .joins(:courses)
+        RUBY
+      end
+
+      it 'accepts properly indented first argument in a method chain' do
+        expect_no_offenses(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+            )
+            .joins(:courses)
+        RUBY
       end
     end
   end
@@ -549,6 +693,100 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         expect_no_offenses(<<~RUBY)
           @diagnostics.process(Diagnostic.new(
             :error, :token, { :token => name }, location))
+        RUBY
+      end
+
+      context 'with outer parentheses' do
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run(:foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                        )
+                        .ids)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, Diagnostic.where(
+              'limit >= 10',
+                        )
+                        .ids)
+          RUBY
+        end
+      end
+
+      context 'without outer parentheses' do
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run :foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                        )
+                        .ids
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run :foo, Diagnostic.where(
+              'limit >= 10',
+                        )
+                        .ids
+          RUBY
+        end
+      end
+    end
+
+    context 'for method chains' do
+      it 'corrects only the first argument, not the entire method chain' do
+        expect_offense(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+                course_sequence_memberships: {
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                  course: :course_components
+                }
+              )
+            .joins(:courses)
+        RUBY
+
+        expect_correction(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+              )
+            .joins(:courses)
+        RUBY
+      end
+
+      it 'corrects an under-indented first argument in a method chain' do
+        expect_offense(<<~RUBY)
+          result = Foo
+            .bar(
+          x: 1
+          ^^^^ Indent the first argument one step more than the start of the previous line.
+            )
+            .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          result = Foo
+            .bar(
+              x: 1
+            )
+            .baz
+        RUBY
+      end
+
+      it 'accepts properly indented first argument in a method chain' do
+        expect_no_offenses(<<~RUBY)
+          sequences = CourseSequence
+            .includes(
+              course_sequence_memberships: {
+                course: :course_components
+              }
+            )
+            .joins(:courses)
         RUBY
       end
     end
@@ -789,6 +1027,62 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
               ).freeze
         RUBY
       end
+
+      context 'for method chains' do
+        it 'corrects only the first argument, not the entire method chain' do
+          expect_offense(<<~RUBY)
+            sequences = CourseSequence
+              .includes(
+                  course_sequence_memberships: {
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
+                    course: :course_components
+                  }
+                )
+              .joins(:courses)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            sequences = CourseSequence
+              .includes(
+                course_sequence_memberships: {
+                  course: :course_components
+                }
+                )
+              .joins(:courses)
+          RUBY
+        end
+
+        it 'corrects an under-indented first argument in a method chain' do
+          expect_offense(<<~RUBY)
+            result = Foo
+              .bar(
+            x: 1
+            ^^^^ Indent the first argument one step more than the start of the previous line.
+              )
+              .baz
+          RUBY
+
+          expect_correction(<<~RUBY)
+            result = Foo
+              .bar(
+                x: 1
+              )
+              .baz
+          RUBY
+        end
+
+        it 'accepts properly indented first argument in a method chain' do
+          expect_no_offenses(<<~RUBY)
+            sequences = CourseSequence
+              .includes(
+                course_sequence_memberships: {
+                  course: :course_components
+                }
+              )
+              .joins(:courses)
+          RUBY
+        end
+      end
     end
 
     context 'when IndentationWidth:Width is 4' do
@@ -879,6 +1173,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
                         )
           RUBY
         end
+
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run(:foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than `Diagnostic.where(`.
+                        )
+                        .ids)
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run(:foo, Diagnostic.where(
+                        'limit >= 10',
+                        )
+                        .ids)
+          RUBY
+        end
       end
 
       context 'without outer parentheses' do
@@ -899,6 +1210,23 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
             foo = bar * run(
                           :foo, defaults.merge(
                                   bar: 3))
+          RUBY
+        end
+
+        it 'corrects only the first argument in a method chain, not the entire chain' do
+          expect_offense(<<~RUBY)
+            run :foo, Diagnostic.where(
+                          'limit >= 10',
+                          ^^^^^^^^^^^^^ Indent the first argument one step more than `Diagnostic.where(`.
+                        )
+                        .ids
+          RUBY
+
+          expect_correction(<<~RUBY)
+            run :foo, Diagnostic.where(
+                        'limit >= 10',
+                        )
+                        .ids
           RUBY
         end
       end


### PR DESCRIPTION
Fixes #14817

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
