### PR TITLE
[Fix #14857] Fix false positives in `Style/IfUnlessModifier`

### DIFF
--- a/changelog/fix_false_positive_in_style_if_unless_modifier.md
+++ b/changelog/fix_false_positive_in_style_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#14857](https://github.com/rubocop/rubocop/issues/14857): Fix false positives in `Style/IfUnlessModifier` when modifier forms are used inside string interpolations. ([@koic][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -89,9 +89,9 @@ module RuboCop
           [Style::SoleNestedConditional]
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
-          return if endless_method?(node.body)
+          return if endless_method?(node.body) || node.ancestors.any?(&:dstr_type?)
 
           condition = node.condition
           return if defined_nodes(condition).any? { |n| defined_argument_is_undefined?(node, n) } ||
@@ -106,7 +106,7 @@ module RuboCop
             ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         RUBY
       end
 
+      context 'and the long line is allowed because modifier forms are used inside string interpolations' do
+        it 'accepts when using `if` inside string interpolation' do
+          expect_no_offenses(<<~'RUBY')
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#{'string1' if cond1} #{'string2' if cond2}"
+          RUBY
+        end
+
+        it 'accepts when using `unless` inside string interpolation' do
+          expect_no_offenses(<<~'RUBY')
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#{'string1' unless cond1} #{'string2' unless cond2}"
+          RUBY
+        end
+      end
+
       context 'and the long line is allowed because AllowURI is true' do
         it 'accepts' do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes false positives in `Style/IfUnlessModifier` when modifier forms are used inside string interpolations.

If this is treated as an offense, the auto-correction would result in string interpolation with awkward indentation, making it harder to read. Therefore, it would be appropriate to allow this case.

Fixes #14857.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
