### PR TITLE
CI: Remove rspec4 job

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -124,25 +124,3 @@ jobs:
         env:
           PARSER_ENGINE: parser_prism
         run: bundle exec rake prism_spec
-
-  rspec4:
-    runs-on: ubuntu-latest
-    name: RSpec 4
-    steps:
-      - uses: actions/checkout@v6
-      - name: Use latest RSpec 4 from `4-0-dev` branch
-        run: |
-          sed -e "/'rspec', '~> 3/d" -i Gemfile
-          cat << EOF > Gemfile.local
-            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-core', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-expectations', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-mocks', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-support', github: 'rspec/rspec', branch: '4-0-dev'
-          EOF
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - name: spec
-        run: bundle exec rake spec


### PR DESCRIPTION
~[The 4-0-dev branch](https://github.com/rspec/rspec/tree/4-0-dev) hasn't been used in a couple of years; the RSpec 4.0-pre development seems to happen on [the main branch](https://github.com/rspec/rspec/tree/main).~

Related: #10806

Update: We have been running CI against rspec's 4-0-dev branch for a time while it was being worked on. Now that RSpec v4.0.0.beta1 has been released, we can remove this CI job again.