### PR TITLE
Fix a false positive for Style/ModuleMemberExistenceCheck with non-constant receiver

### DIFF
--- a/changelog/fix_false_positive_for_style_module_member_existence_check_with_non_constant_receiver.md
+++ b/changelog/fix_false_positive_for_style_module_member_existence_check_with_non_constant_receiver.md
@@ -1,0 +1,1 @@
+* [#14935](https://github.com/rubocop/rubocop/pull/14935): Fix a false positive for `Style/ModuleMemberExistenceCheck` when the receiver of `included_modules` is not a constant. ([@sucicfilip][])

--- a/lib/rubocop/cop/style/module_member_existence_check.rb
+++ b/lib/rubocop/cop/style/module_member_existence_check.rb
@@ -82,13 +82,9 @@ module RuboCop
           return unless module_member_inclusion?(parent)
           return unless simple_method_argument?(node) && simple_method_argument?(parent)
           return if allowed_method?(node.method_name)
+          return unless module_receiver?(node)
 
-          offense_range = node.location.selector.join(parent.source_range.end)
-          replacement = replacement_for(node, parent)
-
-          add_offense(offense_range, message: format(MSG, replacement: replacement)) do |corrector|
-            corrector.replace(offense_range, replacement)
-          end
+          register_offense(node, parent)
         end
         alias on_csend on_send
 
@@ -103,6 +99,19 @@ module RuboCop
           else
             "#{replacement_method}(#{parent.first_argument.source}, #{node.first_argument.source})"
           end
+        end
+
+        def register_offense(node, parent)
+          offense_range = node.location.selector.join(parent.source_range.end)
+          replacement = replacement_for(node, parent)
+
+          add_offense(offense_range, message: format(MSG, replacement: replacement)) do |corrector|
+            corrector.replace(offense_range, replacement)
+          end
+        end
+
+        def module_receiver?(node)
+          node.receiver.nil? || node.receiver.const_type?
         end
 
         def simple_method_argument?(node)

--- a/spec/rubocop/cop/style/module_member_existence_check_spec.rb
+++ b/spec/rubocop/cop/style/module_member_existence_check_spec.rb
@@ -4,45 +4,51 @@ RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
   shared_examples 'module member inclusion' do |array_returning_method, predicate_method, has_inherit_param = true|
     it "registers an offense when using `.#{array_returning_method}.include?(method)`" do
       expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-        x.#{array_returning_method}.include?(method)
-          ^{array_returning_method}^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+        Foo.#{array_returning_method}.include?(method)
+            ^{array_returning_method}^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.#{predicate_method}(method)
+        Foo.#{predicate_method}(method)
       RUBY
     end
 
     it "registers an offense when using `.#{array_returning_method}.include? method`" do
       expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-        x.#{array_returning_method}.include? method
-          ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+        Foo.#{array_returning_method}.include? method
+            ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.#{predicate_method}(method)
+        Foo.#{predicate_method}(method)
       RUBY
     end
 
     it "registers an offense when using `.#{array_returning_method}.member?(method)`" do
       expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-        x.#{array_returning_method}.member?(method)
-          ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+        Foo.#{array_returning_method}.member?(method)
+            ^{array_returning_method}^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.#{predicate_method}(method)
+        Foo.#{predicate_method}(method)
       RUBY
     end
 
     it "registers an offense when using `&.#{array_returning_method}&.include?(method)`" do
       expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-        x&.#{array_returning_method}&.include?(method)
-           ^{array_returning_method}^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+        Foo&.#{array_returning_method}&.include?(method)
+             ^{array_returning_method}^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
       RUBY
 
       expect_correction(<<~RUBY)
-        x&.#{predicate_method}(method)
+        Foo&.#{predicate_method}(method)
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is not a constant' do
+      expect_no_offenses(<<~RUBY)
+        some_method.#{array_returning_method}.include?(method)
       RUBY
     end
 
@@ -60,40 +66,40 @@ RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
     if has_inherit_param
       it "registers an offense when using `.#{array_returning_method}(false).include?(method)`" do
         expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-          x.#{array_returning_method}(false).include?(method)
-            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, false)` instead.
+          Foo.#{array_returning_method}(false).include?(method)
+              ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, false)` instead.
         RUBY
 
         expect_correction(<<~RUBY)
-          x.#{predicate_method}(method, false)
+          Foo.#{predicate_method}(method, false)
         RUBY
       end
 
       it "registers an offense when using `.#{array_returning_method}(true).include?(method)`" do
         expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-          x.#{array_returning_method}(true).include?(method)
-            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
+          Foo.#{array_returning_method}(true).include?(method)
+              ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method)` instead.
         RUBY
 
         expect_correction(<<~RUBY)
-          x.#{predicate_method}(method)
+          Foo.#{predicate_method}(method)
         RUBY
       end
 
       it "registers an offense when using `.#{array_returning_method}(inherit).include?(method)`" do
         expect_offense(<<~RUBY, array_returning_method: array_returning_method)
-          x.#{array_returning_method}(inherit).include?(method)
-            ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, inherit)` instead.
+          Foo.#{array_returning_method}(inherit).include?(method)
+              ^{array_returning_method}^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{predicate_method}(method, inherit)` instead.
         RUBY
 
         expect_correction(<<~RUBY)
-          x.#{predicate_method}(method, inherit)
+          Foo.#{predicate_method}(method, inherit)
         RUBY
       end
     else
       it "does not register an offense when using `.#{array_returning_method}(inherit).include?(method)`" do
         expect_no_offenses(<<~RUBY)
-          x.#{array_returning_method}(inherit).include?(method)
+          Foo.#{array_returning_method}(inherit).include?(method)
         RUBY
       end
     end


### PR DESCRIPTION
Fix a false positive for `Style/ModuleMemberExistenceCheck` when the receiver of `included_modules` is not a constant.

The cop was registering an offense for any receiver, including arbitrary method calls that return non-module objects (such as `ActiveRecord::Relation`). In those cases, the autocorrection produces semantically incorrect code, replacing `.included_modules.include?(Foo)` with `.include?(Foo)` changes the meaning entirely, since `include?` on a relation checks for record membership rather than module inclusion.

The fix restricts the cop to only flag cases where the receiver is a constant or there is no explicit receiver (implicit `self` in a class body), which are the only cases where the replacement is guaranteed to be equivalent.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/