### PR TITLE
Add rationale to Style cop docs (batch 3)

### DIFF
--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -3,10 +3,13 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of Module#attr.
+      # Checks for uses of `Module#attr`. The `attr` method has confusing
+      # behavior: with a single argument it creates a reader (like `attr_reader`),
+      # but with a second boolean argument it creates an accessor (deprecated in
+      # Ruby 1.9). Use `attr_reader` or `attr_accessor` to make intent explicit.
       #
       # @example
-      #   # bad - creates a single attribute accessor (deprecated in Ruby 1.9)
+      #   # bad
       #   attr :something, true
       #   attr :one, :two, :three # behaves as attr_reader
       #

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -8,6 +8,9 @@ module RuboCop
       # parameter. An `each` call with a block on a single line is always
       # allowed.
       #
+      # NOTE: `each` is preferred in idiomatic Ruby because `for` leaks
+      # its loop variable into the surrounding scope.
+      #
       # @example EnforcedStyle: each (default)
       #   # bad
       #   def foo

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module Style
       # Checks for uses of the keyword `not` instead of `!`.
+      # The `not` keyword has lower precedence than `!`, which can
+      # lead to surprising behavior and often requires parentheses.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -4,6 +4,10 @@ module RuboCop
   module Cop
     module Style
       # Checks for simple usages of parallel assignment.
+      # Parallel assignment is less readable than individual
+      # assignments and makes it harder to follow what each
+      # variable is being set to.
+      #
       # This will only complain when the number of variables
       # being assigned matched the number of assigning variables.
       #

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of Proc.new where Kernel#proc
-      # would be more appropriate.
+      # Checks for uses of `Proc.new` where `Kernel#proc`
+      # would be more appropriate. `proc` is the shorter and
+      # more idiomatic way to create procs in Ruby.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Several Style cops have documentation that describes what they check but not
why the pattern is problematic. This adds brief rationale to:

- `Style/ParallelAssignment` - less readable, harder to follow individual assignments
- `Style/For` - `each` is idiomatic, `for` leaks its loop variable
- `Style/Proc` - `proc` is shorter and more idiomatic than `Proc.new`
- `Style/Attr` - confusing dual behavior, `attr_reader`/`attr_accessor` are explicit
- `Style/Not` - lower precedence than `!`, often requires parentheses

Part of a broader effort to improve cop documentation across the codebase.