### PR TITLE
[Fix #14835] Extend Lint/AmbiguousBlockAssociation for do...end block misassociation

### DIFF
--- a/changelog/change_extend_lint_ambiguous_block_association_for_20260731134400.md
+++ b/changelog/change_extend_lint_ambiguous_block_association_for_20260731134400.md
@@ -1,0 +1,1 @@
+* [#14835](https://github.com/rubocop/rubocop/issues/14835): Extend `Lint/AmbiguousBlockAssociation` to detect `do...end` blocks likely intended for enumerable methods in arguments. ([@hammadxcm][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1624,7 +1624,7 @@ Lint/AmbiguousBlockAssociation:
                  parentheses.
   Enabled: true
   VersionAdded: '0.48'
-  VersionChanged: '1.13'
+  VersionChanged: '<<next>>'
   AllowedMethods: []
   AllowedPatterns: []
 

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -6,6 +6,11 @@ module RuboCop
       # Checks for ambiguous block association with method
       # when param passed without parentheses.
       #
+      # This cop also detects `do...end` blocks that are likely intended for
+      # an enumerable method in the arguments but actually bind to the outer
+      # method call. For example, in `render json: data.map do |x| x end`,
+      # Ruby parses the `do...end` block as belonging to `render`, not `map`.
+      #
       # This cop can customize allowed methods with `AllowedMethods`.
       # By default, there are no allowed methods.
       #
@@ -19,6 +24,18 @@ module RuboCop
       #   some_method(a { |val| puts val })
       #   # or (different meaning)
       #   some_method(a) { |val| puts val }
+      #
+      #   # bad
+      #   render json: data.map do |item|
+      #     item.to_h
+      #   end
+      #
+      #   # good
+      #   render json: data.map { |item| item.to_h }
+      #
+      #   # good
+      #   mapped = data.map { |item| item.to_h }
+      #   render json: mapped
       #
       #   # good
       #   # Operator methods require no disambiguation
@@ -58,6 +75,19 @@ module RuboCop
         MSG = 'Parenthesize the param `%<param>s` to make sure that the ' \
               'block will be associated with the `%<method>s` method ' \
               'call.'
+        MSG_DO_END_BLOCK = '`%<inner_method>s` is called without a block because the ' \
+                           '`do` block binds to `%<outer_method>s`. ' \
+                           'Use braces or extract to a variable.'
+
+        BLOCK_METHODS = %i[
+          map collect flat_map collect_concat
+          select filter find_all reject
+          find detect
+          each each_with_object each_with_index
+          reduce inject
+          sort_by min_by max_by
+          group_by filter_map
+        ].to_set.freeze
 
         def on_send(node)
           return unless node.arguments?
@@ -74,7 +104,35 @@ module RuboCop
         end
         alias on_csend on_send
 
+        def on_block(node)
+          return if node.braces?
+
+          send_node = node.send_node
+          block_method_arg = find_ambiguous_block_method(node)
+          return unless block_method_arg
+
+          add_offense(block_method_arg,
+                      message: format(MSG_DO_END_BLOCK,
+                                      inner_method: block_method_arg.method_name,
+                                      outer_method: send_node.method_name))
+        end
+        alias on_numblock on_block
+        alias on_itblock on_block
+
         private
+
+        def find_ambiguous_block_method(block_node)
+          send_node = block_node.send_node
+          return unless send_node.send_type? && send_node.arguments?
+          return if send_node.parenthesized?
+
+          block_method_arg = find_block_method_arg(send_node)
+          return unless block_method_arg
+          return if allowed_method?(block_method_arg.method_name) ||
+                    matches_allowed_pattern?(block_method_arg.source)
+
+          block_method_arg
+        end
 
         def ambiguous_block_association?(send_node)
           send_node.last_argument.any_block_type? && !send_node.last_argument.send_node.arguments?
@@ -90,6 +148,19 @@ module RuboCop
           block_param = send_node.last_argument
 
           format(MSG, param: block_param.source, method: block_param.send_node.source)
+        end
+
+        # Only the call the `do` block could actually have attached to is a candidate:
+        # the one whose source ends where the arguments end. This skips calls chained
+        # into another call (`foo bar.map.to_a`) and calls buried inside a
+        # parenthesized subcall (`foo bar(baz.map)`), which were never block candidates.
+        def find_block_method_arg(send_node)
+          end_pos = send_node.source_range.end_pos
+
+          send_node.last_argument.each_node(:call).find do |node|
+            node.source_range.end_pos == end_pos &&
+              BLOCK_METHODS.include?(node.method_name) && !node.arguments?
+          end
         end
 
         def wrap_in_parentheses(corrector, node)

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -141,6 +141,139 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
     end
   end
 
+  context 'when a do...end block binds to outer method instead of enumerable in arguments' do
+    it 'registers an offense for `map` with keyword argument' do
+      expect_offense(<<~RUBY)
+        render json: queries.map do |q|
+                     ^^^^^^^^^^^ `map` is called without a block because the `do` block binds to `render`. Use braces or extract to a variable.
+          q.to_h
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `select` with positional argument' do
+      expect_offense(<<~RUBY)
+        foo bar.select do |x|
+            ^^^^^^^^^^ `select` is called without a block because the `do` block binds to `foo`. Use braces or extract to a variable.
+          x
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `each`' do
+      expect_offense(<<~RUBY)
+        foo bar.each do |x|
+            ^^^^^^^^ `each` is called without a block because the `do` block binds to `foo`. Use braces or extract to a variable.
+          x
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `filter_map`' do
+      expect_offense(<<~RUBY)
+        foo bar.filter_map do |x|
+            ^^^^^^^^^^^^^^ `filter_map` is called without a block because the `do` block binds to `foo`. Use braces or extract to a variable.
+          x
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation on inner method' do
+      expect_offense(<<~RUBY)
+        foo bar&.map do |x|
+            ^^^^^^^^ `map` is called without a block because the `do` block binds to `foo`. Use braces or extract to a variable.
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the method itself receives the block' do
+      expect_no_offenses(<<~RUBY)
+        bar.map do |x|
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when outer method is parenthesized' do
+      expect_no_offenses(<<~RUBY)
+        render(json: queries.map) do |q|
+          q
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when inner method has arguments' do
+      expect_no_offenses(<<~RUBY)
+        render json: queries.map(&:to_s) do |q|
+          q
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when inner method already has a block' do
+      expect_no_offenses(<<~RUBY)
+        render json: queries.map { |q| q } do |q|
+          q
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for methods not in the block methods list' do
+      expect_no_offenses(<<~RUBY)
+        foo bar.something do |x|
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the enumerable is chained into another call' do
+      expect_no_offenses(<<~RUBY)
+        foo bar.map.to_a do |x|
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the enumerable is inside a parenthesized subcall' do
+      expect_no_offenses(<<~RUBY)
+        foo bar(baz.map) do |x|
+          x
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for braces blocks with parentheses' do
+      expect_no_offenses(<<~RUBY)
+        foo(bar.map { |x| x })
+      RUBY
+    end
+
+    context 'when AllowedMethods includes the inner method' do
+      let(:cop_config) { { 'AllowedMethods' => %w[map] } }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          render json: queries.map do |q|
+            q.to_h
+          end
+        RUBY
+      end
+    end
+
+    context 'when AllowedPatterns matches the inner method' do
+      let(:cop_config) { { 'AllowedPatterns' => [/^queries\.map/] } }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          render json: queries.map do |q|
+            q.to_h
+          end
+        RUBY
+      end
+    end
+  end
+
   context 'when AllowedMethods is enabled' do
     let(:cop_config) { { 'AllowedMethods' => %w[change] } }
 


### PR DESCRIPTION
## Summary

- Extends `Lint/AmbiguousBlockAssociation` to detect `do...end` blocks that are likely intended for an enumerable method in the arguments but actually bind to the outer method call.
- Adds a `BLOCK_METHODS` set of common enumerable/block-accepting methods (`map`, `select`, `each`, `reduce`, etc.) to flag when they appear without a block inside arguments of a non-parenthesized outer method call.
- Respects existing `AllowedMethods` and `AllowedPatterns` configuration for the new detection.

Fixes #14835

## Example

```ruby
# What the programmer writes:
render json: queries.map do |q|
  { _id: q.id }
end

# How Ruby parses it (do...end binds to render, not map):
render(json: queries.map) do |q|
  { _id: q.id }
end
```

The cop now flags `queries.map` with:
> `map` is called without a block because the `do` block binds to `render`. Use braces or extract to a variable.

## Test plan

- [x] Offense cases: `map` with kwargs, `select`/`each`/`filter_map` with positional args, safe navigation (`&.map`)
- [x] No-offense cases: method itself receives the block, parenthesized outer call, inner method has arguments (`map(&:to_s)`), inner method already has a block (`map { }`), non-listed methods, braces blocks
- [x] AllowedMethods/AllowedPatterns integration for `do...end` detection
- [x] Both Parser and Prism engine pass
- [x] `bundle exec rake` passes (all specs + self-lint + doc syntax check)