### PR TITLE
Add rationale to Style cop docs (batch 2)

### DIFF
--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -3,9 +3,11 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of "*" as a substitute for _join_.
+      # Checks for uses of `*` as a substitute for `Array#join`.
+      # Using `join` is clearer about intent and more readable than
+      # overloading the `*` operator for string conversion.
       #
-      # Not all cases can reliably checked, due to Ruby's dynamic
+      # Not all cases can be reliably checked, due to Ruby's dynamic
       # types, so we consider only cases when the first argument is an
       # array literal or the second is a string literal.
       #

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -4,7 +4,8 @@ module RuboCop
   module Cop
     module Style
       # Checks for big numeric literals without `_` between groups
-      # of digits in them.
+      # of digits in them. Underscores make large numbers easier to
+      # read by visually separating groups of digits.
       #
       # Additional allowed patterns can be added by adding regexps to
       # the `AllowedPatterns` configuration. All regexps are treated

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -3,9 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for redundant `begin` blocks.
-      #
-      # Currently it checks for code like this:
+      # Checks for redundant `begin` blocks. A `begin` block is redundant
+      # when the `rescue`/`ensure` can be handled by the enclosing method
+      # or block definition directly, avoiding unnecessary indentation.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for redundant `return` expressions.
+      # Checks for redundant `return` expressions. Ruby methods
+      # implicitly return the value of the last evaluated expression,
+      # so an explicit `return` at the end of a method body is unnecessary.
       #
       # @example
       #   # These bad cases should be extended to handle methods whose body is

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Style
       # Checks for multiple expressions placed on the same line.
       # It also checks for lines terminated with a semicolon.
+      # In idiomatic Ruby, each expression should be on its own line
+      # for readability.
       #
       # This cop has `AllowAsExpressionSeparator` configuration option.
       # It allows `;` to separate several expressions on the same line.


### PR DESCRIPTION
Several Style cops have documentation that describes what they check but not
why the pattern is problematic. This adds brief rationale to:

- `Style/RedundantReturn` - Ruby implicit returns make explicit `return` unnecessary
- `Style/RedundantBegin` - rescue/ensure can be handled by enclosing method/block directly
- `Style/Semicolon` - one expression per line is idiomatic Ruby
- `Style/NumericLiterals` - underscores visually separate digit groups for readability
- `Style/ArrayJoin` - `join` is clearer about intent than overloading `*`

Also fixes a small grammar issue in ArrayJoin ("can reliably checked" → "can be reliably checked").

Part of a broader effort to improve cop documentation across the codebase.