### PR TITLE
[Fix #7201] Add `urls` to JSON formatter offense output

### DIFF
--- a/changelog/new_add_style_guide_urls_to_json_formatter.md
+++ b/changelog/new_add_style_guide_urls_to_json_formatter.md
@@ -1,0 +1,1 @@
+* [#7201](https://github.com/rubocop/rubocop/issues/7201): Add `style_guide_urls` to JSON formatter offense output. ([@fatkodima][])

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -33,7 +33,8 @@ module RuboCop
         },
         message:  message(offense),
         cop_name: offense.cop_name,
-        status:   status || offense.status
+        status:   status || offense.status,
+        urls:     offense.urls
       }
     end
 
@@ -47,7 +48,8 @@ module RuboCop
     def deserialize_offenses(offenses)
       offenses.map! do |o|
         location = location_from_source_buffer(o)
-        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym)
+        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym,
+                         urls: o.fetch('urls', []))
       end
     end
 

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -60,6 +60,14 @@ module RuboCop
       #   the autocorrection for this offense, or `nil` when not available
       attr_reader :corrector
 
+      # @api public
+      #
+      # @!attribute [r] urls
+      #
+      # @return [Array<String>]
+      #   style guide and reference URLs for the offense
+      attr_reader :urls
+
       PseudoSourceRange = Struct.new(:line, :column, :source_line, :begin_pos,
                                      :end_pos) do
         alias_method :first_line, :line
@@ -88,13 +96,14 @@ module RuboCop
 
       # @api private
       def initialize(severity, location, message, cop_name, # rubocop:disable Metrics/ParameterLists
-                     status = :uncorrected, corrector = nil)
+                     status = :uncorrected, corrector = nil, urls: [])
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
         @message = message.freeze
         @cop_name = cop_name.freeze
         @status = status
         @corrector = corrector
+        @urls = urls.freeze
         freeze
       end
 

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -48,12 +48,13 @@ module RuboCop
 
       def hash_for_offense(offense)
         {
-          severity:    offense.severity.name,
-          message:     offense.message,
-          cop_name:    offense.cop_name,
-          corrected:   offense.corrected?,
-          correctable: offense.correctable?,
-          location:    hash_for_location(offense)
+          severity:         offense.severity.name,
+          message:          offense.message,
+          cop_name:         offense.cop_name,
+          corrected:        offense.corrected?,
+          correctable:      offense.correctable?,
+          location:         hash_for_location(offense),
+          style_guide_urls: offense.urls
         }
       end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1268,6 +1268,28 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
                "(#{style_guide_link}, #{reference_link})"
       expect($stdout.string.lines.to_a[-1]).to eq([output, ''].join("\n"))
     end
+
+    it 'includes style_guide_urls in JSON output without --display-style-guide' do
+      create_file('example1.rb', 'puts 0 ')
+      cli.run(['--format', 'json', '--only', 'Layout/TrailingWhitespace', 'example1.rb'])
+
+      json = JSON.parse($stdout.string)
+      offenses = json['files'][0]['offenses']
+      offense = offenses.find { |o| o['cop_name'] == 'Layout/TrailingWhitespace' }
+
+      expect(offense['style_guide_urls'])
+        .to include('https://rubystyle.guide#no-trailing-whitespace')
+    end
+
+    it 'returns empty style_guide_urls in JSON for cops without references' do
+      create_file('example1.rb', 'binding.irb')
+      cli.run(['--format', 'json', '--only', 'Lint/Debugger', 'example1.rb'])
+
+      json = JSON.parse($stdout.string)
+      offense = json['files'][0]['offenses'].find { |o| o['cop_name'] == 'Lint/Debugger' }
+
+      expect(offense['style_guide_urls']).to eq([])
+    end
   end
 
   describe '--show-cops' do

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe RuboCop::Cop::Offense do
     expect(offense).to be_frozen
   end
 
+  describe '#urls' do
+    it 'defaults to an empty array' do
+      expect(offense.urls).to eq([])
+    end
+
+    it 'is frozen' do
+      expect(offense.urls).to be_frozen
+    end
+
+    context 'when urls are provided' do
+      subject(:offense) do
+        described_class.new(:convention, location, 'message', 'CopName', :corrected, nil,
+                            urls: ['https://example.com/style'])
+      end
+
+      it 'stores the provided urls' do
+        expect(offense.urls).to eq(['https://example.com/style'])
+      end
+
+      it 'is frozen' do
+        expect(offense.urls).to be_frozen
+      end
+    end
+  end
+
   %i[severity location message cop_name].each do |a|
     describe "##{a}" do
       it 'is frozen' do

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -128,6 +128,23 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
       expect(hash[:corrected]).to be(true)
     end
 
+    it 'sets empty style_guide_urls by default' do
+      expect(hash[:style_guide_urls]).to eq([])
+    end
+
+    context 'when offense has urls' do
+      let(:offense) do
+        RuboCop::Cop::Offense.new(
+          :convention, location, 'This is message', 'CopName', :corrected, nil,
+          urls: ['https://rubystyle.guide#max-line-length']
+        )
+      end
+
+      it 'sets style_guide_urls from offense urls' do
+        expect(hash[:style_guide_urls]).to eq(['https://rubystyle.guide#max-line-length'])
+      end
+    end
+
     it 'sets value of #hash_for_location for :location key' do
       location_hash = {
         start_line: 2,

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -129,6 +129,27 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         end
       end
 
+      context 'an offense with urls' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :uncorrected, nil,
+            urls: ['https://rubystyle.guide#underscore-unused-vars']
+          )
+        end
+
+        it 'preserves urls through save/load' do
+          cache.save([offense])
+          expect(cache.load[0].urls).to eq(['https://rubystyle.guide#underscore-unused-vars'])
+        end
+      end
+
+      context 'an offense without urls (old cache format)' do
+        it 'defaults to empty urls' do
+          cache.save(offenses)
+          expect(cache.load[0].urls).to eq([])
+        end
+      end
+
       context 'a global Lint/Syntax offense, caused by a parser error' do
         before do
           create_file('example.rb', ['# encoding: unknown'])


### PR DESCRIPTION
(First open source contribution)

Closes https://github.com/rubocop/rubocop/issues/7201

When using `--format=json` with `--display-style-guide` - the URL to the style guide currently needs to be parsed to obtain it programmatically.

This feature adds the `urls` key to rubocop offenses so the url to the style guide can be fetched directly.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
