### PR TITLE
Fix grammar and add missing examples in cop docs

### DIFF
--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Check that the arguments on a multi-line method call are aligned.
+      # Checks that the arguments on a multi-line method call are aligned.
       #
       # @example EnforcedStyle: with_first_argument (default)
       #   # good

--- a/lib/rubocop/cop/layout/array_alignment.rb
+++ b/lib/rubocop/cop/layout/array_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Check that the elements of a multi-line array literal are
+      # Checks that the elements of a multi-line array literal are
       # aligned.
       #
       # @example EnforcedStyle: with_first_element (default)

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Check that the keys, separators, and values of a multi-line hash
+      # Checks that the keys, separators, and values of a multi-line hash
       # literal are aligned according to configuration. The configuration
       # options are:
       #

--- a/lib/rubocop/cop/layout/parameter_alignment.rb
+++ b/lib/rubocop/cop/layout/parameter_alignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Layout
-      # Check that the parameters on a multi-line method call or definition are aligned.
+      # Checks that the parameters on a multi-line method call or definition are aligned.
       #
       # To set the alignment of the first argument, use the
       # `Layout/FirstParameterIndentation` cop.

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Check that certain constants are fully qualified.
+      # Checks that certain constants are fully qualified.
       #
       # This is not enabled by default because it would mark a lot of offenses
       # unnecessarily.

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Check to make sure that if safe navigation is used in an `&&` or `||` condition,
+      # Checks that if safe navigation is used in an `&&` or `||` condition,
       # consistent and appropriate safe navigation, without excess or deficiency,
       # is used for all method calls on the same object.
       #

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -28,16 +28,24 @@ module RuboCop
       #   manual oversight.
       #
       # @example EnforcedStyle: nested (default)
+      #   # bad
+      #   class Foo::Bar
+      #   end
+      #
       #   # good
-      #   # have each child on its own line
       #   class Foo
       #     class Bar
       #     end
       #   end
       #
       # @example EnforcedStyle: compact
+      #   # bad
+      #   class Foo
+      #     class Bar
+      #     end
+      #   end
+      #
       #   # good
-      #   # combine definitions as much as possible
       #   class Foo::Bar
       #   end
       #


### PR DESCRIPTION
Fix 'Check' → 'Checks' grammar in 6 cop descriptions (ArgumentAlignment,
ArrayAlignment, HashAlignment, ParameterAlignment, ConstantResolution,
SafeNavigationConsistency) and add missing `# bad` examples to
ClassAndModuleChildren for both enforced styles.