### PR TITLE
Cache relevant options digest

### DIFF
--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -389,6 +389,29 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     end
   end
 
+  describe '.relevant_options_digest' do
+    before do
+      described_class.instance_variable_set(:@relevant_options_digest, nil)
+    end
+
+    it 'calculates a digest' do
+      options = { only: ['Layout/EmptyLines'] }
+
+      digest = described_class.relevant_options_digest(options)
+
+      expect(digest).to eq('_only_Layout_EmptyLines_')
+    end
+
+    it 'caches options digest' do
+      options = { only: ['Layout/EmptyLines'] }
+
+      expect(options).to receive(:reject).once.and_call_original
+
+      described_class.relevant_options_digest(options)
+      described_class.relevant_options_digest(options)
+    end
+  end
+
   describe 'the cache path' do
     let(:config_store) { instance_double(RuboCop::ConfigStore) }
     let(:puid) { Process.uid.to_s }


### PR DESCRIPTION
In `CacheResult`, relevant options digest is currently calculated for each scanned file separately. This is wasteful because options hash never really changes, so the digest always stays the same. A `ResultCache` is instantiated only in the runner, where the same `options` hash is passed to all instances: https://github.com/rubocop/rubocop/blob/e305f79a463c5b281ec6c1309a028da7718eaa8f/lib/rubocop/runner.rb#L178

This PR caches the digest per options hash. Realistically, there will be only one entry in the cache at all times, so this might be simplified even further than what I did.

It's not a huge optimization, but it shows with scale. I ran RuboCop with cache 10 times on a codebase with ~30k scanned files, and the speed-up is about 0.4 seconds:
<img width="400" height="740" alt="Image 01 03 2026  at 17 58" src="https://github.com/user-attachments/assets/f2ca173a-ad17-4704-97aa-44ae60211328" />
