### PR TITLE
Detect constant reassignment after class/module definition in `Lint/ConstantReassignment`

### DIFF
--- a/changelog/fix_constant_reassignment_class_keyword.md
+++ b/changelog/fix_constant_reassignment_class_keyword.md
@@ -1,0 +1,1 @@
+* [#14897](https://github.com/rubocop/rubocop/pull/14897): Detect constant reassignment after class/module definition in `Lint/ConstantReassignment`. ([@ydakuka][])


### PR DESCRIPTION
- Track `class`/`module` keyword definitions as constant sources, so reassignment like `class FooError < StandardError; end; FooError = Class.new(RuntimeError)` is now detected
- Fix `remove_const` matcher to only match implicit `self` or no receiver (previously `Other.remove_const :FOO` would incorrectly clear tracking)
- Support multiple assignment (`FOO, BAR = 2, 3`) as a reassignment source
- Show full constant path in offense message (e.g. `A::FooError` instead of `FooError`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
