### PR TITLE
[Fix #14874] Fix a clobbering error in `Lint/UselessAssignment`

### DIFF
--- a/changelog/fix_merge_pull_request_14919_from_20260221041553.md
+++ b/changelog/fix_merge_pull_request_14919_from_20260221041553.md
@@ -1,0 +1,1 @@
+* [#14874](https://github.com/rubocop/rubocop/issues/14874): Fix a `Parser::ClobberingError` in `Lint/UselessAssignment` when autocorrecting a useless assignment that wraps a block containing another useless assignment. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -213,7 +213,7 @@ module RuboCop
         end
 
         def remove_local_variable_assignment_part(corrector, node)
-          corrector.replace(node, node.expression.source)
+          corrector.remove(node.loc.name.begin.join(node.expression.source_range.begin))
         end
 
         def variable_in_loop_condition?(assignment_node, variable)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2087,7 +2087,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(cli.run(['--autocorrect', '--format', 'simple', target_file])).to eq(0)
 
         expect($stdout.string.lines.to_a.last)
-          .to eq("1 file inspected, 3 offenses detected, 3 offenses corrected\n")
+          .to eq("1 file inspected, 2 offenses detected, 2 offenses corrected\n")
       end
     end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -2225,6 +2225,24 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a useless assignment wraps a block containing another useless assignment' do
+    it 'registers offenses and corrects' do
+      expect_offense(<<~RUBY)
+        foo = do_something {
+        ^^^ Useless assignment to variable - `foo`.
+          bar = do_something_else
+          ^^^ Useless assignment to variable - `bar`.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something {
+          do_something_else
+        }
+      RUBY
+    end
+  end
+
   context 'using numbered block parameter', :ruby27 do
     it 'does not register an offense when the variable is used' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes a clobbering error in `Lint/UselessAssignment` when autocorrecting a useless assignment that wraps a block containing another useless assignment.

Also update `spec/rubocop/cli/options_spec.rb` to reflect that the fix allows `Lint/UselessAssignment` and `Style/StringLiterals` corrections to be applied in the same pass without conflicting.

Fixes #14874.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
