### PR TITLE
Improve docs for Encoding, SpecialGlobalVars, and Copyright

### DIFF
--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Check that a copyright notice was given in each source file.
+      # Checks that a copyright notice was given in each source file.
       #
       # The default regexp for an acceptable copyright notice can be found in
       # config/default.yml. The default can be changed as follows:

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -3,12 +3,18 @@
 module RuboCop
   module Cop
     module Style
-      # Checks ensures source files have no utf-8 encoding comments.
+      # Checks that source files have no utf-8 encoding comments.
+      # Since Ruby 2.0, UTF-8 is the default source encoding, so
+      # these comments are no longer necessary and just add noise.
+      #
       # @example
       #   # bad
       #   # encoding: UTF-8
       #   # coding: UTF-8
       #   # -*- coding: UTF-8 -*-
+      #
+      #   # good
+      #   # No encoding comment needed
       class Encoding < Base
         include RangeHelp
         extend AutoCorrector

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -4,7 +4,12 @@ module RuboCop
   module Cop
     module Style
       # Looks for uses of Perl-style global variables.
-      # Correcting to global variables in the 'English' library
+      # Perl-style global variables like `$;` or `$/` are cryptic
+      # and hard to understand without consulting documentation.
+      # The `English` library provides descriptive aliases like
+      # `$FIELD_SEPARATOR` and `$INPUT_RECORD_SEPARATOR`.
+      #
+      # Correcting to global variables in the `English` library
       # will add a require statement to the top of the file if
       # enabled by RequireEnglish config.
       #


### PR DESCRIPTION
Fix grammar and add missing rationale/examples to three Style cops:

- `Style/Encoding`: fix grammar, explain why UTF-8 encoding comments are unnecessary since Ruby 2.0, add a `# good` example
- `Style/SpecialGlobalVars`: add rationale explaining why Perl-style globals are problematic
- `Style/Copyright`: fix grammar ('Check' → 'Checks')