### PR TITLE
[Fix #14834] Fix `Layout/IndentationWidth` false positive for chained method blocks when `EnforcedStyleAlignWith` is `start_of_line`

### DIFF
--- a/changelog/fix_layout_indentation_width_false_positive_for_20260214223916.md
+++ b/changelog/fix_layout_indentation_width_false_positive_for_20260214223916.md
@@ -1,0 +1,1 @@
+* [#14834](https://github.com/rubocop/rubocop/issues/14834): Fix `Layout/IndentationWidth` false positive for chained method blocks when `EnforcedStyleAlignWith` is `start_of_line`. ([@krororo][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -473,7 +473,7 @@ module RuboCop
         end
 
         def block_body_indentation_base(node, end_loc)
-          if dot_on_new_line?(node)
+          if style == :relative_to_receiver && dot_on_new_line?(node)
             node.send_node.loc.dot
           else
             end_loc

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -3824,8 +3824,8 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
             Model
               .some_scope
               .find_each do |record|
-                record.do_something
-                record.do_something_else
+              record.do_something
+              record.do_something_else
             end
           end
       end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1739,7 +1739,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           foo
             .bar do |x|
           x
-          ^ Use 2 (not -2) spaces for indentation.
+          ^{} Use 2 (not 0) spaces for indentation.
           end
         RUBY
       end
@@ -1753,32 +1753,22 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
-      it 'accepts block body indented relative to dot when end is at different column' do
+      it 'accepts block body indented relative to start of line when a {} body' do
         expect_no_offenses(<<~RUBY)
           out
             .break
             .sep_with_breaks(inner) { |v|
-              simplified_process(v)
+            simplified_process(v)
           }
         RUBY
       end
 
-      it 'accepts block body indented relative to dot with do...end' do
+      it 'accepts block body indented relative to start of line when a do-end body' do
         expect_no_offenses(<<~RUBY)
           out
             .break
             .sep_with_breaks(inner) do |v|
-              simplified_process(v)
-          end
-        RUBY
-      end
-
-      it 'registers an offense when the chain receiver is long and body not indented relative to dot' do
-        expect_offense(<<~RUBY)
-          ::Some::Very::Long::Module::Name.active
-                                          .in_batches do |batch|
-            process(batch)
-            ^^^^^^^^^^^^^^ Use 2 (not -30) spaces for indentation.
+            simplified_process(v)
           end
         RUBY
       end
@@ -1787,8 +1777,8 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         expect_no_offenses(<<~RUBY)
           ::Some::Very::Long::Module::Name.active
                                           .in_batches do |batch|
-                                            process(batch)
-                                          end
+            process(batch)
+          end
         RUBY
       end
 
@@ -1811,6 +1801,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               .bar do |x|
                 x
             end
+          RUBY
+        end
+
+        it 'accepts block body indented relative to dot when end is at different column' do
+          expect_no_offenses(<<~RUBY)
+            out
+              .break
+              .sep_with_breaks(inner) { |v|
+                simplified_process(v)
+            }
+          RUBY
+        end
+
+        it 'accepts correct indentation when the chain receiver is long' do
+          expect_no_offenses(<<~RUBY)
+            ::Some::Very::Long::Module::Name.active
+                                            .in_batches do |batch|
+                                              process(batch)
+                                            end
           RUBY
         end
       end


### PR DESCRIPTION
fix https://github.com/rubocop/rubocop/issues/14834

Previously, `block_body_indentation_base` used the dot position as the indentation base for blocks in method chains regardless of the configured `EnforcedStyleAlignWith`. This caused a false positive when `EnforcedStyleAlignWith` was `start_of_line`, as the block body was expected to be indented relative to the dot rather than the start of the line.

Now the dot position is only used as the indentation base when `EnforcedStyleAlignWith` is `relative_to_receiver`.

```ruby
# EnforcedStyleAlignWith: start_of_line
records.uniq { |el| el[:profile_id] }
       .map do |message|
  SomeJob.perform_later(message[:id])
end

# EnforcedStyleAlignWith: relative_to_receiver
records.uniq { |el| el[:profile_id] }
       .map do |message|
         SomeJob.perform_later(message[:id])
       end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
