### PR TITLE
[Fix #14981] Add Safe and SafeAutoCorrect to COMMON_PARAMS

### DIFF
--- a/changelog/fix_merge_pull_request_14972_from_20260302120629.md
+++ b/changelog/fix_merge_pull_request_14972_from_20260302120629.md
@@ -1,0 +1,1 @@
+* [#14981](https://github.com/rubocop/rubocop/issues/14981): Fix spurious warning "does not support `Safe`/`SafeAutoCorrect` parameter" when those parameters are set for cops that don't have them in their default configuration. ([@dduugg][])

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -9,7 +9,7 @@ module RuboCop
 
     # @api private
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details
-                       Enabled Reference References].freeze
+                       Enabled Reference References Safe SafeAutoCorrect].freeze
     # @api private
     INTERNAL_PARAMS = %w[Description StyleGuide
                          VersionAdded VersionChanged VersionRemoved

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -179,6 +179,42 @@ RSpec.describe RuboCop::Config do
       end
     end
 
+    # Regression test for https://github.com/rubocop/rubocop/issues/14981
+    # Safe and SafeAutoCorrect are COMMON_PARAMS (valid for any cop), but many
+    # cops do not list them in config/default.yml. Without them in COMMON_PARAMS,
+    # setting these params triggers a spurious "does not support X parameter" warning.
+    context 'when the configuration sets Safe on a cop whose default config omits Safe' do
+      include_context 'mock console output'
+
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint/UselessAssignment:
+            Safe: false
+        YAML
+      end
+
+      it 'does not print a warning' do
+        configuration
+        expect($stderr.string).not_to match(/does not support Safe parameter/)
+      end
+    end
+
+    context 'when the configuration sets SafeAutoCorrect on a cop whose default config omits SafeAutoCorrect' do
+      include_context 'mock console output'
+
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint/UselessAssignment:
+            SafeAutoCorrect: false
+        YAML
+      end
+
+      it 'does not print a warning' do
+        configuration
+        expect($stderr.string).not_to match(/does not support SafeAutoCorrect parameter/)
+      end
+    end
+
     context 'when the configuration includes a valid EnforcedStyle' do
       before do
         create_file(configuration_path, <<~YAML)


### PR DESCRIPTION
## Summary

Fixes #14981.

`Safe` and `SafeAutoCorrect` are valid configuration parameters for all cops — they are listed in `CONFIG_CHECK_KEYS` and actively consumed at runtime in `autocorrect_logic.rb`. However, they were absent from `COMMON_PARAMS`, so `each_invalid_parameter` would emit a spurious warning for any cop that does not have them in its `config/default.yml` entry (the majority of cops).

**Root cause** in `config_validator.rb`:

```ruby
COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details
                   Enabled Reference References].freeze   # Safe/SafeAutoCorrect missing

def each_invalid_parameter(cop_name)
  default_config = ConfigLoader.default_configuration[cop_name]
  @config[cop_name].each_key do |param|
    next if COMMON_PARAMS.include?(param) || default_config.key?(param)
    # SafeAutoCorrect falls through here for most cops → spurious warning
    yield param, supported_params
  end
end
```

**Fix:** add `Safe` and `SafeAutoCorrect` to `COMMON_PARAMS`.

## Test plan

- Added two new examples to `spec/rubocop/config_spec.rb` asserting that setting `Safe: false` or `SafeAutoCorrect: false` on a cop that has no default entry for those keys produces no warning.
- `bundle exec rspec spec/rubocop/config_spec.rb` — 81 examples, 0 failures.