### PR TITLE
Fix dotfile remote configs being ignored in inherit_from

### DIFF
--- a/changelog/fix_dotfile_remote_configs_ignored_in_inherit_from.md
+++ b/changelog/fix_dotfile_remote_configs_ignored_in_inherit_from.md
@@ -1,0 +1,1 @@
+* [#14908](https://github.com/rubocop/rubocop/pull/14908): Fix dotfile remote configs being ignored in `inherit_from` (regression from [#14870](https://github.com/rubocop/rubocop/pull/14870)). ([@knapo][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -233,7 +233,7 @@ module RuboCop
 
     def base_configs(path, inherit_from, file)
       inherit_froms = Array(inherit_from).compact.flat_map do |f|
-        PathUtil.glob?(f) ? Dir.glob(f) : f
+        PathUtil.glob?(f) ? Dir.glob(f, File::FNM_DOTMATCH) : f
       end
 
       configs = inherit_froms.map do |f|

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -283,5 +283,21 @@ RSpec.describe RuboCop::RemoteConfig do
         expect(action.size).to be(254)
       end
     end
+
+    context 'with dotfile on the URL' do
+      let(:remote_config_url) { 'http://example.com/.rubocop-ruby.yml' }
+
+      it 'returns a sanitized cache name' do
+        expect(action).to eq('.rubocop-ruby-6a679e7ffcafb12943fa4fe40bae174e.yml')
+      end
+    end
+
+    context 'with nested dotfile on the URL' do
+      let(:remote_config_url) { 'http://example.com/config/.rubocop.yml' }
+
+      it 'returns a sanitized cache name' do
+        expect(action).to eq('.rubocop-23d066df587770e4428d0f4b44350a2e.yml')
+      end
+    end
   end
 end


### PR DESCRIPTION
After commit a1157d2c / https://github.com/rubocop/rubocop/pull/14870 , remote configuration files with dotfiles in their names (e.g., .rubocop-ruby.yml) were being ignored when specified in inherit_from URLs. This happened because:

1. Cache filenames for dotfiles preserve the leading dot (e.g., .rubocop-ruby-<hash>.yml)
2. Dir.glob by default excludes files starting with a dot unless the File::FNM_DOTMATCH flag is used

This commit adds the File::FNM_DOTMATCH flag to Dir.glob in config_loader_resolver.rb to ensure dotfiles are properly matched when glob patterns are used in inherit_from.

Changes:
- Add File::FNM_DOTMATCH flag to Dir.glob in base_configs method
- Add tests for dotfile URL cache name generation
- Add integration test for loading configs from dotfile URLs

Fixes issue where inherit_from URLs like:
  - https://example.com/.rubocop-ruby.yml
  - https://example.com/.rubocop-rspec.yml were being ignored.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
