### PR TITLE
[Fix #14829] Allow classes without a superclass in `Style/EmptyClassDefinition`

### DIFF
--- a/changelog/fix_allow_classes_without_a_superclass_in_style_class_definition.md
+++ b/changelog/fix_allow_classes_without_a_superclass_in_style_class_definition.md
@@ -1,0 +1,1 @@
+* [#14829](https://github.com/rubocop/rubocop/issues/14829): Allow classes without a superclass in `Style/EmptyClassDefinition`. ([@koic][])

--- a/spec/rubocop/cop/style/empty_class_definition_spec.rb
+++ b/spec/rubocop/cop/style/empty_class_definition_spec.rb
@@ -16,15 +16,9 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       RUBY
     end
 
-    it 'registers an offense for Class.new assignment to constant without parent class' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for Class.new assignment to constant without parent class' do
+      expect_no_offenses(<<~RUBY)
         MyClass = Class.new
-        ^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        class MyClass
-        end
       RUBY
     end
 
@@ -299,26 +293,16 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       RUBY
     end
 
-    it 'registers an offense for two-line class definition without inheritance' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for two-line class definition without inheritance' do
+      expect_no_offenses(<<~RUBY)
         class MyClass
-        ^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        MyClass = Class.new
       RUBY
     end
 
-    it 'registers an offense for single-line class definition without inheritance' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for single-line class definition without inheritance' do
+      expect_no_offenses(<<~RUBY)
         class MyClass; end
-        ^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        MyClass = Class.new
       RUBY
     end
 


### PR DESCRIPTION
This PR updates `Style/EmptyClassDefinition` to ignore empty class definitions without a superclass.

One difference between the two `EnforcedStyle` options is that the `Class.new` form doesn't make the subclass name available to the base class's `inherited` callback, so `EnforcedStyle: class_definition` remains the default. Ignoring classes without a superclass also avoids conflicting with `Lint/EmptyClass` cop.

Resolves #14829.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
