### PR TITLE
Add `InferPredicateMethods` option to `Naming/PredicateMethod`

### DIFF
--- a/changelog/new_merge_pull_request_14919_from_20260222173101.md
+++ b/changelog/new_merge_pull_request_14919_from_20260222173101.md
@@ -1,0 +1,1 @@
+* [#14256](https://github.com/rubocop/rubocop/issues/14256): Add `InferPredicateMethods` option to `Naming/PredicateMethod`. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3107,12 +3107,14 @@ Naming/PredicateMethod:
   Description: 'Checks that predicate methods end with `?` and non-predicate methods do not.'
   Enabled: pending
   VersionAdded: '1.76'
-  VersionChanged: '1.78'
+  VersionChanged: '<<next>>'
   # In `aggressive` mode, the cop will register an offense for predicate methods that
   #   may return a non-boolean value.
   # In `conservative` mode, the cop will *not* register an offense for predicate methods
   #   that may return a non-boolean value.
   Mode: conservative
+  # When `true`, the cop suggests adding `?` to methods that return boolean values.
+  InferPredicateMethods: false
   AllowedMethods:
     - call
   AllowedPatterns: []

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -66,7 +66,7 @@ module RuboCop
       end
 
       # @deprecated Use processed_source.line_with_comment?(line)
-      def end_of_line_comment(line) # rubocop:disable Naming/PredicateMethod
+      def end_of_line_comment(line)
         warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `end_of_line_comment` is deprecated. Use `processed_source.line_with_comment?` instead.
         WARNING


### PR DESCRIPTION
The `Naming/PredicateMethod` cop currently performs two checks: (1) methods returning booleans should end with `?`, and (2) methods ending with `?` should return booleans. Check (1) produces false positives for methods that return booleans as success/failure indicators (e.g. `save` returning `true`/`false`), with no way to disable it independently.

This adds an `InferPredicateMethods` option (default `false`) that controls whether the cop infers predicates from return values. When disabled, only check (2) is performed. When enabled, `AllowedMethods`/`AllowedPatterns` can be used for granular control.

Fixes #14256

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/