### PR TITLE
[Fix #12754] Fix an infinite loop for `Style/IfUnlessModifier` when multiple `if`/`unless` statements share the same line in arrays, method arguments, or hash values

### DIFF
--- a/changelog/fix_infinite_loop_for_style_if_unless_modifier.md
+++ b/changelog/fix_infinite_loop_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#12754](https://github.com/rubocop/rubocop/issues/12754): Fix an infinite loop for `Style/IfUnlessModifier` when multiple `if`/`unless` statements share the same line in arrays, method arguments, or hash values. ([@ydakuka][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4204,4 +4204,22 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       '000000000000000000000000000'
     RUBY
   end
+
+  it 'does not cause an infinite loop between `Style/IfUnlessModifier` and `Layout/EndAlignment`, `Layout/IndentationWidth`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/LineLength:
+        Max: 100
+    YAML
+
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      def previous_or_next_page(page, text, classname)
+        tag :li, link(text, page || '#'), class: [(classname[0..3] if @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page)].join(' ')
+      end
+    RUBY
+
+    status = cli.run(['--autocorrect-all'])
+    expect(status).to eq(0)
+    expect($stderr.string).to eq('')
+  end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -922,6 +922,170 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         RUBY
       end
     end
+
+    context 'when array has multiple if/unless elements on same line' do
+      it 'accepts multiline if when sibling if starts on end line' do
+        expect_no_offenses(<<~RUBY)
+          [if a
+            b
+          end, if c
+            d
+          end]
+        RUBY
+      end
+
+      it 'accepts multiline if when sibling unless starts on end line' do
+        expect_no_offenses(<<~RUBY)
+          [(if a
+            b
+          end), (unless c
+            d
+          end)]
+        RUBY
+      end
+    end
+
+    context 'when array has single if element' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          [(if a
+            ^^ Favor modifier `if` usage [...]
+            b
+          end)]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [(b if a)]
+        RUBY
+      end
+    end
+
+    context 'when array has multiple ifs on separate lines' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          [
+            (if a
+             ^^ Favor modifier `if` usage [...]
+              b
+            end),
+            (if c
+             ^^ Favor modifier `if` usage [...]
+              d
+            end)
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            (b if a),
+            (d if c)
+          ]
+        RUBY
+      end
+    end
+
+    context 'when array has non-if begin sibling' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          [
+            (1 + 2),
+            (if a
+             ^^ Favor modifier `if` usage [...]
+              b
+            end)
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            (1 + 2),
+            (b if a)
+          ]
+        RUBY
+      end
+    end
+
+    context 'when ifs are in nested arrays' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          [
+            [(if a
+              ^^ Favor modifier `if` usage [...]
+              b
+            end)],
+            [(if c
+              ^^ Favor modifier `if` usage [...]
+              d
+            end)]
+          ]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [
+            [(b if a)],
+            [(d if c)]
+          ]
+        RUBY
+      end
+    end
+
+    context 'when three ifs share lines' do
+      it 'accepts all multiline ifs' do
+        expect_no_offenses(<<~RUBY)
+          [if a
+            b
+          end, if c
+            d
+          end, if e
+            f
+          end]
+        RUBY
+      end
+    end
+  end
+
+  context 'when method call has multiple if/unless arguments on same line' do
+    it 'accepts multiline if when sibling if starts on end line' do
+      expect_no_offenses(<<~RUBY)
+        foo(if a
+          b
+        end, if c
+          d
+        end)
+      RUBY
+    end
+
+    it 'accepts multiline if when sibling unless starts on end line' do
+      expect_no_offenses(<<~RUBY)
+        foo((if a
+          b
+        end), (unless c
+          d
+        end))
+      RUBY
+    end
+  end
+
+  context 'when safe navigation method call has multiple if arguments on same line' do
+    it 'accepts multiline if when sibling if starts on end line' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar(if a
+          b
+        end, if c
+          d
+        end)
+      RUBY
+    end
+
+    it 'accepts multiline if when parenthesized sibling if starts on end line' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar((if a
+          b
+        end), (if c
+          d
+        end))
+      RUBY
+    end
   end
 
   context 'when if-end condition is a value in a hash' do
@@ -957,6 +1121,89 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
             x: if a
                  #{body}
                end
+          }
+        RUBY
+      end
+    end
+
+    context 'when hash value has sibling if on end line' do
+      it 'accepts multiline if statements' do
+        expect_no_offenses(<<~RUBY)
+          {
+            x: [(if a
+              b
+            end), (if c
+              d
+            end)]
+          }
+        RUBY
+      end
+    end
+
+    context 'when hash has multiple if values on same line' do
+      it 'accepts multiline if statements' do
+        expect_no_offenses(<<~RUBY)
+          {
+            x: if a
+              b
+            end, y: if c
+              d
+            end
+          }
+        RUBY
+      end
+    end
+
+    context 'when hash has multiple parenthesized if values on same line' do
+      it 'accepts multiline if statements' do
+        expect_no_offenses(<<~RUBY)
+          {x: (if a
+            b
+          end), y: (if c
+            d
+          end)}
+        RUBY
+      end
+    end
+
+    context 'when multiple pairs each have an if value' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          {
+            x: (if a
+                ^^ Favor modifier `if` usage [...]
+              b
+            end),
+            y: (if c
+                ^^ Favor modifier `if` usage [...]
+              d
+            end)
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            x: (b if a),
+            y: (d if c)
+          }
+        RUBY
+      end
+    end
+
+    context 'when single if is direct hash value' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          {
+            x: if a
+               ^^ Favor modifier `if` usage [...]
+              b
+            end
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            x: (b if a)
           }
         RUBY
       end


### PR DESCRIPTION
Fixes #12754

Another PR for the same issue: #14699

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
