### PR TITLE
[Fix #14756] Detect void expressions in `case`/`when` branches

### DIFF
--- a/changelog/fix_lint_void_case_when.md
+++ b/changelog/fix_lint_void_case_when.md
@@ -1,0 +1,1 @@
+* [#14756](https://github.com/rubocop/rubocop/issues/14756): Fix `Lint/Void` to detect void expressions in `case`/`when` branches. ([@bbatsov][])

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1137,6 +1137,128 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'registers an offense for void literal in `case` branch' do
+    expect_offense(<<~RUBY)
+      case foo
+      when 1 then 2
+                  ^ Literal `2` used in void context.
+      end
+      puts 3
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers offenses for void literals in multiple `case` branches' do
+    expect_offense(<<~RUBY)
+      case foo
+      when 1 then 2
+                  ^ Literal `2` used in void context.
+      when 3 then 4
+                  ^ Literal `4` used in void context.
+      else 5
+           ^ Literal `5` used in void context.
+      end
+      puts 6
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense for void variable in `case` branch' do
+    expect_offense(<<~RUBY)
+      x = 1
+      case foo
+      when 1 then x
+                  ^ Variable `x` used in void context.
+      end
+      puts 3
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not register an offense for non-void expression in `case` branch' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1 then do_something
+      end
+      puts 3
+    RUBY
+  end
+
+  it 'does not register an offense for `case` on last line' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1 then 2
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `case` without when body' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1
+      end
+      puts :ok
+    RUBY
+  end
+
+  it 'registers an offense for void literal in `case...in` branch' do
+    expect_offense(<<~RUBY)
+      case foo
+      in 1 then 2
+                ^ Literal `2` used in void context.
+      in 2 then 3
+                ^ Literal `3` used in void context.
+      else 4
+           ^ Literal `4` used in void context.
+      end
+      puts 5
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense for void variable in `case...in` branch' do
+    expect_offense(<<~RUBY)
+      x = 1
+      case foo
+      in 1 then x
+                ^ Variable `x` used in void context.
+      end
+      puts 3
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not register an offense for non-void expression in `case...in` branch' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      in 1 then do_something
+      end
+      puts 3
+    RUBY
+  end
+
+  it 'does not register an offense for `case...in` on last line' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      in 1 then 2
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `case...in` without in_pattern body' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      in 1
+      end
+      puts :ok
+    RUBY
+  end
+
   it 'does not register an offense for `if` without body' do
     expect_no_offenses(<<~RUBY)
       if some_condition


### PR DESCRIPTION
`Lint/Void` already detects void expressions inside `if` branches (e.g. `2 if foo == 1`), but missed the equivalent `case`/`when` pattern. This extends the check to recurse into each `when` body and the `else` branch.

### Before

```ruby
# Detected
2 if foo == 1
puts 3

# NOT detected (now fixed)
case foo when 1 then 2 end
puts 3
```

### Changes

- Extended `check_expression` to recurse into `case` nodes, checking each `when` body and `else` branch
- Added autocorrect guard for `when`/`case` parents (same rationale as the existing `if` guard — can't safely delete a branch body)
- Used `node.parent.type?(:if, :when, :case)` per `InternalAffairs/NodeTypeMultiplePredicates`

### Checklist

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Commit message starts with `[Fix #issue-number]`.
- [x] Feature branch is up-to-date with `master`.
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rubocop` on changed files — no offenses.
- [x] Added an entry to the changelog folder.