### PR TITLE
Fix false positive in `Lint/RedundantSafeNavigation` for `respond_to?`

### DIFF
--- a/changelog/fix_redundant_safe_navigation_respond_to.md
+++ b/changelog/fix_redundant_safe_navigation_respond_to.md
@@ -1,0 +1,1 @@
+* [#14641](https://github.com/rubocop/rubocop/issues/14641): Fix false positive in `Lint/RedundantSafeNavigation` when using `&.respond_to?` with methods defined on `Object` (e.g., `:class`). ([@bbatsov][])

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -199,9 +199,15 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `&.respond_to?` with `nil` specific method as argument in condition' do
+  it 'does not register an offense when using `&.respond_to?` with a method that `nil` responds to as argument in condition' do
     expect_no_offenses(<<~RUBY)
       do_something if foo&.respond_to?(:to_a)
+    RUBY
+  end
+
+  it 'does not register an offense when using `&.respond_to?` with a method defined on `Object` as argument in condition' do
+    expect_no_offenses(<<~RUBY)
+      do_something if foo&.respond_to?(:class)
     RUBY
   end
 


### PR DESCRIPTION
## Summary

- Fixes #14641
- `Lint/RedundantSafeNavigation` incorrectly flagged `foo&.respond_to?(:class)` as redundant, but removing `&.` changes behavior: `nil&.respond_to?(:class)` → `nil` vs `nil.respond_to?(:class)` → `true`
- Expanded the exemption from NilClass-specific methods (`nil.methods - Object.new.methods`) to all methods `nil` responds to (`nil.methods`), covering inherited methods like `:class`, `:frozen?`, `:hash`, `:object_id`

## Test plan

- [x] Added test for `respond_to?(:class)` — the exact scenario from the bug report
- [x] Updated existing test description for clarity
- [x] All 72 existing tests pass
- [x] No RuboCop offenses in the modified cop file