### PR TITLE
[Fix #15001] Fix false positives in `Layout/RedundantLineBreak`

### DIFF
--- a/changelog/fix_false_positives_in_layout_redundant_line_break.md
+++ b/changelog/fix_false_positives_in_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#15001](https://github.com/rubocop/rubocop/issues/15001): Fix false positives in `Layout/RedundantLineBreak` when setting `InspectBlocks: true` and using `rescue` or `ensure` in the block. ([@koic][])

--- a/lib/rubocop/cop/mixin/check_single_line_suitability.rb
+++ b/lib/rubocop/cop/mixin/check_single_line_suitability.rb
@@ -38,7 +38,7 @@ module RuboCop
       end
 
       def safe_to_split?(node)
-        node.each_descendant(:if, :case, :kwbegin, :any_def).none? &&
+        node.each_descendant(:if, :case, :kwbegin, :any_def, :rescue, :ensure).none? &&
           node.each_descendant(:dstr, :str).none? { |n| n.heredoc? || n.value.include?("\n") } &&
           node.each_descendant(:begin, :sym).none?(&:multiline?)
       end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -587,6 +587,22 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
               end
             RUBY
           end
+
+          it 'does not register an offense when using `rescue` in the block' do
+            expect_no_offenses(<<~RUBY)
+              do_something do
+              rescue CustomError
+              end
+            RUBY
+          end
+
+          it 'does not register an offense when using `ensure` in the block' do
+            expect_no_offenses(<<~RUBY)
+              do_something do
+              ensure
+              end
+            RUBY
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -170,5 +170,25 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
         RUBY
       end
     end
+
+    context 'when using `rescue` in the block' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something do
+          rescue CustomError
+          end
+        RUBY
+      end
+    end
+
+    context 'when using `ensure` in the block' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          do_something do
+          ensure
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes false positives in `Layout/RedundantLineBreak` when setting `InspectBlocks: true` and using `rescue` or `ensure` in the block.

Fixes #15001.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
