### PR TITLE
[Fix #14873] Fix an error in `Style/NegatedWhile`

### DIFF
--- a/changelog/fix_an_error_in_style_negated_while.md
+++ b/changelog/fix_an_error_in_style_negated_while.md
@@ -1,0 +1,1 @@
+* [#14873](https://github.com/rubocop/rubocop/issues/14873): Fix an error in `Style/NegatedWhile` when the last expression of an `until` condition is negated. ([@koic][])

--- a/lib/rubocop/cop/correctors/condition_corrector.rb
+++ b/lib/rubocop/cop/correctors/condition_corrector.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         def negated_condition(node)
           condition = node.condition
-          condition = condition.children.first while condition.begin_type?
+          condition = condition.children.last while condition.begin_type?
           condition
         end
       end

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -55,6 +55,19 @@ RSpec.describe RuboCop::Cop::Style::NegatedWhile, :config do
     RUBY
   end
 
+  it 'registers an offense when the last expression of an `until` condition is negated' do
+    expect_offense(<<~RUBY)
+      until (var = foo; !bar)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Favor `while` over `until` for negative conditions.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while (var = foo; bar)
+      end
+    RUBY
+  end
+
   it 'accepts a while where only part of the condition is negated' do
     expect_no_offenses(<<~RUBY)
       while !a_condition && another_condition


### PR DESCRIPTION
This PR fixes an error in `Style/NegatedWhile`
when an `until` condition is a compound expression and the last expression is negated.

Fixes #14873.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
