### PR TITLE
Add bad examples to EmptyLinesAround body cop docs

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -7,15 +7,25 @@ module RuboCop
       # the configuration.
       #
       # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
+      #   # bad
+      #   foo do |bar|
       #
+      #     # ...
+      #
+      #   end
+      #
+      #   # good
       #   foo do |bar|
       #     # ...
       #   end
       #
       # @example EnforcedStyle: empty_lines
-      #   # good
+      #   # bad
+      #   foo do |bar|
+      #     # ...
+      #   end
       #
+      #   # good
       #   foo do |bar|
       #
       #     # ...

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -7,8 +7,16 @@ module RuboCop
       # the configuration.
       #
       # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
+      #   # bad
+      #   class Foo
       #
+      #     def bar
+      #       # ...
+      #     end
+      #
+      #   end
+      #
+      #   # good
       #   class Foo
       #     def bar
       #       # ...
@@ -16,8 +24,14 @@ module RuboCop
       #   end
       #
       # @example EnforcedStyle: empty_lines
-      #   # good
+      #   # bad
+      #   class Foo
+      #     def bar
+      #       # ...
+      #     end
+      #   end
       #
+      #   # good
       #   class Foo
       #
       #     def bar

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -7,8 +7,16 @@ module RuboCop
       # the configuration.
       #
       # @example EnforcedStyle: no_empty_lines (default)
-      #   # good
+      #   # bad
+      #   module Foo
       #
+      #     def bar
+      #       # ...
+      #     end
+      #
+      #   end
+      #
+      #   # good
       #   module Foo
       #     def bar
       #       # ...
@@ -16,8 +24,14 @@ module RuboCop
       #   end
       #
       # @example EnforcedStyle: empty_lines
-      #   # good
+      #   # bad
+      #   module Foo
+      #     def bar
+      #       # ...
+      #     end
+      #   end
       #
+      #   # good
       #   module Foo
       #
       #     def bar


### PR DESCRIPTION
The EmptyLinesAround{Block,Class,Module}Body cops only showed `# good`
examples for each enforced style, making it unclear what code would
trigger an offense. Add the corresponding `# bad` examples for the
`no_empty_lines` and `empty_lines` styles.