### PR TITLE
[Fix #7436] Fix `Style/FormatStringToken` to not autocorrect strings outside of format method context in aggressive mode

### DIFF
--- a/changelog/fix_false_autocorrect_in_style_format_string_token.md
+++ b/changelog/fix_false_autocorrect_in_style_format_string_token.md
@@ -1,0 +1,1 @@
+* [#7436](https://github.com/rubocop/rubocop/issues/7436): Fix `Style/FormatStringToken` to not autocorrect strings outside of format method context in aggressive mode. ([@ydakuka][])


### PR DESCRIPTION
Fixes #7436, #11225 as suggested here https://github.com/rubocop/rubocop/issues/7436#issuecomment-698395229

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
