### PR TITLE
Improve documentation for Security/Eval

### DIFF
--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -3,15 +3,28 @@
 module RuboCop
   module Cop
     module Security
-      # Checks for the use of `Kernel#eval` and `Binding#eval`.
+      # Checks for the use of `Kernel#eval` and `Binding#eval` with
+      # dynamic strings as arguments. Evaluating non-literal strings
+      # can enable code injection attacks and makes it difficult to
+      # reason about what code will actually be executed.
+      #
+      # Calls to `eval` with literal strings are not flagged by this cop,
+      # as they do not pose the same injection risk.
       #
       # @example
       #
       #   # bad
-      #
       #   eval(something)
       #   binding.eval(something)
       #   Kernel.eval(something)
+      #
+      #   # good - use safer alternatives
+      #   obj.public_send(method_name)
+      #   obj.send(method_name, *args)
+      #
+      #   # good - literal strings are allowed
+      #   eval("1 + 1")
+      #   binding.eval("foo")
       class Eval < Base
         MSG = 'The use of `eval` is a serious security risk.'
         RESTRICT_ON_SEND = %i[eval].freeze


### PR DESCRIPTION
Add rationale explaining why dynamic eval is a security risk, document that literal string arguments are not flagged (matching the actual cop behavior), and add good examples showing `public_send`/`send` as safer alternatives.

Part of a broader effort to improve cop documentation across the codebase.