### PR TITLE
Improve `Style/EmptyClassDefinition` message wording

### DIFF
--- a/changelog/fix_empty_class_definition_message_wording.md
+++ b/changelog/fix_empty_class_definition_message_wording.md
@@ -1,0 +1,1 @@
+* [#14827](https://github.com/rubocop/rubocop/issues/14827): Improve `Style/EmptyClassDefinition` message wording. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_class_definition.rb
+++ b/lib/rubocop/cop/style/empty_class_definition.rb
@@ -5,12 +5,12 @@ module RuboCop
     module Style
       # Enforces consistent style for empty class definitions.
       #
-      # This cop can enforce either a two-line class definition or `Class.new`
+      # This cop can enforce either a standard class definition or `Class.new`
       # for classes with no body.
       #
       # The supported styles are:
       #
-      # * class_definition (default) - prefer two-line class definition over `Class.new`
+      # * class_definition (default) - prefer standard class definition over `Class.new`
       # * class_new - prefer `Class.new` over class definition
       #
       # @example EnforcedStyle: class_definition (default)
@@ -41,7 +41,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG_CLASS_DEFINITION =
-          'Prefer a two-line class definition over `Class.new` for classes with no body.'
+          'Prefer standard class definition over `Class.new` for classes with no body.'
         MSG_CLASS_NEW = 'Prefer `Class.new` over class definition for classes with no body.'
 
         # @!method class_new_assignment(node)

--- a/spec/rubocop/cop/style/empty_class_definition_spec.rb
+++ b/spec/rubocop/cop/style/empty_class_definition_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant' do
       expect_offense(<<~RUBY)
         FooError = Class.new(StandardError)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer a two-line class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant without parent class' do
       expect_offense(<<~RUBY)
         MyClass = Class.new
-        ^^^^^^^^^^^^^^^^^^^ Prefer a two-line class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       expect_offense(<<~RUBY)
         module Foo
           BarError = Class.new(StandardError)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer a two-line class definition over `Class.new` for classes with no body.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
         end
       RUBY
 
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant with namespaced parent class' do
       expect_offense(<<~RUBY)
         MyClass = Class.new(Alchemy::Admin::PreviewUrl)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer a two-line class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant with absolute parent class path' do
       expect_offense(<<~RUBY)
         MyClass = Class.new(::Safemode::Jail)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer a two-line class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
The `Style/EmptyClassDefinition` cop message said "Prefer a two-line class definition over `Class.new`..." but the cop doesn't specifically enforce two-line vs single-line — it enforces standard `class` syntax vs `Class.new`. Updated the message and documentation to say "Prefer standard class definition" instead.

Fixes #14827

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/