### PR TITLE
Allowlist `infinite?` for some cops

### DIFF
--- a/changelog/change_allowlist_infinite_for_some_cops.md
+++ b/changelog/change_allowlist_infinite_for_some_cops.md
@@ -1,0 +1,1 @@
+* [#14823](https://github.com/rubocop/rubocop/issues/14823): Add the built-in `infinite?` method to the allowlists for `Naming/PredicateMethod`, `Style/IfWithBooleanLiteralBranches`, and `Style/RedundantCondition`, in addition to the existing `nonzero?`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3113,6 +3113,7 @@ Naming/PredicateMethod:
   AllowBangMethods: false
   # Methods that are known to not return a boolean value, despite ending in `?`.
   WaywardPredicates:
+    - infinite?
     - nonzero?
 
 Naming/PredicatePrefix:
@@ -4444,6 +4445,7 @@ Style/IfWithBooleanLiteralBranches:
   VersionAdded: '1.9'
   SafeAutoCorrect: false
   AllowedMethods:
+    - infinite?
     - nonzero?
 
 Style/IfWithSemicolon:
@@ -5317,6 +5319,7 @@ Style/RedundantCondition:
   VersionAdded: '0.76'
   VersionChanged: '1.73'
   AllowedMethods:
+    - infinite?
     - nonzero?
 
 Style/RedundantConditional:

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -137,6 +137,17 @@ module RuboCop
       #     true
       #   end
       #
+      # @example WaywardPredicates: ['infinite?', 'nonzero?'] (default)
+      #   # good
+      #   def non_predicate_method(num)
+      #     num.infinite?
+      #   end
+      #
+      #   # good
+      #   def non_predicate_method(num)
+      #     num.nonzero?
+      #   end
+      #
       class PredicateMethod < Base
         include AllowedMethods
         include AllowedPattern

--- a/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
+++ b/lib/rubocop/cop/style/if_with_boolean_literal_branches.rb
@@ -54,7 +54,10 @@ module RuboCop
       #   # good (but potentially an unsafe correction)
       #   foo.do_something?
       #
-      # @example AllowedMethods: ['nonzero?'] (default)
+      # @example AllowedMethods: ['infinite?', 'nonzero?'] (default)
+      #   # good
+      #   num.infinite? ? true : false
+      #
       #   # good
       #   num.nonzero? ? true : false
       #

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -58,7 +58,10 @@ module RuboCop
       #   # good
       #   a.nil? || a
       #
-      # @example AllowedMethods: ['nonzero?'] (default)
+      # @example AllowedMethods: ['infinite?', 'nonzero?'] (default)
+      #   # good
+      #   num.infinite? ? true : false
+      #
       #   # good
       #   num.nonzero? ? true : false
       #


### PR DESCRIPTION
This is a partial solution to the composite issues proposed in #14823. This PR adds the built-in `infinite?` method to the allowlists for `Naming/PredicateMethod`, `Style/IfWithBooleanLiteralBranches`, and `Style/RedundantCondition`, in addition to the existing `nonzero?`.

This issue likely stems from having overlooked `infinite?` in the standard API: https://docs.ruby-lang.org/en/4.0/Float.html#method-i-infinite-3F

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
