### PR TITLE
[Fix #14583] Aggregate template fragment autocorrections per iteration

### DIFF
--- a/changelog/fix_template_extractor_autocorrect_20260225231906.md
+++ b/changelog/fix_template_extractor_autocorrect_20260225231906.md
@@ -1,0 +1,1 @@
+* [#14583](https://github.com/rubocop/rubocop/issues/14583): Fix template extractor applying only the last fragment's autocorrection. ([@zeronosu77108][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -350,21 +350,9 @@ module RuboCop
 
     def inspect_file(processed_source, team = mobilize_team(processed_source))
       extracted_ruby_sources = extract_ruby_sources(processed_source)
-      offenses = []
-
-      extracted_ruby_sources.each do |extracted_ruby_source|
-        report = team.investigate(
-          extracted_ruby_source[:processed_source],
-          offset: extracted_ruby_source[:offset],
-          original: processed_source
-        )
-        @errors.concat(team.errors)
-        @warnings.concat(team.warnings)
-        offenses.concat(report.offenses)
-
-        break if team.updated_source_file?
-      end
-
+      offenses = team.investigate_fragments(extracted_ruby_sources, original: processed_source)
+      @errors.concat(team.errors)
+      @warnings.concat(team.warnings)
       [offenses, team.updated_source_file?]
     end
 


### PR DESCRIPTION
Fixes #14583.

## Summary

When template extractors (e.g. ERB, Haml) return multiple Ruby fragments,
`Runner#inspect_file` previously called `Team#investigate` per fragment,
each of which independently wrote the corrected source to the file.
This caused later writes to overwrite earlier corrections, so only the
last fragment's autocorrection was actually applied.

This PR introduces `Team#investigate_fragments`, which collects all
fragment corrections into a single `Corrector` against the original
source buffer and applies them in one write per inspection-loop iteration.
Adds regression tests for multi-fragment autocorrection.

### Changes

- Extract `Team#investigate_with_corrector` from `investigate`; returns report + corrector without writing to disk.
- Add `Team#investigate_fragments` to iterate over fragments, merge their correctors, and call `autocorrect` once.
- Factor out `Team#investigate_fragment` / `Team#merge_corrector!` to reduce duplication with `collate_corrections`.
- Simplify `Team#autocorrect` to accept a corrector directly instead of a report.
- Delegate `Runner#inspect_file` to `Team#investigate_fragments` instead of looping over fragments itself.
- Add regression tests for multi-fragment autocorrection.

### How it works

```
Before (per fragment):
  fragment 1 → investigate → write file   (ok)
  fragment 2 → investigate → write file   ← overwrites fragment 1's fix
  fragment 3 → investigate → write file   ← overwrites fragment 2's fix

After (aggregated):
  fragment 1 → investigate → collect corrector
  fragment 2 → investigate → merge corrector
  fragment 3 → investigate → merge corrector
  write file once                          ← all fixes applied
```

The existing `Team#investigate` public API is unchanged.
The `offset: 0` / stdin correction path also remains safe (related to #14779).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/