### PR TITLE
[Fix #14931] Ignore directive comments inside comments

### DIFF
--- a/changelog/fix_ignore_directive_comments_inside_comments.md
+++ b/changelog/fix_ignore_directive_comments_inside_comments.md
@@ -1,0 +1,1 @@
+* [#14931](https://github.com/rubocop/rubocop/issues/14931): Ignore directive comments inside comments. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# The Lint/RedundantCopEnableDirective and Lint/RedundantCopDisableDirective
-# cops need to be disabled so as to be able to provide a (bad) example of an
-# unneeded enable.
-
-# rubocop:disable Lint/RedundantCopEnableDirective
-# rubocop:disable Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Lint
@@ -130,6 +124,3 @@ module RuboCop
     end
   end
 end
-
-# rubocop:enable Lint/RedundantCopDisableDirective
-# rubocop:enable Lint/RedundantCopEnableDirective

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -52,7 +52,8 @@ module RuboCop
     def initialize(comment, cop_registry = Cop::Registry.global)
       @comment = comment
       @cop_registry = cop_registry
-      @match_data = comment.text.match(DIRECTIVE_COMMENT_REGEXP)
+      match_data = comment.text.match(DIRECTIVE_COMMENT_REGEXP)
+      @match_data = match_data&.pre_match&.match?(/\A#\s*\z/) ? nil : match_data
       @mode, @cops = match_captures
     end
 

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -101,6 +101,18 @@ RSpec.describe RuboCop::DirectiveComment do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when directive comment is used as a comment' do
+      let(:text) { '#   # rubocop:disable AbcSize' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when directive comment follows other comment content' do
+      let(:text) { '# some comment # rubocop:disable Metrics/AbcSize' }
+
+      it { is_expected.to eq(%w[disable Metrics/AbcSize]) }
+    end
   end
 
   describe '#single_line?' do


### PR DESCRIPTION
This PR prevents directive comments embedded in comments from being treated as directives, avoiding the following false positive:

```console
$ bundle exec rubocop lib/rubocop/cop/migration/department_name.rb --cache=false
Inspecting 1 file
/Users/koic/src/github.com/rubocop/rubocop/lib/rubocop/cop/migration/department_name.rb:
Warning: no department given for AbcSize. Run `rubocop -a --only Migration/DepartmentName` to fix.
.

1 file inspected, no offenses detected
```

Fixes #14931.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
