### PR TITLE
[Fix #14847] Fix false positive for `Layout/MultilineMethodCallIndentation` when a method is chained after a single-line block

### DIFF
--- a/changelog/fix_false_positive_for_layout_multiline_method_call_indentation_with_single_line_block.md
+++ b/changelog/fix_false_positive_for_layout_multiline_method_call_indentation_with_single_line_block.md
@@ -1,0 +1,1 @@
+* [#14847](https://github.com/rubocop/rubocop/issues/14847): Fix false positive for `Layout/MultilineMethodCallIndentation` when a method is chained after a single-line block. ([@ydakuka][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -337,24 +337,33 @@ module RuboCop
         end
 
         def find_multiline_block_chain_node(node)
-          return find_continuation_receiver(node) if node.block_node
+          return find_continuation_node(node) if node.block_node
 
           handle_descendant_block(node)
         end
 
-        def find_continuation_receiver(node)
+        def find_continuation_node(node)
           receiver = node.receiver
-          return unless receiver.call_type? && receiver.loc.dot && receiver.receiver
+          return receiver.send_node if single_line_block_receiver?(receiver)
+          return unless receiver.call_type? && receiver.loc.dot
+          return receiver if receiver.receiver.begin_type? && node.block_node.single_line?
           return unless receiver.loc.dot.line > receiver.receiver.last_line
 
           receiver
         end
 
+        def single_line_block_receiver?(receiver)
+          receiver.single_line? && receiver.any_block_type?
+        end
+
         def handle_descendant_block(node)
+          receiver = node.receiver
+          return receiver.send_node if single_line_block_receiver?(receiver)
+
           block_node = node.each_descendant(:any_block).first
           return unless block_node&.multiline?
 
-          node.receiver.call_type? ? node.receiver : block_node.parent
+          receiver.call_type? ? receiver : block_node.parent
         end
 
         def first_call_has_a_dot(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -953,6 +953,73 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts aligned method chained after single-line block on both calls' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+                .qux { quux }
+      RUBY
+    end
+
+    it 'accepts aligned method chained after single-line block only on first call' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+                .qux
+      RUBY
+    end
+
+    it 'accepts aligned method chained after single-line block only on second call' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar
+                .qux { quux }
+      RUBY
+    end
+
+    it 'accepts aligned method chained after single-line block with safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+                &.qux { quux }
+      RUBY
+    end
+
+    it 'registers an offense for misaligned method chained after single-line block on both calls' do
+      expect_offense(<<~RUBY)
+        (0..foo).bar { baz }
+          .qux { quux }
+          ^^^^ Align `.qux` with `.bar` on line 1.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (0..foo).bar { baz }
+                .qux { quux }
+      RUBY
+    end
+
+    it 'registers an offense for misaligned method chained after single-line block only on first call' do
+      expect_offense(<<~RUBY)
+        (0..foo).bar { baz }
+          .qux
+          ^^^^ Align `.qux` with `.bar` on line 1.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (0..foo).bar { baz }
+                .qux
+      RUBY
+    end
+
+    it 'registers an offense for misaligned method chained after single-line block only on second call' do
+      expect_offense(<<~RUBY)
+        (0..foo).bar
+          .qux { quux }
+          ^^^^ Align `.qux` with `.bar` on line 1.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (0..foo).bar
+                .qux { quux }
+      RUBY
+    end
+
     it 'registers an offense and corrects misaligned methods in local variable assignment' do
       expect_offense(<<~RUBY)
         a = b.c.
@@ -1377,6 +1444,27 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts method chained after single-line block on both calls with receiver-relative indent' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+                  .qux { quux }
+      RUBY
+    end
+
+    it 'accepts method chained after single-line block only on first call with receiver-relative indent' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+                  .qux
+      RUBY
+    end
+
+    it 'accepts method chained after single-line block only on second call with receiver-relative indent' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar
+                  .qux { quux }
+      RUBY
+    end
+
     it 'registers an offense and corrects one space indentation of 2nd line' do
       expect_offense(<<~RUBY)
         a
@@ -1641,6 +1729,27 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           .nil?
           ^^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
         end
+      RUBY
+    end
+
+    it 'accepts indented method chained after single-line block on both calls' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+          .qux { quux }
+      RUBY
+    end
+
+    it 'accepts indented method chained after single-line block only on first call' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar { baz }
+          .qux
+      RUBY
+    end
+
+    it 'accepts indented method chained after single-line block only on second call' do
+      expect_no_offenses(<<~RUBY)
+        (0..foo).bar
+          .qux { quux }
       RUBY
     end
 


### PR DESCRIPTION
Fixes #14847

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
