### PR TITLE
[Fix #14756] Extend to detect more void contexts

### DIFF
--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1151,4 +1151,97 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       ((); 1)
     RUBY
   end
+
+  it 'registers an offense for void literal in case statement' do
+    expect_offense(<<~RUBY)
+      case foo when 1 then 2 end
+                           ^ Literal `2` used in void context.
+      top
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case foo when 1 then end
+      top
+    RUBY
+  end
+
+  it 'registers offenses for void literals in all case branches' do
+    expect_offense(<<~RUBY)
+      case foo
+      when 1 then 2
+                  ^ Literal `2` used in void context.
+      when 3 then 4
+                  ^ Literal `4` used in void context.
+      else 5
+           ^ Literal `5` used in void context.
+      end
+      top
+    RUBY
+  end
+
+  it 'does not register an offense for case statement on last line' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1 then 2
+      else 3
+      end
+    RUBY
+  end
+
+  it 'registers an offense for void literal in `next` within `each` block' do
+    expect_offense(<<~RUBY)
+      [1].each { next 2 }
+                      ^ Literal `2` used in void context.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1].each { next }
+    RUBY
+  end
+
+  it 'does not register an offense for `next` with value in `map` block' do
+    expect_no_offenses(<<~RUBY)
+      [1].map { next 2 }
+    RUBY
+  end
+
+  it 'registers an offense for void literal in `break` within `each` block' do
+    expect_offense(<<~RUBY)
+      [1].each { break 2 }
+                       ^ Literal `2` used in void context.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [1].each { break }
+    RUBY
+  end
+
+  it 'does not register an offense for `break` with value in `map` block' do
+    expect_no_offenses(<<~RUBY)
+      [1].map { break 2 }
+    RUBY
+  end
+
+  it 'registers an offense for void literal in case/in pattern matching' do
+    expect_offense(<<~RUBY)
+      case foo
+      in 1 then 2
+                ^ Literal `2` used in void context.
+      in 3 then 4
+                ^ Literal `4` used in void context.
+      else 5
+           ^ Literal `5` used in void context.
+      end
+      top
+    RUBY
+  end
+
+  it 'does not register an offense for case/in on last line' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      in 1 then 2
+      else 3
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Detect void context literals in:
- `case/when` branches
- `case/in` pattern matching branches
- `next` with value in `each` blocks
- `break` with value in `each` blocks

Before this change, only `if` modifier form was detected:
```  
2 if foo == 1  # detected
```
Now case statements and block control flow are also detected:
```
  case foo when 1 then 2 end  # detected
  [1].each { next 2 }         # detected
  [1].each { break 2 }        # detected
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
