### PR TITLE
Layout/MultilineMethodCallIndentation false positive for method chains inside hash pairs in method arguments #14916


### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -170,10 +170,23 @@ module RuboCop
           return false unless rhs.source.start_with?('.', '&.')
 
           first_call = first_call_has_a_dot(node)
-          return false if first_call == node.receiver
+          if first_call == node.receiver
+            # For 2-level chains (e.g. Foo.bar.baz), skip dot alignment check
+            # unless the hash pair is inside a parenthesized method argument
+            # (where the chain is an independent expression in the argument).
+            return false unless hash_pair_in_method_argument?(node)
+          end
 
           dot = first_call.loc.dot
           dot.line == node.first_line && dot.column == rhs.column
+        end
+
+        def hash_pair_in_method_argument?(node)
+          pair_ancestor = find_pair_ancestor(node)
+          return false unless pair_ancestor
+
+          hash_node = pair_ancestor.parent
+          hash_node&.parent&.send_type? && hash_node.parent.parenthesized?
         end
 
         def check_regular_indentation(node, lhs, rhs, given_style)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -542,6 +542,50 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           RUBY
         end
 
+        it 'accepts nested method chain inside hash pair argument of outer method chain' do
+          expect_no_offenses(<<~RUBY)
+            @abc = Abc.published
+                      .where(id: Xyz.select(:id)
+                                    .joins(:abc_xyz)
+                                    .where.not(abc_xyz: { id: 123 }))
+          RUBY
+        end
+
+        it 'accepts nested method chain with safe navigation inside hash pair argument' do
+          expect_no_offenses(<<~RUBY)
+            result = Foo.bar
+                        .baz(key: Value&.something(:id)
+                                       &.other_thing)
+          RUBY
+        end
+
+        it 'accepts nested method chain inside hash pair argument without assignment' do
+          expect_no_offenses(<<~RUBY)
+            Foo.bar
+               .where(name: Other.select(:name)
+                                 .distinct)
+          RUBY
+        end
+
+        it 'accepts nested method chain with multiple hash pairs' do
+          expect_no_offenses(<<~RUBY)
+            Abc.published
+               .where(id: Xyz.select(:id)
+                             .joins(:abc),
+                      name: Qux.pluck(:name)
+                               .uniq)
+          RUBY
+        end
+
+        it 'accepts deeply nested method chain inside hash pair argument' do
+          expect_no_offenses(<<~RUBY)
+            Abc.scope
+               .where(id: Xyz.active
+                             .where(status: Qux.find(:status)
+                                               .compact))
+          RUBY
+        end
+
         it 'registers an offense for misaligned method chain in hash pair' do
           expect_offense(<<~RUBY)
             {


### PR DESCRIPTION
issue #14916

Problem
A false positive was introduced in RuboCop's Layout/MultilineMethodCallIndentation cop. When a method chain containing hash pairs is passed as an argument to another method, nested method chains within those hash values are incorrectly flagged as misaligned.

Falsely flagged code example:


@abc = Abc.published
          .where(id: Xyz.select(:id)
                        .joins(:abc_xyz)         # false positive here
                        .where.not(abc_xyz: { id: 123 }))
Root cause
The aligned_with_first_line_dot? method in [multiline_method_call_indentation.rb:169]. This guard was necessary for hash literals but also prevented correct dot-alignment detection for parenthesized method arguments.

Fix
Two changes in [multiline_method_call_indentation.rb]

aligned_with_first_line_dot? (line 173) — the return false if first_call == node.receiver guard no longer applies when the hash pair is inside a parenthesized method argument.

New method hash_pair_in_method_argument? (line 184) — detects whether the hash pair is inside a parenthesized method call (e.g. .where(id: ...)) to distinguish hash literals from method arguments.

Tests added
5 new tests in [multiline_method_call_indentation_spec.rb]

Nested method chain inside hash pair argument of outer method chain (original bug case)
Same case with safe navigation (&.)
Same case without assignment
Same case with multiple hash pairs
Same case with deep nesting (3 levels)
Result
257 tests passing (0 failures) on both Parser and Prism parsers.