### PR TITLE
Register redundant parentheses around block body in `Style/RedundantParentheses`

### DIFF
--- a/changelog/change_style_redundant_parentheses_false_negative_block_body.md
+++ b/changelog/change_style_redundant_parentheses_false_negative_block_body.md
@@ -1,0 +1,1 @@
+* [#14955](https://github.com/rubocop/rubocop/pull/14955): Register redundant parentheses around block body in `Style/RedundantParentheses`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -155,6 +155,9 @@ module RuboCop
           return 'a literal' if node.literal? && disallowed_literal?(begin_node, node)
           return 'a variable' if node.variable?
           return 'a constant' if node.const_type?
+          if begin_node.parent&.any_block_type? && begin_node.parent.body == begin_node
+            return 'block body'
+          end
           if node.assignment? && (begin_node.parent.nil? || begin_node.parent.begin_type?)
             return 'an assignment'
           end
@@ -308,10 +311,10 @@ module RuboCop
         end
 
         def singular_parenthesized_parent?(begin_node)
-          return true unless begin_node.parent
-          return false if begin_node.parent.type?(:splat, :kwsplat)
+          return true unless (parent = begin_node.parent)
+          return false if parent.type?(:splat, :kwsplat)
 
-          parentheses?(begin_node) && begin_node.parent.children.one?
+          parent.children.one?
         end
 
         def only_begin_arg?(args)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -828,11 +828,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'registers an offense for parens around a block body' do
+  it 'registers an offense for parens around a block body with do..end syntax' do
     expect_offense(<<~RUBY)
       x do
         (foo; bar)
-        ^^^^^^^^^^ Don't use parentheses around a method call.
+        ^^^^^^^^^^ Don't use parentheses around block body.
       end
     RUBY
 
@@ -840,6 +840,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       x do
         foo; bar
       end
+    RUBY
+  end
+
+  it 'registers an offense for parens around a block body with braces syntax' do
+    expect_offense(<<~RUBY)
+      let(:foo) { (bar + baz) }
+                  ^^^^^^^^^^^ Don't use parentheses around block body.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      let(:foo) { bar + baz }
     RUBY
   end
 


### PR DESCRIPTION
Currently, code such as:
```ruby
let(:foo) { (bar + baz) }
```
will not register redundant parentheses with `Style/RedundantParentheses`.

The cop currently detects some redundant parens around block bodies (e.g. the existing "registers an offense for parens around a block body" spec), but that logic hasn't been implemented for block bodies specifically, so it's only a side effect in certain scenarios.

This PR adds logic to explicitly handle parens around block bodies. With it, the above example is autocorrected to:
```ruby
let(:foo) { bar + baz }
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
