### PR TITLE
Don't add parentheses around `return` without arguments in `Style/AndOr`

### DIFF
--- a/changelog/fix_style_and_or_unnecessary_parentheses_around_return.md
+++ b/changelog/fix_style_and_or_unnecessary_parentheses_around_return.md
@@ -1,0 +1,1 @@
+* [#14984](https://github.com/rubocop/rubocop/pull/14984): Fix `Style/AndOr` adding unnecessary parentheses around `return` without arguments. ([@eugeneius][])

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -128,6 +128,7 @@ module RuboCop
 
         def correct_other(node, corrector)
           return if node.parenthesized_call?
+          return if node.children.empty? && node.equal?(node.parent.children.last)
 
           corrector.wrap(node, '(', ')')
         end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -333,6 +333,32 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'with `return` without arguments on the right' do
+      it 'autocorrects "and" with && without adding parentheses' do
+        expect_offense(<<~RUBY)
+          foo and return
+              ^^^ Use `&&` instead of `and`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo && return
+        RUBY
+      end
+    end
+
+    context 'with `return` with arguments on the right' do
+      it 'autocorrects "and" with && and adds parentheses' do
+        expect_offense(<<~RUBY)
+          foo and return x
+              ^^^ Use `&&` instead of `and`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo && (return x)
+        RUBY
+      end
+    end
+
     context 'with !obj.method arg on right' do
       it 'autocorrects "and" with && and adds parens' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
When `EnforcedStyle: always` is set, autocorrection wraps `return` in parentheses when converting `and`/`or` to `&&`/`||`. This is necessary when `return` has arguments (e.g. `return x`), but redundant otherwise.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/