### PR TITLE
Fix a false positive for Lint/Void

### DIFF
--- a/changelog/fix_false_positive_for_lint_void.md
+++ b/changelog/fix_false_positive_for_lint_void.md
@@ -1,0 +1,1 @@
+* [#14928](https://github.com/rubocop/rubocop/issues/14928): Fix a false positive for `Lint/Void` when `nil` is used in `case` branch. ([@5hun-s][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -189,7 +189,9 @@ module RuboCop
         end
 
         def check_literal(node)
-          return if !entirely_literal?(node) || node.xstr_type? || node.range_type?
+          if !entirely_literal?(node) || node.xstr_type? || node.range_type? || node.nil_type?
+            return
+          end
 
           add_offense(node, message: format(LIT_MSG, lit: node.source)) do |corrector|
             autocorrect_void_expression(corrector, node)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1187,6 +1187,16 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'does not register an offense for `nil` in `case` branch' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1
+        nil
+      end
+      puts 3
+    RUBY
+  end
+
   it 'does not register an offense for `case` on last line' do
     expect_no_offenses(<<~RUBY)
       case foo


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop/issues/14928

This PR fixes a false positive for Lint/Void when `nil` is used as the body of a `when` branch in a `case` statement.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
