### PR TITLE
[Fix #14997] Fix false positives in `Style/FileOpen`

### DIFF
--- a/changelog/fix_false_positives_in_style_file_open_cop.md
+++ b/changelog/fix_false_positives_in_style_file_open_cop.md
@@ -1,0 +1,1 @@
+* [#14997](https://github.com/rubocop/rubocop/issues/14997): Fix false positives in `Style/FileOpen` when assigning `File.open` to an instance variable, class variable, global variable, or constant. ([@koic][])

--- a/lib/rubocop/cop/style/file_open.rb
+++ b/lib/rubocop/cop/style/file_open.rb
@@ -72,7 +72,7 @@ module RuboCop
         def offensive_usage?(node)
           return true unless node.value_used?
 
-          node.parent.assignment? || receiver_of_chained_call?(node)
+          node.parent.lvasgn_type? || receiver_of_chained_call?(node)
         end
 
         def receiver_of_chained_call?(node)

--- a/spec/rubocop/cop/style/file_open_spec.rb
+++ b/spec/rubocop/cop/style/file_open_spec.rb
@@ -8,13 +8,6 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
     RUBY
   end
 
-  it 'registers an offense when assigning `File.open` to a variable' do
-    expect_offense(<<~RUBY)
-      f = File.open('file')
-          ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
-    RUBY
-  end
-
   it 'registers an offense when using `::File.open` without a block' do
     expect_offense(<<~RUBY)
       ::File.open('file')
@@ -33,6 +26,37 @@ RSpec.describe RuboCop::Cop::Style::FileOpen, :config do
     expect_offense(<<~RUBY)
       File.open('file', 'w')
       ^^^^^^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
+    RUBY
+  end
+
+  it 'registers an offense when assigning `File.open` to a local variable' do
+    expect_offense(<<~RUBY)
+      f = File.open('file')
+          ^^^^^^^^^^^^^^^^^ `File.open` without a block may leak a file descriptor; use the block form.
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `File.open` to an instance variable' do
+    expect_no_offenses(<<~RUBY)
+      @ivar = File.open('file')
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `File.open` to a class variable' do
+    expect_no_offenses(<<~RUBY)
+      @@cvar = File.open('file')
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `File.open` to a global variable' do
+    expect_no_offenses(<<~RUBY)
+      $gvar = File.open('file')
+    RUBY
+  end
+
+  it 'does not register an offense when assigning `File.open` to a constant' do
+    expect_no_offenses(<<~RUBY)
+      CONST = File.open('file')
     RUBY
   end
 


### PR DESCRIPTION
This PR fixes false positives in `Style/FileOpen`
when assigning `File.open` to an instance variable, class variable, global variable, or constant.

Assignments to local variables may produce false positives because the file may be closed elsewhere.

Fixes #14997.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
