### PR TITLE
[Fix #14857] Fix an infinite loop for `Style/IfUnlessModifier` when `if`/`unless` is inside string interpolation

### DIFF
--- a/changelog/fix_infinite_loop_in_style_if_unless_modifier.md
+++ b/changelog/fix_infinite_loop_in_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#14857](https://github.com/rubocop/rubocop/issues/14857): Fix an infinite loop for `Style/IfUnlessModifier` when `if`/`unless` is inside string interpolation. ([@ydakuka][])

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4222,4 +4222,25 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(status).to eq(0)
     expect($stderr.string).to eq('')
   end
+
+  it 'does not cause an infinite loop for `Style/IfUnlessModifier` ' \
+     'with `if`/`unless` inside string interpolation in a method' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~'RUBY')
+      "<li class='#{'xn-openable' if item.key?(:items)} item_#{index + 1} #{'active' if is_active_menu(item[:key])}' #{item[:bar]}>
+        #{foo}
+      </li>"
+    RUBY
+
+    status = cli.run(['--autocorrect-all'])
+    expect(status).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(source_file.read).to eq(<<~'RUBY')
+      # frozen_string_literal: true
+
+      "<li class='#{'xn-openable' if item.key?(:items)} item_#{index + 1} #{'active' if is_active_menu(item[:key])}' #{item[:bar]}>
+        #{foo}
+      </li>"
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -1323,4 +1323,60 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       end
     end
   end
+
+  context 'when if/unless is inside string interpolation' do
+    it 'does not register an offense for if modifier form' do
+      expect_no_offenses(<<~'RUBY')
+        "#{('x' if condition)}"
+      RUBY
+    end
+
+    it 'does not register an offense for if normal form' do
+      expect_no_offenses(<<~'RUBY')
+        "#{if condition
+             'x'
+           end}"
+      RUBY
+    end
+
+    it 'does not register an offense for unless modifier form' do
+      expect_no_offenses(<<~'RUBY')
+        "#{('x' unless condition)}"
+      RUBY
+    end
+
+    it 'does not register an offense for unless normal form' do
+      expect_no_offenses(<<~'RUBY')
+        "#{unless condition
+             'x'
+           end}"
+      RUBY
+    end
+
+    it 'does not register an offense inside a heredoc' do
+      expect_no_offenses(<<~'RUBY')
+        <<~HEREDOC
+          #{if condition
+               'x'
+             end}
+        HEREDOC
+      RUBY
+    end
+
+    it 'does not register an offense inside a %Q{} string' do
+      expect_no_offenses(<<~'RUBY')
+        %Q{#{if condition
+               'x'
+             end}}
+      RUBY
+    end
+
+    it 'does not register an offense inside nested string interpolation' do
+      expect_no_offenses(<<~'RUBY')
+        "outer #{func("#{if condition
+                           'x'
+                         end}")}"
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #14857

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
