### PR TITLE
[Fix #14859] Fix an error in `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_an_error_in_layout_multiline_method_call_indentation_cop.md
+++ b/changelog/fix_an_error_in_layout_multiline_method_call_indentation_cop.md
@@ -1,0 +1,1 @@
+* [#14859](https://github.com/rubocop/rubocop/issues/14859): Fix an error in `Layout/MultilineMethodCallIndentation` when a multiline method call includes a keyword argument whose value is a method call with a block. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -269,7 +269,7 @@ module RuboCop
           return unless rhs.source.start_with?('.', '&.')
 
           node = semantic_alignment_node(node)
-          return unless node&.loc&.selector && node.loc.dot
+          return unless node&.loc?(:selector) && node.loc.dot
 
           node.loc.dot.join(node.loc.selector)
         end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -116,6 +116,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'does not register an offense when a keyword argument value is a method call with a block' do
+      expect_no_offenses(<<~RUBY)
+        Foo
+          .do_something(
+            key: value do
+            end
+          )
+      RUBY
+    end
+
     it 'accepts alignment of method with assignment and operator-like method' do
       expect_no_offenses(<<~RUBY)
         query = x.|(


### PR DESCRIPTION
This PR fixes an error in `Layout/MultilineMethodCallIndentation` when a multiline method call includes a keyword argument whose value is a method call with a block.

Fixes #14859.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
