### PR TITLE
[Fix #8773] Fix false positives in `Style/HashTransform{Keys,Values}`

### DIFF
--- a/changelog/fix_fix_false_positives_in_20260223111924.md
+++ b/changelog/fix_fix_false_positives_in_20260223111924.md
@@ -1,0 +1,1 @@
+* [#8773](https://github.com/rubocop/rubocop/issues/8773): Fix false positives in `Style/HashTransformKeys` and `Style/HashTransformValues`. ([@sferik][])

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'hash_transform_method/autocorrection'
+
 module RuboCop
   module Cop
     # Common functionality for Style/HashTransformKeys and
@@ -27,65 +29,13 @@ module RuboCop
         end
       end
 
-      # Internal helper class to hold autocorrect data
-      Autocorrection = Struct.new(:match, :block_node, :leading, :trailing) do
-        def self.from_each_with_object(node, match)
-          new(match, node, 0, 0)
-        end
-
-        def self.from_hash_brackets_map(node, match)
-          new(match, node.children.last, 'Hash['.length, ']'.length)
-        end
-
-        def self.from_map_to_h(node, match)
-          if node.parent&.block_type? && node.parent.send_node == node
-            strip_trailing_chars = 0
-          else
-            map_range = node.children.first.source_range
-            node_range = node.source_range
-            strip_trailing_chars = node_range.end_pos - map_range.end_pos
-          end
-
-          new(match, node.children.first, 0, strip_trailing_chars)
-        end
-
-        def self.from_to_h(node, match)
-          new(match, node, 0, 0)
-        end
-
-        def strip_prefix_and_suffix(node, corrector)
-          expression = node.source_range
-          corrector.remove_leading(expression, leading)
-          corrector.remove_trailing(expression, trailing)
-        end
-
-        def set_new_method_name(new_method_name, corrector)
-          range = block_node.send_node.loc.selector
-          if (send_end = block_node.send_node.loc.end)
-            # If there are arguments (only true in the `each_with_object`
-            # case)
-            range = range.begin.join(send_end)
-          end
-          corrector.replace(range, new_method_name)
-        end
-
-        def set_new_arg_name(transformed_argname, corrector)
-          corrector.replace(block_node.arguments, "|#{transformed_argname}|")
-        end
-
-        def set_new_body_expression(transforming_body_expr, corrector)
-          body_source = transforming_body_expr.source
-          if transforming_body_expr.hash_type? && !transforming_body_expr.braces?
-            body_source = "{ #{body_source} }"
-          end
-
-          corrector.replace(block_node.body, body_source)
-        end
-      end
-
-      # @!method array_receiver?(node)
-      def_node_matcher :array_receiver?, <<~PATTERN
-        {(array ...) (send _ :each_with_index) (send _ :with_index _ ?) (send _ :zip ...)}
+      # @!method hash_receiver?(node)
+      def_node_matcher :hash_receiver?, <<~PATTERN
+        {(hash ...)
+         (send _ {:to_h :to_hash :merge :merge! :update :invert :except :tally} ...)
+         (block (send _ {:group_by :to_h :tally :transform_keys :transform_keys!
+                         :transform_values :transform_values!}) ...)
+         (block (send _ :each_with_object (hash)) ...)}
       PATTERN
 
       def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler

--- a/lib/rubocop/cop/mixin/hash_transform_method/autocorrection.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method/autocorrection.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module HashTransformMethod
+      # Internal helper class to hold autocorrect data
+      Autocorrection = Struct.new(:match, :block_node, :leading, :trailing) do
+        def self.from_each_with_object(node, match)
+          new(match, node, 0, 0)
+        end
+
+        def self.from_hash_brackets_map(node, match)
+          new(match, node.children.last, 'Hash['.length, ']'.length)
+        end
+
+        def self.from_map_to_h(node, match)
+          if node.parent&.block_type? && node.parent.send_node == node
+            strip_trailing_chars = 0
+          else
+            map_range = node.children.first.source_range
+            node_range = node.source_range
+            strip_trailing_chars = node_range.end_pos - map_range.end_pos
+          end
+
+          new(match, node.children.first, 0, strip_trailing_chars)
+        end
+
+        def self.from_to_h(node, match)
+          new(match, node, 0, 0)
+        end
+
+        def strip_prefix_and_suffix(node, corrector)
+          expression = node.source_range
+          corrector.remove_leading(expression, leading)
+          corrector.remove_trailing(expression, trailing)
+        end
+
+        def set_new_method_name(new_method_name, corrector)
+          range = block_node.send_node.loc.selector
+          if (send_end = block_node.send_node.loc.end)
+            # If there are arguments (only true in the `each_with_object`
+            # case)
+            range = range.begin.join(send_end)
+          end
+          corrector.replace(range, new_method_name)
+        end
+
+        def set_new_arg_name(transformed_argname, corrector)
+          corrector.replace(block_node.arguments, "|#{transformed_argname}|")
+        end
+
+        def set_new_body_expression(transforming_body_expr, corrector)
+          body_source = transforming_body_expr.source
+          if transforming_body_expr.hash_type? && !transforming_body_expr.braces?
+            body_source = "{ #{body_source} }"
+          end
+
+          corrector.replace(block_node.body, body_source)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     context 'with inline block' do
       it 'flags each_with_object when transform_keys could be used' do
         expect_offense(<<~RUBY)
-          x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+          {a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
         RUBY
 
         expect_correction(<<~RUBY)
-          x.transform_keys {|k| foo(k)}
+          {a: 1, b: 2}.transform_keys {|k| foo(k)}
         RUBY
       end
     end
@@ -18,14 +18,14 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     context 'with multiline block' do
       it 'flags each_with_object when transform_keys could be used' do
         expect_offense(<<~RUBY)
-          some_hash.each_with_object({}) do |(key, val), memo|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+          some_hash.to_h.each_with_object({}) do |(key, val), memo|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
             memo[key.to_sym] = val
           end
         RUBY
 
         expect_correction(<<~RUBY)
-          some_hash.transform_keys do |key|
+          some_hash.to_h.transform_keys do |key|
             key.to_sym
           end
         RUBY
@@ -35,94 +35,110 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     context 'with safe navigation operator' do
       it 'flags each_with_object when transform_keys could be used' do
         expect_offense(<<~RUBY)
-          x&.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+          x.to_h&.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
         RUBY
 
         expect_correction(<<~RUBY)
-          x&.transform_keys {|k| foo(k)}
+          x.to_h&.transform_keys {|k| foo(k)}
         RUBY
       end
     end
 
     it 'does not flag each_with_object when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
+        {a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
       RUBY
     end
 
     it 'does not flag each_with_object when key transformation uses value' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(v)] = v}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[foo(v)] = v}')
     end
 
     it 'does not flag each_with_object when no transformation occurs' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = v}')
     end
 
     it 'does not flag each_with_object when its argument is not modified' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| other_h[k.to_sym] = v}
+        {a: 1, b: 2}.each_with_object({}) {|(k, v), h| other_h[k.to_sym] = v}
       RUBY
     end
 
     it 'does not flag `each_with_object` when its argument is used in the key' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) { |(k, v), h| h[h[k.to_sym]] = v }
+        {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[h[k.to_sym]] = v }
       RUBY
     end
 
-    it 'does not flag each_with_object when its receiver is array literal' do
+    it 'does not flag each_with_object when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+      RUBY
+    end
+
+    it 'does not flag each_with_object when receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].each_with_object({}) {|(k, v), h| h[foo(k)] = v}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
+    it 'does not flag each_with_object when receiver is a method chain through non-hash methods' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+        x.to_enum(:foreach, path).select { |entry| entry.file? }.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    it 'flags each_with_object when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.to_h.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.to_h.transform_keys {|k| foo(k)}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    it 'flags each_with_object when receiver is a group_by block' do
+      expect_offense(<<~RUBY)
+        x.group_by { |e| e.type }.each_with_object({}) {|(k, v), h| h[foo(k)] = v}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.group_by { |e| e.type }.transform_keys {|k| foo(k)}
       RUBY
     end
 
     it 'flags _.map{...}.to_h when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k.to_sym, v]}.to_h
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+        {a: 1, b: 2}.map {|k, v| [k.to_sym, v]}.to_h
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        {a: 1, b: 2}.transform_keys {|k| k.to_sym}
       RUBY
     end
 
     it 'flags _.map{...}.to_h when transform_keys could be used when line break before `to_h`' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k.to_sym, v]}.
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+        {a: 1, b: 2}.map {|k, v| [k.to_sym, v]}.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
           to_h
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        {a: 1, b: 2}.transform_keys {|k| k.to_sym}
       RUBY
     end
 
     it 'flags _.map {...}.to_h when transform_keys could be used when wrapped in another block' do
       expect_offense(<<~RUBY)
         wrapping do
-          x.map do |k, v|
-          ^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+          {a: 1, b: 2}.map do |k, v|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
             [k.to_sym, v]
           end.to_h
         end
@@ -130,7 +146,7 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
 
       expect_correction(<<~RUBY)
         wrapping do
-          x.transform_keys do |k|
+          {a: 1, b: 2}.transform_keys do |k|
             k.to_sym
           end
         end
@@ -138,55 +154,77 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
     end
 
     it 'does not flag _.map{...}.to_h when both key & value are transformed' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
+      expect_no_offenses('{a: 1, b: 2}.map {|k, v| [k.to_sym, foo(v)]}.to_h')
     end
 
     it 'flags Hash[_.map{...}] when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        Hash[x.map {|k, v| [k.to_sym, v]}]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
+        Hash[{a: 1, b: 2}.map {|k, v| [k.to_sym, v]}]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        {a: 1, b: 2}.transform_keys {|k| k.to_sym}
       RUBY
     end
 
     it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
-      expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
+      expect_no_offenses('Hash[{a: 1, b: 2}.map {|k, v| [k.to_sym, foo(v)]}]')
     end
 
     it 'does not flag _.map {...}.to_h when key block argument is unused' do
       expect_no_offenses(<<~RUBY)
-        x.map {|_k, v| [v, v]}.to_h
+        {a: 1, b: 2}.map {|_k, v| [v, v]}.to_h
       RUBY
     end
 
     it 'does not flag key transformation in the absence of to_h' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, v]}')
+      expect_no_offenses('{a: 1, b: 2}.map {|k, v| [k.to_sym, v]}')
     end
 
-    it 'does not flag key transformation when receiver is array literal' do
+    it 'does not flag key transformation when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.map {|k, v| [k.to_sym, v]}.to_h
+      RUBY
+    end
+
+    it 'does not flag `_.map{...}.to_h` when its receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].map {|k, v| [k.to_sym, v]}.to_h
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
+    it 'does not flag `Hash[_.map{...}]` when its receiver is not a hash' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }.to_h
+        Hash[x.map { |k, v| [k.to_sym, v] }]
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
+    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }.to_h
+        Hash[[1, 2, 3].map { |k, v| [k.to_sym, v] }]
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }.to_h
+    it 'flags _.map{...}.to_h when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.to_h.map {|k, v| [k.to_sym, v]}.to_h
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `map {...}.to_h`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.to_h.transform_keys {|k| k.to_sym}
+      RUBY
+    end
+
+    it 'flags Hash[_.map{...}] when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        Hash[x.merge(y).map {|k, v| [k.to_sym, v]}]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `Hash[_.map {...}]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.merge(y).transform_keys {|k| k.to_sym}
       RUBY
     end
 
@@ -230,59 +268,63 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
         end
       RUBY
     end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each_with_index.map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each.with_index.map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k.to_sym, v] }]
-      RUBY
-    end
   end
 
   context 'below Ruby 2.5', :ruby24, unsupported_on: :prism do
     it 'does not flag even if transform_keys could be used' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[foo(k)] = v}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[foo(k)] = v}')
     end
   end
 
   context 'when using Ruby 2.6 or newer', :ruby26 do
     it 'flags _.to_h{...} when transform_keys could be used' do
       expect_offense(<<~RUBY)
-        x.to_h {|k, v| [k.to_sym, v]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+        {a: 1, b: 2}.to_h {|k, v| [k.to_sym, v]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_keys {|k| k.to_sym}
+        {a: 1, b: 2}.transform_keys {|k| k.to_sym}
+      RUBY
+    end
+
+    it 'flags _.to_h{...} when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.merge(y).to_h {|k, v| [k.to_sym, v]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.merge(y).transform_keys {|k| k.to_sym}
+      RUBY
+    end
+
+    it 'flags _.to_h{...} when receiver is tally' do
+      expect_offense(<<~RUBY)
+        x.tally.to_h {|k, v| [k.to_sym, v]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_keys` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.tally.transform_keys {|k| k.to_sym}
       RUBY
     end
 
     it 'does not flag `_.to_h{...}` when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
-        x.to_h { |k, v| [k.to_sym, foo(v)] }
+        {a: 1, b: 2}.to_h { |k, v| [k.to_sym, foo(v)] }
       RUBY
     end
 
     it 'does not flag _.to_h {...} when key block argument is unused' do
       expect_no_offenses(<<~RUBY)
-        x.to_h {|_k, v| [v, v]}
+        {a: 1, b: 2}.to_h {|_k, v| [v, v]}
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h { |k, v| [k.to_sym, v] }
       RUBY
     end
 
@@ -292,21 +334,9 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       RUBY
     end
 
-    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+    it 'does not flag `_.to_h{...}` when its receiver is a method chain through non-hash methods' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.to_h { |k, v| [k.to_sym, v] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k.to_sym, v] }
+        x.to_enum(:foreach, path).select { |e| e.file? }.map { |e| [e, name(e)] }.each { |e, p| e.extract(p) }.to_h { |k, v| [k.to_sym, v] }
       RUBY
     end
   end
@@ -314,7 +344,7 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
   context 'below Ruby 2.6', :ruby25, unsupported_on: :prism do
     it 'does not flag _.to_h{...}' do
       expect_no_offenses(<<~RUBY)
-        x.to_h {|k, v| [k.to_sym, v]}
+        {a: 1, b: 2}.to_h {|k, v| [k.to_sym, v]}
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     context 'with inline block' do
       it 'flags each_with_object when transform_values could be used' do
         expect_offense(<<~RUBY)
-          x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+          {a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
         RUBY
 
         expect_correction(<<~RUBY)
-          x.transform_values {|v| foo(v)}
+          {a: 1, b: 2}.transform_values {|v| foo(v)}
         RUBY
       end
     end
@@ -18,14 +18,14 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     context 'with multiline block' do
       it 'flags each_with_object when transform_values could be used' do
         expect_offense(<<~RUBY)
-          some_hash.each_with_object({}) do |(key, val), memo|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+          some_hash.to_h.each_with_object({}) do |(key, val), memo|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
             memo[key] = val * val
           end
         RUBY
 
         expect_correction(<<~RUBY)
-          some_hash.transform_values do |val|
+          some_hash.to_h.transform_values do |val|
             val * val
           end
         RUBY
@@ -35,94 +35,110 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     context 'with safe navigation operator' do
       it 'flags each_with_object when transform_values could be used' do
         expect_offense(<<~RUBY)
-          x&.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+          x.to_h&.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
         RUBY
 
         expect_correction(<<~RUBY)
-          x&.transform_values {|v| foo(v)}
+          x.to_h&.transform_values {|v| foo(v)}
         RUBY
       end
     end
 
     it 'does not flag each_with_object when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
+        {a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k.to_sym] = foo(v)}
       RUBY
     end
 
     it 'does not flag each_with_object when value transformation uses key' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = k.to_s}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = k.to_s}')
     end
 
     it 'does not flag each_with_object when no transformation occurs' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = v}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = v}')
     end
 
     it 'does not flag each_with_object when its argument is not modified' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) {|(k, v), h| other_h[k] = v * v}
+        {a: 1, b: 2}.each_with_object({}) {|(k, v), h| other_h[k] = v * v}
       RUBY
     end
 
     it 'does not flag `each_with_object` when its argument is used in the value' do
       expect_no_offenses(<<~RUBY)
-        x.each_with_object({}) { |(k, v), h| h[k] = h.count }
+        {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[k] = h.count }
       RUBY
     end
 
-    it 'does not flag each_with_object when receiver is array literal' do
+    it 'does not flag each_with_object when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+      RUBY
+    end
+
+    it 'does not flag each_with_object when receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].each_with_object({}) {|(k, v), h| h[k] = foo(v)}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `each_with_index`' do
+    it 'does not flag each_with_object when receiver is a method chain through non-hash methods' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+        x.to_enum(:foreach, path).select { |entry| entry.file? }.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+    it 'flags each_with_object when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.to_h.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.to_h.transform_values {|v| foo(v)}
       RUBY
     end
 
-    it 'does not flag `each_with_object` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+    it 'flags each_with_object when receiver is a group_by block' do
+      expect_offense(<<~RUBY)
+        x.group_by { |e| e.type }.each_with_object({}) {|(k, v), h| h[k] = foo(v)}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `each_with_object`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.group_by { |e| e.type }.transform_values {|v| foo(v)}
       RUBY
     end
 
     it 'flags _.map {...}.to_h when transform_values could be used' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k, foo(v)]}.to_h
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+        {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.to_h
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
+        {a: 1, b: 2}.transform_values {|v| foo(v)}
       RUBY
     end
 
     it 'flags _.map {...}.to_h when transform_values could be used when line break before `to_h`' do
       expect_offense(<<~RUBY)
-        x.map {|k, v| [k, foo(v)]}.
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+        {a: 1, b: 2}.map {|k, v| [k, foo(v)]}.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
           to_h
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
+        {a: 1, b: 2}.transform_values {|v| foo(v)}
       RUBY
     end
 
     it 'flags _.map {...}.to_h when transform_values could be used when wrapped in another block' do
       expect_offense(<<~RUBY)
         wrapping do
-          x.map do |k, v|
-          ^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+          {a: 1, b: 2}.map do |k, v|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
             [k, v.to_s]
           end.to_h
         end
@@ -130,7 +146,7 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
 
       expect_correction(<<~RUBY)
         wrapping do
-          x.transform_values do |v|
+          {a: 1, b: 2}.transform_values do |v|
             v.to_s
           end
         end
@@ -138,55 +154,77 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
     end
 
     it 'does not flag _.map{...}.to_h when both key & value are transformed' do
-      expect_no_offenses('x.map {|k, v| [k.to_sym, foo(v)]}.to_h')
+      expect_no_offenses('{a: 1, b: 2}.map {|k, v| [k.to_sym, foo(v)]}.to_h')
     end
 
     it 'flags Hash[_.map{...}] when transform_values could be used' do
       expect_offense(<<~RUBY)
-        Hash[x.map {|k, v| [k, foo(v)]}]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
+        Hash[{a: 1, b: 2}.map {|k, v| [k, foo(v)]}]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
+        {a: 1, b: 2}.transform_values {|v| foo(v)}
       RUBY
     end
 
     it 'does not flag Hash[_.map{...}] when both key & value are transformed' do
-      expect_no_offenses('Hash[x.map {|k, v| [k.to_sym, foo(v)]}]')
+      expect_no_offenses('Hash[{a: 1, b: 2}.map {|k, v| [k.to_sym, foo(v)]}]')
     end
 
     it 'does not flag _.map {...}.to_h when value block argument is unused' do
       expect_no_offenses(<<~RUBY)
-        x.map {|k, _v| [k, k]}.to_h
+        {a: 1, b: 2}.map {|k, _v| [k, k]}.to_h
       RUBY
     end
 
     it 'does not flag value transformation in the absence of to_h' do
-      expect_no_offenses('x.map {|k, v| [k, foo(v)]}')
+      expect_no_offenses('{a: 1, b: 2}.map {|k, v| [k, foo(v)]}')
     end
 
-    it 'does not flag value transformation when receiver is array literal' do
+    it 'does not flag value transformation when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.map {|k, v| [k, foo(v)]}.to_h
+      RUBY
+    end
+
+    it 'does not flag `_.map{...}.to_h` when its receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
         [1, 2, 3].map {|k, v| [k, foo(v)]}.to_h
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `each_with_index`' do
+    it 'does not flag `Hash[_.map{...}]` when its receiver is not a hash' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }.to_h
+        Hash[x.map { |k, v| [k, foo(v)] }]
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `with_index`' do
+    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }.to_h
+        Hash[[1, 2, 3].map { |k, v| [k, foo(v)] }]
       RUBY
     end
 
-    it 'does not flag `_.map{...}.to_h` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }.to_h
+    it 'flags _.map{...}.to_h when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.to_h.map {|k, v| [k, foo(v)]}.to_h
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `map {...}.to_h`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.to_h.transform_values {|v| foo(v)}
+      RUBY
+    end
+
+    it 'flags Hash[_.map{...}] when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        Hash[x.merge(y).map {|k, v| [k, foo(v)]}]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `Hash[_.map {...}]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.merge(y).transform_values {|v| foo(v)}
       RUBY
     end
 
@@ -200,41 +238,39 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
         {a: 1, b: 2}.transform_values {|v| foo(v)}.to_h {|k, v| [v, k]}
       RUBY
     end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is an array literal' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `each_with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each_with_index.map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[[1, 2, 3].each.with_index.map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
-
-    it 'does not flag `Hash[_.map{...}]` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        Hash[%i[a b c].zip([1, 2, 3]).map { |k, v| [k, foo(v)] }]
-      RUBY
-    end
   end
 
   context 'when using Ruby 2.6 or newer', :ruby26 do
     it 'flags _.to_h{...} when transform_values could be used' do
       expect_offense(<<~RUBY)
-        x.to_h {|k, v| [k, foo(v)]}
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+        {a: 1, b: 2}.to_h {|k, v| [k, foo(v)]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
       RUBY
 
       expect_correction(<<~RUBY)
-        x.transform_values {|v| foo(v)}
+        {a: 1, b: 2}.transform_values {|v| foo(v)}
+      RUBY
+    end
+
+    it 'flags _.to_h{...} when receiver is a hash-producing method' do
+      expect_offense(<<~RUBY)
+        x.merge(y).to_h {|k, v| [k, foo(v)]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.merge(y).transform_values {|v| foo(v)}
+      RUBY
+    end
+
+    it 'flags _.to_h{...} when receiver is tally' do
+      expect_offense(<<~RUBY)
+        x.tally.to_h {|k, v| [k, foo(v)]}
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `transform_values` over `to_h {...}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.tally.transform_values {|v| foo(v)}
       RUBY
     end
 
@@ -262,13 +298,19 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
 
     it 'does not flag `_.to_h{...}` when both key & value are transformed' do
       expect_no_offenses(<<~RUBY)
-        x.to_h { |k, v| [k.to_sym, foo(v)] }
+        {a: 1, b: 2}.to_h { |k, v| [k.to_sym, foo(v)] }
       RUBY
     end
 
     it 'does not flag _.to_h {...} when value block argument is unused' do
       expect_no_offenses(<<~RUBY)
-        x.to_h {|k, _v| [k, k]}
+        {a: 1, b: 2}.to_h {|k, _v| [k, k]}
+      RUBY
+    end
+
+    it 'does not flag `_.to_h{...}` when receiver is not a hash' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h { |k, v| [k, foo(v)] }
       RUBY
     end
 
@@ -278,35 +320,23 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       RUBY
     end
 
-    it 'does not flag `_.to_h{...}` when its receiver is `each_with_index`' do
+    it 'does not flag `_.to_h{...}` when its receiver is a method chain through non-hash methods' do
       expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each_with_index.to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `with_index`' do
-      expect_no_offenses(<<~RUBY)
-        [1, 2, 3].each.with_index.to_h { |k, v| [k, foo(v)] }
-      RUBY
-    end
-
-    it 'does not flag `_.to_h{...}` when its receiver is `zip`' do
-      expect_no_offenses(<<~RUBY)
-        %i[a b c].zip([1, 2, 3]).to_h { |k, v| [k, foo(v)] }
+        x.to_enum(:foreach, path).select { |e| e.file? }.map { |e| [e, name(e)] }.each { |e, p| e.extract(p) }.to_h { |k, v| [k, foo(v)] }
       RUBY
     end
   end
 
   context 'below Ruby 2.4', :ruby23, unsupported_on: :prism do
     it 'does not flag even if transform_values could be used' do
-      expect_no_offenses('x.each_with_object({}) {|(k, v), h| h[k] = foo(v)}')
+      expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = foo(v)}')
     end
   end
 
   context 'below Ruby 2.6', :ruby25, unsupported_on: :prism do
     it 'does not flag _.to_h{...}' do
       expect_no_offenses(<<~RUBY)
-        x.to_h {|k, v| [k, foo(v)]}
+        {a: 1, b: 2}.to_h {|k, v| [k, foo(v)]}
       RUBY
     end
   end


### PR DESCRIPTION
Replace the denylist approach (`array_receiver?`) with an allowlist (`hash_receiver?`) so these cops only flag when the receiver is known to produce a Hash — a hash literal, or a call to a method like `to_h`, `merge`, `group_by`, `tally`, etc.

Previously the cops flagged any receiver that wasn't an array literal or a few specific methods (`each_with_index`, `with_index`, `zip`), which caused false positives on arbitrary method chains such as `enum.select { ... }.map { ... }.each { ... }.to_h { ... }`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
