### PR TITLE
[Fix #14985] Fix incorrect autocorrection in `Lint/SafeNavigationChain`

### DIFF
--- a/changelog/fix_incorrect_autocorrection_in_lint_safe_navigation_chain.md
+++ b/changelog/fix_incorrect_autocorrection_in_lint_safe_navigation_chain.md
@@ -1,0 +1,1 @@
+* [#14985](https://github.com/rubocop/rubocop/issues/14985): Fix incorrect autocorrection in `Lint/SafeNavigationChain` when chaining a method call after safe navigation in the if branch of a ternary. ([@koic][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -37,20 +37,25 @@ module RuboCop
           }
         PATTERN
 
+        # rubocop:disable Metrics/AbcSize
         def on_send(node)
           return unless require_safe_navigation?(node)
 
           bad_method?(node) do |safe_nav, method|
             return if nil_methods.include?(method) || PLUS_MINUS_METHODS.include?(node.method_name)
+            return if ternary_safe_navigation?(node, safe_nav)
 
             begin_range = node.loc.dot || safe_nav.source_range.end
             location = begin_range.join(node.source_range.end)
 
             add_offense(location) do |corrector|
+              next if ternary_else_branch?(node, safe_nav)
+
               autocorrect(corrector, offense_range: location, send_node: node)
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 
@@ -59,6 +64,18 @@ module RuboCop
           return true unless parent&.and_type?
 
           parent.rhs != node || parent.lhs.receiver != parent.rhs.receiver
+        end
+
+        def ternary_safe_navigation?(node, safe_nav)
+          return false unless (parent = node.parent)
+
+          parent.if_type? && node.equal?(parent.if_branch) && parent.condition == safe_nav
+        end
+
+        def ternary_else_branch?(node, safe_nav)
+          return false unless (parent = node.parent)
+
+          parent.if_type? && node.equal?(parent.else_branch) && parent.condition == safe_nav
         end
 
         # @param [Parser::Source::Range] offense_range

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -398,6 +398,35 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    # NOTE: `foo&.bar` in the true branch is handled by `Lint/RedundantSafeNavigation`.
+    it 'does not register an offense when chaining a method call after safe navigation in the if branch of a ternary' do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar ? foo&.bar - 1 : baz
+      RUBY
+    end
+
+    it 'registers an offense when chaining a method call after safe navigation in the else branch of a ternary' do
+      expect_offense(<<~RUBY)
+        foo&.bar ? baz : foo&.bar - 1
+                                 ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      # NOTE: The receiver in the else branch may be nil, so chaining could raise `NoMethodError`.
+      # Autocorrection is not possible as the intent is ambiguous.
+      expect_no_corrections
+    end
+
+    it 'registers an offense and corrects when chaining a method call after safe navigation in the else branch of an unrelated ternary' do
+      expect_offense(<<~RUBY)
+        cond ? baz : user&.team.name
+                               ^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? baz : user&.team&.name
+      RUBY
+    end
+
     it 'registers an offense for safe navigation on the left-hand side of a `-` operator when inside an array' do
       expect_offense(<<~RUBY)
         [foo, a&.baz - 1]


### PR DESCRIPTION
This PR fixes incorrect autocorrection in `Lint/SafeNavigationChain` when chaining a method call after safe navigation in the if branch of a ternary.

`foo&.bar ? foo&.bar - 1 : baz` should be detected by `Lint/RedundantSafeNavigation` as
`foo&.bar ? foo.bar - 1 : baz`, which will be addressed separately.

For `foo&.bar ? baz : foo&.bar - 1`, the code in the else branch chains a method call on a receiver that may be nil. Autocorrection is not possible because the intended logic cannot be determined automatically.

Fixes #14985.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
