### PR TITLE
[Fix #14791] Fix autocorrect producing `SyntaxError` in `Lint/InterpolationCheck` when single quoted string contains double quotes with invalid interpolation

### DIFF
--- a/changelog/fix_syntax_error_for_lint_interpolation_check.md
+++ b/changelog/fix_syntax_error_for_lint_interpolation_check.md
@@ -1,0 +1,1 @@
+* [#14791](https://github.com/rubocop/rubocop/issues/14791): Fix autocorrect producing `SyntaxError` in `Lint/InterpolationCheck` when single quoted string contains double quotes with invalid interpolation. ([@ydakuka][])

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -54,9 +54,14 @@ module RuboCop
         end
 
         def valid_syntax?(node)
-          double_quoted_string = node.source.gsub(/\A'|'\z/, '"')
+          double_quoted_string = if node.source.include?('"')
+                                   node.source.sub(/\A'/, '%{').sub(/'\z/, '}')
+                                 else
+                                   node.source.gsub(/\A'|'\z/, '"')
+                                 end
 
-          parse(double_quoted_string).valid_syntax?
+          processed_source = parse(double_quoted_string)
+          processed_source.valid_syntax? && processed_source.ast.dstr_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when containing a closing brace without double quotes' do
+    expect_offense(<<~'RUBY')
+      'foo #{bar} }'
+      ^^^^^^^^^^^^^^ Interpolation in single quoted string detected. Use double quoted strings if you need interpolation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "foo #{bar} }"
+    RUBY
+  end
+
   it 'registers an offense and corrects when including interpolation and double quoted string in single quoted string' do
     expect_offense(<<~'RUBY')
       'foo "#{bar}"'
@@ -84,6 +95,18 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck, :config do
   it 'does not register an offense when using invalid syntax in interpolation' do
     expect_no_offenses(<<~'RUBY')
       '#{%<expression>s}'
+    RUBY
+  end
+
+  it 'does not register an offense when using invalid syntax in interpolation with double quotes' do
+    expect_no_offenses(<<~'RUBY')
+      'Text `A("#{%<base>s}/%<path>s")` and `B` with C.'
+    RUBY
+  end
+
+  it 'does not register an offense when double quotes and unbalanced braces would break percent literal' do
+    expect_no_offenses(<<~'RUBY')
+      'a "b" } #{c}'
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #14791

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
