### PR TITLE
Tweak autocorrection in `Style/HashAsLastArrayItem`

### DIFF
--- a/changelog/change_autocorrection_in_style_hash_as_last_array_item.md
+++ b/changelog/change_autocorrection_in_style_hash_as_last_array_item.md
@@ -1,0 +1,1 @@
+* [#14872](https://github.com/rubocop/rubocop/pull/14872): Tweak autocorrection in `Style/HashAsLastArrayItem` when multiline hash elements. ([@koic][])

--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -69,7 +69,12 @@ module RuboCop
           return if node.braces?
 
           add_offense(node, message: 'Wrap hash in `{` and `}`.') do |corrector|
-            corrector.wrap(node, '{', '}')
+            if node.single_line? || same_line?(node, node.parent)
+              corrector.wrap(node, '{', '}')
+            else
+              indent = indent(node)
+              corrector.wrap(node, "{\n#{indent}", "\n#{indent}}")
+            end
           end
         end
 

--- a/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
+++ b/spec/rubocop/cop/style/hash_as_last_array_item_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects when the array contains only hash elements without braces' do
+    it 'registers an offense and corrects when the single-line array contains only hash elements without braces' do
       expect_offense(<<~RUBY)
         [one: 1, two: 2]
          ^^^^^^^^^^^^^^ Wrap hash in `{` and `}`.
@@ -23,6 +23,40 @@ RSpec.describe RuboCop::Cop::Style::HashAsLastArrayItem, :config do
 
       expect_correction(<<~RUBY)
         [{one: 1, two: 2}]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the multiline array contains only hash elements without braces' do
+      expect_offense(<<~RUBY)
+        [
+          one: 1,
+          ^^^^^^^ Wrap hash in `{` and `}`.
+          two: 2
+        ]
+      RUBY
+
+      # NOTE: Hash element indentation is handled by
+      # `Layout/FirstHashElementIndentation` and `Layout/HashAlignment` cops.
+      expect_correction(<<~RUBY)
+        [
+          {
+          one: 1,
+          two: 2
+          }
+        ]
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the multiline array on the same line contains only hash elements without braces' do
+      expect_offense(<<~RUBY)
+        [one: 1,
+         ^^^^^^^ Wrap hash in `{` and `}`.
+         two: 2]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [{one: 1,
+         two: 2}]
       RUBY
     end
 


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14842.

This PR tweaks autocorrection in `Style/HashAsLastArrayItem` when multiline hash elements.

```ruby
[
  one: 1,
  two: 2
]
```

## Before

Braces are added on the same lines as the elements.

```ruby
[
  {one: 1,
  two: 2}
]
```

## After

Braces are added on their own lines before and after the elements.

```ruby
[
  {
  one: 1,
  two: 2
  }
]
```

Hash element indentation is handled by `Layout/FirstHashElementIndentation` and `Layout/HashAlignment` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
