### PR TITLE
[Fix #14865] Fix false negatives in `Style/MethodDefParentheses`

### DIFF
--- a/changelog/fix_false_negatives_in_style_method_def_parentheses.md
+++ b/changelog/fix_false_negatives_in_style_method_def_parentheses.md
@@ -1,0 +1,1 @@
+* [#14865](https://github.com/rubocop/rubocop/issues/14865): Fix false negatives in `Style/MethodDefParentheses` when using splat or forwarding arguments without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -103,8 +103,6 @@ module RuboCop
         MSG_MISSING = 'Use def with parentheses when there are parameters.'
 
         def on_def(node)
-          return if forced_parentheses?(node)
-
           args = node.arguments
 
           if require_parentheses?(args)
@@ -113,10 +111,10 @@ module RuboCop
             else
               correct_style_detected
             end
+          elsif forced_parentheses?(node)
+            correct_style_detected
           elsif parentheses?(args)
             unwanted_parentheses(args)
-          else
-            correct_style_detected
           end
         end
         alias on_defs on_def

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -188,6 +188,54 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       RUBY
     end
 
+    it 'registers an offense when using rest arguments without parentheses' do
+      expect_offense(<<~RUBY)
+        def foo *args
+                ^^^^^ Use def with parentheses when there are parameters.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(*args)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using keyword rest arguments without parentheses' do
+      expect_offense(<<~RUBY)
+        def foo **opts
+                ^^^^^^ Use def with parentheses when there are parameters.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(**opts)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using block argument without parentheses' do
+      expect_offense(<<~RUBY)
+        def foo &block
+                ^^^^^^ Use def with parentheses when there are parameters.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(&block)
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using forwarding arguments without parentheses', :ruby31 do
+      expect_offense(<<~RUBY)
+        def foo ...
+                ^^^ Use def with parentheses when there are parameters.
+          bar ...
+        end
+      RUBY
+    end
+
     it 'reports an offense for class def with parameters but no parens' do
       expect_offense(<<~RUBY)
         def Test.func a, b


### PR DESCRIPTION
This PR fixes false negatives in `Style/MethodDefParentheses` when using splat or forwarding arguments without parentheses.

Fixes #14865.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
