### PR TITLE
[Fix #14958] Fix false positives in `Style/FileOpen`

### DIFF
--- a/changelog/fix_false_positives_in_style_file_open_20260226103448.md
+++ b/changelog/fix_false_positives_in_style_file_open_20260226103448.md
@@ -1,0 +1,1 @@
+* [#14958](https://github.com/rubocop/rubocop/issues/14958): Fix false positives in `Style/FileOpen` when `File.open` is passed as an argument or returned from a method. ([@sferik][])

--- a/lib/rubocop/cop/style/file_open.rb
+++ b/lib/rubocop/cop/style/file_open.rb
@@ -11,11 +11,17 @@ module RuboCop
       # to resource exhaustion. Using the block form ensures the file is
       # automatically closed when the block exits.
       #
+      # This cop only registers an offense when the result of `File.open` is
+      # assigned to a variable or has a method chained on it, as those are the
+      # clearest indicators that the block form should be used instead. When
+      # `File.open` is used as a return value or passed as an argument, the
+      # caller is likely managing the file descriptor intentionally.
+      #
       # @safety
-      #   This cop is unsafe because it detects all `File.open` calls without
-      #   a block, including intentional uses such as one-shot reads
-      #   (`File.open("f").read`) where the file descriptor is closed by the
-      #   garbage collector.
+      #   This cop is unsafe because it relies on syntax heuristics and cannot
+      #   verify whether the file descriptor is safely managed. For example, it
+      #   still flags intentional one-shot reads (`File.open("f").read`) where
+      #   the file descriptor is closed by the garbage collector.
       #
       # @example
       #   # bad
@@ -32,6 +38,14 @@ module RuboCop
       #   # good
       #   File.open('file', &:read)
       #
+      #   # good - pass an open file object to an API that manages its lifecycle
+      #   process(io: File.open('file'))
+      #
+      #   # good - return an open file object for the caller to manage
+      #   def json_key_io
+      #     File.open('file')
+      #   end
+      #
       #   # good - use File.read for one-shot reads
       #   File.read('file')
       #
@@ -47,6 +61,7 @@ module RuboCop
         def on_send(node)
           return unless file_open?(node)
           return if block_form?(node)
+          return unless offensive_usage?(node)
 
           add_offense(node)
         end
@@ -56,6 +71,16 @@ module RuboCop
 
         def block_form?(node)
           node.block_argument? || node.parent&.block_type?
+        end
+
+        def offensive_usage?(node)
+          return true unless node.value_used?
+
+          node.parent&.assignment? || receiver_of_chained_call?(node)
+        end
+
+        def receiver_of_chained_call?(node)
+          node.parent&.call_type? && node.parent.receiver == node
         end
       end
     end

--- a/spec/rubocop/cop/style/file_open_spec.rb
+++ b/spec/rubocop/cop/style/file_open_spec.rb
@@ -36,10 +36,23 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
     RUBY
   end
 
-  it 'registers an offense when passing `File.open` as an argument' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when passing `File.open` as an argument' do
+    expect_no_offenses(<<~RUBY)
       process(File.open('file'))
-              ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
+    RUBY
+  end
+
+  it 'does not register an offense when passing `File.open` as a keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      process(io: File.open('file'))
+    RUBY
+  end
+
+  it 'does not register an offense when returning `File.open` from a method' do
+    expect_no_offenses(<<~RUBY)
+      def json_key_io
+        File.open('file')
+      end
     RUBY
   end
 


### PR DESCRIPTION
Sorry for introducing this bug in https://github.com/rubocop/rubocop/pull/14942!

Here is another attempt at fixing https://github.com/rubocop/rubocop/issues/14958 (in addition to https://github.com/rubocop/rubocop/pull/14959).

CC: @ydakuka @koic

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
