### PR TITLE
[Fix #14837] Fix an error for `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_an_error_for_style_if_unless_modifier.md
+++ b/changelog/fix_an_error_for_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#14837](https://github.com/rubocop/rubocop/issues/14837): Fix an error for `Style/IfUnlessModifier` when the first value uses a normal `if` and the others use modifier `if`. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -264,7 +264,7 @@ module RuboCop
         end
 
         def shares_line_with?(inner, node)
-          inner.loc.line == node.loc.end.line || inner.loc.end.line == node.loc.line
+          same_line?(inner, node.loc.end) || same_line?(inner.loc.end, node)
         end
 
         def find_containing_collection(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -1208,6 +1208,27 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         RUBY
       end
     end
+
+    context 'when the first value uses a normal `if` and the others use modifier `if`' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          {
+            first_key: if first_cond
+                       ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+                            first_expr
+                          end,
+            second_key: (second_expr if second_cond)
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            first_key: (first_expr if first_cond),
+            second_key: (second_expr if second_cond)
+          }
+        RUBY
+      end
+    end
   end
 
   context 'when if-end condition has a first line comment' do


### PR DESCRIPTION
This PR fixes an error for `Style/IfUnlessModifier` when the first value uses a normal `if` and the others use modifier `if`.

Fixes #14837.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
