### PR TITLE
Fix false negative in `Layout/MultilineAssignmentLayout` for block variants

### DIFF
--- a/changelog/fix_multiline_assignment_layout_block.md
+++ b/changelog/fix_multiline_assignment_layout_block.md
@@ -1,0 +1,1 @@
+* [#14880](https://github.com/rubocop/rubocop/issues/14880): Fix a false negative in `Layout/MultilineAssignmentLayout` when using `numblock` or `itblock` with `SupportedTypes: ['block']`. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -69,6 +69,8 @@ module RuboCop
         SAME_LINE_OFFENSE = 'Right hand side of multi-line assignment is not ' \
                             'on the same line as the assignment operator `=`.'
 
+        BLOCK_TYPES = %i[block numblock itblock].freeze
+
         # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_assignment(node, rhs)
           return if node.send_type? && node.loc.operator&.source != '='
@@ -111,7 +113,10 @@ module RuboCop
         private
 
         def supported_types
-          @supported_types ||= cop_config['SupportedTypes'].map(&:to_sym)
+          @supported_types ||= cop_config['SupportedTypes'].flat_map do |type|
+            sym = type.to_sym
+            sym == :block ? BLOCK_TYPES : sym
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -171,6 +171,24 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
             end
         RUBY
       end
+
+      it 'registers an offense for numblock on the same line', :ruby27 do
+        expect_offense(<<~RUBY)
+          bars = foo.map {
+          ^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            _1.bar
+          }
+        RUBY
+      end
+
+      it 'registers an offense for itblock on the same line', :ruby34 do
+        expect_offense(<<~RUBY)
+          bars = foo.map {
+          ^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            it.bar
+          }
+        RUBY
+      end
     end
   end
 
@@ -336,6 +354,26 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           foo = items.map do |item|
               item.do_something
             end
+        RUBY
+      end
+
+      it 'registers an offense for numblock on separate lines', :ruby27 do
+        expect_offense(<<~RUBY)
+          bars =
+          ^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+            foo.map {
+              _1.bar
+            }
+        RUBY
+      end
+
+      it 'registers an offense for itblock on separate lines', :ruby34 do
+        expect_offense(<<~RUBY)
+          bars =
+          ^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
+            foo.map {
+              it.bar
+            }
         RUBY
       end
     end


### PR DESCRIPTION
When `SupportedTypes` includes `'block'`, the cop only matched the `:block` AST node type but not `:numblock` (Ruby 2.7 numbered parameters) or `:itblock` (Ruby 3.4 `it` parameter). This expands the `supported_types` method to automatically include all three block node types when `'block'` is configured.

Fixes #14880

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/