### PR TITLE
[Fix #14773] Extend `Lint/StructNewOverride` to also check `Data.define`

### DIFF
--- a/changelog/new_extend_struct_new_override_to_data_define.md
+++ b/changelog/new_extend_struct_new_override_to_data_define.md
@@ -1,0 +1,1 @@
+* [#14773](https://github.com/rubocop/rubocop/issues/14773): Extend `Lint/StructNewOverride` to also check `Data.define` for method overrides. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2469,9 +2469,10 @@ Lint/SharedMutableDefault:
   VersionAdded: '1.70'
 
 Lint/StructNewOverride:
-  Description: 'Disallow overriding the `Struct` built-in methods via `Struct.new`.'
+  Description: 'Disallow overriding the `Struct` built-in methods via `Struct.new` or the `Data` built-in methods via `Data.define`.'
   Enabled: true
   VersionAdded: '0.81'
+  VersionChanged: '<<next>>'
 
 Lint/SuppressedException:
   Description: "Don't suppress exceptions."

--- a/lib/rubocop/cop/lint/struct_new_override.rb
+++ b/lib/rubocop/cop/lint/struct_new_override.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Lint
       # Checks unexpected overrides of the `Struct` built-in methods
-      # via `Struct.new`.
+      # via `Struct.new` and the `Data` built-in methods via `Data.define`.
       #
       # @example
       #   # bad
@@ -14,6 +14,12 @@ module RuboCop
       #   b.clone #=> true (overriding `Object#clone`)
       #   b.count #=> 1 (overriding `Enumerable#count`)
       #
+      #   # bad
+      #   Bad = Data.define(:members, :to_s)
+      #   b = Bad.new(members: [], to_s: "bad")
+      #   b.members #=> [] (overriding `Data#members`)
+      #   b.to_s #=> "bad" (overriding `Data#to_s`)
+      #
       #   # good
       #   Good = Struct.new(:id, :name)
       #   g = Good.new(1, "foo")
@@ -21,10 +27,13 @@ module RuboCop
       #   g.clone #=> #<struct Good id=1, name="foo">
       #   g.count #=> 2
       #
+      #   # good
+      #   Good = Data.define(:id, :name)
+      #
       class StructNewOverride < Base
-        MSG = '`%<member_name>s` member overrides `Struct#%<method_name>s` ' \
+        MSG = '`%<member_name>s` member overrides `%<class_name>s#%<method_name>s` ' \
               'and it may be unexpected.'
-        RESTRICT_ON_SEND = %i[new].freeze
+        RESTRICT_ON_SEND = %i[new define].freeze
 
         # This is based on `Struct.instance_methods.sort` in Ruby 4.0.0.
         STRUCT_METHOD_NAMES = %i[
@@ -43,30 +52,53 @@ module RuboCop
           sum take take_while tally tap then to_a to_enum to_h to_s to_set uniq values values_at
           yield_self zip
         ].freeze
+
+        # This is based on `Data.define.instance_methods.sort` in Ruby 3.4.
+        DATA_METHOD_NAMES = %i[
+          ! != !~ <=> == === __id__ __send__ class clone deconstruct deconstruct_keys
+          define_singleton_method display dup enum_for eql? equal? extend freeze frozen? hash
+          inspect instance_eval instance_exec instance_of? instance_variable_defined?
+          instance_variable_get instance_variable_set instance_variables is_a? itself kind_of?
+          members method methods nil? object_id private_methods protected_methods public_method
+          public_methods public_send remove_instance_variable respond_to? send singleton_class
+          singleton_method singleton_methods tap then to_enum to_h to_s with yield_self
+        ].freeze
+
         STRUCT_MEMBER_NAME_TYPES = %i[sym str].freeze
 
-        # @!method struct_new(node)
-        def_node_matcher :struct_new, <<~PATTERN
-          (send
-            (const {nil? cbase} :Struct) :new ...)
+        # @!method struct_new_or_data_define(node)
+        def_node_matcher :struct_new_or_data_define, <<~PATTERN
+          {
+            (send (const {nil? cbase} :Struct) :new ...)
+            (send (const {nil? cbase} :Data) :define ...)
+          }
         PATTERN
 
         def on_send(node)
-          return unless struct_new(node)
+          return unless struct_new_or_data_define(node)
 
+          class_name = node.receiver.short_name
+          method_names = class_name == :Struct ? STRUCT_METHOD_NAMES : DATA_METHOD_NAMES
+
+          each_member_name(node, class_name) do |arg, member_name|
+            next unless method_names.include?(member_name.to_sym)
+
+            message = format(MSG, member_name: member_name.inspect,
+                                  class_name: class_name,
+                                  method_name: member_name.to_s)
+            add_offense(arg, message: message)
+          end
+        end
+
+        private
+
+        def each_member_name(node, class_name)
           node.arguments.each_with_index do |arg, index|
-            # Ignore if the first argument is a class name
-            next if index.zero? && arg.str_type?
-
-            # Ignore if the argument is not a member name
+            # Ignore if the first argument is a class name (Struct.new only)
+            next if class_name == :Struct && index.zero? && arg.str_type?
             next unless STRUCT_MEMBER_NAME_TYPES.include?(arg.type)
 
-            member_name = arg.value
-
-            next unless STRUCT_METHOD_NAMES.include?(member_name.to_sym)
-
-            message = format(MSG, member_name: member_name.inspect, method_name: member_name.to_s)
-            add_offense(arg, message: message)
+            yield arg, arg.value
           end
         end
       end

--- a/spec/rubocop/cop/lint/struct_new_override_spec.rb
+++ b/spec/rubocop/cop/lint/struct_new_override_spec.rb
@@ -1,81 +1,140 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::StructNewOverride, :config do
-  it 'registers an offense using `Struct.new(symbol)`' do
-    expect_offense(<<~RUBY)
-      Bad = Struct.new(:members)
-                       ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
-
-  it 'registers an offense using `::Struct.new(symbol)`' do
-    expect_offense(<<~RUBY)
-      Bad = ::Struct.new(:members)
+  context 'with Struct.new' do
+    it 'registers an offense using `Struct.new(symbol)`' do
+      expect_offense(<<~RUBY)
+        Bad = Struct.new(:members)
                          ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(string, ...symbols)`' do
-    expect_offense(<<~RUBY)
-      Struct.new('Bad', :members, :name)
-                        ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+    it 'registers an offense using `::Struct.new(symbol)`' do
+      expect_offense(<<~RUBY)
+        Bad = ::Struct.new(:members)
+                           ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(...symbols)`' do
-    expect_offense(<<~RUBY)
-      Bad = Struct.new(:name, :members, :address)
-                              ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+    it 'registers an offense using `Struct.new(string, ...symbols)`' do
+      expect_offense(<<~RUBY)
+        Struct.new('Bad', :members, :name)
+                          ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(symbol, string)`' do
-    expect_offense(<<~RUBY)
-      Bad = Struct.new(:name, "members")
-                              ^^^^^^^^^ `"members"` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+    it 'registers an offense using `Struct.new(...symbols)`' do
+      expect_offense(<<~RUBY)
+        Bad = Struct.new(:name, :members, :address)
+                                ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(...)` with a block' do
-    expect_offense(<<~RUBY)
-      Struct.new(:members) do
-                 ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-        def members?
-          !members.empty?
+    it 'registers an offense using `Struct.new(symbol, string)`' do
+      expect_offense(<<~RUBY)
+        Bad = Struct.new(:name, "members")
+                                ^^^^^^^^^ `"members"` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
+
+    it 'registers an offense using `Struct.new(...)` with a block' do
+      expect_offense(<<~RUBY)
+        Struct.new(:members) do
+                   ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+          def members?
+            !members.empty?
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(...)` with multiple overrides' do
-    expect_offense(<<~RUBY)
-      Struct.new(:members, :clone, :zip)
-                                   ^^^^ `:zip` member overrides `Struct#zip` and it may be unexpected.
-                           ^^^^^^ `:clone` member overrides `Struct#clone` and it may be unexpected.
-                 ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+    it 'registers an offense using `Struct.new(...)` with multiple overrides' do
+      expect_offense(<<~RUBY)
+        Struct.new(:members, :clone, :zip)
+                                     ^^^^ `:zip` member overrides `Struct#zip` and it may be unexpected.
+                             ^^^^^^ `:clone` member overrides `Struct#clone` and it may be unexpected.
+                   ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
 
-  it 'registers an offense using `Struct.new(...)` with an option argument' do
-    expect_offense(<<~RUBY)
-      Struct.new(:members, keyword_init: true)
-                 ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
-    RUBY
-  end
+    it 'registers an offense using `Struct.new(...)` with an option argument' do
+      expect_offense(<<~RUBY)
+        Struct.new(:members, keyword_init: true)
+                   ^^^^^^^^ `:members` member overrides `Struct#members` and it may be unexpected.
+      RUBY
+    end
 
-  it 'does not register an offense with no overrides' do
-    expect_no_offenses(<<~RUBY)
-      Good = Struct.new(:id, :name)
-    RUBY
-  end
+    it 'does not register an offense with no overrides' do
+      expect_no_offenses(<<~RUBY)
+        Good = Struct.new(:id, :name)
+      RUBY
+    end
 
-  it 'does not register an offense with an override within a given block' do
-    expect_no_offenses(<<~RUBY)
-      Good = Struct.new(:id, :name) do
-        def members
-          super.tap { |ret| pp "members: " + ret.to_s }
+    it 'does not register an offense with an override within a given block' do
+      expect_no_offenses(<<~RUBY)
+        Good = Struct.new(:id, :name) do
+          def members
+            super.tap { |ret| pp "members: " + ret.to_s }
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
+  end
+
+  context 'with Data.define' do
+    it 'registers an offense using `Data.define(symbol)`' do
+      expect_offense(<<~RUBY)
+        Bad = Data.define(:members)
+                          ^^^^^^^^ `:members` member overrides `Data#members` and it may be unexpected.
+      RUBY
+    end
+
+    it 'registers an offense using `::Data.define(symbol)`' do
+      expect_offense(<<~RUBY)
+        Bad = ::Data.define(:members)
+                            ^^^^^^^^ `:members` member overrides `Data#members` and it may be unexpected.
+      RUBY
+    end
+
+    it 'registers an offense using `Data.define(...)` with multiple overrides' do
+      expect_offense(<<~RUBY)
+        Data.define(:members, :to_s)
+                              ^^^^^ `:to_s` member overrides `Data#to_s` and it may be unexpected.
+                    ^^^^^^^^ `:members` member overrides `Data#members` and it may be unexpected.
+      RUBY
+    end
+
+    it 'registers an offense using `Data.define(...)` with a block' do
+      expect_offense(<<~RUBY)
+        Data.define(:members) do
+                    ^^^^^^^^ `:members` member overrides `Data#members` and it may be unexpected.
+          def members?
+            !members.empty?
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense with no overrides' do
+      expect_no_offenses(<<~RUBY)
+        Good = Data.define(:id, :name)
+      RUBY
+    end
+
+    it 'does not register an offense for Struct-only methods' do
+      expect_no_offenses(<<~RUBY)
+        Good = Data.define(:count, :first, :length)
+      RUBY
+    end
+
+    it 'does not register an offense with an override within a given block' do
+      expect_no_offenses(<<~RUBY)
+        Good = Data.define(:id, :name) do
+          def members
+            super.tap { |ret| pp "members: " + ret.to_s }
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Extends `Lint/StructNewOverride` to also detect overrides of built-in `Data` methods via `Data.define`, in addition to the existing `Struct.new` detection.

`Data.define(:to_s)` overrides `Data#to_s` in the same surprising way that `Struct.new(:to_s)` overrides `Struct#to_s`. This change makes the cop catch both cases.

### Changes

- Added `DATA_METHOD_NAMES` constant (based on `Data.define.instance_methods` in Ruby 3.4) — a smaller set than `STRUCT_METHOD_NAMES` since `Data` doesn't include `Enumerable`
- Extended the node matcher to match both `Struct.new(...)` and `Data.define(...)` (but not `Struct.define` or `Data.new`)
- Parameterized the offense message to show `Struct#method` or `Data#method` as appropriate
- Added tests for `Data.define` including a case verifying that Struct-only methods (e.g. `:count`, `:first`) are **not** flagged for `Data`

### Checklist

Before submitting the PR make sure the following are checked:

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Commit message starts with `[Fix #issue-number]`.
- [x] Feature branch is up-to-date with `master`.
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rubocop` on changed files — no offenses.
- [x] Added an entry to the changelog folder.