### PR TITLE
[Fix #14816] Add note about cache root of remote configuration files

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -139,6 +139,11 @@ The remote config file is cached locally and is only updated if:
 * The file has not been updated in the last 24 hours.
 * The remote copy has a newer modification time than the local copy.
 
+This local cache is stored in xref:usage/caching.adoc#cache-path[the configured cache path],
+maintaining the remote filename prefix. Please note that the root of relative paths specified
+in `Include` or `Exclude` changes depending on the configuration file name,
+as explained in xref:#path-relativity["Path relativity"]. This behavior was introduced in RuboCop 1.84.
+
 You can inherit from both remote and local files in the same config and the
 same inheritance rules apply to remote URLs and inheriting from local
 files where the first file in the list has the lowest precedence and the


### PR DESCRIPTION
This commit fixes #14816, especially https://github.com/rubocop/rubocop/issues/14816#issuecomment-3822630116.

#14625, #14761, and #14870 have changed the root path of remote configuration caches. This patch added a note about it to the docs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
