### PR TITLE
[Fix #14916] Fix false positive for `Layout/MultilineMethodCallIndentation` when method chain is inside a hash pair value passed to a multiline chained method call

### DIFF
--- a/changelog/fix_false_positive_for_layout_multiline_method_call_indentation_in_multiline_chain_hash_pair.md
+++ b/changelog/fix_false_positive_for_layout_multiline_method_call_indentation_in_multiline_chain_hash_pair.md
@@ -1,0 +1,1 @@
+* [#14916](https://github.com/rubocop/rubocop/issues/14916): Fix false positive for `Layout/MultilineMethodCallIndentation` when method chain is inside a hash pair value passed to a multiline chained method call. ([@ydakuka][])

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -560,6 +560,73 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
         end
       end
 
+      context 'when inside a hash pair in a multiline chain method call' do
+        it 'accepts method chain inside hash pair passed to a chained method' do
+          expect_no_offenses(<<~RUBY)
+            @foo = Foo
+                   .where(id: Bar.select(:id)
+                     .joins(:bar)
+                     .where.not(bar: { id: 123 }))
+          RUBY
+        end
+
+        it 'accepts method chain inside hash pair passed to a chained method with safe navigation' do
+          expect_no_offenses(<<~RUBY)
+            @foo = Foo
+                   &.where(id: Bar.select(:id)
+                     &.joins(:bar))
+          RUBY
+        end
+
+        it 'accepts method chain inside hash pair when outer chain uses trailing dot' do
+          expect_no_offenses(<<~RUBY)
+            @foo = Foo.
+                   where(id: Bar.select(:id)
+                     .joins(:bar))
+          RUBY
+        end
+
+        it 'accepts multiple hash pairs with chains in the same multiline chain call' do
+          expect_no_offenses(<<~RUBY)
+            Foo
+              .where(id: Bar.select(:id)
+                .joins(:bar),
+                     name: Car.find(:name)
+                .strip)
+          RUBY
+        end
+
+        it 'accepts method chain inside hash pair with explicit hash braces in multiline chain' do
+          expect_no_offenses(<<~RUBY)
+            Foo
+              .where({id: Bar.select(:id)
+                .joins(:bar)})
+          RUBY
+        end
+
+        it 'accepts chaining after a multiline chain call with hash pair' do
+          expect_no_offenses(<<~RUBY)
+            Foo
+              .where(id: Bar.select(:id)
+                .joins(:bar))
+              .order(:name)
+          RUBY
+        end
+
+        it 'still registers an offense for same-line chain with hash pair' do
+          expect_offense(<<~RUBY)
+            Foo.where(id: Bar.select(:id)
+                                    .joins(:bar))
+                                    ^^^^^^ Align `.joins` with `Bar.select(:id)` on line 1.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Foo.where(id: Bar.select(:id)
+                          .joins(:bar))
+          RUBY
+        end
+      end
+
       context 'when inside a hash pair with block receiver' do
         it 'accepts method chain after block inside hash pair' do
           expect_no_offenses(<<~RUBY)
@@ -1776,6 +1843,60 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
                       .baz)
       RUBY
     end
+
+    context 'when inside a hash pair in a multiline chain method call' do
+      it 'accepts method chain inside hash pair passed to a chained method' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo
+                   .where(id: Bar.select(:id)
+                     .joins(:bar)
+                     .where.not(bar: { id: 123 }))
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair when outer chain uses trailing dot' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo.
+                   where(id: Bar.select(:id)
+                     .joins(:bar))
+        RUBY
+      end
+
+      it 'accepts multiple hash pairs with chains in the same multiline chain call' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where(id: Bar.select(:id)
+              .joins(:bar),
+                   name: Car.find(:name)
+              .strip)
+        RUBY
+      end
+
+      it 'accepts chaining after a multiline chain call with hash pair' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where(id: Bar.select(:id)
+              .joins(:bar))
+            .order(:name)
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair passed to a chained method with safe navigation' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo
+                   &.where(id: Bar.select(:id)
+                     &.joins(:bar))
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair with explicit hash braces in multiline chain' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where({id: Bar.select(:id)
+              .joins(:bar)})
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is indented' do
@@ -2177,6 +2298,60 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
         method(key: value.foo.bar
           .baz)
       RUBY
+    end
+
+    context 'when inside a hash pair in a multiline chain method call' do
+      it 'accepts method chain inside hash pair passed to a chained method' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo
+            .where(id: Bar.select(:id)
+              .joins(:bar)
+              .where.not(bar: { id: 123 }))
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair when outer chain uses trailing dot' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo.
+            where(id: Bar.select(:id)
+              .joins(:bar))
+        RUBY
+      end
+
+      it 'accepts multiple hash pairs with chains in the same multiline chain call' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where(id: Bar.select(:id)
+              .joins(:bar),
+                   name: Car.find(:name)
+              .strip)
+        RUBY
+      end
+
+      it 'accepts chaining after a multiline chain call with hash pair' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where(id: Bar.select(:id)
+              .joins(:bar))
+            .order(:name)
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair passed to a chained method with safe navigation' do
+        expect_no_offenses(<<~RUBY)
+          @foo = Foo
+            &.where(id: Bar.select(:id)
+              &.joins(:bar))
+        RUBY
+      end
+
+      it 'accepts method chain inside hash pair with explicit hash braces in multiline chain' do
+        expect_no_offenses(<<~RUBY)
+          Foo
+            .where({id: Bar.select(:id)
+              .joins(:bar)})
+        RUBY
+      end
     end
 
     context 'when indentation width is overridden for this cop' do


### PR DESCRIPTION
Fixes #14916

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
