### PR TITLE
Fix false positive in `Lint/Void` for `nil` in case/when branches

### DIFF
--- a/changelog/fix_merge_pull_request_14932_from_20260222190945.md
+++ b/changelog/fix_merge_pull_request_14932_from_20260222190945.md
@@ -1,0 +1,1 @@
+* [#14928](https://github.com/rubocop/rubocop/issues/14928): Fix false positive in `Lint/Void` for `nil` in `case`/`when` branches. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -142,15 +142,21 @@ module RuboCop
         end
 
         def check_case_expression(case_node)
-          case_node.each_when { |when_node| check_expression(when_node.body) if when_node.body }
-          check_expression(case_node.else_branch) if case_node.else_branch
+          case_node.each_when do |when_node|
+            check_void_branch(when_node.body)
+          end
+          check_void_branch(case_node.else_branch)
         end
 
         def check_case_match_expression(case_node)
           case_node.each_in_pattern do |in_pattern_node|
-            check_expression(in_pattern_node.body) if in_pattern_node.body
+            check_void_branch(in_pattern_node.body)
           end
-          check_expression(case_node.else_branch) if case_node.else_branch
+          check_void_branch(case_node.else_branch)
+        end
+
+        def check_void_branch(body)
+          check_void_expression_nodes(body) if body && !body.nil_type?
         end
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -1204,6 +1204,16 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
+  it 'does not register an offense for `nil` in `case` branch' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      when 1 then nil
+      else do_something
+      end
+      puts :ok
+    RUBY
+  end
+
   it 'registers an offense for void literal in `case...in` branch' do
     expect_offense(<<~RUBY)
       case foo
@@ -1239,6 +1249,16 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       in 1 then do_something
       end
       puts 3
+    RUBY
+  end
+
+  it 'does not register an offense for `nil` in `case...in` branch' do
+    expect_no_offenses(<<~RUBY)
+      case foo
+      in 1 then nil
+      else do_something
+      end
+      puts :ok
     RUBY
   end
 


### PR DESCRIPTION
Commit e4d45492c (Fix #14756) added void expression detection in `case`/`when` branches but incorrectly flags explicit `nil`, which is commonly used to mean "do nothing in this branch." An empty when body is already accepted, so explicit `nil` should be too.

Also switches from `check_expression` to `check_void_expression_nodes` for consistency with the analogous `check_if_expression`.

Fixes #14928