### PR TITLE
Fix false negatives in `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_negatives_in_style_redundant_parentheses.md
+++ b/changelog/fix_false_negatives_in_style_redundant_parentheses.md
@@ -1,0 +1,1 @@
+* [#14988](https://github.com/rubocop/rubocop/pull/14988): Fix false negative in `Style/RedundantParentheses` when redundant parentheses around range literals in block body. ([@koic][])

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -176,7 +176,7 @@ module RuboCop
           if first_non_comment_token
             0...first_non_comment_token.line
           else
-            (0..)
+            0..
           end
         end
 

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -139,6 +139,8 @@ module RuboCop
           node = begin_node.children.first
 
           if (message = find_offense_message(begin_node, node))
+            return offense(begin_node, message) if message == 'block body'
+
             if node.range_type? && !argument_of_parenthesized_method_call?(begin_node, node)
               begin_node = begin_node.parent
             end
@@ -155,7 +157,8 @@ module RuboCop
           return 'a literal' if node.literal? && disallowed_literal?(begin_node, node)
           return 'a variable' if node.variable?
           return 'a constant' if node.const_type?
-          return 'block body' if begin_node.parent&.any_block_type? && !node.range_type?
+          return 'block body' if begin_node.parent&.any_block_type? || body_range?(begin_node, node)
+
           if node.assignment? && (begin_node.parent.nil? || begin_node.parent.begin_type?)
             return 'an assignment'
           end
@@ -265,6 +268,14 @@ module RuboCop
           else
             !raised_to_power_negative_numeric?(begin_node, node)
           end
+        end
+
+        def body_range?(begin_node, node)
+          return false unless node.range_type?
+          return false unless (parent = begin_node.parent)
+
+          (node.begin.nil? && begin_node == parent.children.first) ||
+            (node.end.nil? && begin_node == parent.children.last)
         end
 
         def disallowed_one_line_pattern_matching?(begin_node, node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -886,40 +886,125 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
-  it 'accepts parentheses around an irange inside a block' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers parentheses around an irange inside a block' do
+    expect_offense(<<~RUBY)
       something do
         (a..b)
+        ^^^^^^ Don't use parentheses around block body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        a..b
       end
     RUBY
   end
 
-  it 'accepts parentheses around an erange inside a block' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers parentheses around an erange inside a block' do
+    expect_offense(<<~RUBY)
       something do
         (a...b)
+        ^^^^^^^ Don't use parentheses around block body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        a...b
       end
     RUBY
   end
 
-  it 'accepts parentheses around an irange inside a braces block' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers parentheses around an irange inside a braces block' do
+    expect_offense(<<~RUBY)
       something { (a..b) }
+                  ^^^^^^ Don't use parentheses around block body.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something { a..b }
     RUBY
   end
 
-  it 'accepts parentheses around a beginless range inside a block' do
+  it 'registers parentheses around a beginless range inside a block' do
+    expect_offense(<<~RUBY)
+      something do
+        (..b)
+        ^^^^^ Don't use parentheses around block body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        ..b
+      end
+    RUBY
+  end
+
+  it 'registers parentheses around a beginless range followed by an expression inside a block' do
+    expect_offense(<<~RUBY)
+      something do
+        (..b)
+        ^^^^^ Don't use parentheses around block body.
+        x
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        ..b
+        x
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around a beginless range preceded by an expression inside a block' do
     expect_no_offenses(<<~RUBY)
       something do
+        x
         (..b)
       end
     RUBY
   end
 
-  it 'accepts parentheses around an endless range inside a block' do
+  it 'registers parentheses around an endless range inside a block' do
+    expect_offense(<<~RUBY)
+      something do
+        (a..)
+        ^^^^^ Don't use parentheses around block body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        a..
+      end
+    RUBY
+  end
+
+  it 'registers parentheses around an endless range preceded by an expression inside a block' do
+    expect_offense(<<~RUBY)
+      something do
+        x
+        (a..)
+        ^^^^^ Don't use parentheses around block body.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something do
+        x
+        a..
+      end
+    RUBY
+  end
+
+  it 'accepts parentheses around an endless range followed by an expression inside a block' do
     expect_no_offenses(<<~RUBY)
       something do
         (a..)
+        x
       end
     RUBY
   end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/14964#issuecomment-3976774697.

This PR fixes false negative in `Style/RedundantParentheses` when redundant parentheses around range literals in block body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
