### PR TITLE
[Fix #14964] Fix false positives in `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_remove_redundant_code_in_style_file_open_20260227211937.md
+++ b/changelog/fix_remove_redundant_code_in_style_file_open_20260227211937.md
@@ -1,0 +1,1 @@
+* [#14964](https://github.com/rubocop/rubocop/issues/14964): Fix false positives in `Style/RedundantParentheses` when parenthesizing a range in a block body. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -155,9 +155,7 @@ module RuboCop
           return 'a literal' if node.literal? && disallowed_literal?(begin_node, node)
           return 'a variable' if node.variable?
           return 'a constant' if node.const_type?
-          if begin_node.parent&.any_block_type? && begin_node.parent.body == begin_node
-            return 'block body'
-          end
+          return 'block body' if begin_node.parent&.any_block_type? && !node.range_type?
           if node.assignment? && (begin_node.parent.nil? || begin_node.parent.begin_type?)
             return 'an assignment'
           end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -886,6 +886,44 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses around an irange inside a block' do
+    expect_no_offenses(<<~RUBY)
+      something do
+        (a..b)
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around an erange inside a block' do
+    expect_no_offenses(<<~RUBY)
+      something do
+        (a...b)
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around an irange inside a braces block' do
+    expect_no_offenses(<<~RUBY)
+      something { (a..b) }
+    RUBY
+  end
+
+  it 'accepts parentheses around a beginless range inside a block' do
+    expect_no_offenses(<<~RUBY)
+      something do
+        (..b)
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around an endless range inside a block' do
+    expect_no_offenses(<<~RUBY)
+      something do
+        (a..)
+      end
+    RUBY
+  end
+
   it 'registers an offense when the use of parentheses around `&&` expressions in assignment' do
     expect_offense(<<~RUBY)
       var = (foo && bar)


### PR DESCRIPTION
This PR fixes false positives in `Style/RedundantParentheses` when parenthesizing a range in a block body.

Fixes #14964.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
