### PR TITLE
[Fix #14861] Fix an error in `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_style_if_unless_modifier_crash_on_ternary.md
+++ b/changelog/fix_style_if_unless_modifier_crash_on_ternary.md
@@ -1,0 +1,1 @@
+* [#14861](https://github.com/rubocop/rubocop/issues/14861): Fix an error in `Style/IfUnlessModifier` when the first value uses a normal `if` and the others use ternary operator. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -253,7 +253,7 @@ module RuboCop
 
         def sibling_if_shares_line?(child, node)
           inner = unwrap_begin(child)
-          inner&.if_type? && shares_line_with?(inner, node)
+          inner&.if_type? && !inner.ternary? && shares_line_with?(inner, node)
         end
 
         def unwrap_begin(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -1229,6 +1229,27 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         RUBY
       end
     end
+
+    context 'when the first value uses a normal `if` and the others use ternary operator' do
+      it 'corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          {
+            first_key: if first_cond
+                       ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+                         first_expr
+                       end,
+            second_key: second_cond ? second_then : second_else
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {
+            first_key: (first_expr if first_cond),
+            second_key: second_cond ? second_then : second_else
+          }
+        RUBY
+      end
+    end
   end
 
   context 'when if-end condition has a first line comment' do


### PR DESCRIPTION
This PR fixes an error in `Style/IfUnlessModifier` when the first value uses a normal  `if` and the others use ternary operator.

Fixes #14861.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
