### PR TITLE
Fix EmptyLinesAfterModuleInclusion false positive for include in array

### DIFF
--- a/changelog/fix_empty_lines_after_module_inclusion_nested.md
+++ b/changelog/fix_empty_lines_after_module_inclusion_nested.md
@@ -1,0 +1,1 @@
+* [#14839](https://github.com/rubocop/rubocop/pull/14839): Fix a false positive for `Layout/EmptyLinesAfterModuleInclusion` when `include` is nested inside an array. ([@eugeneius][])

--- a/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
+++ b/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         def on_send(node)
           return if node.receiver || node.arguments.empty?
-          return if node.parent&.type?(:send, :any_block)
+          return if node.parent&.type?(:send, :any_block, :array)
 
           return if next_line_empty_or_enable_directive_comment?(node.last_line)
 

--- a/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
@@ -262,6 +262,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
     RUBY
   end
 
+  it 'does not register an offense for `include` inside an array' do
+    expect_no_offenses(<<~RUBY)
+      it 'something' do
+        match([include(foo), anything])
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `include` has zero arguments' do
     expect_no_offenses(<<~RUBY)
       class Foo


### PR DESCRIPTION
This cop was incorrectly registering an offense for `include` calls nested inside an array, as used in RSpec's `include` compound matcher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/