### PR TITLE
Display ZJIT usage when running under LSP

### DIFF
--- a/changelog/new_display_zjit_usage_when_running_under_lsp.md
+++ b/changelog/new_display_zjit_usage_when_running_under_lsp.md
@@ -1,0 +1,1 @@
+* [#15000](https://github.com/rubocop/rubocop/pull/15000): Display ZJIT usage when running under LSP. ([@koic][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -61,9 +61,16 @@ module RuboCop
 
       handle 'initialized' do |_request|
         version = RuboCop::Version::STRING
-        yjit = Object.const_defined?('RubyVM::YJIT') && RubyVM::YJIT.enabled? ? ' +YJIT' : ''
+        # Only one JIT can be enabled at the same time, since YJIT and ZJIT are mutually exclusive.
+        jit = if Object.const_defined?('RubyVM::YJIT') && RubyVM::YJIT.enabled?
+                '+YJIT'
+              elsif Object.const_defined?('RubyVM::ZJIT') && RubyVM::ZJIT.enabled?
+                '+ZJIT'
+              else
+                ''
+              end
 
-        Logger.log("RuboCop #{version} language server#{yjit} initialized, PID #{Process.pid}")
+        Logger.log("RuboCop #{version} language server#{jit} initialized, PID #{Process.pid}")
       end
 
       handle 'shutdown' do |request|

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -45,6 +45,8 @@ module RuboCop
         write_port_and_token_files
 
         pid = fork do
+          # NOTE: As of Ruby 4.0.0, ZJIT is still under development, while YJIT is production-ready,
+          # so support for ZJIT is deferred.
           if defined?(RubyVM::YJIT.enable)
             RubyVM::YJIT.enable
           end


### PR DESCRIPTION
When an LSP server is started with ZJIT enabled from an LSP client, display ZJIT usage while running under LSP.
This is needed because whether ZJIT is enabled is determined by the LSP client.

Also add source code comments clarifying the intention to keep YJIT as the default for server mode.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
