### PR TITLE
[Fix #14833] Fix false positive for `Layout/MultilineMethodCallIndentation` when a multi-dot method chain is inside a hash pair value

### DIFF
--- a/changelog/fix_false_positive_for_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_positive_for_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#14833](https://github.com/rubocop/rubocop/issues/14833): Fix false positive for `Layout/MultilineMethodCallIndentation` when a multi-dot method chain is inside a hash pair value. ([@ydakuka][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -153,6 +153,7 @@ module RuboCop
 
         def check_hash_pair_indentation(node, lhs, rhs)
           @base = find_hash_pair_alignment_base(node) || lhs.source_range
+          return if aligned_with_first_line_dot?(node, rhs)
 
           calculate_column_delta_offense(rhs, @base.column)
         end
@@ -163,6 +164,16 @@ module RuboCop
 
           first_call = first_call_has_a_dot(node)
           first_call.loc.dot.join(first_call.loc.selector)
+        end
+
+        def aligned_with_first_line_dot?(node, rhs)
+          return false unless rhs.source.start_with?('.', '&.')
+
+          first_call = first_call_has_a_dot(node)
+          return false if first_call == node.receiver
+
+          dot = first_call.loc.dot
+          dot.line == node.first_line && dot.column == rhs.column
         end
 
         def check_regular_indentation(node, lhs, rhs, given_style)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -486,6 +486,62 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           RUBY
         end
 
+        it 'accepts method chain in hash pair passed to method with non-constant receiver' do
+          expect_no_offenses(<<~RUBY)
+            method(key: value.foo.bar
+                             .baz)
+          RUBY
+        end
+
+        it 'accepts method chain in hash literal with non-constant receiver' do
+          expect_no_offenses(<<~RUBY)
+            {
+              key: value.foo.bar
+                        .baz
+            }
+          RUBY
+        end
+
+        it 'accepts safe navigation method chain in hash pair' do
+          expect_no_offenses(<<~RUBY)
+            method(key: value&.foo&.bar
+                             &.baz)
+          RUBY
+        end
+
+        it 'accepts multi-dot chain aligned with receiver start in hash pair' do
+          expect_no_offenses(<<~RUBY)
+            method(key: value.foo.bar
+                        .baz)
+          RUBY
+        end
+
+        it 'registers an offense for misaligned multi-dot chain in hash pair' do
+          expect_offense(<<~RUBY)
+            method(key: value.foo.bar
+                          .baz)
+                          ^^^^ Align `.baz` with `value.foo.bar` on line 1.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            method(key: value.foo.bar
+                        .baz)
+          RUBY
+        end
+
+        it 'registers an offense for trailing dot multi-dot chain in hash pair' do
+          expect_offense(<<~RUBY)
+            method(key: value.foo.bar.
+                             baz)
+                             ^^^ Align `baz` with `value.foo.bar.` on line 1.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            method(key: value.foo.bar.
+                        baz)
+          RUBY
+        end
+
         it 'registers an offense for misaligned method chain in hash pair' do
           expect_offense(<<~RUBY)
             {
@@ -1625,6 +1681,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
                         .first
       RUBY
     end
+
+    it 'accepts multi-dot method chain in hash pair passed to method' do
+      expect_no_offenses(<<~RUBY)
+        method(key: value.foo.bar
+                      .baz)
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is indented' do
@@ -1997,6 +2060,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
               .tap { |h| h[:component] = true }
               .to_json,
         )
+      RUBY
+    end
+
+    it 'accepts multi-dot method chain in hash pair passed to method' do
+      expect_no_offenses(<<~RUBY)
+        method(key: value.foo.bar
+          .baz)
       RUBY
     end
 


### PR DESCRIPTION
Fixes #14833

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
