### PR TITLE
Add rationale to Style cop docs (batch 4)

### DIFF
--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -4,7 +4,10 @@ module RuboCop
   module Cop
     module Style
       # Enforces the use of either `#alias` or `#alias_method`
-      # depending on configuration.
+      # depending on configuration. Consistent use of one or the
+      # other prevents confusion about their different semantics
+      # (e.g., `alias` is resolved at parse time, while `alias_method`
+      # is resolved at runtime).
       # It also flags uses of `alias :symbol` rather than `alias bareword`.
       #
       # However, it will always enforce `method_alias` when used `alias`

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -3,9 +3,10 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of if/then/else/end constructs on a single line.
-      # `AlwaysCorrectToMultiline` config option can be set to true to autocorrect all offenses to
-      # multi-line constructs. When `AlwaysCorrectToMultiline` is false (default case) the
+      # Checks for uses of `if/then/else/end` constructs on a single line.
+      # A ternary operator (`?:`) or multi-line `if` is more readable.
+      # `AlwaysCorrectToMultiline` config option can be set to `true` to autocorrect all offenses to
+      # multi-line constructs. When `AlwaysCorrectToMultiline` is `false` (default case) the
       # autocorrect will first try converting them to ternary operators.
       #
       # @example

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -4,7 +4,9 @@ module RuboCop
   module Cop
     module Style
       # Checks for single-line method definitions that contain a body.
-      # It will accept single-line methods with no body.
+      # Single-line methods with a body are harder to read and debug
+      # than their multi-line equivalents. It will accept single-line
+      # methods with no body.
       #
       # Endless methods added in Ruby 3.0 are also accepted by this cop.
       #


### PR DESCRIPTION
Several Style cops have documentation that describes what they check but not
why the pattern is problematic. This adds brief rationale to:

- `Style/Alias` - consistent usage prevents confusion about parse-time vs runtime semantics
- `Style/SingleLineMethods` - single-line methods with bodies are harder to read and debug
- `Style/OneLineConditional` - ternary or multi-line `if` is more readable

Part of a broader effort to improve cop documentation across the codebase.