### PR TITLE
Add new `InternalAffairs/ItblockHandler` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -230,6 +230,10 @@ InternalAffairs/StyleDetectedApiUse:
   Exclude:
     - 'lib/rubocop/cop/mixin/percent_array.rb'
 
+InternalAffairs/ItblockHandler:
+  Exclude:
+    - 'lib/rubocop/cop/internal_affairs/*.rb'
+
 InternalAffairs/NumblockHandler:
   Exclude:
     - 'lib/rubocop/cop/internal_affairs/*.rb'

--- a/changelog/new_itblock_handler.md
+++ b/changelog/new_itblock_handler.md
@@ -1,0 +1,1 @@
+* [#14781](https://github.com/rubocop/rubocop/pull/14781): Add new `InternalAffairs/ItblockHandler` cop. ([@bbatsov][])

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -92,7 +92,7 @@ module RuboCop
           (str "true")
         PATTERN
 
-        def on_block(node) # rubocop:disable Metrics/MethodLength, InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable Metrics/MethodLength, InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           gem_specification(node) do |block_var|
             metadata_value = metadata(node)
             mfa_value = mfa_value(metadata_value)

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -7,6 +7,7 @@ require_relative 'internal_affairs/empty_line_between_expect_offense_and_correct
 require_relative 'internal_affairs/example_description'
 require_relative 'internal_affairs/example_heredoc_delimiter'
 require_relative 'internal_affairs/inherit_deprecated_cop_class'
+require_relative 'internal_affairs/itblock_handler'
 require_relative 'internal_affairs/lambda_or_proc'
 require_relative 'internal_affairs/location_exists'
 require_relative 'internal_affairs/location_expression'

--- a/lib/rubocop/cop/internal_affairs/itblock_handler.rb
+++ b/lib/rubocop/cop/internal_affairs/itblock_handler.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks for missing `itblock` handlers. The blocks with the `it`
+      # parameter introduced in Ruby 3.4 are parsed with a node type of
+      # `itblock` instead of block. Cops that define `block` handlers
+      # need to define `itblock` handlers or disable this cop for them.
+      #
+      # @example
+      #
+      #   # bad
+      #   class BlockRelatedCop < Base
+      #     def on_block(node)
+      #     end
+      #   end
+      #
+      #   # good
+      #   class BlockRelatedCop < Base
+      #     def on_block(node)
+      #     end
+      #
+      #     alias on_itblock on_block
+      #   end
+      #
+      #   class BlockRelatedCop < Base
+      #     def on_block(node)
+      #     end
+      #
+      #     alias_method :on_itblock, :on_block
+      #   end
+      #
+      #   class BlockRelatedCop < Base
+      #     def on_block(node)
+      #     end
+      #
+      #     def on_itblock(node)
+      #     end
+      #   end
+      class ItblockHandler < Base
+        MSG = 'Define on_itblock to handle blocks with the `it` parameter.'
+
+        def on_def(node)
+          return unless block_handler?(node)
+          return unless node.parent
+
+          add_offense(node) unless itblock_handler?(node.parent)
+        end
+
+        private
+
+        # @!method block_handler?(node)
+        def_node_matcher :block_handler?, <<~PATTERN
+          (def :on_block (args (arg :node)) ...)
+        PATTERN
+
+        # @!method itblock_handler?(node)
+        def_node_matcher :itblock_handler?, <<~PATTERN
+          {
+            `(def :on_itblock (args (arg :node)) ...)
+            `(alias (sym :on_itblock) (sym :on_block))
+            `(send nil? :alias_method (sym :on_itblock) (sym :on_block))
+          }
+        PATTERN
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -29,7 +29,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           arguments = node.arguments
 
           return unless node.arguments? && pipes?(arguments)

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -47,7 +47,7 @@ module RuboCop
           check(node, [:operator].freeze) if node.keyword?
         end
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           check(node, %i[begin end].freeze)
         end
 

--- a/lib/rubocop/cop/lint/empty_block.rb
+++ b/lib/rubocop/cop/lint/empty_block.rb
@@ -63,7 +63,7 @@ module RuboCop
       class EmptyBlock < Base
         MSG = 'Empty block detected.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return if node.body
           return if allow_empty_lambdas? && node.lambda_or_proc?
           return if cop_config['AllowComments'] && allow_comment?(node)

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -31,6 +31,7 @@ module RuboCop
           end
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -39,6 +40,7 @@ module RuboCop
           {
             (block (call _recv {:reduce :inject} !sym) _blockargs $(begin ...))
             (numblock (call _recv {:reduce :inject} !sym) _argscount $(begin ...))
+            (itblock (call _recv {:reduce :inject} !sym) _argscount $(begin ...))
           }
         PATTERN
 

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -65,7 +65,9 @@ module RuboCop
 
         maximum_target_ruby_version 2.7
 
-        def on_block(node)
+        # NOTE: itblock is not handled because this cop is limited to Ruby <= 2.7
+        # via `maximum_target_ruby_version`, so itblock nodes (Ruby 3.4+) are never encountered.
+        def on_block(node) # rubocop:disable InternalAffairs/ItblockHandler
           return unless node.body
           return unless unsorted_dir_loop?(node.send_node)
 

--- a/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
+++ b/lib/rubocop/cop/lint/unmodified_reduce_accumulator.rb
@@ -120,6 +120,7 @@ module RuboCop
           check_return_values(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -88,7 +88,7 @@ module RuboCop
         {(array ...) (send _ :each_with_index) (send _ :with_index _ ?) (send _ :zip ...)}
       PATTERN
 
-      def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+      def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
         on_bad_each_with_object(node) do |*match|
           handle_possible_offense(node, match, 'each_with_object')
         end

--- a/lib/rubocop/cop/naming/block_parameter_name.rb
+++ b/lib/rubocop/cop/naming/block_parameter_name.rb
@@ -38,7 +38,7 @@ module RuboCop
       class BlockParameterName < Base
         include UncommunicativeName
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless node.arguments?
 
           check(node, node.arguments)

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         MSG = 'Use `Integer#times` for a simple loop which iterates a fixed number of times.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless offending?(node)
 
           send_node = node.send_node

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -40,6 +40,8 @@ module RuboCop
           end
         end
 
+        alias on_itblock on_block
+
         def on_numblock(node)
           each_with_object_numblock_candidate?(node) do |method, body|
             _, method_name, method_arg = *method

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         MSG = 'Omit pipes for the empty block parameters.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           send_node = node.send_node
           check(node) unless send_node.send_type? && send_node.lambda_literal?
         end

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         MSG = 'Omit parentheses for the empty lambda parameters.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           send_node = node.send_node
           return unless send_node.send_type?
 

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -43,7 +43,7 @@ module RuboCop
           { ({return next break} nil) (nil) }
         PATTERN
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless node.lambda_or_proc?
           return unless nil_return?(node.body)
 

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -52,7 +52,7 @@ module RuboCop
             ${nil? basic_literal? const_type?})
         PATTERN
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           redundant_fetch_block_candidate?(node) do |send, body|
             return if should_not_check?(send, body)
 

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         MSG = 'Name `%<method>s` block params `|%<params>s|`.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless node.single_line?
 
           return unless eligible_method?(node)

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         MSG = 'Useless trailing comma present in block arguments.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           # lambda literal (`->`) never has block arguments.
           return if node.send_node.lambda_literal?
           return unless useless_trailing_comma?(node)

--- a/spec/rubocop/cop/internal_affairs/itblock_handler_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/itblock_handler_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::InternalAffairs::ItblockHandler, :config do
+  it 'registers an offense for cops with forgotten itblock handlers' do
+    expect_offense <<~RUBY
+      class Cop < Base
+        def on_block(node)
+        ^^^^^^^^^^^^^^^^^^ Define on_itblock to handle blocks with the `it` parameter.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for cops with on_itblock alias' do
+    expect_no_offenses <<~RUBY
+      class Cop < Base
+        def on_block(node)
+        end
+
+        alias on_itblock on_block
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for cops with on_itblock alias_method' do
+    expect_no_offenses <<~RUBY
+      class Cop < Base
+        def on_block(node)
+        end
+
+        alias_method :on_itblock, :on_block
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for cops with on_itblock method' do
+    expect_no_offenses <<~RUBY
+      class Cop < Base
+        def on_block(node)
+        end
+
+        def on_itblock(node)
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -65,6 +65,28 @@ RSpec.describe RuboCop::Cop::Lint::NextWithoutAccumulator, :config do
           RUBY
         end
       end
+
+      context 'Ruby 3.4', :ruby34 do
+        it 'registers an offense for a bare next' do
+          expect_offense(<<~RUBY)
+            (1..4).#{reduce_alias}(0) do
+              next if it.odd?
+              ^^^^ Use `next` with an accumulator argument in a `reduce`.
+              it + 1
+            end
+          RUBY
+        end
+
+        it 'registers an offense for a bare `next` in the block of safe navigation method call' do
+          expect_offense(<<~RUBY)
+            (1..4)&.#{reduce_alias}(0) do
+              next if it.odd?
+              ^^^^ Use `next` with an accumulator argument in a `reduce`.
+              it + 1
+            end
+          RUBY
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/unmodified_reduce_accumulator_spec.rb
@@ -669,6 +669,16 @@ RSpec.describe RuboCop::Cop::Lint::UnmodifiedReduceAccumulator, :config do
           RUBY
         end
       end
+
+      context 'itblocks', :ruby34 do
+        it 'does not register an offense when using itblock with reduce' do
+          expect_no_offenses(<<~RUBY)
+            (1..4).#{method}(0) do
+              it + 1
+            end
+          RUBY
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject, :config do
     end
   end
 
+  context 'Ruby 3.4', :ruby34 do
+    it 'does not register an offense when using itblock with inject' do
+      expect_no_offenses(<<~RUBY)
+        [].inject({}) do
+          it[foo] = bar
+          it
+        end
+      RUBY
+    end
+  end
+
   it 'correctly autocorrects' do
     expect_offense(<<~RUBY)
       [1, 2, 3].inject({}) do |h, i|


### PR DESCRIPTION
Ruby 3.4 introduced `it` block parameters, parsed as `itblock` nodes (similar to how Ruby 2.7 introduced numbered parameters parsed as `numblock`). This adds a matching `InternalAffairs/ItblockHandler` cop that ensures cops defining `on_block` also define `on_itblock`, mirroring the existing `InternalAffairs/NumblockHandler` cop.

Closes #14781

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/