### PR TITLE
Fix incorrect autocorrection for `Style/IfUnlessModifier` when multiple `if`/`unless` modifier forms are on the same line inside a collection

### DIFF
--- a/changelog/fix_incorrect_autocorrection_for_style_if_unless_modifier_in_collection.md
+++ b/changelog/fix_incorrect_autocorrection_for_style_if_unless_modifier_in_collection.md
@@ -1,0 +1,1 @@
+* [#14930](https://github.com/rubocop/rubocop/pull/14930): Fix incorrect autocorrection for `Style/IfUnlessModifier` when multiple `if`/`unless` modifier forms are on the same line inside a collection. ([@ydakuka][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -101,6 +101,7 @@ module RuboCop
 
           add_offense(node.loc.keyword, message: format(msg, keyword: node.keyword)) do |corrector|
             next if part_of_ignored_node?(node)
+            next if another_modifier_if_on_same_line?(node)
 
             autocorrect(corrector, node)
             ignore_node(node)
@@ -278,6 +279,16 @@ module RuboCop
           return node if node&.type?(:array, :call)
 
           node.parent if node&.type?(:pair)
+        end
+
+        def another_modifier_if_on_same_line?(node)
+          collection = find_containing_collection(node)
+          return false unless collection
+
+          line = node.source_range.line
+          collection.each_descendant(:if).any? do |sibling|
+            sibling != node && sibling.modifier_form? && sibling.source_range.line == line
+          end
         end
 
         def non_simple_if_unless?(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4219,7 +4219,15 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
 
     status = cli.run(['--autocorrect-all'])
-    expect(status).to eq(0)
+    expect(status).to eq(1)
     expect($stderr.string).to eq('')
+    expect(source_file.read).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      def previous_or_next_page(page, text, classname)
+        tag :li, link(text, page || '#'),
+            class: [(classname[0..3] if @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page)].join(' ')
+      end
+    RUBY
   end
 end


### PR DESCRIPTION
Alternative approach for same issue: #14699

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
