### PR TITLE
[Fix #14918] Fix incorrect documentation of `Style/HashAsLastArrayItem`

### DIFF
--- a/lib/rubocop/cop/style/hash_as_last_array_item.rb
+++ b/lib/rubocop/cop/style/hash_as_last_array_item.rb
@@ -6,8 +6,13 @@ module RuboCop
       # Checks for presence or absence of braces around hash literal as a last
       # array item depending on configuration.
       #
-      # NOTE: This cop will ignore arrays where all items are hashes, regardless of
-      # EnforcedStyle.
+      # NOTE: This cop will ignore arrays where multiple items are all hashes,
+      # regardless of `EnforcedStyle`.
+      #
+      # [source,ruby]
+      # ----
+      # [{ one: 1 }, { two: 2 }]
+      # ----
       #
       # @example EnforcedStyle: braces (default)
       #   # bad
@@ -16,8 +21,11 @@ module RuboCop
       #   # good
       #   [1, 2, { one: 1, two: 2 }]
       #
+      #   # bad
+      #   [one: 1, two: 2]
+      #
       #   # good
-      #   [{ one: 1 }, { two: 2 }]
+      #   [{ one: 1, two: 2 }]
       #
       # @example EnforcedStyle: no_braces
       #   # bad
@@ -26,8 +34,11 @@ module RuboCop
       #   # good
       #   [1, 2, one: 1, two: 2]
       #
+      #   # bad
+      #   [{ one: 1, two: 2 }]
+      #
       #   # good
-      #   [{ one: 1 }, { two: 2 }]
+      #   [one: 1, two: 2]
       class HashAsLastArrayItem < Base
         include RangeHelp
         include ConfigurableEnforcedStyle


### PR DESCRIPTION
This PR updates the documentation for `Style/HashAsLastArrayItem` that was missed in #14842.

Fixes #14918.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
