### PR TITLE
Add rationale to Style cop docs (batch 1)

### DIFF
--- a/lib/rubocop/cop/style/begin_block.rb
+++ b/lib/rubocop/cop/style/begin_block.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for BEGIN blocks.
+      # Checks for `BEGIN` blocks. They are Perl-style constructs that execute
+      # code before the rest of the file is parsed, making the control flow
+      # harder to follow and reason about.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -4,6 +4,10 @@ module RuboCop
   module Cop
     module Style
       # Checks for uses of the case equality operator (`===`).
+      # The `===` operator has different behavior depending on the
+      # receiver and its use outside of `case`/`when` is confusing.
+      # Prefer more explicit alternatives like `is_a?`, `include?`,
+      # or `match?`.
       #
       # If `AllowOnConstant` option is enabled, the cop will ignore violations when the receiver of
       # the case equality operator is a constant.

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -4,7 +4,9 @@ module RuboCop
   module Cop
     module Style
       # Checks for methods invoked via the `::` operator instead
-      # of the `.` operator (like `FileUtils::rmdir` instead of `FileUtils.rmdir`).
+      # of the `.` operator (like `FileUtils::rmdir` instead of
+      # `FileUtils.rmdir`). The `::` operator is conventionally used to
+      # reference constants, so using it for method calls can be misleading.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for END blocks.
+      # Checks for `END` blocks. `END` blocks are Perl-style constructs
+      # and `Kernel#at_exit` is the idiomatic Ruby alternative, as it's
+      # explicit and can be used anywhere.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -3,7 +3,10 @@
 module RuboCop
   module Cop
     module Style
-      # Looks for uses of global variables.
+      # Looks for uses of global variables. Global variables introduce
+      # shared mutable state that makes code harder to test, debug,
+      # and reason about, since any part of the program can read or modify them.
+      #
       # It does not report offenses for built-in global variables.
       # Built-in global variables are allowed by default. Additionally
       # users can allow additional variables via the AllowedVariables option.


### PR DESCRIPTION
Several Style cops have documentation that describes what they check but not
why the pattern is problematic. This adds brief rationale to:

- `Style/BeginBlock` - Perl-style, hard to follow control flow
- `Style/EndBlock` - Perl-style, `at_exit` is the idiomatic alternative
- `Style/GlobalVars` - shared mutable state, hard to test and debug
- `Style/CaseEquality` - confusing behavior outside case/when, prefer explicit alternatives
- `Style/ColonMethodCall` - `::` conventionally references constants, misleading for method calls

Part of a broader effort to improve cop documentation across the codebase.