### PR TITLE
Fix false obsolete config error for extracted cops loaded as plugins

### DIFF
--- a/changelog/fix_extracted_cop_plugin_loaded_check.md
+++ b/changelog/fix_extracted_cop_plugin_loaded_check.md
@@ -1,0 +1,1 @@
+* [#14800](https://github.com/rubocop/rubocop/issues/14800): Fix false obsolete configuration error for extracted cops when loaded as plugins. ([@bbatsov][])

--- a/lib/rubocop/config_obsoletion/extracted_cop.rb
+++ b/lib/rubocop/config_obsoletion/extracted_cop.rb
@@ -39,8 +39,10 @@ module RuboCop
       end
 
       def plugin_loaded?
-        # Plugins loaded via `require` are included in `loaded_features`.
-        config.loaded_plugins.include?(gem) || config.loaded_features.include?(gem)
+        # Plugins loaded via `plugins` are Plugin objects with an `about.name` attribute.
+        # Plugins loaded via `require` are included in `loaded_features` as strings.
+        config.loaded_plugins.any? { |plugin| plugin.about.name == gem } ||
+          config.loaded_features.include?(gem)
       end
     end
   end

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe RuboCop::ConfigObsoletion do
 
   let(:configuration) { RuboCop::Config.new(hash, loaded_path) }
   let(:loaded_path) { 'example/.rubocop.yml' }
-  let(:plugins) { [] }
+  let(:plugin_names) { [] }
+  let(:plugins) { plugin_names.map { |name| plugin_stub(name) } }
   let(:requires) { [] }
+
+  def plugin_stub(name)
+    about = Struct.new(:name).new(name)
+    Struct.new(:about).new(about)
+  end
 
   before do
     allow(configuration).to receive_messages(loaded_plugins: plugins, loaded_features: requires)
@@ -241,7 +247,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
       end
 
       context 'when the plugin extensions are loaded' do
-        let(:plugins) { %w[rubocop-rails rubocop-performance] }
+        let(:plugin_names) { %w[rubocop-rails rubocop-performance] }
 
         it 'does not print a warning message' do
           expect { config_obsoletion.reject_obsolete! }.not_to raise_error
@@ -249,7 +255,7 @@ RSpec.describe RuboCop::ConfigObsoletion do
       end
 
       context 'when only one plugin extension is loaded' do
-        let(:plugins) { %w[rubocop-performance] }
+        let(:plugin_names) { %w[rubocop-performance] }
 
         let(:expected_message) do
           <<~OUTPUT.chomp


### PR DESCRIPTION
`ExtractedCop#plugin_loaded?` compared the gem name string (e.g. `"rubocop-performance"`) directly against Plugin objects in `config.loaded_plugins` using `include?`, which never matched. This caused a false `"Performance/* has been extracted to rubocop-performance"` error even when rubocop-performance was properly loaded as a plugin.

The fix uses `any? { |plugin| plugin.about.name == gem }` to correctly compare against plugin names, consistent with how `ConfigLoaderResolver#resolve_plugins` already does it.

Also updated the test stubs to use plugin-like objects instead of plain strings, so the tests actually exercise the real comparison logic.

Fixes #14800

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/