### PR TITLE
Autoload formatters

### DIFF
--- a/changelog/change_autoload_formatters.md
+++ b/changelog/change_autoload_formatters.md
@@ -1,0 +1,1 @@
+* [#14969](https://github.com/rubocop/rubocop/pull/14969): Autoload formatters; they're required only when actually used. ([@lovro-bikic][])

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -3,32 +3,33 @@
 module RuboCop
   # The bootstrap module for formatter.
   module Formatter
-    require_relative 'formatter/text_util'
+    autoload :Colorizable, 'rubocop/formatter/colorizable'
+    autoload :TextUtil, 'rubocop/formatter/text_util'
 
-    require_relative 'formatter/base_formatter'
-    require_relative 'formatter/simple_text_formatter'
+    autoload :BaseFormatter, 'rubocop/formatter/base_formatter'
+    autoload :SimpleTextFormatter, 'rubocop/formatter/simple_text_formatter'
 
     # relies on simple text
-    require_relative 'formatter/clang_style_formatter'
-    require_relative 'formatter/disabled_config_formatter'
-    require_relative 'formatter/emacs_style_formatter'
-    require_relative 'formatter/file_list_formatter'
-    require_relative 'formatter/fuubar_style_formatter'
-    require_relative 'formatter/github_actions_formatter'
-    require_relative 'formatter/html_formatter'
-    require_relative 'formatter/json_formatter'
-    require_relative 'formatter/junit_formatter'
-    require_relative 'formatter/markdown_formatter'
-    require_relative 'formatter/offense_count_formatter'
-    require_relative 'formatter/pacman_formatter'
-    require_relative 'formatter/progress_formatter'
-    require_relative 'formatter/quiet_formatter'
-    require_relative 'formatter/tap_formatter'
-    require_relative 'formatter/worst_offenders_formatter'
+    autoload :ClangStyleFormatter, 'rubocop/formatter/clang_style_formatter'
+    autoload :DisabledConfigFormatter, 'rubocop/formatter/disabled_config_formatter'
+    autoload :EmacsStyleFormatter, 'rubocop/formatter/emacs_style_formatter'
+    autoload :FileListFormatter, 'rubocop/formatter/file_list_formatter'
+    autoload :FuubarStyleFormatter, 'rubocop/formatter/fuubar_style_formatter'
+    autoload :GitHubActionsFormatter, 'rubocop/formatter/github_actions_formatter'
+    autoload :HTMLFormatter, 'rubocop/formatter/html_formatter'
+    autoload :JSONFormatter, 'rubocop/formatter/json_formatter'
+    autoload :JUnitFormatter, 'rubocop/formatter/junit_formatter'
+    autoload :MarkdownFormatter, 'rubocop/formatter/markdown_formatter'
+    autoload :OffenseCountFormatter, 'rubocop/formatter/offense_count_formatter'
+    autoload :PacmanFormatter, 'rubocop/formatter/pacman_formatter'
+    autoload :ProgressFormatter, 'rubocop/formatter/progress_formatter'
+    autoload :QuietFormatter, 'rubocop/formatter/quiet_formatter'
+    autoload :TapFormatter, 'rubocop/formatter/tap_formatter'
+    autoload :WorstOffendersFormatter, 'rubocop/formatter/worst_offenders_formatter'
 
     # relies on progress formatter
-    require_relative 'formatter/auto_gen_config_formatter'
+    autoload :AutoGenConfigFormatter, 'rubocop/formatter/auto_gen_config_formatter'
 
-    require_relative 'formatter/formatter_set'
+    autoload :FormatterSet, 'rubocop/formatter/formatter_set'
   end
 end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'colorizable'
-
 module RuboCop
   module Formatter
     # A basic formatter that displays only files with offenses.


### PR DESCRIPTION
This PR updates `lib/rubocop/formatter.rb` so it autoloads constants (most of which are different formatters) rather than requiring them.

I was profiling RuboCop and I noticed that every run requires all formatters:
<img width="1440" height="550" alt="image" src="https://github.com/user-attachments/assets/30c48e31-41d0-43ab-9936-882d347ac6e5" />

Realistically, most RuboCop runs will use only one or two formatters, so requiring them all is unnecessary. Some formatters even require additional dependencies (for example, `OffenseCountFormatter` [requires `ruby-progressbar`](https://github.com/rubocop/rubocop/blob/eb973f45f8f61d247ef53346d4f88b88ef5fa094/lib/rubocop/formatter/offense_count_formatter.rb#L3)) which is an even bigger hit, especially if that formatter isn't used in the run.

I ran some benchmarks on the optimization. Here are my timings when running RuboCop on a single file (`bundle exec rubocop file.rb`):
```
# Require
Runs: 20
Average time (s): 2.11989
Std deviation (s): 0.0610234

# Autoload
Runs: 20
Average time (s): 2.09513
Std deviation (s): 0.0562741

Delta time (s): -0,02476
Delta time (ms): -24,76
```

I also ran `ruby-memory-profiler --pretty --no-detailed run -- bundle exec rubocop file.rb`:
```
# Before
Total allocated: 103.43 MB (833252 objects)
Total retained:  11.71 MB (112222 objects)

# After
Total allocated: 96.31 MB (793091 objects)
Total retained:  10.93 MB (109188 objects)

Delta allocated: -7.12 MB (-40161 objects)
Delta retained: -0.78 MB (-3034 objects)
```

Summary: time savings are ~25ms (-1,2% compared to baseline), memory savings are ~7 MB (-6.9% compared to baseline).

Credits: this was inspired by the work I saw in https://github.com/rubocop/rubocop/issues/14732#issuecomment-3699082937 (thx @byroot for the idea!).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
