### PR TITLE
Add enforcement levels for cop filtering

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -172,11 +172,18 @@ AllCops:
   # For now this will behave as if set to false but in future ruby versions
   # (likely 4.0) it will be true by default.
   StringLiteralsFrozenByDefault: ~
+  # Enforcement levels allow selecting a strictness tier for analysis.
+  # When set, only cops tagged with an enforcement level at or below the
+  # configured level will be enabled. Cops without an Enforcement tag are
+  # unaffected. Can be overridden by the `--enforcement` command-line option.
+  # Valid choices are: essential, standard, strict.
+  # Enforcement: ~
 
 #################### Bundler ###############################
 
 Bundler/DuplicatedGem:
   Description: 'Checks for duplicate gem entries in Gemfile.'
+  Enforcement: essential
   Enabled: true
   Severity: warning
   VersionAdded: '0.46'
@@ -638,6 +645,7 @@ Layout/EmptyLineBetweenDefs:
 
 Layout/EmptyLines:
   Description: "Don't use several empty lines in a row."
+  Enforcement: standard
   StyleGuide: '#two-or-more-empty-lines'
   Enabled: true
   VersionAdded: '0.49'
@@ -754,6 +762,7 @@ Layout/EndAlignment:
 
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
+  Enforcement: standard
   StyleGuide: '#crlf'
   Enabled: true
   VersionAdded: '0.49'
@@ -1002,6 +1011,7 @@ Layout/HeredocIndentation:
 
 Layout/IndentationConsistency:
   Description: 'Keep indentation straight.'
+  Enforcement: standard
   StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
@@ -1037,6 +1047,7 @@ Layout/IndentationStyle:
 
 Layout/IndentationWidth:
   Description: 'Use 2 spaces for indentation.'
+  Enforcement: standard
   StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
@@ -1061,6 +1072,7 @@ Layout/InitialIndentation:
 
 Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
+  Enforcement: standard
   StyleGuide: '#hash-space'
   Enabled: true
   VersionAdded: '0.49'
@@ -1404,6 +1416,7 @@ Layout/SpaceAroundMethodCallOperator:
 
 Layout/SpaceAroundOperators:
   Description: 'Use a single space around operators.'
+  Enforcement: standard
   StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
@@ -1505,6 +1518,7 @@ Layout/SpaceInsideBlockBraces:
                  Checks that block braces have or don't have surrounding space.
                  For blocks taking parameters, checks that the left brace has
                  or doesn't have trailing space.
+  Enforcement: standard
   Enabled: true
   VersionAdded: '0.49'
   EnforcedStyle: space
@@ -1595,6 +1609,7 @@ Layout/TrailingEmptyLines:
 
 Layout/TrailingWhitespace:
   Description: 'Avoid trailing whitespace.'
+  Enforcement: standard
   StyleGuide: '#no-trailing-whitespace'
   Enabled: true
   VersionAdded: '0.49'
@@ -1686,6 +1701,7 @@ Lint/BooleanSymbol:
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.33'
 
@@ -1732,6 +1748,7 @@ Lint/DataDefineOverride:
 
 Lint/Debugger:
   Description: 'Checks for debugger calls.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.14'
   VersionChanged: '1.63'
@@ -1857,6 +1874,7 @@ Lint/DuplicateElsifCondition:
 
 Lint/DuplicateHashKey:
   Description: 'Checks for duplicate keys in hash literals.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.34'
   VersionChanged: '0.77'
@@ -1873,6 +1891,7 @@ Lint/DuplicateMatchPattern:
 
 Lint/DuplicateMethods:
   Description: 'Checks for duplicate method definitions.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.29'
 
@@ -1933,6 +1952,7 @@ Lint/EmptyConditionalBody:
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
+  Enforcement: essential
   Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.10'
@@ -1997,11 +2017,13 @@ Lint/FloatOutOfRange:
   Description: >-
                  Catches floating-point literals too large or small for Ruby to
                  represent.
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.36'
 
 Lint/FormatParameterMismatch:
   Description: 'Checks for a mismatch between the format fields and the arguments to `format`/`sprintf`/`%`.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.33'
 
@@ -2489,6 +2511,7 @@ Lint/StructNewOverride:
 
 Lint/SuppressedException:
   Description: "Don't suppress exceptions."
+  Enforcement: essential
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
   VersionAdded: '0.9'
@@ -2514,6 +2537,7 @@ Lint/SymbolConversion:
 
 Lint/Syntax:
   Description: 'Checks for syntax errors.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.9'
 
@@ -2588,6 +2612,7 @@ Lint/UnmodifiedReduceAccumulator:
 
 Lint/UnreachableCode:
   Description: 'Checks for unreachable code.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.9'
 
@@ -2656,6 +2681,7 @@ Lint/UselessAccessModifier:
 
 Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
+  Enforcement: essential
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
   AutoCorrect: contextual
@@ -2733,6 +2759,7 @@ Lint/UselessTimes:
 
 Lint/Void:
   Description: 'Checks for operators, literals, lambdas, and procs used in void context.'
+  Enforcement: essential
   Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.9'
@@ -2743,6 +2770,7 @@ Lint/Void:
 
 Metrics/AbcSize:
   Description: 'Checks that the ABC size of methods is not higher than the configured maximum.'
+  Enforcement: strict
   References:
     - https://wiki.c2.com/?AbcMetric
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
@@ -2758,6 +2786,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.44'
   VersionChanged: '1.5'
@@ -2784,6 +2813,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.87'
@@ -2801,6 +2831,7 @@ Metrics/CollectionLiteralLength:
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
   Description: 'Checks that the cyclomatic complexity of methods is not higher than the configured maximum.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
@@ -2810,6 +2841,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
+  Enforcement: strict
   StyleGuide: '#short-methods'
   Enabled: true
   VersionAdded: '0.25'
@@ -2831,6 +2863,7 @@ Metrics/ModuleLength:
 
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
+  Enforcement: strict
   StyleGuide: '#too-many-params'
   Enabled: true
   VersionAdded: '0.25'
@@ -2841,6 +2874,7 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Description: 'Checks that the perceived complexity of methods is not higher than the configured maximum.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
@@ -2917,6 +2951,7 @@ Naming/ClassAndModuleCamelCase:
 
 Naming/ConstantName:
   Description: 'Constants should use SCREAMING_SNAKE_CASE.'
+  Enforcement: standard
   StyleGuide: '#screaming-snake-case'
   Enabled: true
   VersionAdded: '0.50'
@@ -3062,6 +3097,7 @@ Naming/MemoizedInstanceVariableName:
 
 Naming/MethodName:
   Description: 'Use the configured style when naming methods.'
+  Enforcement: standard
   StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
@@ -3173,6 +3209,7 @@ Naming/RescuedExceptionsVariableName:
 
 Naming/VariableName:
   Description: 'Use the configured style when naming variables.'
+  Enforcement: standard
   StyleGuide: '#snake-case-symbols-methods-vars'
   Enabled: true
   VersionAdded: '0.50'
@@ -3222,6 +3259,7 @@ Security/CompoundHash:
 
 Security/Eval:
   Description: 'Checks for the use of `Kernel#eval` and `Binding#eval` with dynamic arguments.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.47'
 
@@ -3258,6 +3296,7 @@ Security/MarshalLoad:
 
 Security/Open:
   Description: 'Checks for the use of `Kernel#open` and `URI.open` with dynamic data.'
+  Enforcement: essential
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '1.0'
@@ -3291,6 +3330,7 @@ Style/AccessModifierDeclarations:
 
 Style/AccessorGrouping:
   Description: 'Checks for grouping of accessors in `class` and `module` bodies.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.87'
   EnforcedStyle: grouped
@@ -3601,6 +3641,7 @@ Style/CharacterLiteral:
 
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
+  Enforcement: standard
   StyleGuide: '#namespace-definition'
   # Moving from compact to nested children requires knowledge of whether the
   # outer parent is a module or a class. Moving from nested to compact requires
@@ -3701,6 +3742,7 @@ Style/CollectionCompact:
 # Align with the style guide.
 Style/CollectionMethods:
   Description: 'Enforces the use of consistent method names from the `Enumerable` module.'
+  Enforcement: strict
   StyleGuide: '#map-find-select-reduce-include-size'
   Enabled: false
   VersionAdded: '0.9'
@@ -3936,6 +3978,7 @@ Style/DocumentDynamicEvalDefinition:
 
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
+  Enforcement: strict
   Enabled: true
   VersionAdded: '0.9'
   AllowedConstants: []
@@ -4078,6 +4121,7 @@ Style/EndBlock:
 
 Style/EndlessMethod:
   Description: 'Avoid the use of multi-lined endless method definitions.'
+  Enforcement: strict
   StyleGuide: '#endless-methods'
   Enabled: pending
   VersionAdded: '1.8'
@@ -4258,6 +4302,7 @@ Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
                  to help transition to frozen string literals by default.
+  Enforcement: standard
   Enabled: true
   VersionAdded: '0.36'
   VersionChanged: '0.79'
@@ -4298,6 +4343,7 @@ Style/GlobalVars:
 
 Style/GuardClause:
   Description: 'Checks for conditionals that can be replaced with guard clauses.'
+  Enforcement: strict
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
@@ -4385,6 +4431,7 @@ Style/HashSyntax:
   Description: >-
                  Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
                  { :a => 1, :b => 2 }.
+  Enforcement: standard
   StyleGuide: '#hash-literals'
   Enabled: true
   VersionAdded: '0.9'
@@ -4452,6 +4499,7 @@ Style/IfUnlessModifier:
   Description: >-
                  Favor modifier if/unless usage when you have a
                  single-line body.
+  Enforcement: strict
   StyleGuide: '#if-as-a-modifier'
   Enabled: true
   VersionAdded: '0.9'
@@ -4754,6 +4802,7 @@ Style/MissingElse:
                 Style/UnlessElse and Style/EmptyElse be enabled.
                 This will conflict with Style/EmptyElse if
                 Style/EmptyElse is configured to style "both".
+  Enforcement: strict
   Enabled: false
   VersionAdded: '0.30'
   VersionChanged: '0.38'
@@ -5010,6 +5059,7 @@ Style/Next:
 
 Style/NilComparison:
   Description: 'Prefer x.nil? to x == nil.'
+  Enforcement: standard
   StyleGuide: '#predicate-methods'
   Enabled: true
   VersionAdded: '0.12'
@@ -5528,6 +5578,7 @@ Style/RedundantRegexpEscape:
 
 Style/RedundantReturn:
   Description: "Don't use return where it's not required."
+  Enforcement: standard
   StyleGuide: '#no-explicit-return'
   Enabled: true
   VersionAdded: '0.10'
@@ -5537,6 +5588,7 @@ Style/RedundantReturn:
 
 Style/RedundantSelf:
   Description: "Don't use self where it's not needed."
+  Enforcement: standard
   StyleGuide: '#no-self-unless-required'
   Enabled: true
   VersionAdded: '0.10'
@@ -5858,6 +5910,7 @@ Style/StringHashKeys:
 
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
+  Enforcement: standard
   StyleGuide: '#consistent-string-literals'
   Enabled: true
   VersionAdded: '0.9'
@@ -5945,6 +5998,7 @@ Style/SymbolLiteral:
 
 Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
+  Enforcement: standard
   Enabled: true
   Safe: false
   VersionAdded: '0.26'
@@ -6017,6 +6071,7 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInArrayLiteral:
   Description: 'Checks for trailing comma in array literals.'
+  Enforcement: standard
   StyleGuide: '#no-trailing-array-commas'
   Enabled: true
   VersionAdded: '0.53'

--- a/docs/design/presets.md
+++ b/docs/design/presets.md
@@ -1,4 +1,4 @@
-# Presets Design Exploration
+# Enforcement Levels — Design Exploration
 
 ## The Problem
 
@@ -12,35 +12,20 @@ Related: #14005, #10726, #12582, #14913.
 
 ## Naming
 
-The feature needs a name that fits RuboCop's police theme. Options:
+We considered many police-themed alternatives (patrol, directive, protocol,
+jurisdiction, squad, dispatch, etc.) and settled on **enforcement** — it's
+self-documenting, on-theme, and requires no explanation.
 
-| Name | Metaphor | Usage example | Pros | Cons |
-|------|----------|---------------|------|------|
-| **Preset** | Generic | `preset: standard` | Familiar, self-explanatory | Boring, no theme |
-| **Patrol** | Police patrol levels | `patrol: highway` | Fun, maps well to strictness tiers | Slightly whimsical |
-| **Directive** | Police directive/order | `directive: standard` | Authoritative feel | Suggested in #14005 already |
-| **Detail** | Police detail/assignment | `detail: standard` | Professional tone | Less intuitive |
-| **Protocol** | Enforcement protocol | `protocol: standard` | Fits well, serious tone | Slightly clinical |
-| **Precinct** | Police precinct | `precinct: downtown` | Fun organizational metaphor | Naming the levels gets weird |
-| **Rank** | Officer ranks | `rank: sergeant` | Built-in hierarchy (cadet < officer < sergeant < captain) | Implies the user is "less" at lower levels |
-| **Code** | Police codes (10-codes) | `code: ten-four` | Very on-theme | Confusingly overloaded with "source code" |
-| **Beat** | Police beat (patrol area) | `beat: standard` | Simple, on-theme | Less obvious meaning |
+Usage:
 
-**Recommendation:** "Patrol" strikes a nice balance between thematic and
-understandable. The levels map naturally to police patrol types:
+```yaml
+AllCops:
+  Enforcement: standard
+```
 
-- `community` — light touch, only essential checks (bugs, security, syntax)
-- `beat` — standard patrol, the recommended default for most projects
-- `highway` — stricter enforcement, style guide compliance
-- `tactical` — maximum enforcement, all cops enabled
+## Enforcement Levels
 
-Alternative: stick with the neutral "preset" and use thematic level names.
-
-## Proposed Levels
-
-Regardless of naming, we need to define what each level contains:
-
-### Level 1: Essential / Community
+### Level 1: `essential`
 
 Cops that catch real bugs, security issues, and broken code. Nobody would
 disagree with these. Think: "if this cop fires, you almost certainly have a
@@ -53,31 +38,31 @@ problem."
 - No layout or formatting cops
 - ~150 cops
 
-### Level 2: Standard / Beat (recommended default)
+### Level 2: `standard` (recommended default)
 
 The "sensible defaults" level. Adds widely-accepted style and naming
 conventions that most Ruby developers agree on. This is what new projects
 should start with.
 
-- Everything in Level 1
+- Everything in `essential`
 - Layout cops for consistent formatting (indentation, spacing, blank lines)
 - Non-controversial `Style/` cops (`Style/StringLiterals`, `Style/FrozenStringLiteralComment`, etc.)
 - Non-controversial `Naming/` cops
 - Non-controversial `Metrics/` cops (reasonable method length, etc.)
 - ~300 cops
 
-### Level 3: Strict / Highway
+### Level 3: `strict`
 
 Full Ruby Style Guide compliance. Adds opinionated cops that enforce the
 community style guide comprehensively.
 
-- Everything in Level 2
+- Everything in `standard`
 - Opinionated `Style/` cops (`Style/Documentation`, `Style/EndlessMethod`, etc.)
 - Stricter `Metrics/` thresholds
 - All pending cops that are ready for general use
 - ~380 cops
 
-### Level 4: Maximum / Tactical
+### Level 4: `all`
 
 Everything enabled. For teams that want maximum enforcement.
 
@@ -87,19 +72,19 @@ Everything enabled. For teams that want maximum enforcement.
 
 ## Implementation Approaches
 
-### Approach A: Cop-level metadata (tag each cop with its preset level)
+### Approach A: Cop-level metadata (tag each cop with its enforcement level)
 
-Add a `Preset` field to each cop in `config/default.yml`:
+Add an `Enforcement` field to each cop in `config/default.yml`:
 
 ```yaml
 Style/FrozenStringLiteralComment:
   Enabled: true
-  Preset: essential
+  Enforcement: essential
   Description: '...'
 
 Style/Documentation:
   Enabled: true
-  Preset: strict
+  Enforcement: strict
   Description: '...'
 ```
 
@@ -107,44 +92,44 @@ Usage in `.rubocop.yml`:
 
 ```yaml
 AllCops:
-  Preset: standard   # enable all cops at "standard" level and below
+  Enforcement: standard   # enable all cops at "standard" level and below
 ```
 
 **Pros:**
 - Single source of truth — each cop declares its level
-- Simple mental model: `Preset: standard` means "enable everything at standard and below"
-- Easy to query: `rubocop --list-cops --preset essential`
-- Eliminates the `pending` state — new cops get a preset level immediately
-- Clean merge semantics: user can override individual cops after choosing a preset
+- Simple mental model: `Enforcement: standard` means "enable everything at standard and below"
+- Easy to query: `rubocop --list-cops --enforcement essential`
+- Eliminates the `pending` state — new cops get an enforcement level immediately
+- Clean merge semantics: user can override individual cops after choosing a level
 - No new files to maintain
 
 **Cons:**
 - Requires adding metadata to all 450+ cops in `config/default.yml`
-- Preset level for each cop is a subjective decision that may generate debate
-- Tightly couples cop definitions to preset classification
+- Enforcement level for each cop is a subjective decision that may generate debate
+- Tightly couples cop definitions to enforcement classification
 - Harder for extension gems to participate (they'd need to tag their cops too)
 
 **Implementation:**
-- Add `Preset` field to cop metadata in `config/default.yml`
-- Define preset hierarchy in `ConfigLoader` (`essential < standard < strict < all`)
-- In `Config#cop_enabled?`, check cop's preset against the configured level
-- Pending cops become cops with a preset level but `Enabled: pending` goes away
+- Add `Enforcement` field to cop metadata in `config/default.yml`
+- Define level hierarchy in `ConfigLoader` (`essential < standard < strict < all`)
+- In `Config#cop_enabled?`, check cop's enforcement level against the configured level
+- Pending cops become cops with an enforcement level — `Enabled: pending` goes away
 
-### Approach B: Standalone preset config files
+### Approach B: Standalone enforcement config files
 
-Ship preset configs as YAML files in `config/presets/`:
+Ship enforcement level configs as YAML files in `config/enforcement/`:
 
 ```
-config/presets/essential.yml
-config/presets/standard.yml
-config/presets/strict.yml
-config/presets/all.yml
+config/enforcement/essential.yml
+config/enforcement/standard.yml
+config/enforcement/strict.yml
+config/enforcement/all.yml
 ```
 
 Each file inherits from the level below and adds cops:
 
 ```yaml
-# config/presets/standard.yml
+# config/enforcement/standard.yml
 inherit_from: essential.yml
 
 Style/StringLiterals:
@@ -157,7 +142,8 @@ Layout/IndentationWidth:
 Usage in `.rubocop.yml`:
 
 ```yaml
-inherit_preset: standard
+AllCops:
+  Enforcement: standard
 
 # User overrides:
 Style/Documentation:
@@ -166,47 +152,46 @@ Style/Documentation:
 
 **Pros:**
 - Uses existing inheritance machinery (`inherit_from` under the hood)
-- Preset definitions are easy to read and diff
-- Extension gems can ship their own preset files
-- Users can create custom presets by inheriting from built-in ones
+- Level definitions are easy to read and diff
+- Extension gems can ship their own enforcement level files
+- Users can create custom levels by inheriting from built-in ones
 - No changes to cop metadata format
 
 **Cons:**
 - Multiple files to maintain, with cop lists that must stay in sync with `default.yml`
-- Adding a new cop requires editing both `default.yml` and a preset file
-- Merge order complexity: how does `inherit_preset` interact with `inherit_from`?
+- Adding a new cop requires editing both `default.yml` and an enforcement file
+- Merge order complexity: how does `Enforcement` interact with `inherit_from`?
 - `DisabledByDefault` interaction needs careful thought
-- Risk of preset files drifting out of sync
+- Risk of enforcement files drifting out of sync
 
 **Implementation:**
-- Add `inherit_preset` key to config format
+- Add `AllCops: Enforcement` key to config format
 - Resolve it early in `ConfigLoader`, before `inherit_from`
-- Preset files use `DisabledByDefault: true` + explicitly enable their cops
-- Each preset inherits from the one below it
+- Enforcement files use `DisabledByDefault: true` + explicitly enable their cops
+- Each level inherits from the one below it
 - User config merges on top as usual
 
-### Approach C: Hybrid — metadata + generated preset files
+### Approach C: Hybrid — metadata + generated enforcement files
 
-Tag cops with preset levels in `default.yml` (like Approach A), but also
-generate standalone preset YAML files from those tags (for transparency and
-for extension gems to reference).
+Tag cops with enforcement levels in `default.yml` (like Approach A), but also
+generate standalone YAML files from those tags (for transparency and for
+extension gems to reference).
 
 ```yaml
 # config/default.yml
 Style/FrozenStringLiteralComment:
   Enabled: true
-  Preset: essential
+  Enforcement: essential
 ```
 
 A rake task generates:
 
 ```yaml
-# config/presets/essential.yml (auto-generated, do not edit)
-# Contains all cops tagged Preset: essential or lower
+# config/enforcement/essential.yml (auto-generated, do not edit)
+# Contains all cops tagged Enforcement: essential or lower
 ```
 
-Usage: same as Approach A (`AllCops: Preset: standard`) or Approach B
-(`inherit_preset: standard`), or both.
+Usage: same as Approach A (`AllCops: Enforcement: standard`).
 
 **Pros:**
 - Single source of truth (cop metadata) with generated artifacts for transparency
@@ -219,7 +204,7 @@ Usage: same as Approach A (`AllCops: Preset: standard`) or Approach B
 - Two representations of the same data (even if one is auto-generated)
 - More complex than either A or B alone
 
-### Approach D: Convention-based (departments as presets)
+### Approach D: Convention-based (departments as enforcement levels)
 
 Instead of a new mechanism, reorganize cops into departments that map to
 strictness levels. For example, move bug-catching cops to `Lint/`, rename
@@ -236,7 +221,8 @@ strictness levels. For example, move bug-catching cops to `Lint/`, rename
 - Many cops don't fit neatly into one strictness level
 - Essentially a non-starter for existing users
 
-**Verdict:** Not recommended. Departments and presets are orthogonal concepts.
+**Verdict:** Not recommended. Departments and enforcement levels are orthogonal
+concepts.
 
 ## Comparison Matrix
 
@@ -249,16 +235,16 @@ strictness levels. For example, move bug-catching cops to `Lint/`, rename
 | Simple mental model | Yes | Yes | Medium | Yes |
 | Migration effort | Medium | Medium | High | Very High |
 | Risk of drift | None | High | Low | None |
-| Custom user presets | No | Yes | Yes | No |
+| Custom user levels | No | Yes | Yes | No |
 
 ## Recommendation
 
 **Approach A (cop-level metadata)** is the simplest and cleanest for RuboCop's
 core. It has a single source of truth, a clear mental model, and eliminates the
 `pending` state entirely. The main downside — extension gem support — can be
-addressed by having extension gems also tag their cops with `Preset` levels.
+addressed by having extension gems also tag their cops with enforcement levels.
 
-If custom user presets are a priority, **Approach C (hybrid)** gives the best
+If custom user levels are a priority, **Approach C (hybrid)** gives the best
 of both worlds at the cost of a build step.
 
 **Approach B (standalone files)** is the most flexible but introduces
@@ -267,30 +253,36 @@ projects.
 
 ## Open Questions
 
-1. **Should presets replace `pending` entirely?** New cops could be assigned a
-   preset level immediately. If your configured preset includes that level,
-   you get the cop. No more "pending" state.
+1. **Should enforcement levels replace `pending` entirely?** New cops could be
+   assigned an enforcement level immediately. If your configured level includes
+   it, you get the cop. No more "pending" state.
 
-2. **How do presets interact with `NewCops: enable/disable`?** Probably:
-   `NewCops` becomes irrelevant if presets replace pending. Or `NewCops` only
-   applies to cops above your preset level.
+2. **How do enforcement levels interact with `NewCops: enable/disable`?**
+   Probably: `NewCops` becomes irrelevant if enforcement levels replace
+   pending. Or `NewCops` only applies to cops above your configured level.
 
-3. **Can users define custom presets?** Approach A says no (but you can still
-   override individual cops). Approach B/C say yes.
+3. **Can users define custom enforcement levels?** Approach A says no (but you
+   can still override individual cops). Approach B/C say yes.
 
 4. **Should the default change?** Currently RuboCop enables almost everything
-   by default. With presets, the default could be `standard` instead of `all`,
-   which would be a major improvement for new users but a breaking change for
-   existing ones.
+   by default. With enforcement levels, the default could be `standard` instead
+   of `all`, which would be a major improvement for new users but a breaking
+   change for existing ones.
 
 5. **How do extension gems participate?** They'd need to tag their cops with
-   preset levels too. We'd need to define guidelines and possibly validate
-   that extension cops have valid preset tags.
+   enforcement levels too. We'd need to define guidelines and possibly validate
+   that extension cops have valid levels.
 
 6. **What about `DisabledByDefault` / `EnabledByDefault`?** These global
-   switches would need clear interaction semantics with presets. Probably:
-   preset overrides these settings.
+   switches would need clear interaction semantics with enforcement levels.
+   Probably: enforcement level overrides these settings.
 
-7. **Naming the levels.** The police-themed names are fun but need to be
-   immediately understandable. A compromise: use descriptive names with
-   optional aliases (`essential`, `standard`, `strict`, `all`).
+7. **CLI support.** Should `rubocop --enforcement essential` work as a one-off
+   override? Useful for CI pipelines that want different levels for different
+   stages (e.g., `essential` for PRs, `strict` for main branch).
+
+8. **Migration path.** For 2.0, we could:
+   - Default `Enforcement` to `standard` (breaking change, but the whole point)
+   - Provide `rubocop --init` that generates `.rubocop.yml` with `Enforcement: all`
+     for teams that want the current behavior
+   - Print a one-time migration notice explaining the change

--- a/docs/design/presets.md
+++ b/docs/design/presets.md
@@ -1,0 +1,296 @@
+# Presets Design Exploration
+
+## The Problem
+
+RuboCop ships 400+ cops enabled by default, which overwhelms new users and
+generates hundreds of offenses on first run. The `pending` mechanism defers
+enablement decisions but creates a growing backlog (currently 148 cops). Users
+want to pick a level of enforcement that matches their project's needs without
+manually configuring hundreds of cops.
+
+Related: #14005, #10726, #12582, #14913.
+
+## Naming
+
+The feature needs a name that fits RuboCop's police theme. Options:
+
+| Name | Metaphor | Usage example | Pros | Cons |
+|------|----------|---------------|------|------|
+| **Preset** | Generic | `preset: standard` | Familiar, self-explanatory | Boring, no theme |
+| **Patrol** | Police patrol levels | `patrol: highway` | Fun, maps well to strictness tiers | Slightly whimsical |
+| **Directive** | Police directive/order | `directive: standard` | Authoritative feel | Suggested in #14005 already |
+| **Detail** | Police detail/assignment | `detail: standard` | Professional tone | Less intuitive |
+| **Protocol** | Enforcement protocol | `protocol: standard` | Fits well, serious tone | Slightly clinical |
+| **Precinct** | Police precinct | `precinct: downtown` | Fun organizational metaphor | Naming the levels gets weird |
+| **Rank** | Officer ranks | `rank: sergeant` | Built-in hierarchy (cadet < officer < sergeant < captain) | Implies the user is "less" at lower levels |
+| **Code** | Police codes (10-codes) | `code: ten-four` | Very on-theme | Confusingly overloaded with "source code" |
+| **Beat** | Police beat (patrol area) | `beat: standard` | Simple, on-theme | Less obvious meaning |
+
+**Recommendation:** "Patrol" strikes a nice balance between thematic and
+understandable. The levels map naturally to police patrol types:
+
+- `community` — light touch, only essential checks (bugs, security, syntax)
+- `beat` — standard patrol, the recommended default for most projects
+- `highway` — stricter enforcement, style guide compliance
+- `tactical` — maximum enforcement, all cops enabled
+
+Alternative: stick with the neutral "preset" and use thematic level names.
+
+## Proposed Levels
+
+Regardless of naming, we need to define what each level contains:
+
+### Level 1: Essential / Community
+
+Cops that catch real bugs, security issues, and broken code. Nobody would
+disagree with these. Think: "if this cop fires, you almost certainly have a
+problem."
+
+- All `Lint/` cops (except highly opinionated ones like `Lint/EmptyBlock`)
+- All `Security/` cops
+- `Bundler/` and `Gemspec/` cops that catch deprecated/broken usage
+- Critical `Style/` cops that prevent bugs (e.g., `Style/MutableConstant`)
+- No layout or formatting cops
+- ~150 cops
+
+### Level 2: Standard / Beat (recommended default)
+
+The "sensible defaults" level. Adds widely-accepted style and naming
+conventions that most Ruby developers agree on. This is what new projects
+should start with.
+
+- Everything in Level 1
+- Layout cops for consistent formatting (indentation, spacing, blank lines)
+- Non-controversial `Style/` cops (`Style/StringLiterals`, `Style/FrozenStringLiteralComment`, etc.)
+- Non-controversial `Naming/` cops
+- Non-controversial `Metrics/` cops (reasonable method length, etc.)
+- ~300 cops
+
+### Level 3: Strict / Highway
+
+Full Ruby Style Guide compliance. Adds opinionated cops that enforce the
+community style guide comprehensively.
+
+- Everything in Level 2
+- Opinionated `Style/` cops (`Style/Documentation`, `Style/EndlessMethod`, etc.)
+- Stricter `Metrics/` thresholds
+- All pending cops that are ready for general use
+- ~380 cops
+
+### Level 4: Maximum / Tactical
+
+Everything enabled. For teams that want maximum enforcement.
+
+- All cops enabled
+- Equivalent to current `AllCops: NewCops: enable` + `AllCops: DisabledByDefault: false`
+- ~450+ cops
+
+## Implementation Approaches
+
+### Approach A: Cop-level metadata (tag each cop with its preset level)
+
+Add a `Preset` field to each cop in `config/default.yml`:
+
+```yaml
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Preset: essential
+  Description: '...'
+
+Style/Documentation:
+  Enabled: true
+  Preset: strict
+  Description: '...'
+```
+
+Usage in `.rubocop.yml`:
+
+```yaml
+AllCops:
+  Preset: standard   # enable all cops at "standard" level and below
+```
+
+**Pros:**
+- Single source of truth — each cop declares its level
+- Simple mental model: `Preset: standard` means "enable everything at standard and below"
+- Easy to query: `rubocop --list-cops --preset essential`
+- Eliminates the `pending` state — new cops get a preset level immediately
+- Clean merge semantics: user can override individual cops after choosing a preset
+- No new files to maintain
+
+**Cons:**
+- Requires adding metadata to all 450+ cops in `config/default.yml`
+- Preset level for each cop is a subjective decision that may generate debate
+- Tightly couples cop definitions to preset classification
+- Harder for extension gems to participate (they'd need to tag their cops too)
+
+**Implementation:**
+- Add `Preset` field to cop metadata in `config/default.yml`
+- Define preset hierarchy in `ConfigLoader` (`essential < standard < strict < all`)
+- In `Config#cop_enabled?`, check cop's preset against the configured level
+- Pending cops become cops with a preset level but `Enabled: pending` goes away
+
+### Approach B: Standalone preset config files
+
+Ship preset configs as YAML files in `config/presets/`:
+
+```
+config/presets/essential.yml
+config/presets/standard.yml
+config/presets/strict.yml
+config/presets/all.yml
+```
+
+Each file inherits from the level below and adds cops:
+
+```yaml
+# config/presets/standard.yml
+inherit_from: essential.yml
+
+Style/StringLiterals:
+  Enabled: true
+Layout/IndentationWidth:
+  Enabled: true
+# ... etc
+```
+
+Usage in `.rubocop.yml`:
+
+```yaml
+inherit_preset: standard
+
+# User overrides:
+Style/Documentation:
+  Enabled: false
+```
+
+**Pros:**
+- Uses existing inheritance machinery (`inherit_from` under the hood)
+- Preset definitions are easy to read and diff
+- Extension gems can ship their own preset files
+- Users can create custom presets by inheriting from built-in ones
+- No changes to cop metadata format
+
+**Cons:**
+- Multiple files to maintain, with cop lists that must stay in sync with `default.yml`
+- Adding a new cop requires editing both `default.yml` and a preset file
+- Merge order complexity: how does `inherit_preset` interact with `inherit_from`?
+- `DisabledByDefault` interaction needs careful thought
+- Risk of preset files drifting out of sync
+
+**Implementation:**
+- Add `inherit_preset` key to config format
+- Resolve it early in `ConfigLoader`, before `inherit_from`
+- Preset files use `DisabledByDefault: true` + explicitly enable their cops
+- Each preset inherits from the one below it
+- User config merges on top as usual
+
+### Approach C: Hybrid — metadata + generated preset files
+
+Tag cops with preset levels in `default.yml` (like Approach A), but also
+generate standalone preset YAML files from those tags (for transparency and
+for extension gems to reference).
+
+```yaml
+# config/default.yml
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Preset: essential
+```
+
+A rake task generates:
+
+```yaml
+# config/presets/essential.yml (auto-generated, do not edit)
+# Contains all cops tagged Preset: essential or lower
+```
+
+Usage: same as Approach A (`AllCops: Preset: standard`) or Approach B
+(`inherit_preset: standard`), or both.
+
+**Pros:**
+- Single source of truth (cop metadata) with generated artifacts for transparency
+- Combines the simplicity of A with the composability of B
+- Generated files can be inspected, diffed, and used by extension gems
+- Rake task catches drift automatically
+
+**Cons:**
+- Build step required (generated files must be kept up to date)
+- Two representations of the same data (even if one is auto-generated)
+- More complex than either A or B alone
+
+### Approach D: Convention-based (departments as presets)
+
+Instead of a new mechanism, reorganize cops into departments that map to
+strictness levels. For example, move bug-catching cops to `Lint/`, rename
+`Style/` to only contain the standard-tier cops, and create a new
+`StyleGuide/` department for the strict tier.
+
+**Pros:**
+- No new config machinery needed
+- Uses existing department enable/disable (`Style: { Enabled: false }`)
+
+**Cons:**
+- Massive breaking change (renaming hundreds of cops)
+- Departments serve a different purpose (categorization by _type_, not _strictness_)
+- Many cops don't fit neatly into one strictness level
+- Essentially a non-starter for existing users
+
+**Verdict:** Not recommended. Departments and presets are orthogonal concepts.
+
+## Comparison Matrix
+
+| Criteria | A (metadata) | B (files) | C (hybrid) | D (departments) |
+|----------|:---:|:---:|:---:|:---:|
+| Single source of truth | Yes | No | Yes | N/A |
+| No new files to maintain | Yes | No | Partial | Yes |
+| Extension gem support | Medium | Good | Good | Poor |
+| Uses existing config machinery | No | Yes | Partial | Yes |
+| Simple mental model | Yes | Yes | Medium | Yes |
+| Migration effort | Medium | Medium | High | Very High |
+| Risk of drift | None | High | Low | None |
+| Custom user presets | No | Yes | Yes | No |
+
+## Recommendation
+
+**Approach A (cop-level metadata)** is the simplest and cleanest for RuboCop's
+core. It has a single source of truth, a clear mental model, and eliminates the
+`pending` state entirely. The main downside — extension gem support — can be
+addressed by having extension gems also tag their cops with `Preset` levels.
+
+If custom user presets are a priority, **Approach C (hybrid)** gives the best
+of both worlds at the cost of a build step.
+
+**Approach B (standalone files)** is the most flexible but introduces
+maintenance burden and drift risk that we've seen cause problems in other
+projects.
+
+## Open Questions
+
+1. **Should presets replace `pending` entirely?** New cops could be assigned a
+   preset level immediately. If your configured preset includes that level,
+   you get the cop. No more "pending" state.
+
+2. **How do presets interact with `NewCops: enable/disable`?** Probably:
+   `NewCops` becomes irrelevant if presets replace pending. Or `NewCops` only
+   applies to cops above your preset level.
+
+3. **Can users define custom presets?** Approach A says no (but you can still
+   override individual cops). Approach B/C say yes.
+
+4. **Should the default change?** Currently RuboCop enables almost everything
+   by default. With presets, the default could be `standard` instead of `all`,
+   which would be a major improvement for new users but a breaking change for
+   existing ones.
+
+5. **How do extension gems participate?** They'd need to tag their cops with
+   preset levels too. We'd need to define guidelines and possibly validate
+   that extension cops have valid preset tags.
+
+6. **What about `DisabledByDefault` / `EnabledByDefault`?** These global
+   switches would need clear interaction semantics with presets. Probably:
+   preset overrides these settings.
+
+7. **Naming the levels.** The police-themed names are fun but need to be
+   immediately understandable. A compromise: use descriptive names with
+   optional aliases (`essential`, `standard`, `strict`, `all`).

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -17,6 +17,7 @@ module RuboCop
     CopConfig = Struct.new(:name, :metadata)
 
     EMPTY_CONFIG = {}.freeze
+    ENFORCEMENT_HIERARCHY = { 'essential' => 0, 'standard' => 1, 'strict' => 2 }.freeze
     DEFAULT_RAILS_VERSION = 5.0
     attr_reader :loaded_path
 
@@ -201,6 +202,17 @@ module RuboCop
       !!for_cop(name)['Enabled']
     end
 
+    def enforcement_level
+      for_all_cops['Enforcement']
+    end
+
+    def cop_within_enforcement?(cop_enforcement)
+      return true unless enforcement_level
+
+      ENFORCEMENT_HIERARCHY.fetch(cop_enforcement, 0) <=
+        ENFORCEMENT_HIERARCHY.fetch(enforcement_level, 0)
+    end
+
     def disabled_new_cops?
       for_all_cops['NewCops'] == 'disable'
     end
@@ -381,7 +393,7 @@ module RuboCop
       Lockfile.new(lockfile_path).gem_versions
     end
 
-    def enable_cop?(qualified_cop_name, cop_options)
+    def enable_cop?(qualified_cop_name, cop_options) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       # If the cop is explicitly enabled or `Lint/Syntax`, the other checks can be skipped.
       return true if cop_options['Enabled'] == true || qualified_cop_name == 'Lint/Syntax'
 
@@ -389,6 +401,11 @@ module RuboCop
       cop_enabled = cop_options.fetch('Enabled') { !for_all_cops['DisabledByDefault'] }
       return true if cop_enabled == 'override_department'
       return false if department && department['Enabled'] == false
+
+      # Enforcement level filtering — only when configured and cop is tagged
+      return false if enforcement_level &&
+                      cop_options['Enforcement'] &&
+                      !cop_within_enforcement?(cop_options['Enforcement'])
 
       cop_enabled
     end

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -9,13 +9,15 @@ module RuboCop
 
     # @api private
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details
-                       Enabled Reference References Safe SafeAutoCorrect].freeze
+                       Enabled Reference References Safe SafeAutoCorrect Enforcement].freeze
     # @api private
     INTERNAL_PARAMS = %w[Description StyleGuide
                          VersionAdded VersionChanged VersionRemoved
-                         Reference References Safe SafeAutoCorrect].freeze
+                         Reference References Safe SafeAutoCorrect Enforcement].freeze
     # @api private
     NEW_COPS_VALUES = %w[pending disable enable].freeze
+    # @api private
+    ENFORCEMENT_LEVELS = %w[essential standard strict].freeze
 
     # @api private
     CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect References].to_set.freeze
@@ -31,7 +33,7 @@ module RuboCop
       @target_ruby = TargetRuby.new(config)
     end
 
-    def validate
+    def validate # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       check_cop_config_value(@config)
       reject_conflicting_safe_settings
 
@@ -47,6 +49,8 @@ module RuboCop
       check_obsoletions
       alert_about_unrecognized_cops(invalid_cop_names)
       validate_new_cops_parameter
+      validate_enforcement_parameter
+      validate_cop_enforcement_levels(valid_cop_names)
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
       validate_syntax_cop
@@ -172,6 +176,33 @@ module RuboCop
                 "Valid choices are: #{NEW_COPS_VALUES.join(', ')}"
 
       raise ValidationError, message
+    end
+
+    def validate_enforcement_parameter
+      enforcement = @config.for_all_cops['Enforcement']
+      return if enforcement.nil?
+      return if ENFORCEMENT_LEVELS.include?(enforcement)
+
+      message = "invalid #{enforcement} for `Enforcement` found in " \
+                "#{smart_loaded_path}\n" \
+                "Valid choices are: #{ENFORCEMENT_LEVELS.join(', ')}"
+
+      raise ValidationError, message
+    end
+
+    def validate_cop_enforcement_levels(valid_cop_names)
+      valid_cop_names.each do |name|
+        next if name == 'AllCops'
+
+        level = @config[name]&.[]('Enforcement')
+        next unless level
+        next if ENFORCEMENT_LEVELS.include?(level)
+
+        warn Rainbow(<<~MESSAGE).yellow
+          Warning: #{name} has invalid Enforcement level '#{level}'.
+          Valid choices are: #{ENFORCEMENT_LEVELS.join(', ')}
+        MESSAGE
+      end
     end
 
     def validate_parameter_shape(valid_cop_names)

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -198,7 +198,7 @@ module RuboCop
         @disabled_cache[config] ||= reject { |cop| enabled?(cop, config) }
       end
 
-      def enabled?(cop, config)
+      def enabled?(cop, config) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         return true if options[:only]&.include?(cop.cop_name)
 
         # We need to use `cop_name` in this case, because `for_cop` uses caching
@@ -206,6 +206,12 @@ module RuboCop
         cfg = config.for_cop(cop.cop_name)
 
         cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config)
+
+        # CLI --enforcement overrides config-level enforcement
+        if cop_enabled && options[:enforcement] && cfg['Enforcement']
+          cop_enabled = Config::ENFORCEMENT_HIERARCHY.fetch(cfg['Enforcement'], 0) <=
+                        Config::ENFORCEMENT_HIERARCHY.fetch(options[:enforcement], 0)
+        end
 
         if options.fetch(:safe, false)
           cop_enabled && cfg.fetch('Safe', true)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -21,6 +21,7 @@ module RuboCop
         AutoCorrect
         Description
         Enabled
+        Enforcement
         Exclude
         Include
         Reference

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -98,6 +98,7 @@ module RuboCop
         option(opts, '--only-recognized-file-types')
         option(opts, '--ignore-parent-exclusion')
         option(opts, '--ignore-unrecognized-cops')
+        option(opts, '--enforcement LEVEL')
         option(opts, '--force-default-config')
         option(opts, '-s', '--stdin FILE')
         option(opts, '--editor-mode')
@@ -392,6 +393,7 @@ module RuboCop
         raise OptionArgumentError, '-C/--cache argument must be true or false'
       end
 
+      validate_enforcement
       validate_auto_gen_config
       validate_autocorrect
       validate_display_only_failed
@@ -406,6 +408,17 @@ module RuboCop
       raise OptionArgumentError, "Incompatible cli options: #{incompatible_options.inspect}"
     end
     # rubocop:enable Metrics/AbcSize
+
+    def validate_enforcement
+      return unless @options.key?(:enforcement)
+
+      level = @options[:enforcement]
+      valid = ConfigValidator::ENFORCEMENT_LEVELS
+      return if valid.include?(level)
+
+      raise OptionArgumentError,
+            "Invalid enforcement level '#{level}'. Valid choices are: #{valid.join(', ')}"
+    end
 
     def validate_auto_gen_config
       return if @options.key?(:auto_gen_config)
@@ -581,6 +594,11 @@ module RuboCop
       ignore_parent_exclusion:          ['Prevent from inheriting `AllCops/Exclude` from',
                                          'parent folders.'],
       ignore_unrecognized_cops:         ['Ignore unrecognized cops or departments in the config.'],
+      enforcement:                      ['Run only cops at or below the given',
+                                         'enforcement level.',
+                                         '  [essential] critical cops only',
+                                         '  [standard] essential + common cops',
+                                         '  [strict] essential + standard + strict cops'],
       force_default_config:             ['Use default configuration even if configuration',
                                          'files are present in the directory tree.'],
       format:                           ['Choose an output formatter. This option',

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2646,4 +2646,33 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       RESULT
     end
   end
+
+  describe '--enforcement' do
+    before do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          DisabledByDefault: true
+      YAML
+    end
+
+    it 'runs only essential-tagged cops when set to essential' do
+      create_file('example.rb', <<~RUBY)
+        def foo
+          x = 1
+        end
+      RUBY
+
+      expect(cli.run(%w[--enforcement essential
+                        --format simple
+                        --only Lint/UselessAssignment
+                        example.rb])).to eq(1)
+      expect($stdout.string).to include('Lint/UselessAssignment')
+    end
+
+    it 'rejects invalid enforcement levels' do
+      create_file('example.rb', 'x = 1')
+      expect(cli.run(['--enforcement', 'invalid'])).to eq(2)
+      expect($stderr.string).to include('Invalid enforcement level')
+    end
+  end
 end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1132,6 +1132,7 @@ RSpec.describe RuboCop::ConfigLoader do
               default_config['Metrics/MethodLength']['Description'],
               'StyleGuide' => '#short-methods',
               'Enabled' => true,
+              'Enforcement' => 'strict',
               'VersionAdded' =>
               default_config['Metrics/MethodLength']['VersionAdded'],
               'VersionChanged' =>

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -454,6 +454,33 @@ RSpec.describe RuboCop::Config do
       end
     end
 
+    context 'when the configuration includes an invalid Enforcement value' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          AllCops:
+            Enforcement: invalid
+        YAML
+      end
+
+      it 'raises validation error' do
+        expect { configuration.validate }
+          .to raise_error(RuboCop::ValidationError, /invalid.*Enforcement/)
+      end
+    end
+
+    context 'when the configuration includes a valid Enforcement value' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          AllCops:
+            Enforcement: standard
+        YAML
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.not_to raise_error
+      end
+    end
+
     context 'when the configuration includes Lint/Syntax cop' do
       before do
         # Force reloading default configuration
@@ -985,6 +1012,110 @@ RSpec.describe RuboCop::Config do
         it 'enables the cop that is not mentioned' do
           expect(cop_enabled('VeryCustomDepartment/CustomCop')).to be true
         end
+      end
+    end
+
+    context 'when enforcement level is configured' do
+      let(:hash) do
+        {
+          'AllCops' => { 'Enforcement' => 'standard' },
+          'Style/StringLiterals' => { 'Enforcement' => 'standard' },
+          'Style/Documentation' => { 'Enforcement' => 'strict' },
+          'Lint/UselessAssignment' => { 'Enforcement' => 'essential' }
+        }
+      end
+
+      it 'enables cops at or below the configured level' do
+        expect(cop_enabled('Lint/UselessAssignment')).to be true
+        expect(cop_enabled('Style/StringLiterals')).to be true
+      end
+
+      it 'disables cops above the configured level' do
+        expect(cop_enabled('Style/Documentation')).to be false
+      end
+
+      context 'when cop is explicitly enabled' do
+        let(:hash) do
+          {
+            'AllCops' => { 'Enforcement' => 'essential' },
+            'Style/Documentation' => { 'Enabled' => true, 'Enforcement' => 'strict' }
+          }
+        end
+
+        it 'respects explicit Enabled: true over enforcement level' do
+          expect(cop_enabled('Style/Documentation')).to be true
+        end
+      end
+
+      context 'when cop has no enforcement tag' do
+        let(:hash) do
+          {
+            'AllCops' => { 'Enforcement' => 'essential' },
+            'Style/AndOr' => {}
+          }
+        end
+
+        it 'is unaffected by enforcement filtering' do
+          expect(cop_enabled('Style/AndOr')).to be true
+        end
+      end
+    end
+  end
+
+  describe '#enforcement_level' do
+    context 'when Enforcement is set' do
+      let(:hash) { { 'AllCops' => { 'Enforcement' => 'standard' } } }
+
+      it 'returns the configured enforcement level' do
+        expect(configuration.enforcement_level).to eq('standard')
+      end
+    end
+
+    context 'when Enforcement is not set' do
+      let(:hash) { {} }
+
+      it 'returns nil' do
+        expect(configuration.enforcement_level).to be_nil
+      end
+    end
+  end
+
+  describe '#cop_within_enforcement?' do
+    context 'when enforcement level is standard' do
+      let(:hash) { { 'AllCops' => { 'Enforcement' => 'standard' } } }
+
+      it 'returns true for essential cops' do
+        expect(configuration).to be_cop_within_enforcement('essential')
+      end
+
+      it 'returns true for standard cops' do
+        expect(configuration).to be_cop_within_enforcement('standard')
+      end
+
+      it 'returns false for strict cops' do
+        expect(configuration).not_to be_cop_within_enforcement('strict')
+      end
+    end
+
+    context 'when enforcement level is essential' do
+      let(:hash) { { 'AllCops' => { 'Enforcement' => 'essential' } } }
+
+      it 'returns true for essential cops' do
+        expect(configuration).to be_cop_within_enforcement('essential')
+      end
+
+      it 'returns false for standard cops' do
+        expect(configuration).not_to be_cop_within_enforcement('standard')
+      end
+    end
+
+    context 'when enforcement level is strict' do
+      let(:hash) { { 'AllCops' => { 'Enforcement' => 'strict' } } }
+
+      it 'returns true for all levels' do
+        expect(configuration).to be_cop_within_enforcement('essential')
+        expect(configuration).to be_cop_within_enforcement('standard')
+        expect(configuration).to be_cop_within_enforcement('strict')
       end
     end
   end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -272,6 +272,28 @@ RSpec.describe RuboCop::Cop::Registry do
       expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
     end
 
+    context 'when specifying `--enforcement` command-line option' do
+      let(:options) { { enforcement: 'essential' } }
+      let(:config) do
+        RuboCop::Config.new(
+          'Lint/DuplicateMethods' => { 'Enabled' => true, 'Enforcement' => 'essential' },
+          'Metrics/MethodLength' => { 'Enabled' => true, 'Enforcement' => 'strict' }
+        )
+      end
+
+      it 'includes cops at or below the enforcement level' do
+        expect(enabled_cops).to include(RuboCop::Cop::Lint::DuplicateMethods)
+      end
+
+      it 'excludes cops above the enforcement level' do
+        expect(enabled_cops).not_to include(RuboCop::Cop::Metrics::MethodLength)
+      end
+
+      it 'includes cops without an enforcement tag' do
+        expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+      end
+    end
+
     context 'when new cops are introduced' do
       let(:config) { RuboCop::Config.new('Lint/BooleanSymbol' => { 'Enabled' => 'pending' }) }
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --ignore-parent-exclusion    Prevent from inheriting `AllCops/Exclude` from
                                                parent folders.
                   --ignore-unrecognized-cops   Ignore unrecognized cops or departments in the config.
+                  --enforcement LEVEL          Run only cops at or below the given
+                                               enforcement level.
+                                                 [essential] critical cops only
+                                                 [standard] essential + common cops
+                                                 [strict] essential + standard + strict cops
                   --force-default-config       Use default configuration even if configuration
                                                files are present in the directory tree.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
@@ -439,6 +444,24 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'raises cop errors' do
         results = options.parse %w[--raise-cop-error]
         expect(results).to eq([{ raise_cop_error: true }, []])
+      end
+    end
+
+    describe '--enforcement' do
+      it 'accepts valid enforcement levels' do
+        %w[essential standard strict].each do |level|
+          expect { options.parse(['--enforcement', level]) }.not_to raise_error
+        end
+      end
+
+      it 'sets the enforcement option' do
+        results = options.parse %w[--enforcement standard]
+        expect(results.first[:enforcement]).to eq('standard')
+      end
+
+      it 'raises an error for invalid enforcement level' do
+        expect { options.parse %w[--enforcement invalid] }
+          .to raise_error(RuboCop::OptionArgumentError, /Invalid enforcement level/)
       end
     end
 


### PR DESCRIPTION
This is a **prototype implementation** of enforcement levels for RuboCop cops, as discussed in #14005. The idea is to let users pick a strictness tier instead of configuring 400+ cops individually.

## How it works

Cops in `config/default.yml` can be tagged with `Enforcement: essential|standard|strict`. When a user sets `AllCops: Enforcement: standard` (or passes `--enforcement standard`), only cops tagged at or below that level are active. The levels are hierarchical:

- **essential** — critical correctness and security cops (e.g. `Lint/DuplicateMethods`, `Security/Eval`)
- **standard** — essential + common style/layout/naming cops (e.g. `Style/StringLiterals`, `Layout/IndentationWidth`)
- **strict** — all of the above + opinionated cops (e.g. `Style/Documentation`, `Metrics/MethodLength`)

## Design decisions

**Opt-in only.** When `Enforcement` is not configured, behavior is identical to today. No existing users are affected.

**Explicit `Enabled: true` wins.** If a user explicitly enables a cop in their `.rubocop.yml`, enforcement filtering doesn't override that. This lets users cherry-pick cops above their chosen tier.

**Untagged cops are unaffected.** Cops without an `Enforcement` tag behave exactly as before — they're not filtered regardless of the configured level. This is important for the prototype since only ~49 cops are tagged so far.

**CLI flag overrides config.** `--enforcement essential` takes precedence over `AllCops: Enforcement: strict` in the config file, similar to how `--disable-pending-cops` overrides `NewCops: enable`.

**`pending` stays parallel.** The pending cop system is untouched. Enforcement levels are a separate dimension.

## Why "enforcement levels" and not "presets"?

"Presets" implies a predefined bundle of configuration (like ESLint's `extends`), which is broader than what this does. "Enforcement levels" more accurately describes the mechanism: each cop declares the level of enforcement strictness it belongs to, and users pick how strict they want to be. It's a single dial, not a config bundle.

## Relationship to severity

This is conceptually similar to the existing `Severity` parameter, but serves a different purpose. Severity controls how offenses are reported and whether they cause a non-zero exit code (`--fail-level`). Enforcement level controls whether a cop runs at all. A cop could be `Severity: warning` but `Enforcement: essential` (important enough to always run, but reported as a warning), or `Severity: convention` but `Enforcement: strict` (only for teams that want strict checks). In practice, severity is rarely used, and if enforcement levels prove useful we might eventually retire severity.

## What's in the prototype

- ~49 cops tagged across departments (15 essential, 20 standard, 14 strict)
- `AllCops: Enforcement` config option with validation
- `--enforcement LEVEL` CLI flag
- Full spec coverage for all new code paths
- `bundle exec rake` passes cleanly

The cop assignments are illustrative, not final — the goal is to prove the mechanism works and get feedback on the approach before tagging all 400+ cops.

Refs #14005