### PR TITLE
[Fix #14880] Recognize block on different line from left side of multi-line assignment in `Layout/MultilineAssignmentLayout`

### DIFF
--- a/changelog/fix_recognize_different_line_block_in_layout_multiline_assignment_layout.md
+++ b/changelog/fix_recognize_different_line_block_in_layout_multiline_assignment_layout.md
@@ -1,0 +1,1 @@
+* [#14880](https://github.com/rubocop/rubocop/issues/14880): Recognize block on different line from left side of multi-line assignment in `Layout/MultilineAssignmentLayout`. ([@sanfrecce-osaka][])

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -69,14 +69,16 @@ module RuboCop
         SAME_LINE_OFFENSE = 'Right hand side of multi-line assignment is not ' \
                             'on the same line as the assignment operator `=`.'
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_assignment(node, rhs)
           return if node.send_type? && node.loc.operator&.source != '='
           return unless rhs
           return unless supported_types.include?(rhs.type)
-          return if rhs.single_line?
+          return if rhs.single_line? && (!rhs.block_type? || same_line?(node, rhs.loc.begin))
 
           check_by_enforced_style(node, rhs)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def check_by_enforced_style(node, rhs)
           case style

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -123,6 +123,54 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           end
         RUBY
       end
+
+      it 'registers an offense when multi-line assignments using single-line block is on different line' do
+        expect_offense(<<~RUBY)
+          foo = items
+          ^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            .map { |item| item.do_something }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo =
+           items
+            .map { |item| item.do_something }
+        RUBY
+      end
+
+      it 'allows multi-line assignments using single-line block is on different and separate line' do
+        expect_no_offenses(<<~RUBY)
+          foo =
+            items.map { |item| item.do_something }
+        RUBY
+      end
+
+      it 'registers an offense when multi-line assignments using multi-line block is on different line' do
+        expect_offense(<<~RUBY)
+          foo = items
+          ^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            .map do |item|
+              item.do_something
+            end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo =
+           items
+            .map do |item|
+              item.do_something
+            end
+        RUBY
+      end
+
+      it 'allows multi-line assignments using multi-line block is on different and separate line' do
+        expect_no_offenses(<<~RUBY)
+          foo =
+            items.map do |item|
+              item.do_something
+            end
+        RUBY
+      end
     end
   end
 
@@ -244,6 +292,50 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           foo << items.map do |item|
             "#{item}!"
           end
+        RUBY
+      end
+
+      it 'allows multi-line assignments using single-line block is on different line' do
+        expect_no_offenses(<<~RUBY)
+          foo = items
+            .map { |item| item.do_something }
+        RUBY
+      end
+
+      it 'registers an offense multi-line assignments using single-line block is on different and separate line' do
+        expect_offense(<<~RUBY)
+          foo =
+          ^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+            items.map { |item| item.do_something }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = items.map { |item| item.do_something }
+        RUBY
+      end
+
+      it 'allows multi-line assignments using multi-line block is on different line' do
+        expect_no_offenses(<<~RUBY)
+          foo = items
+            .map do |item|
+              item.do_something
+            end
+        RUBY
+      end
+
+      it 'registers an offense multi-line assignments using multi-line block is on different and separate line' do
+        expect_offense(<<~RUBY)
+          foo =
+          ^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+            items.map do |item|
+              item.do_something
+            end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = items.map do |item|
+              item.do_something
+            end
         RUBY
       end
     end


### PR DESCRIPTION
fixed #14880 

`RuboCop::AST::BlockNode#single_line?` determines whether block is a single line, so when block is on a different line from the left-hand side, `rhs.single_line?` returned true, resulting in a false negative.
So I fixed it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
