### PR TITLE
Fix false positive in `Lint/UselessConstantScoping` for files with multiple access modifiers preceding the constant

### DIFF
--- a/changelog/fix_support_files_with_multiple_modifiers_in_lint_useless_constant_scoping_20260223225349.md
+++ b/changelog/fix_support_files_with_multiple_modifiers_in_lint_useless_constant_scoping_20260223225349.md
@@ -1,0 +1,1 @@
+* [#14945](https://github.com/rubocop/rubocop/pull/14945): Support files with multiple modifiers in `Lint/UselessConstantScoping`. ([@h-lame][])

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -48,12 +48,12 @@ module RuboCop
 
         def after_private_modifier?(left_siblings)
           access_modifier_candidates = left_siblings.compact.select do |left_sibling|
-            left_sibling.respond_to?(:send_type?) && left_sibling.send_type?
+            left_sibling.respond_to?(:bare_access_modifier?) && left_sibling.bare_access_modifier?
           end
 
-          access_modifier_candidates.any? do |candidate|
-            candidate.command?(:private) && candidate.arguments.none?
-          end
+          return false if access_modifier_candidates.empty?
+
+          access_modifier_candidates.last.command?(:private)
         end
 
         def private_constantize?(right_siblings, const_value)

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -11,6 +11,58 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
     RUBY
   end
 
+  it 'does not register an offense when there are multiple preceding access modifiers if the most recent one is not `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        public
+
+        CONST = 42
+      end
+    RUBY
+  end
+
+  it 'registers an offense when there are multiple preceding access modifiers and the most recent one is not `private` but has args to limit what it affects' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+
+        public bar
+
+        CONST = 42
+        ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when there are multiple preceding access modifiers and the most recent one is not `private` and has args to limit what it affects if the constant is declared a `private_constant` later' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        public bar
+
+        CONST = 42
+
+        private_constant :CONST
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a non-modifier method call exists between `private` and the constant' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+
+        do_something
+
+        CONST = 42
+        ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
   it 'registers an offense when using constant not defined in `private_constant`' do
     expect_offense(<<~RUBY)
       class Foo


### PR DESCRIPTION
Fix a false positive in `Lint/UselessConstantScoping` when a file has multiple access modifiers. It should only raise an offense when the unadorned access modifier that is closest to the constant in question is `private`.

    # bad
    class Foo
      private

      CONST = 42
    end

    # good
    class Foo
      private

      def bar; 1; end

      public

      CONST = 42
    end

    # bad
    class Foo
      private

      def bar; 1; end

      public :bar

      CONST = 42
    end

This means finding all the modifiers without arguments that come before the constant definition, and only raising an offense when the one closest to the constant definition is `private`. This retains the behaviour to not raise the offense if the constant has been flagged as a `private_constant` further down the file.

I think we can separately debate if bouncing between `public` and `private` and `public` modifiers across a file is good or not, and even write a separate cop for it, but either way `Lint/UselessConstantScoping` is definitely wrong to look for _any_ `private` modifier preceding the constant definition and flag that when it should flag the one that is closest and any reasonable developer would expect to apply.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
