### PR TITLE
Add rationale to Style cop docs for consistency cops

### DIFF
--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -4,8 +4,10 @@ module RuboCop
   module Cop
     module Style
       # Checks for grouping of accessors in `class` and `module` bodies.
-      # By default it enforces accessors to be placed in grouped declarations,
-      # but it can be configured to enforce separating them in multiple declarations.
+      # By default it enforces accessors to be placed in grouped
+      # declarations, reducing boilerplate. It can also be configured
+      # to enforce separating them into individual declarations for
+      # easier diffing and per-attribute documentation.
       #
       # NOTE: If there is a method call before the accessor method it is always allowed
       # as it might be intended like Sorbet.

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -4,8 +4,11 @@ module RuboCop
   module Cop
     module Style
       # Checks for non-ascii (non-English) characters
-      # in comments. You could set an array of allowed non-ascii chars in
-      # `AllowedChars` attribute (copyright notice "©" by default).
+      # in comments. Non-ascii characters can cause issues with
+      # portability and encoding across different environments
+      # and editors. You could set an array of allowed non-ascii
+      # chars in `AllowedChars` attribute (copyright notice "©"
+      # by default).
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks if usage of %() or %Q() matches configuration.
+      # Checks if usage of `%()` or `%Q()` matches configuration.
+      # Consistent use of one style makes the codebase easier
+      # to read.
       #
       # @example EnforcedStyle: bare_percent (default)
       #   # bad

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -3,7 +3,10 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for trailing inline comments.
+      # Checks for trailing inline comments. Inline comments can
+      # make lines harder to read, especially when they are long.
+      # Placing comments on their own line above the code they
+      # describe is often clearer.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of the `then` keyword in multi-line if statements.
+      # Checks for uses of the `then` keyword in multi-line `if` statements.
+      # In multi-line `if` statements, `then` is redundant because the newline
+      # already separates the condition from the body.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -4,9 +4,8 @@ module RuboCop
   module Cop
     module Style
       # Checks for comparison of something with nil using `==` and
-      # `nil?`.
-      #
-      # Supported styles are: predicate, comparison.
+      # `nil?`. Enforcing a consistent style (either the `nil?`
+      # predicate or `==` comparison) improves readability.
       #
       # @example EnforcedStyle: predicate (default)
       #

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module Style
       # Enforces the consistent usage of `%`-literal delimiters.
+      # Using consistent delimiters across the codebase reduces
+      # cognitive load when reading `%`-literals.
       #
       # Specify the 'default' key to set all preferred delimiters at once. You
       # can continue to specify individual preferred delimiters to override the


### PR DESCRIPTION
Several Style cops that enforce consistency have documentation that just says
"Checks for X" or "Enforces X" without explaining why consistency matters
in each case. This adds brief rationale to:

- `Style/AsciiComments` - portability and encoding issues
- `Style/BarePercentLiterals` - consistent usage improves readability
- `Style/InlineComment` - inline comments can make lines harder to read
- `Style/MultilineIfThen` - `then` is redundant when newline separates condition from body
- `Style/NilComparison` - consistent style improves readability
- `Style/PercentLiteralDelimiters` - consistent delimiters reduce cognitive load
- `Style/AccessorGrouping` - reduces boilerplate (grouped) or eases diffing (separated)

Part of a broader effort to improve cop documentation across the codebase.