### PR TITLE
Add examples to BlockNesting and DepartmentName docs

### DIFF
--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module Metrics
       # Checks for excessive nesting of conditional and looping constructs.
+      # Deeply nested code is harder to read, understand, and maintain.
+      # Extracting nested logic into methods improves clarity.
       #
       # You can configure if blocks are considered using the `CountBlocks` and `CountModifierForms`
       # options. When both are set to `false` (the default) blocks and modifier forms are not
@@ -11,6 +13,27 @@ module RuboCop
       # calculation as well.
       #
       # The maximum level of nesting allowed is configurable.
+      #
+      # @example Max: 3 (default)
+      #   # bad
+      #   if condition1
+      #     if condition2
+      #       if condition3
+      #         if condition4
+      #           do_something
+      #         end
+      #       end
+      #     end
+      #   end
+      #
+      #   # good
+      #   if condition1
+      #     if condition2
+      #       if condition3
+      #         do_something
+      #       end
+      #     end
+      #   end
       class BlockNesting < Base
         NESTING_BLOCKS = %i[case case_match if while while_post until until_post for resbody].freeze
 

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
+# Lint/RedundantCopDisableDirective needs to be disabled so as
+# to be able to provide examples of rubocop:disable comments.
+# rubocop:disable Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Migration
-      # Check that cop names in rubocop:disable comments are given with
+      # Checks that cop names in rubocop:disable comments are given with
       # department name.
+      #
+      # @example
+      #   # bad
+      #   # rubocop:disable AbcSize
+      #
+      #   # good
+      #   # rubocop:disable Metrics/AbcSize
       class DepartmentName < Base
         include RangeHelp
         extend AutoCorrector
@@ -79,3 +89,4 @@ module RuboCop
     end
   end
 end
+# rubocop:enable Lint/RedundantCopDisableDirective


### PR DESCRIPTION
- `Metrics/BlockNesting`: add rationale about deep nesting hurting readability, add bad/good examples for the default `Max: 3` setting
- `Migration/DepartmentName`: fix grammar ('Check' → 'Checks'), add bad/good examples showing a cop name without a department prefix