### PR TITLE
Update cut_release.rake to reference bug_report.yml

### DIFF
--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -54,7 +54,7 @@ namespace :cut_release do
   end
 
   def update_issue_template(old_version, new_version)
-    update_file('.github/ISSUE_TEMPLATE/bug_report.md') do |issue_template|
+    update_file('.github/ISSUE_TEMPLATE/bug_report.yml') do |issue_template|
       issue_template.sub("#{old_version} (using Parser ", "#{new_version} (using Parser ")
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/commit/8c1ffe99a2a27878a2b329af7a85bf5f51565f45

.github/ISSUE_TEMPLATE/bug_report.md renamed to .github/ISSUE_TEMPLATE/bug_report.yml.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
