### PR TITLE
Add `mise.toml` as source for TargetRubyVersion

### DIFF
--- a/changelog/new_add_mise_toml_as_source_for_target_ruby_version_20260220083228.md
+++ b/changelog/new_add_mise_toml_as_source_for_target_ruby_version_20260220083228.md
@@ -1,0 +1,1 @@
+* [#14921](https://github.com/rubocop/rubocop/pull/14921): Add `mise.toml` as source for TargetRubyVersion. ([@kitsane][])

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -710,7 +710,7 @@ AllCops:
 If a `TargetRubyVersion` is not specified in your config, then RuboCop will
 check your project for a series of other files where the Ruby version may be
 specified already. The files that will be checked are (in this order):
-`*.gemspec`, `.ruby-version`, `.tool-versions`, and `Gemfile.lock`.
+`*.gemspec`, `.ruby-version`, `mise.toml`, `.tool-versions`, and `Gemfile.lock`.
 
 The target ruby version may also be specified by setting the
 `RUBOCOP_TARGET_RUBY_VERSION` environment variable to the desired version: for

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -160,21 +160,18 @@ module RuboCop
     # The target ruby version may be found in a .ruby-version file.
     # @api private
     class RubyVersionFile < Source
-      RUBY_VERSION_FILENAME = '.ruby-version'
-      RUBY_VERSION_PATTERN = /\A(?:ruby-)?(?<version>\d+\.\d+)/.freeze
-
       def name
-        "`#{RUBY_VERSION_FILENAME}`"
+        "`#{filename}`"
       end
 
       private
 
       def filename
-        RUBY_VERSION_FILENAME
+        '.ruby-version'
       end
 
       def pattern
-        RUBY_VERSION_PATTERN
+        /\A(?:ruby-)?(?<version>\d+\.\d+)/.freeze
       end
 
       def find_version
@@ -193,21 +190,29 @@ module RuboCop
     # starting with `ruby`.
     # @api private
     class ToolVersionsFile < RubyVersionFile
-      TOOL_VERSIONS_FILENAME = '.tool-versions'
-      TOOL_VERSIONS_PATTERN = /^(?:ruby )(?<version>\d+\.\d+)/.freeze
-
-      def name
-        "`#{TOOL_VERSIONS_FILENAME}`"
-      end
-
       private
 
       def filename
-        TOOL_VERSIONS_FILENAME
+        '.tool-versions'
       end
 
       def pattern
-        TOOL_VERSIONS_PATTERN
+        /^(?:ruby )(?<version>\d+\.\d+)/.freeze
+      end
+    end
+
+    # The target ruby version may be found in a mise.toml file, in a line
+    # starting with `ruby = "`.
+    # @api private
+    class MiseTomlFile < RubyVersionFile
+      private
+
+      def filename
+        'mise.toml'
+      end
+
+      def pattern
+        /^ruby = "(?<version>\d+\.\d+)/.freeze
       end
     end
 
@@ -275,6 +280,7 @@ module RuboCop
       RuboCopConfig,
       GemspecFile,
       RubyVersionFile,
+      MiseTomlFile,
       ToolVersionsFile,
       BundlerLockFile,
       Default


### PR DESCRIPTION
We switched from [asdf](https://asdf-vm.com/) to [mise](https://mise.jdx.dev/) with its [`mise.toml` configuration file](https://mise.jdx.dev/configuration.html) and found out RuboCop doesn't read the target Ruby version from there yet.

-------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
