### PR TITLE
Fix `Lint/InterpolationCheck` autocorrect causing a SyntaxError

### DIFF
--- a/changelog/fix_interpolation_check_syntax_error.md
+++ b/changelog/fix_interpolation_check_syntax_error.md
@@ -1,0 +1,1 @@
+* [#14791](https://github.com/rubocop/rubocop/issues/14791): Fix `Lint/InterpolationCheck` autocorrect causing a `SyntaxError` when the string contains double quotes and invalid interpolation syntax. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -54,9 +54,13 @@ module RuboCop
         end
 
         def valid_syntax?(node)
-          double_quoted_string = node.source.gsub(/\A'|'\z/, '"')
+          corrected = if node.source.include?('"')
+                        node.source.sub(/\A'/, '%{').sub(/'\z/, '}')
+                      else
+                        node.source.gsub(/\A'|'\z/, '"')
+                      end
 
-          parse(double_quoted_string).valid_syntax?
+          parse(corrected).valid_syntax?
         end
       end
     end

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -86,4 +86,10 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck, :config do
       '#{%<expression>s}'
     RUBY
   end
+
+  it 'does not register an offense when using interpolation with format specifiers and double quotes' do
+    expect_no_offenses(<<~'RUBY')
+      msg = 'Text `A("#{%<base>s}/%<path>s}")` and `B` with C.'
+    RUBY
+  end
 end


### PR DESCRIPTION
`Lint/InterpolationCheck` autocorrects `'..#{..}..'` to `"..#{..}.."`, falling back to `%{..#{..}..}` when the string contains double quotes. However, `valid_syntax?` always checked the `"..."` form, which could pass even when the actual `%{...}` form would be invalid.

For example, `'Text `A("#{%<base>s}/%<path>s}")` and `B` with C.'` passes the `"..."` validity check (the inner `"` closes the string and `#` becomes a comment), but the `%{...}` form is invalid because `#{%<base>s}` becomes real interpolation with invalid Ruby inside.

Now `valid_syntax?` checks the actual corrected form matching the delimiter logic from `autocorrect`.

Fixes #14791

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/