### PR TITLE
[Fix #14841] Fix false negatives in `Style/HashAsLastArrayItem`

### DIFF
--- a/changelog/fix_false_negatives_in_style_hash_as_last_array_item.md
+++ b/changelog/fix_false_negatives_in_style_hash_as_last_array_item.md
@@ -1,0 +1,1 @@
+* [#14841](https://github.com/rubocop/rubocop/issues/14841): Fix false negatives in `Style/HashAsLastArrayItem` when an array contains only a single hash element. ([@koic][])

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -36,7 +36,7 @@ module RuboCop
         def on_hash(node)
           return if node.children.first&.kwsplat_type?
           return unless (array = containing_array(node))
-          return unless last_array_item?(array, node) && explicit_array?(array)
+          return unless expected_braced_last_array_item?(array, node) && explicit_array?(array)
 
           if braces_style?
             check_braces(node)
@@ -52,10 +52,12 @@ module RuboCop
           parent if parent&.array_type?
         end
 
-        def last_array_item?(array, node)
-          return false if array.child_nodes.all?(&:hash_type?)
+        def expected_braced_last_array_item?(array, node)
+          return false if array.each_value.all? do |node|
+            node.hash_type? && (braces_style? ? node.braces? : !node.braces?)
+          end
 
-          array.children.last.equal?(node)
+          !array.values[-2]&.hash_type? && array.values.last.equal?(node)
         end
 
         def explicit_array?(array)

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -203,13 +203,13 @@ module RuboCop
 
         return [] if new_text == text
 
-        [
+        [{
           newText: new_text,
           range: {
             start: { line: 0, character: 0 },
             end: { line: text.count("\n") + 1, character: 0 }
           }
-        ]
+        }]
       end
 
       def diagnostic(file_uri, text)

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when the array contains only hash elements without braces' do
+      expect_offense(<<~RUBY)
+        [one: 1, two: 2]
+         ^^^^^^^^^^^^^^ Wrap hash in `{` and `}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [{one: 1, two: 2}]
+      RUBY
+    end
+
     it 'does not register an offense when hash with braces' do
       expect_no_offenses(<<~RUBY)
         [1, 2, { one: 1, two: 2 }]
@@ -68,6 +79,17 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
 
       expect_correction(<<~RUBY)
         [1, 2,  one: 1, two: 2, ]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the array contains only hash elements with braces' do
+      expect_offense(<<~RUBY)
+        [{one: 1, two: 2}]
+         ^^^^^^^^^^^^^^^^ Omit the braces around the hash.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [one: 1, two: 2]
       RUBY
     end
 

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'server initializes and responds with proper capabilities' do
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         id: 2,
         method: 'initialize',
         params: { probably: "Don't need real params for this test?" }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'did open' do
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         method: 'textDocument/didOpen',
         params: {
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
             version: 0
           }
         }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                 code_actions: [
                   {
                     edit: {
-                      documentChanges: [
+                      documentChanges: [{
                         edits: [
                           {
                             newText: "# frozen_string_literal: true\n",
@@ -92,14 +92,14 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                           }
                         ],
                         textDocument: { uri: 'file:///path/to/file.rb', version: nil }
-                      ]
+                      }]
                     },
                     kind: 'quickfix',
                     title: 'Autocorrect Style/FrozenStringLiteralComment',
                     isPreferred: true
                   }, {
                     edit: {
-                      documentChanges: [
+                      documentChanges: [{
                         edits: [
                           {
                             newText: ' # rubocop:disable Style/FrozenStringLiteralComment',
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                           }
                         ],
                         textDocument: { uri: 'file:///path/to/file.rb', version: nil }
-                      ]
+                      }]
                     },
                     kind: 'quickfix',
                     title: 'Disable Style/FrozenStringLiteralComment for this line'
@@ -134,23 +134,23 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                 code_actions: [
                   {
                     edit: {
-                      documentChanges: [
-                        edits: [
+                      documentChanges: [{
+                        edits: [{
                           newText: '', range: {
                             end: { character: 6, line: 2 },
                             start: { character: 4, line: 2 }
                           }
-                        ],
+                        }],
                         textDocument: { uri: 'file:///path/to/file.rb', version: nil }
-                      ]
+                      }]
                     },
                     kind: 'quickfix',
                     title: 'Autocorrect Layout/SpaceInsideArrayLiteralBrackets',
                     isPreferred: true
                   }, {
                     edit: {
-                      documentChanges: [
-                        edits: [
+                      documentChanges: [{
+                        edits: [{
                           newText: ' # rubocop:disable Layout/SpaceInsideArrayLiteralBrackets',
                           range: {
                             end: { character: 7, line: 2 },
@@ -158,9 +158,9 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                               character: 7, line: 2
                             }
                           }
-                        ],
+                        }],
                         textDocument: { uri: 'file:///path/to/file.rb', version: nil }
-                      ]
+                      }]
                     },
                     kind: 'quickfix',
                     title: 'Disable Layout/SpaceInsideArrayLiteralBrackets for this line'
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
   describe 'did open with multiline literal offense' do
     let(:long_line) { 'a' * 130 }
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         method: 'textDocument/didOpen',
         params: {
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
             version: 0
           }
         }
-      ]
+      }]
     end
 
     it 'uses block comments for disable quickfix inside multiline literals' do
@@ -243,7 +243,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'did open with multibyte character(utf-16)' do
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         method: 'textDocument/didOpen',
         params: {
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
             version: 0
           }
         }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -352,12 +352,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: "puts 'bye'\n",
           range: {
             start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -460,12 +460,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: "puts 'bye'\n",
           range: {
             start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -523,12 +523,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: "# frozen_string_literal: true\n\nputs 'bye'\n",
           range: {
             start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -593,7 +593,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts foo.equal?(bar)
             puts 'hi'
@@ -601,7 +601,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -669,7 +669,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts foo.equal?(bar)
               puts "hi"
@@ -677,7 +677,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -745,7 +745,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts foo.equal?(bar)
             puts 'hi'
@@ -753,7 +753,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -818,7 +818,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts 'hi'
             puts 'bye'
@@ -826,7 +826,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -894,7 +894,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts "hi"
             puts 'bye'
@@ -902,7 +902,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -970,7 +970,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts 'hi'
             puts 'bye'
@@ -978,7 +978,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -1047,7 +1047,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(format_result).to eq(
         jsonrpc: '2.0',
         id: 20,
-        result: [
+        result: [{
           newText: <<~RUBY,
             puts foo.equal?(bar)
             puts "hi"
@@ -1055,7 +1055,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           range: {
             start: { line: 0, character: 0 }, end: { line: 3, character: 0 }
           }
-        ]
+        }]
       )
     end
   end
@@ -1085,7 +1085,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
   describe 'initialized' do
     let(:requests) do
       [
-        jsonrpc: '2.0', id: 1, method: 'initialized', params: {}
+        { jsonrpc: '2.0', id: 1, method: 'initialized', params: {} }
       ]
     end
 
@@ -1142,7 +1142,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'unknown commands' do
     let(:requests) do
-      [
+      [{
         id: 18,
         jsonrpc: '2.0',
         method: 'textDocument/didMassage',
@@ -1154,7 +1154,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
             version: 0
           }
         }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -1173,7 +1173,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
   describe 'methodless requests are acked' do
     let(:requests) do
       [
-        jsonrpc: '2.0', id: 1, result: {}
+        { jsonrpc: '2.0', id: 1, result: {} }
       ]
     end
 
@@ -1186,7 +1186,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
   describe 'methodless and idless requests are dropped' do
     let(:requests) do
       [
-        jsonrpc: '2.0', result: {}
+        { jsonrpc: '2.0', result: {} }
       ]
     end
 
@@ -1216,7 +1216,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           method: 'workspace/executeCommand',
           params: {
             command: 'rubocop.formatAutocorrects',
-            arguments: [uri: 'file:///path/to/file.rb']
+            arguments: [{ uri: 'file:///path/to/file.rb' }]
           }
         }
       ]
@@ -1232,12 +1232,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           label: 'Format with RuboCop autocorrects',
           edit: {
             changes: {
-              'file:///path/to/file.rb': [
+              'file:///path/to/file.rb': [{
                 newText: "puts 'hi'\n",
                 range: {
                   start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
                 }
-              ]
+              }]
             }
           }
         }
@@ -1265,7 +1265,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           method: 'workspace/executeCommand',
           params: {
             command: 'rubocop.formatAutocorrects',
-            arguments: [uri: 'file:///path/to/file.rb']
+            arguments: [{ uri: 'file:///path/to/file.rb' }]
           }
         }
       ]
@@ -1281,12 +1281,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           label: 'Format with RuboCop autocorrects',
           edit: {
             changes: {
-              'file:///path/to/file.rb': [
+              'file:///path/to/file.rb': [{
                 newText: "foo { |_unused_variable| 42 }\n",
                 range: {
                   start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
                 }
-              ]
+              }]
             }
           }
         }
@@ -1314,7 +1314,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           method: 'workspace/executeCommand',
           params: {
             command: 'rubocop.formatAutocorrectsAll',
-            arguments: [uri: 'file:///path/to/file.rb']
+            arguments: [{ uri: 'file:///path/to/file.rb' }]
           }
         }
       ]
@@ -1330,7 +1330,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           label: 'Format all with RuboCop autocorrects',
           edit: {
             changes: {
-              'file:///path/to/file.rb': [
+              'file:///path/to/file.rb': [{
                 newText: <<~RUBY,
                   # frozen_string_literal: true
 
@@ -1339,7 +1339,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                 range: {
                   start: { line: 0, character: 0 }, end: { line: 1, character: 0 }
                 }
-              ]
+              }]
             }
           }
         }
@@ -1349,15 +1349,15 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'execute command with unsupported command' do
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         id: 99,
         method: 'workspace/executeCommand',
         params: {
           command: 'rubocop.somethingElse',
-          arguments: [uri: 'file:///path/to/file.rb']
+          arguments: [{ uri: 'file:///path/to/file.rb' }]
         }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -1375,7 +1375,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
 
   describe 'did open on ignored path' do
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         method: 'textDocument/didOpen',
         params: {
@@ -1387,7 +1387,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
             version: 0
           }
         }
-      ]
+      }]
     end
 
     it 'handles requests' do
@@ -1606,12 +1606,12 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
 
     let(:requests) do
-      [
+      [{
         jsonrpc: '2.0',
         id: 2,
         method: 'initialize',
         params: { probably: "Don't need real params for this test?" }
-      ]
+      }]
     end
 
     it 'logs an internal server error message' do


### PR DESCRIPTION
## Summary

This PR fixes false negatives in `Style/HashAsLastArrayItem` when an array contains only a single hash element.

Fixes #14841.

## Additional Information

While updating an existing false negative, I noticed that adding braces to multi-line hash elements looks unnatural, so I made some manual adjustments. I plan to address this separately as an existing issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
