### PR TITLE
[Fix #14854] Fix a clobbering error in `Style/BlockDelimiters`

### DIFF
--- a/changelog/fix_a_clobbering_error_in_style_block_delimiters.md
+++ b/changelog/fix_a_clobbering_error_in_style_block_delimiters.md
@@ -1,0 +1,1 @@
+* [#14854](https://github.com/rubocop/rubocop/issues/14854): Fix a clobbering error in `Style/BlockDelimiters` when autocorrecting nested multi-line blocks with adjacent curly braces. ([@koic][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -198,12 +198,13 @@ module RuboCop
         alias on_csend on_send
 
         def on_block(node)
-          return if ignored_node?(node)
+          return if part_of_ignored_node?(node)
           return if proper_block_style?(node)
 
           message = message(node)
           add_offense(node.loc.begin, message: message) do |corrector|
             autocorrect(corrector, node)
+            ignore_node(node)
           end
         end
 

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -624,6 +624,17 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
         RUBY
       end
 
+      it 'registers an offense for nested multi-line blocks with trailing comment' do
+        expect_offense(<<~RUBY)
+          blcck {
+                ^ Avoid using `{...}` for multi-line blocks.
+          }
+          block { foo {
+                ^ Avoid using `{...}` for multi-line blocks.
+          } }.bar # comment
+        RUBY
+      end
+
       it 'registers an offense when there is a comment after the closing brace and block body is not empty' do
         expect_offense(<<~RUBY)
           baz.map { |x|
@@ -815,16 +826,15 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       it 'autocorrects adjacent curly braces correctly' do
         expect_offense(<<~RUBY)
           (0..3).each { |a| a.times {
-                                    ^ Avoid using `{...}` for multi-line blocks.
                       ^ Avoid using `{...}` for multi-line blocks.
             puts a
           }}
         RUBY
 
         expect_correction(<<~RUBY)
-          (0..3).each do |a| a.times do
+          (0..3).each do |a| a.times {
             puts a
-          end end
+          } end
         RUBY
       end
 


### PR DESCRIPTION
This PR fixes a clobbering error in `Style/BlockDelimiters` when autocorrecting nested multi-line blocks with adjacent curly braces.

Fixes #14854.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
