### PR TITLE
Add support for `String.new` with interpolated strings to `Style/RedundantInterpolationUnfreeze`

### DIFF
--- a/changelog/change_style_redundant_interpolation_unfreeze_string_new.md
+++ b/changelog/change_style_redundant_interpolation_unfreeze_string_new.md
@@ -1,0 +1,1 @@
+* [#14956](https://github.com/rubocop/rubocop/pull/14956): Add support for `String.new` with interpolated strings to `Style/RedundantInterpolationUnfreeze`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/style/redundant_interpolation_unfreeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_interpolation_unfreeze_spec.rb
@@ -102,6 +102,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolationUnfreeze, :config do
       RUBY
     end
 
+    it 'registers an offense for `String.new` with interpolated string' do
+      expect_offense(<<~'RUBY')
+        String.new("#{1}")
+        ^^^^^^^^^^ Don't unfreeze interpolated strings as they are already unfrozen.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "#{1}"
+      RUBY
+    end
+
     it 'registers no offense for uninterpolated heredoc' do
       expect_no_offenses(<<~'RUBY')
         foo(+<<~'MSG')
@@ -139,6 +150,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantInterpolationUnfreeze, :config do
     it 'registers no offense when there is no receiver' do
       expect_no_offenses(<<~RUBY)
         dup
+      RUBY
+    end
+
+    it 'registers no offense for `String.new` with interpolated string and keyword arguments' do
+      expect_no_offenses(<<~'RUBY')
+        String.new("#{1}", encoding: Encoding::US_ASCII)
       RUBY
     end
   end


### PR DESCRIPTION
Updates `Style/RedundantInterpolationUnfreeze` so it registers the following code as an offense:
```ruby
String.new("#{foo} bar")
```
and autocorrects to:
```ruby
"#{foo} bar"
```

I've noticed this pattern being used to "unfreeze" strings, but interpolated strings are not frozen in the first place (since they're not literals).

[Here are GitHub search results](https://github.com/search?q=%2F%5B%5E%5Cw%5E%3A%5DString%5C.new%5C(%22.*%23%5C%7B.%2B%5C%7D.*%22%5C)%2F%20lang%3Aruby&type=code&p=3) for this pattern; at the time of writing, there are 1.1k results.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
