### PR TITLE
[Fix #14821] Fix `Style/IfInsideElse` autocorrect moving comments into wrong branch

### DIFF
--- a/changelog/fix_style_if_inside_else_comment_autocorrect.md
+++ b/changelog/fix_style_if_inside_else_comment_autocorrect.md
@@ -1,0 +1,1 @@
+* [#14821](https://github.com/rubocop/rubocop/issues/14821): Fix `Style/IfInsideElse` autocorrect moving comments into the wrong branch when a comment precedes the nested `if` in an `else`. ([@hammadxcm][])

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
           return if node.ternary? || node.unless?
 
@@ -72,6 +72,7 @@ module RuboCop
 
           return unless else_branch&.if_type? && else_branch.if?
           return if allow_if_modifier_in_else_branch?(else_branch)
+          return if comments_between_else_and_if?(node, else_branch)
 
           add_offense(else_branch.loc.keyword) do |corrector|
             next if part_of_ignored_node?(node)
@@ -80,7 +81,7 @@ module RuboCop
             ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 
@@ -137,6 +138,18 @@ module RuboCop
 
         def if_condition_range(node, condition)
           range_between(node.loc.keyword.begin_pos, condition.source_range.end_pos)
+        end
+
+        def comments_between_else_and_if?(node, else_branch)
+          return false if else_branch.modifier_form?
+
+          else_end = node.loc.else.end_pos
+          if_begin = else_branch.loc.keyword.begin_pos
+
+          processed_source.comments.any? do |comment|
+            comment_pos = comment.source_range.begin_pos
+            comment_pos > else_end && comment_pos < if_begin
+          end
         end
 
         def allow_if_modifier_in_else_branch?(else_branch)

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -372,6 +372,35 @@ RSpec.describe RuboCop::Cop::Style::IfInsideElse, :config do
     RUBY
   end
 
+  it "isn't offended if there is a comment before the nested if" do
+    expect_no_offenses(<<~RUBY)
+      if a
+        blah
+      else
+        # Not A!
+
+        if b
+          foo
+        else
+          bar
+        end
+      end
+    RUBY
+  end
+
+  it "isn't offended if there is a comment directly before the nested if" do
+    expect_no_offenses(<<~RUBY)
+      if a
+        blah
+      else
+        # comment
+        if b
+          foo
+        end
+      end
+    RUBY
+  end
+
   it "isn't offended by if..elsif..else" do
     expect_no_offenses(<<~RUBY)
       if a


### PR DESCRIPTION
## Summary

Fixes #14821.

When an `else` block starts with a comment before a nested `if`, the `Style/IfInsideElse` autocorrector replaces `else` with `elsif cond` but leaves the comment in place — causing it to incorrectly appear inside the `elsif` true branch body.

**Before autocorrect:**
```ruby
if cond_a
  body_a
else
  # Not A!

  if cond_b
    body_b
  else
    body_c
  end
end
```

**Incorrect autocorrect (before this fix):**
```ruby
if cond_a
  body_a
elsif cond_b
  # Not A!

  body_b
else
  body_c
end
```

The comment `# Not A!` is moved into the `elsif` true branch, changing its semantic meaning.

**Fix:** Skip the offense when comments exist between the `else` keyword and the nested `if` keyword (non-modifier form only). Modifier `if` forms are unaffected since their autocorrection handles preceding comments correctly.

## Changes

- `lib/rubocop/cop/style/if_inside_else.rb` — Added `comments_between_else_and_if?` guard and helper method
- `spec/rubocop/cop/style/if_inside_else_spec.rb` — Added 2 test cases covering the comment scenarios
- `changelog/fix_style_if_inside_else_comment_autocorrect.md` — Changelog entry

## Test plan

- [x] `bundle exec rake` passes (all specs + self-lint + doc syntax check)
- [x] Specs pass with both Parser and Prism engines
- [x] Verified the original reproduction case no longer triggers an offense
- [x] Verified existing behavior (no comments) still triggers offenses correctly