### PR TITLE
[Fix #14098] Mark `Lint/SafeNavigationConsistency` autocorrect as unsafe

### DIFF
--- a/changelog/fix_safe_navigation_consistency_unsafe_autocorrect.md
+++ b/changelog/fix_safe_navigation_consistency_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#14098](https://github.com/rubocop/rubocop/issues/14098): Mark `Lint/SafeNavigationConsistency` autocorrect as unsafe. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2409,8 +2409,9 @@ Lint/SafeNavigationConsistency:
                  consistent and appropriate safe navigation, without excess or deficiency,
                  is used for all method calls on the same object.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.55'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   AllowedMethods:
     - present?
     - blank?

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -7,6 +7,12 @@ module RuboCop
       # consistent and appropriate safe navigation, without excess or deficiency,
       # is used for all method calls on the same object.
       #
+      # @safety
+      #   Autocorrection is unsafe because if the receiver is not a local variable
+      #   but a method call, it may not be idempotent. For example, replacing
+      #   `foo&.bar` with `foo.bar` could raise `NoMethodError` if `foo` returns
+      #   `nil` on a subsequent call.
+      #
       # @example
       #   # bad
       #   foo&.bar && foo&.baz


### PR DESCRIPTION
The autocorrect for `Lint/SafeNavigationConsistency` can change `foo&.bar` to `foo.bar`, which assumes the receiver is idempotent. When the receiver is a method call rather than a local variable, it may return `nil` on a subsequent call, making the autocorrected code raise `NoMethodError`.

This marks the autocorrection as unsafe via `SafeAutoCorrect: false` and adds a `@safety` note to the cop documentation explaining the rationale.

### Changes

- Added `SafeAutoCorrect: false` to `config/default.yml`
- Added `@safety` documentation note to the cop
- Changelog entry

### Checklist

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Commit message starts with `[Fix #issue-number]`.
- [x] Feature branch is up-to-date with `master`.
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rubocop` on changed files — no offenses.
- [x] Added an entry to the changelog folder.