### PR TITLE
[Fix #6963] Fix false positives in `Lint/Void` for `each` blocks

### DIFF
--- a/changelog/fix_fix_false_positives_in_lint_void_for_each_blocks_20260223121208.md
+++ b/changelog/fix_fix_false_positives_in_lint_void_for_each_blocks_20260223121208.md
@@ -1,0 +1,1 @@
+* [#6963](https://github.com/rubocop/rubocop/issues/6963): Fix false positives in `Lint/Void` for `each` blocks where the return value may be meaningful (e.g., `Enumerator#each`). ([@sferik][])

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -855,46 +855,34 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     expect_no_corrections
   end
 
-  it 'registers two offenses for void literals in a `#each` method' do
+  it 'registers an offense only for non-last void literal in a `#each` method' do
     expect_offense(<<~RUBY)
       array.each do |_item|
         42
         ^^ Literal `42` used in void context.
         42
-        ^^ Literal `42` used in void context.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       array.each do |_item|
+        42
       end
     RUBY
   end
 
-  it 'registers an offense for void constant in a `#each` method' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for a constant as last expression in a `#each` method' do
+    expect_no_offenses(<<~RUBY)
       array.each do |_item|
         CONST
-        ^^^^^ Constant `CONST` used in void context.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      array.each do |_item|
       end
     RUBY
   end
 
-  it 'handles `#each` block with single expression' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for a literal as single expression in `#each` block' do
+    expect_no_offenses(<<~RUBY)
       array.each do |_item|
         42
-        ^^ Literal `42` used in void context.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      array.each do |_item|
       end
     RUBY
   end


### PR DESCRIPTION
Since `Enumerator#each` uses the block's return value (e.g., `[1,2,3].filter.each { |item| item >= 2 }` returns `[2, 3]`), and the cop cannot distinguish `Array#each` from `Enumerator#each`, the last expression in any `each` block should not be flagged as void.

Non-last expressions in multi-expression `each` blocks are still checked.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
