### PR TITLE
[Fix #14973] Fix `Style/ReduceToHash` false positive when accumulator is read in key/value

### DIFF
--- a/changelog/fix_fix_style_reduce_to_hash_false_positive_when_20260301165326.md
+++ b/changelog/fix_fix_style_reduce_to_hash_false_positive_when_20260301165326.md
@@ -1,0 +1,1 @@
+* [#14973](https://github.com/rubocop/rubocop/pull/14973): Fix `Style/ReduceToHash` false positive when accumulator is read in key/value. ([@sferik][])

--- a/lib/rubocop/cop/style/reduce_to_hash.rb
+++ b/lib/rubocop/cop/style/reduce_to_hash.rb
@@ -98,8 +98,23 @@ module RuboCop
                          inject_to_hash?(block_node)
                        end
           return unless key
+          return if accumulator_used_in_expressions?(block_node, key, value)
 
           register_offense(node, block_node, key, value)
+        end
+
+        def accumulator_used_in_expressions?(block_node, key, value)
+          acc_name = accumulator_name(block_node)
+          references_variable?(key, acc_name) || references_variable?(value, acc_name)
+        end
+
+        def accumulator_name(block_node)
+          index = block_node.method?(:each_with_object) ? 1 : 0
+          block_node.argument_list[index].name
+        end
+
+        def references_variable?(node, name)
+          node.each_node(:lvar).any? { |lvar| lvar.children.first == name }
         end
 
         def register_offense(send_node, block_node, key_expr, value_expr)

--- a/spec/rubocop/cop/style/reduce_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/reduce_to_hash_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe RuboCop::Cop::Style::ReduceToHash, :config do
           array.each_with_object({}) { |elem, hash| other[elem] = true }
         RUBY
       end
+
+      it 'does not register an offense when the accumulator is read in the value' do
+        expect_no_offenses(<<~RUBY)
+          array.each_with_object({}) do |elem, hash|
+            hash[elem.id] = hash[elem.id].to_i + 1
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the accumulator is read in the key' do
+        expect_no_offenses(<<~RUBY)
+          array.each_with_object({}) do |elem, hash|
+            hash[hash.size] = elem
+          end
+        RUBY
+      end
     end
 
     context 'with `inject({})` pattern' do
@@ -150,6 +166,15 @@ RSpec.describe RuboCop::Cop::Style::ReduceToHash, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when the accumulator is read in the value' do
+        expect_no_offenses(<<~RUBY)
+          array.inject({}) do |hash, elem|
+            hash[elem.id] = hash[elem.id].to_i + 1
+            hash
+          end
+        RUBY
+      end
     end
 
     context 'with `reduce({})` pattern' do
@@ -174,6 +199,12 @@ RSpec.describe RuboCop::Cop::Style::ReduceToHash, :config do
 
         expect_correction(<<~RUBY)
           array.to_h { [_1.id, _1.name] }
+        RUBY
+      end
+
+      it 'does not register an offense when the accumulator is read in the value with numbered params' do
+        expect_no_offenses(<<~RUBY)
+          array.each_with_object({}) { _2[_1.id] = _2[_1.id].to_i + 1 }
         RUBY
       end
 


### PR DESCRIPTION
When the accumulator variable (e.g. `hash`) is referenced inside the key or value expression of `hash[key] = value`, converting to `to_h` is invalid because the variable no longer exists in the new block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
