### PR TITLE
Complete ERB/Haml autocorrection in a single run

### DIFF
--- a/changelog/fix_handle_multi_source_template_autocorrect_in_one_20260305010004.md
+++ b/changelog/fix_handle_multi_source_template_autocorrect_in_one_20260305010004.md
@@ -1,0 +1,1 @@
+* [#14987](https://github.com/rubocop/rubocop/pull/14987): Complete ERB and Haml autocorrection in a single run. ([@alpaca-tc][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -350,7 +350,9 @@ module RuboCop
 
     def inspect_file(processed_source, team = mobilize_team(processed_source))
       extracted_ruby_sources = extract_ruby_sources(processed_source)
-      offenses = extracted_ruby_sources.flat_map do |extracted_ruby_source|
+      offenses = []
+
+      extracted_ruby_sources.each do |extracted_ruby_source|
         report = team.investigate(
           extracted_ruby_source[:processed_source],
           offset: extracted_ruby_source[:offset],
@@ -358,8 +360,11 @@ module RuboCop
         )
         @errors.concat(team.errors)
         @warnings.concat(team.warnings)
-        report.offenses
+        offenses.concat(report.offenses)
+
+        break if team.updated_source_file?
       end
+
       [offenses, team.updated_source_file?]
     end
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4222,4 +4222,69 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect(status).to eq(0)
     expect($stderr.string).to eq('')
   end
+
+  context 'when a custom ruby extractor returns multiple processed sources for one file' do
+    def with_ruby_extractor(ruby_extractor)
+      RuboCop::Runner.ruby_extractors.unshift(ruby_extractor)
+      yield
+    ensure
+      RuboCop::Runner.ruby_extractors.shift
+    end
+
+    it 'applies autocorrections for all extracted sources in one run' do
+      path = 'example.rb'
+
+      create_file(path, <<~RUBY.split("\n"))
+        Hash.new()
+        Hash.new()
+        Hash.new()
+      RUBY
+
+      ruby_extractor = lambda do |_processed_source|
+        offset = 0
+        File.read(path).lines.map do |line|
+          current_offset = offset
+          offset += line.bytesize
+
+          {
+            offset: current_offset,
+            processed_source: RuboCop::ProcessedSource.new(
+              line,
+              3.4,
+              path,
+              parser_engine:
+              parser_engine
+            )
+          }
+        end
+      end
+
+      with_ruby_extractor(ruby_extractor) do
+        expect(cli.run(%w[--autocorrect-all --only Style/EmptyLiteral])).to eq(0)
+        expect(File.read(path)).to eq(<<~RUBY)
+          {}
+          {}
+          {}
+        RUBY
+        expect($stdout.string).to eq(<<~RESULT)
+          Inspecting 1 file
+          C
+
+          Offenses:
+
+          example.rb:1:1: C: [Corrected] Style/EmptyLiteral: Use hash literal {} instead of Hash.new().
+          Hash.new()
+          ^^^^^^^^^^
+          example.rb:2:1: C: [Corrected] Style/EmptyLiteral: Use hash literal {} instead of Hash.new().
+          Hash.new()
+          ^^^^^^^^^^
+          example.rb:3:1: C: [Corrected] Style/EmptyLiteral: Use hash literal {} instead of Hash.new().
+          Hash.new()
+          ^^^^^^^^^^
+
+          1 file inspected, 3 offenses detected, 3 offenses corrected
+        RESULT
+      end
+    end
+  end
 end


### PR DESCRIPTION
rubocop-erb and rubocop-haml autocorrect template files that contain multiple embedded Ruby fragments.

For these files, `extract_ruby_sources` returns an array of extracted Ruby blocks. For example, a template with three embedded snippets is split into three processed sources.

Previously, RuboCop iterated those extracted blocks and autocorrected them one by one while saving the file each time. That meant the next save could overwrite earlier fragment fixes, so changes from block 1 could be lost when block 2 was saved, and changes from blocks 1 and 2 could be lost when block 3 was saved.

In addition, `updated_source_file?` was effectively judged by the final extracted block. After block 3 finished, it could return `false` while earlier fixes had already been overwritten, causing the loop to stop. As a result, only the last extracted block's autocorrection could remain in the file.

This change makes RuboCop reload `processed_source` after an update is detected, so the loop continues from the latest file state instead of progressing with stale extracted sources.

Also add a regression spec for a custom extractor that returns multiple sources and verify all offenses are corrected in one run.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
