### PR TITLE
 Make `Lint/RedundantSafeNavigation` aware of safe navigation in conditional true branch

### DIFF
--- a/changelog/change_make_lint_redundant_safe_navigation_aware_of_safe_navigation_in_conditional_true_branch.md
+++ b/changelog/change_make_lint_redundant_safe_navigation_aware_of_safe_navigation_in_conditional_true_branch.md
@@ -1,0 +1,1 @@
+* [#14989](https://github.com/rubocop/rubocop/pull/14989): Make `Lint/RedundantSafeNavigation` aware of safe navigation in conditional true branch. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -62,6 +62,22 @@ module RuboCop
       #   do_something if attrs.respond_to?(:[])
       #
       #   # bad
+      #   foo&.bar ? foo&.bar.baz : qux
+      #
+      #   # good
+      #   foo&.bar ? foo.bar.baz : qux
+      #
+      #   # bad
+      #   if foo&.bar
+      #     foo&.bar.baz
+      #   end
+      #
+      #   # good
+      #   if foo&.bar
+      #     foo.bar.baz
+      #   end
+      #
+      #   # bad
       #   while node&.is_a?(BeginNode)
       #     node = node.parent
       #   end

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -82,17 +82,18 @@ module RuboCop
             !NIL_METHODS.include?(method_name) && !@additional_nil_methods.include?(method_name)
           end
 
-          # rubocop:disable Metrics/PerceivedComplexity
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           def sole_condition_of_parent_if?(node)
             parent = node.parent
 
             while parent
               if parent.if_type?
-                if parent.condition == node
+                condition = parent.condition
+                if condition == node || (condition.csend_type? && !condition.receiver.equal?(node))
                   return true
-                elsif parent.elsif?
-                  parent = find_top_if(parent)
                 end
+
+                parent = find_top_if(parent) if parent.elsif?
               elsif else_branch?(parent)
                 # Find the top `if` for `else`.
                 parent = parent.parent
@@ -103,7 +104,7 @@ module RuboCop
 
             false
           end
-          # rubocop:enable Metrics/PerceivedComplexity
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
           def else_branch?(node)
             node.parent&.if_type? && node.parent.else_branch == node

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -423,6 +423,48 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
 
+    it 'registers an offense when safe navigation receiver is a csend condition of a ternary if branch' do
+      expect_offense(<<~RUBY)
+        foo&.bar ? foo&.bar.baz : qux
+                      ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo&.bar ? foo.bar.baz : qux
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in the else branch of a ternary with a csend condition' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar ? qux : foo&.bar.baz
+      RUBY
+    end
+
+    it 'registers an offense when safe navigation receiver is a csend condition of an if true branch' do
+      expect_offense(<<~RUBY)
+        if foo&.bar
+          foo&.bar.baz
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo&.bar
+          foo.bar.baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in the else branch of an if with a csend condition' do
+      expect_no_offenses(<<~RUBY)
+        if foo&.bar
+          qux
+        else
+          foo&.bar.baz
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when method is called on receiver in lhs of condition' do
       expect_offense(<<~RUBY)
         if foo.condition? && other_condition


### PR DESCRIPTION
This PR makes `Lint/RedundantSafeNavigation` detect redundant safe navigation in the true branch of a conditional when the condition is a safe navigation call (e.g., `foo&.bar`). Since the condition guarantees the receiver is non-nil, safe navigation on the same receiver in the true branch is redundant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
