### PR TITLE
[Fix #11462] Fix over-indentation when autocorrecting nested hashes with `Layout/FirstHashElementIndentation`

### DIFF
--- a/changelog/fix_over_indentation_when_autocorrecting_nested_hashes_with_layout_first_hash_element_indentation.md
+++ b/changelog/fix_over_indentation_when_autocorrecting_nested_hashes_with_layout_first_hash_element_indentation.md
@@ -1,0 +1,1 @@
+* [#11462](https://github.com/rubocop/rubocop/issues/11462): Fix over-indentation when autocorrecting nested hashes with `Layout/FirstHashElementIndentation`. ([@ydakuka][])

--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -135,7 +135,13 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)
+          line_range = if !node.is_a?(AST::Node) || node.value.first_line <= node.key.first_line
+                         node
+                       else
+                         processed_source.buffer.line_range(node.loc.line)
+                       end
+
+          AlignmentCorrector.correct(corrector, processed_source, line_range, @column_delta)
         end
 
         def brace_alignment_style

--- a/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_indentation_spec.rb
@@ -192,6 +192,67 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects only the key line when value starts on next line' do
+      expect_offense(<<~RUBY)
+        a = {
+            a:
+            ^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+          {
+            b: 1
+          }
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = {
+          a:
+          {
+            b: 1
+          }
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects key and value lines when value starts on the same line' do
+      expect_offense(<<~RUBY)
+        a = {
+            a: {
+            ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+              b: 1
+            }
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = {
+          a: {
+            b: 1
+          }
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects value lines when value starts on the same line' do
+      expect_offense(<<~RUBY)
+        a = {
+            a: [
+            ^^^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+              1,
+              2
+            ]
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a = {
+          a: [
+            1,
+            2
+          ]
+        }
+      RUBY
+    end
+
     it 'accepts correctly indented first pair' do
       expect_no_offenses(<<~RUBY)
         a = {
@@ -358,6 +419,27 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
           RUBY
         end
 
+        it 'registers an offense and corrects only the key line when value starts on next line in a method call' do
+          expect_offense(<<~RUBY)
+            func({
+                     a:
+                     ^^ Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
+                   {
+                     b: 1
+                   }
+                 })
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func({
+                   a:
+                   {
+                     b: 1
+                   }
+                 })
+          RUBY
+        end
+
         it 'registers an offense for a hash that is a value of a multi pairs hash' \
            'when the indent of its elements is not based on the hash key' do
           expect_offense(<<~RUBY)
@@ -470,6 +552,27 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
           expect_correction(<<~RUBY)
             func(x: {
               a: 1, b: 2 })
+          RUBY
+        end
+
+        it 'registers an offense and corrects only the key line when value starts on next line in a method call' do
+          expect_offense(<<~RUBY)
+            func({
+                   a:
+                   ^^ Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.
+              {
+                b: 1
+              }
+            })
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func({
+              a:
+              {
+                b: 1
+              }
+            })
           RUBY
         end
 
@@ -680,6 +783,28 @@ RSpec.describe RuboCop::Cop::Layout::FirstHashElementIndentation, :config do
           func({
                  a: 1
                })
+        RUBY
+      end
+
+      it 'registers an offense and corrects only the key line when value starts on next line' do
+        expect_offense(<<~RUBY)
+          var = {
+                    a:
+                    ^^ Use 2 spaces for indentation in a hash, relative to the position of the opening brace.
+                  {
+                    b: 1
+                  }
+                  }
+                  ^ Indent the right brace the same as the left brace.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = {
+                  a:
+                  {
+                    b: 1
+                  }
+                }
         RUBY
       end
     end


### PR DESCRIPTION
Fixes #11462

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
