### PR TITLE
[Fix #14829] Fix conflicting `Lint/EmptyClass` and `Style/EmptyClassDefinition` cops

### DIFF
--- a/changelog/fix_conflicting_lint_empty_class_and_style_empty_class_definition.md
+++ b/changelog/fix_conflicting_lint_empty_class_and_style_empty_class_definition.md
@@ -1,0 +1,1 @@
+* [#14829](https://github.com/rubocop/rubocop/issues/14829): Fix conflicting `Lint/EmptyClass` and `Style/EmptyClassDefinition` cops when both are enabled with default settings. ([@ydakuka][])

--- a/lib/rubocop/cop/lint/empty_class.rb
+++ b/lib/rubocop/cop/lint/empty_class.rb
@@ -75,7 +75,8 @@ module RuboCop
 
         def on_class(node)
           add_offense(node, message: CLASS_MSG) unless body_or_allowed_comment_lines?(node) ||
-                                                       node.parent_class
+                                                       node.parent_class ||
+                                                       empty_class_definition_enforced?
         end
 
         def on_sclass(node)
@@ -83,6 +84,11 @@ module RuboCop
         end
 
         private
+
+        def empty_class_definition_enforced?
+          empty_class_definition_config = config.for_enabled_cop('Style/EmptyClassDefinition')
+          empty_class_definition_config['EnforcedStyle'] == 'class_definition'
+        end
 
         def body_or_allowed_comment_lines?(node)
           return true if node.body

--- a/spec/rubocop/cop/lint/empty_class_spec.rb
+++ b/spec/rubocop/cop/lint/empty_class_spec.rb
@@ -2,6 +2,14 @@
 
 RSpec.describe RuboCop::Cop::Lint::EmptyClass, :config do
   let(:cop_config) { { 'AllowComments' => false } }
+  let(:other_cops) do
+    {
+      'Style/EmptyClassDefinition' => {
+        'Enabled' => false,
+        'EnforcedStyle' => 'class_definition'
+      }
+    }
+  end
 
   it 'registers an offense for empty class' do
     expect_offense(<<~RUBY)
@@ -63,6 +71,69 @@ RSpec.describe RuboCop::Cop::Lint::EmptyClass, :config do
         end
       end
     RUBY
+  end
+
+  context 'when Style/EmptyClassDefinition is enabled with class_definition style' do
+    let(:other_cops) do
+      {
+        'Style/EmptyClassDefinition' => {
+          'Enabled' => true,
+          'EnforcedStyle' => 'class_definition'
+        }
+      }
+    end
+
+    it 'does not register an offense for empty class' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+        end
+      RUBY
+    end
+
+    it 'still registers an offense for empty metaclass' do
+      expect_offense(<<~RUBY)
+        class << obj
+        ^^^^^^^^^^^^ Empty metaclass detected.
+        end
+      RUBY
+    end
+  end
+
+  context 'when Style/EmptyClassDefinition is pending with class_definition style' do
+    let(:other_cops) do
+      {
+        'Style/EmptyClassDefinition' => {
+          'Enabled' => 'pending',
+          'EnforcedStyle' => 'class_definition'
+        }
+      }
+    end
+
+    it 'does not register an offense for empty class' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+        end
+      RUBY
+    end
+  end
+
+  context 'when Style/EmptyClassDefinition is enabled with class_new style' do
+    let(:other_cops) do
+      {
+        'Style/EmptyClassDefinition' => {
+          'Enabled' => true,
+          'EnforcedStyle' => 'class_new'
+        }
+      }
+    end
+
+    it 'registers an offense for empty class' do
+      expect_offense(<<~RUBY)
+        class Foo
+        ^^^^^^^^^ Empty class detected.
+        end
+      RUBY
+    end
   end
 
   context 'when AllowComments is true' do


### PR DESCRIPTION
Fixes #14829

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
