### PR TITLE
[Fix #14895] Rename `class_definition` to `class_keyword` in `EnforcedStyle` of `Style/EmptyClassDefinition`

### DIFF
--- a/changelog/change_rename_enforced_style_of_style_empty_class_definition.md
+++ b/changelog/change_rename_enforced_style_of_style_empty_class_definition.md
@@ -1,0 +1,1 @@
+* [#14895](https://github.com/rubocop/rubocop/issues/14895): Rename `class_definition` to `class_keyword` in `EnforcedStyle` of `Style/EmptyClassDefinition`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3987,10 +3987,11 @@ Style/EmptyClassDefinition:
   Description: 'Enforces consistent style for empty class definitions.'
   Enabled: pending
   VersionAdded: '1.84'
-  EnforcedStyle: class_definition
+  EnforcedStyle: class_keyword
   SupportedStyles:
-    - class_definition
+    - class_keyword
     - class_new
+    - class_definition # Deprecated.
 
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -245,3 +245,8 @@ changed_enforced_styles:
     parameters: EnforcedStyle
     value: rails
     alternative: indented_internal_methods
+  - cops: Style/EmptyClassDefinition
+    parameters: EnforcedStyle
+    value: class_definition
+    alternative: class_keyword
+    severity: warning

--- a/lib/rubocop/cop/style/empty_class_definition.rb
+++ b/lib/rubocop/cop/style/empty_class_definition.rb
@@ -8,12 +8,7 @@ module RuboCop
       # This cop can enforce either a standard class definition or `Class.new`
       # for classes with no body.
       #
-      # The supported styles are:
-      #
-      # * class_definition (default) - prefer standard class definition over `Class.new`
-      # * class_new - prefer `Class.new` over class definition
-      #
-      # @example EnforcedStyle: class_definition (default)
+      # @example EnforcedStyle: class_keyword (default)
       #   # bad
       #   FooError = Class.new(StandardError)
       #
@@ -40,9 +35,9 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        MSG_CLASS_DEFINITION =
-          'Prefer standard class definition over `Class.new` for classes with no body.'
-        MSG_CLASS_NEW = 'Prefer `Class.new` over class definition for classes with no body.'
+        MSG_CLASS_KEYWORD =
+          'Use the `class` keyword instead of `Class.new` to define an empty class.'
+        MSG_CLASS_NEW = 'Use `Class.new` instead of the `class` keyword to define an empty class.'
 
         # @!method class_new_assignment(node)
         def_node_matcher :class_new_assignment, <<~PATTERN
@@ -50,11 +45,11 @@ module RuboCop
         PATTERN
 
         def on_casgn(node)
-          return unless style == :class_definition
+          return unless %i[class_keyword class_definition].include?(style)
           return unless (class_new_node = class_new_assignment(node))
           return if (arg = class_new_node.first_argument) && !arg.const_type?
 
-          add_offense(node, message: MSG_CLASS_DEFINITION) do |corrector|
+          add_offense(node, message: MSG_CLASS_KEYWORD) do |corrector|
             autocorrect_class_new(corrector, node, class_new_node)
           end
         end

--- a/spec/rubocop/cop/style/empty_class_definition_spec.rb
+++ b/spec/rubocop/cop/style/empty_class_definition_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
-  context 'when EnforcedStyle is class_definition' do
-    let(:cop_config) { { 'EnforcedStyle' => 'class_definition' } }
+  context 'when EnforcedStyle is class_keyword' do
+    let(:cop_config) { { 'EnforcedStyle' => 'class_keyword' } }
 
     it 'registers an offense for Class.new assignment to constant' do
       expect_offense(<<~RUBY)
         FooError = Class.new(StandardError)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant without parent class' do
       expect_offense(<<~RUBY)
         MyClass = Class.new
-        ^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       expect_offense(<<~RUBY)
         module Foo
           BarError = Class.new(StandardError)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
         end
       RUBY
 
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant with namespaced parent class' do
       expect_offense(<<~RUBY)
         MyClass = Class.new(Alchemy::Admin::PreviewUrl)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for Class.new assignment to constant with absolute parent class path' do
       expect_offense(<<~RUBY)
         MyClass = Class.new(::Safemode::Jail)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer standard class definition over `Class.new` for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for two-line class definition with inheritance' do
       expect_offense(<<~RUBY)
         class FooError < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
       RUBY
 
@@ -291,7 +291,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for single-line class definition with inheritance' do
       expect_offense(<<~RUBY)
         class FooError < StandardError; end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -302,7 +302,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for two-line class definition without inheritance' do
       expect_offense(<<~RUBY)
         class MyClass
-        ^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
       RUBY
 
@@ -314,7 +314,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for single-line class definition without inheritance' do
       expect_offense(<<~RUBY)
         class MyClass; end
-        ^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -326,7 +326,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       expect_offense(<<~RUBY)
         module Foo
           class BarError < StandardError
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
           end
         end
       RUBY
@@ -341,7 +341,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for class definition with namespaced parent class' do
       expect_offense(<<~RUBY)
         class MyClass < Alchemy::Admin::PreviewUrl
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
       RUBY
 
@@ -353,7 +353,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'registers an offense for class definition with absolute parent class path' do
       expect_offense(<<~RUBY)
         class MyClass < ::Safemode::Jail
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
       RUBY
 
@@ -378,7 +378,7 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       expect_offense(<<~RUBY)
         module Foo
           class Bar < Baz; end
-          ^^^^^^^^^^^^^^^^^^^^ Prefer `Class.new` over class definition for classes with no body.
+          ^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
         end
       RUBY
 
@@ -402,6 +402,22 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     it 'does not register an offense for single-line class with body' do
       expect_no_offenses(<<~RUBY)
         class FooError < StandardError; def initialize; end; end
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is class_definition (deprecated)' do
+    let(:cop_config) { { 'EnforcedStyle' => 'class_definition' } }
+
+    it 'registers an offense for Class.new assignment to constant' do
+      expect_offense(<<~RUBY)
+        FooError = Class.new(StandardError)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooError < StandardError
+        end
       RUBY
     end
   end


### PR DESCRIPTION
This PR renames `class_definition` to `class_keyword` in `EnforcedStyle` of `Style/EmptyClassDefinition`.

When the old configuration is used:

```yaml
Style/EmptyClassDefinition:
  EnforcedStyle: class_definition
```

only a warning is shown and no error occurs. In other words, the rename can be performed without introducing a breaking change.

```console
$ bundle exec rubocop
Warning: obsolete `EnforcedStyle: class_definition` (for `Style/EmptyClassDefinition`) found in .rubocop.yml
`EnforcedStyle: class_definition` has been renamed to `EnforcedStyle: class_keyword`.
```

Fixes #14895.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
