### PR TITLE
Add `AllowedParentClasses` option to `Style/EmptyClassDefinition`

### DIFF
--- a/changelog/new_merge_pull_request_14972_from_20260302043608.md
+++ b/changelog/new_merge_pull_request_14972_from_20260302043608.md
@@ -1,0 +1,1 @@
+* [#14961](https://github.com/rubocop/rubocop/issues/14961): Add `AllowedParentClasses` option to `Style/EmptyClassDefinition`. ([@hammadkhan][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3993,11 +3993,13 @@ Style/EmptyClassDefinition:
   Description: 'Enforces consistent style for empty class definitions.'
   Enabled: pending
   VersionAdded: '1.84'
+  VersionChanged: '<<next>>'
   EnforcedStyle: class_keyword
   SupportedStyles:
     - class_keyword
     - class_new
     - class_definition # Deprecated.
+  AllowedParentClasses: []
 
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'

--- a/lib/rubocop/cop/style/empty_class_definition.rb
+++ b/lib/rubocop/cop/style/empty_class_definition.rb
@@ -10,15 +10,19 @@ module RuboCop
       #
       # The supported styles are:
       #
-      # * class_definition (default) - prefer standard class definition over `Class.new`
+      # * class_keyword (default) - prefer standard class definition over `Class.new`
       # * class_new - prefer `Class.new` over class definition
       #
       # One difference between the two styles is that the `Class.new` form does not make
       # the subclass name available to the base class's `inherited` callback.
-      # For this reason, `EnforcedStyle: class_definition` is set as the default style.
+      # For this reason, `EnforcedStyle: class_keyword` is set as the default style.
       # Class definitions without a superclass, which are not involved in inheritance,
       # are not detected. This ensures safe detection regardless of the applied style.
       # This avoids overlapping responsibilities with the `Lint/EmptyClass` cop.
+      #
+      # Use `AllowedParentClasses` to permit both styles for specific parent classes.
+      # For example, adding `StandardError` allows both `Error = Class.new(StandardError)`
+      # and `class Error < StandardError; end` regardless of the enforced style.
       #
       # @example EnforcedStyle: class_keyword (default)
       #   # bad
@@ -42,6 +46,14 @@ module RuboCop
       #   # good
       #   FooError = Class.new(StandardError)
       #
+      # @example AllowedParentClasses: ['StandardError']
+      #   # good - allowed regardless of EnforcedStyle
+      #   FooError = Class.new(StandardError)
+      #
+      #   # good - allowed regardless of EnforcedStyle
+      #   class FooError < StandardError
+      #   end
+      #
       class EmptyClassDefinition < Base
         include ConfigurableEnforcedStyle
         extend AutoCorrector
@@ -59,6 +71,7 @@ module RuboCop
           return unless %i[class_keyword class_definition].include?(style)
           return unless (class_new_node = class_new_assignment(node))
           return if (arg = class_new_node.first_argument) && !arg.const_type?
+          return if allowed_parent_class?(class_new_node.first_argument.source)
 
           add_offense(node, message: MSG_CLASS_KEYWORD) do |corrector|
             autocorrect_class_new(corrector, node, class_new_node)
@@ -69,6 +82,7 @@ module RuboCop
           return unless style == :class_new
           return unless node.parent_class
           return if (body = node.body) && !body.children.empty?
+          return if allowed_parent_class?(node.parent_class.source)
 
           add_offense(node, message: MSG_CLASS_NEW) do |corrector|
             autocorrect_class_definition(corrector, node)
@@ -76,6 +90,14 @@ module RuboCop
         end
 
         private
+
+        def allowed_parent_class?(parent_class_name)
+          allowed_parent_classes.include?(parent_class_name)
+        end
+
+        def allowed_parent_classes
+          cop_config.fetch('AllowedParentClasses', [])
+        end
 
         def autocorrect_class_new(corrector, node, class_new_node)
           indent = ' ' * node.loc.column

--- a/spec/rubocop/cop/style/empty_class_definition_spec.rb
+++ b/spec/rubocop/cop/style/empty_class_definition_spec.rb
@@ -267,6 +267,90 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
     end
   end
 
+  context 'when EnforcedStyle is class_keyword with AllowedParentClasses' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'class_keyword', 'AllowedParentClasses' => ['StandardError'] }
+    end
+
+    it 'does not register an offense for Class.new with an allowed parent class' do
+      expect_no_offenses(<<~RUBY)
+        FooError = Class.new(StandardError)
+      RUBY
+    end
+
+    it 'registers an offense for Class.new with a non-allowed parent class' do
+      expect_offense(<<~RUBY)
+        FooError = Class.new(ActiveRecord::Base)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FooError < ActiveRecord::Base
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for class keyword with allowed parent class' do
+      expect_no_offenses(<<~RUBY)
+        class FooError < StandardError
+        end
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is class_new with AllowedParentClasses' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'class_new', 'AllowedParentClasses' => ['ApplicationRecord'] }
+    end
+
+    it 'does not register an offense for class keyword with an allowed parent class' do
+      expect_no_offenses(<<~RUBY)
+        class MyModel < ApplicationRecord
+        end
+      RUBY
+    end
+
+    it 'registers an offense for class keyword with a non-allowed parent class' do
+      expect_offense(<<~RUBY)
+        class FooError < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Class.new` instead of the `class` keyword to define an empty class.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        FooError = Class.new(StandardError)
+      RUBY
+    end
+
+    it 'does not register an offense for Class.new with allowed parent class' do
+      expect_no_offenses(<<~RUBY)
+        MyModel = Class.new(ApplicationRecord)
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is class_keyword with AllowedParentClasses containing namespaced class' do
+    let(:cop_config) { { 'EnforcedStyle' => 'class_keyword', 'AllowedParentClasses' => ['Alchemy::Admin::PreviewUrl'] } }
+
+    it 'does not register an offense for Class.new with an allowed namespaced parent class' do
+      expect_no_offenses(<<~RUBY)
+        MyClass = Class.new(Alchemy::Admin::PreviewUrl)
+      RUBY
+    end
+
+    it 'registers an offense for Class.new with a non-allowed parent class' do
+      expect_offense(<<~RUBY)
+        MyClass = Class.new(StandardError)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyClass < StandardError
+        end
+      RUBY
+    end
+  end
+
   context 'when EnforcedStyle is class_new' do
     let(:cop_config) { { 'EnforcedStyle' => 'class_new' } }
 


### PR DESCRIPTION
Fixes #14961

## Summary

- Add `AllowedParentClasses` configuration option to `Style/EmptyClassDefinition` so that specific parent classes can be exempt from the enforced style. This allows both `Class.new(Parent)` and `class Foo < Parent; end` forms to coexist for listed classes.
- Fix outdated YARD documentation that referenced the deprecated `class_definition` style instead of `class_keyword`.

### Example

```yaml
Style/EmptyClassDefinition:
  EnforcedStyle: class_keyword
  AllowedParentClasses:
    - StandardError
```

With this configuration, both forms are accepted for `StandardError`:

```ruby
# good
class MyModel < ApplicationRecord
end

# also good
Error = Class.new(StandardError)
```

## Test plan

- [x] Added specs for `AllowedParentClasses` under `EnforcedStyle: class_keyword`
- [x] Added specs for `AllowedParentClasses` under `EnforcedStyle: class_new`
- [x] Added specs for namespaced parent classes in `AllowedParentClasses`
- [x] Verified non-allowed parent classes are still flagged
- [x] `bundle exec rake` passes (all specs + self-lint + doc syntax check)