### PR TITLE
Fix RedundantCopDisableDirective false positive for AllowComments cops

### DIFF
--- a/changelog/fix_redundant_cop_disable_directive_with_allow_comments.md
+++ b/changelog/fix_redundant_cop_disable_directive_with_allow_comments.md
@@ -1,0 +1,1 @@
+* [#14890](https://github.com/rubocop/rubocop/pull/14890): Fix a false positive for `Lint/RedundantCopDisableDirective` when a `rubocop:disable` comment is used to suppress `Lint/EmptyWhen`, `Lint/EmptyConditionalBody`, `Lint/EmptyInPattern`, or `Style/SymbolProc`. ([@eugeneius][])

--- a/lib/rubocop/cop/lint/empty_conditional_body.rb
+++ b/lib/rubocop/cop/lint/empty_conditional_body.rb
@@ -70,7 +70,7 @@ module RuboCop
 
         def on_if(node)
           return if node.body || same_line?(node.loc.begin, node.loc.end)
-          return if cop_config['AllowComments'] && contains_comments?(node)
+          return if allow_comments?(node)
 
           range = offense_range(node)
 
@@ -82,6 +82,11 @@ module RuboCop
         end
 
         private
+
+        def allow_comments?(node)
+          cop_config['AllowComments'] && contains_comments?(node) &&
+            !comments_contain_disables?(node, name)
+        end
 
         def offense_range(node)
           if node.loc.else

--- a/lib/rubocop/cop/lint/empty_in_pattern.rb
+++ b/lib/rubocop/cop/lint/empty_in_pattern.rb
@@ -53,10 +53,17 @@ module RuboCop
         def on_case_match(node)
           node.in_pattern_branches.each do |branch|
             next if branch.body
-            next if cop_config['AllowComments'] && contains_comments?(branch)
+            next if allow_comments?(branch)
 
             add_offense(branch)
           end
+        end
+
+        private
+
+        def allow_comments?(node)
+          cop_config['AllowComments'] && contains_comments?(node) &&
+            !comments_contain_disables?(node, name)
         end
       end
     end

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -50,10 +50,17 @@ module RuboCop
         def on_case(node)
           node.when_branches.each do |when_node|
             next if when_node.body
-            next if cop_config['AllowComments'] && contains_comments?(when_node)
+            next if allow_comments?(when_node)
 
             add_offense(when_node)
           end
+        end
+
+        private
+
+        def allow_comments?(node)
+          cop_config['AllowComments'] && contains_comments?(node) &&
+            !comments_contain_disables?(node, name)
         end
       end
     end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -179,7 +179,7 @@ module RuboCop
             return if allowed_method_name?(dispatch_node.method_name)
             return if allow_if_method_has_argument?(node.send_node)
             return if node.block_type? && destructuring_block_argument?(arguments_node)
-            return if allow_comments? && contains_comments?(node)
+            return if allow_comments?(node)
 
             register_offense(node, method_name, dispatch_node.method_name)
           end
@@ -273,8 +273,9 @@ module RuboCop
           !!cop_config.fetch('AllowMethodsWithArguments', false) && send_node.arguments.any?
         end
 
-        def allow_comments?
-          cop_config.fetch('AllowComments', false)
+        def allow_comments?(node)
+          cop_config.fetch('AllowComments', false) && contains_comments?(node) &&
+            !comments_contain_disables?(node, name)
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -667,6 +667,90 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
+      context 'when using `rubocop:disable` line comment for `Lint/EmptyWhen`' do
+        it 'does not register an offense for `Lint/RedundantCopDisableDirective`' do
+          create_file('.rubocop.yml', <<~YAML)
+            Lint/EmptyWhen:
+              Enabled: true
+            Lint/RedundantCopDisableDirective:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            case x
+            when 1 # rubocop:disable Lint/EmptyWhen
+            when 2
+              :ok
+            end
+          RUBY
+          expect(cli.run(['example.rb'])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
+
+      context 'when using `rubocop:disable` line comment for `Lint/EmptyConditionalBody`' do
+        it 'does not register an offense for `Lint/RedundantCopDisableDirective`' do
+          create_file('.rubocop.yml', <<~YAML)
+            Lint/EmptyConditionalBody:
+              Enabled: true
+            Lint/RedundantCopDisableDirective:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            if condition # rubocop:disable Lint/EmptyConditionalBody
+            end
+          RUBY
+          expect(cli.run(['example.rb'])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
+
+      context 'when using `rubocop:disable` line comment for `Lint/EmptyInPattern`' do
+        it 'does not register an offense for `Lint/RedundantCopDisableDirective`' do
+          create_file('.rubocop.yml', <<~YAML)
+            Lint/EmptyInPattern:
+              Enabled: true
+            Lint/RedundantCopDisableDirective:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            case [1]
+            in [a] # rubocop:disable Lint/EmptyInPattern
+            in [a, b]
+              :ok
+            end
+          RUBY
+          expect(cli.run(['example.rb'])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
+
+      context 'when using `rubocop:disable` line comment for `Style/SymbolProc`' do
+        it 'does not register an offense for `Lint/RedundantCopDisableDirective`' do
+          create_file('.rubocop.yml', <<~YAML)
+            Style/SymbolProc:
+              Enabled: true
+              AllowComments: true
+            Lint/RedundantCopDisableDirective:
+              Enabled: true
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            something do |e| # rubocop:disable Style/SymbolProc
+              e.upcase
+            end
+          RUBY
+          expect(cli.run(['example.rb'])).to eq(0)
+          expect($stdout.string).to include('1 file inspected, no offenses detected')
+        end
+      end
+
       shared_examples 'RedundantCopDisableDirective not run' do |state, config|
         context "and RedundantCopDisableDirective is #{state}" do
           it 'does not report RedundantCopDisableDirective offenses' do


### PR DESCRIPTION
`Lint/EmptyWhen`, `Lint/EmptyConditionalBody`, `Lint/EmptyInPattern` and `Style/SymbolProc` were treating `rubocop:disable` directives as comments, so no offenses were registered and `Lint/RedundantCopDisableDirective` incorrectly flagged the directives as unnecessary. This is the same issue previously fixed for `Lint/EmptyBlock` in https://github.com/rubocop/rubocop/pull/8972 and `Style/RedundantInitialize` in https://github.com/rubocop/rubocop/pull/13654.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/