### PR TITLE
[Fix #14958] Fix false positives in `Style/FileOpen`

### DIFF
--- a/changelog/fix_false_positives_in_style_file_open.md
+++ b/changelog/fix_false_positives_in_style_file_open.md
@@ -1,0 +1,1 @@
+* [#14958](https://github.com/rubocop/rubocop/issues/14958): Fix false positives in `Style/FileOpen` when no method is chained on `File.open` and the return value is not assigned. ([@koic][])

--- a/lib/rubocop/cop/style/file_open.rb
+++ b/lib/rubocop/cop/style/file_open.rb
@@ -46,17 +46,13 @@ module RuboCop
 
         def on_send(node)
           return unless file_open?(node)
-          return if block_form?(node)
+          return if node.block_argument?
+          return unless (parent = node.parent)
+          return if parent.type?(:begin, :block)
 
           add_offense(node)
         end
         alias on_csend on_send
-
-        private
-
-        def block_form?(node)
-          node.block_argument? || node.parent&.block_type?
-        end
       end
     end
   end

--- a/spec/rubocop/cop/style/file_open_spec.rb
+++ b/spec/rubocop/cop/style/file_open_spec.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
-  it 'registers an offense when using `File.open` without a block' do
-    expect_offense(<<~RUBY)
-      File.open('file')
-      ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
-    RUBY
-  end
-
   it 'registers an offense when assigning `File.open` to a variable' do
     expect_offense(<<~RUBY)
       f = File.open('file')
@@ -15,24 +8,10 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
     RUBY
   end
 
-  it 'registers an offense when using `::File.open` without a block' do
-    expect_offense(<<~RUBY)
-      ::File.open('file')
-      ^^^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
-    RUBY
-  end
-
-  it 'registers an offense when chaining methods on `File.open`' do
+  it 'registers an offense when chaining methods on `File.open.read`' do
     expect_offense(<<~RUBY)
       File.open('file').read
       ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
-    RUBY
-  end
-
-  it 'registers an offense when using `File.open` with mode argument' do
-    expect_offense(<<~RUBY)
-      File.open('file', 'w')
-      ^^^^^^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
     RUBY
   end
 
@@ -40,6 +19,24 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
     expect_offense(<<~RUBY)
       process(File.open('file'))
               ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
+    RUBY
+  end
+
+  it 'does not register an offense when using `File.open` without a block' do
+    expect_no_offenses(<<~RUBY)
+      File.open('file')
+    RUBY
+  end
+
+  it 'does not register an offense when using `::File.open` without a block' do
+    expect_no_offenses(<<~RUBY)
+      ::File.open('file')
+    RUBY
+  end
+
+  it 'does not register an offense when using `File.open` with mode argument without a block' do
+    expect_no_offenses(<<~RUBY)
+      File.open('file', 'w')
     RUBY
   end
 
@@ -60,6 +57,12 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
   it 'does not register an offense when using `File.open` with a block-pass' do
     expect_no_offenses(<<~RUBY)
       File.open('file', &:read)
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `File.open` with a block-pass' do
+    expect_no_offenses(<<~RUBY)
+      content = File.open('file', &:read)
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false positives in `Style/FileOpen` when no method is chained on `File.open` and the return value is not assigned.

When `File.open` is called without chaining a method or assigning its return value, the `File` object may be intentionally returned from the enclosing method. In such cases, no corresponding close call is expected, and the usage should not be considered a candidate for rewriting to the block form.

Fixes #14958.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
