### PR TITLE
[Fix #14843] Fix an error in `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_an_error_in_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_an_error_in_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#14843](https://github.com/rubocop/rubocop/issues/14843): Fix an error in `Layout/MultilineMethodCallIndentation` when a multiline method call follows a hash access. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -322,9 +322,9 @@ module RuboCop
         end
 
         def method_on_receiver_last_line?(node, base_receiver, type)
-          base_receiver &&
-            node.loc.dot.line == base_receiver.last_line &&
-            base_receiver.type?(type)
+          return false unless base_receiver
+
+          same_line?(node.loc.dot, base_receiver.source_range.end) && base_receiver.type?(type)
         end
 
         def get_dot_right_above(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -1230,6 +1230,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts correctly indented method calls after a hash access' do
+      expect_no_offenses(<<~RUBY)
+        hash[:key]
+          .do_something
+      RUBY
+    end
+
     it 'accepts indentation of consecutive lines in typical RSpec code' do
       expect_no_offenses(<<~RUBY)
         expect { Foo.new }.to change { Bar.count }


### PR DESCRIPTION
This PR fixes an error in `Layout/MultilineMethodCallIndentation` when a multiline method call follows a hash access.

Fixes #14843.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
