### PR TITLE
Change `Style/EndlessMethod` cop to consider receivers

### DIFF
--- a/changelog/change_change_style_endless_method_to_consider_receivers.md
+++ b/changelog/change_change_style_endless_method_to_consider_receivers.md
@@ -1,0 +1,1 @@
+* [#14917](https://github.com/rubocop/rubocop/pull/14917): Change `Style/EndlessMethod` cop to consider receivers. ([@fatkodima][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -157,6 +157,7 @@ module RuboCop
             handle_require_always_style(node)
           end
         end
+        alias on_defs on_def
 
         private
 
@@ -207,7 +208,7 @@ module RuboCop
 
         def correct_to_multiline(corrector, node)
           replacement = <<~RUBY.strip
-            def #{node.method_name}#{arguments(node)}
+            def #{receiver(node)}#{node.method_name}#{arguments(node)}
               #{node.body.source}
             end
           RUBY
@@ -217,8 +218,12 @@ module RuboCop
 
         def endless_replacement(node)
           <<~RUBY.strip
-            def #{node.method_name}#{arguments(node)} = #{node.body.source}
+            def #{receiver(node)}#{node.method_name}#{arguments(node)} = #{node.body.source}
           RUBY
+        end
+
+        def receiver(node)
+          node.receiver ? "#{node.receiver.source}#{node.loc.operator.source}" : ''
         end
 
         def arguments(node, missing = '')

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'registers an offense for an endless method on self' do
+        expect_offense(<<~RUBY)
+          def self.my_method() = x
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.my_method
+            x
+          end
+        RUBY
+      end
+
+      it 'registers an offense for an endless method on self with ::' do
+        expect_offense(<<~RUBY)
+          def self::my_method() = x
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self::my_method
+            x
+          end
+        RUBY
+      end
+
       it 'registers an offense for an endless method with arguments' do
         expect_offense(<<~RUBY)
           def my_method(a, b) = x
@@ -59,6 +85,12 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for an endless method on self' do
+        expect_no_offenses(<<~RUBY)
+          def self.my_method() = x
+        RUBY
+      end
+
       it 'does not register an offense for an endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x
@@ -86,6 +118,40 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
             x.foo
                              .bar
                              .baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method on self' do
+        expect_offense(<<~RUBY)
+          def self.my_method() = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                                 .bar
+                                 .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.my_method
+            x.foo
+                                 .bar
+                                 .baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method on self with ::' do
+        expect_offense(<<~RUBY)
+          def self::my_method() = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                                   .bar
+                                   .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self::my_method
+            x.foo
+                                   .bar
+                                   .baz
           end
         RUBY
       end
@@ -131,6 +197,12 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
       it 'does not register an offense for an endless method' do
         expect_no_offenses(<<~RUBY)
           def my_method() = x
+        RUBY
+      end
+
+      it 'does not register an offense for an endless method on self' do
+        expect_no_offenses(<<~RUBY)
+          def self.my_method() = x
         RUBY
       end
 
@@ -182,6 +254,12 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for a single line endless method on self' do
+        expect_no_offenses(<<~RUBY)
+          def self.my_method() = x
+        RUBY
+      end
+
       it 'does not register an offense for a single line endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x
@@ -201,6 +279,40 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
             x.foo
                              .bar
                              .baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method on self' do
+        expect_offense(<<~RUBY)
+          def self.my_method() = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                                  .bar
+                                  .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.my_method
+            x.foo
+                                  .bar
+                                  .baz
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a multiline endless method on self with ::' do
+        expect_offense(<<~RUBY)
+          def self::my_method() = x.foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid endless method definitions with multiple lines.
+                                    .bar
+                                    .baz
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self::my_method
+            x.foo
+                                    .bar
+                                    .baz
           end
         RUBY
       end
@@ -392,6 +504,12 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for an endless method on self' do
+        expect_no_offenses(<<~RUBY)
+          def self.my_method() = x
+        RUBY
+      end
+
       it 'does not register an offense for an endless method with arguments' do
         expect_no_offenses(<<~RUBY)
           def my_method(a, b) = x
@@ -483,6 +601,32 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
 
         expect_correction(<<~RUBY)
           def my_method = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method on self' do
+        expect_offense(<<~RUBY)
+          def self.my_method
+          ^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.my_method = x
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a single line method on self with ::' do
+        expect_offense(<<~RUBY)
+          def self::my_method
+          ^^^^^^^^^^^^^^^^^^^ Use endless method definitions.
+            x
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self::my_method = x
         RUBY
       end
 


### PR DESCRIPTION
Currently, `Style/EndlessMethod` considers only method definitions like
```ruby
def foo = x
```

but ignores the ones with a receiver like
```ruby
def self.foo = x
```