### PR TITLE
[Fix #14858] Fix an error in `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_an_error_in_layout_first_argument_indentation.md
+++ b/changelog/fix_an_error_in_layout_first_argument_indentation.md
@@ -1,0 +1,1 @@
+* [#14858](https://github.com/rubocop/rubocop/issues/14858): Fix an infinite loop error in `Layout/FirstArgumentIndentation` when first arguments are over-indented in nested method calls. ([@koic][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -187,6 +187,7 @@ module RuboCop
         def should_correct_entire_chain?(send_node, top_level_send)
           return false unless style == :special_for_inner_method_call_in_parentheses
           return false unless inner_call?(top_level_send)
+          return false unless display_column(send_node.source_range) < column_delta.abs
 
           top_level_send != send_node || begins_its_line?(top_level_send.loc.end)
         end

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -132,6 +132,50 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
 
+      it 'registers an offense and corrects over-indented first arguments in nested method calls' do
+        expect_offense(<<~RUBY)
+          foo
+            .bar(
+            baz(
+            ^^^^ Indent the first argument one step more than the start of the previous line.
+                qux
+                ^^^ Bad indentation of the first argument.
+              )
+            )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo
+            .bar(
+              baz(
+                qux
+                )
+            )
+        RUBY
+      end
+
+      it 'registers an offense and corrects over-indented first arguments in nested method calls with hash arguments' do
+        expect_offense(<<~RUBY)
+          foo
+            .bar(
+            bar(
+            ^^^^ Indent the first argument one step more than the start of the previous line.
+                key: value
+                ^^^^^^^^^^ Bad indentation of the first argument.
+              )
+            )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo
+            .bar(
+              bar(
+                key: value
+                )
+            )
+        RUBY
+      end
+
       context 'when using safe navigation operator' do
         it 'registers an offense and corrects an under-indented 1st argument' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes an infinite loop error in `Layout/FirstArgumentIndentation` when first arguments are over-indented in nested method calls.

Fixes #14858.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
