### PR TITLE
Enable Layout/IndentationWidth autocorrect for tab indentation

### DIFF
--- a/changelog/fix_enable_layout_indentation_width_autocorrect_for_tabs.md
+++ b/changelog/fix_enable_layout_indentation_width_autocorrect_for_tabs.md
@@ -1,0 +1,1 @@
+* [#15003](https://github.com/rubocop/rubocop/pull/15003): Enable `Layout/IndentationWidth` and `Style/ClassAndModuleChildren` autocorrect for tab indentation. ([@ioquatix][])

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -12,20 +12,40 @@ module RuboCop
       class << self
         attr_reader :processed_source
 
-        def correct(corrector, processed_source, node, column_delta)
+        def correct(corrector, processed_source, node, column_delta, &block) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
           return unless node
 
           @processed_source = processed_source
-          # Disable autocorrection for tabs as it requires special handling
-          return if using_tabs?
 
           expr = node.respond_to?(:loc) ? node.source_range : node
-          return if block_comment_within?(expr)
+          return if block_comment_in_scope?(node)
 
           taboo_ranges = inside_string_ranges(node)
 
-          each_line(expr) do |line_begin_pos|
-            autocorrect_line(corrector, line_begin_pos, expr, column_delta, taboo_ranges)
+          if block
+            each_line(expr) do |line_begin_pos, line_content|
+              line_delta = yield line_begin_pos, line_content
+              next if line_delta.zero?
+
+              line_delta /= configured_indentation_width if using_tabs?
+              autocorrect_line(corrector, line_begin_pos, expr, line_delta, taboo_ranges)
+            end
+          else
+            # Callers pass column_delta in display columns. For tabs, each tab =
+            # configured_indentation_width columns, so convert to character count.
+            column_delta /= configured_indentation_width if using_tabs?
+
+            if using_tabs? && column_delta.negative?
+              # Only correct the first line for tab removal; nested offenses are
+              # corrected separately. Avoids wrong per-line deltas for structures
+              # with 'end' keywords.
+              first_line_pos = expr.source_buffer.line_range(expr.line).begin_pos
+              autocorrect_line(corrector, first_line_pos, expr, column_delta, taboo_ranges)
+            else
+              each_line(expr) do |line_begin_pos, _line_content|
+                autocorrect_line(corrector, line_begin_pos, expr, column_delta, taboo_ranges)
+              end
+            end
           end
         end
 
@@ -52,7 +72,7 @@ module RuboCop
           return if taboo_ranges.any? { |t| within?(range, t) }
 
           if column_delta.positive? && range.resize(1).source != "\n"
-            corrector.insert_before(range, ' ' * column_delta)
+            corrector.insert_before(range, indent_char * column_delta)
           elsif /\A[ \t]+\z/.match?(range.source)
             corrector.remove(range)
           end
@@ -83,28 +103,69 @@ module RuboCop
           node.loc?(:begin) && node.loc?(:end)
         end
 
-        def block_comment_within?(expr)
-          processed_source.comments.select(&:document?).any? do |c|
-            within?(c.source_range, expr)
+        # Skip correction if the node or any ancestor contains a block comment.
+        # This avoids correcting indentation inside scopes that have =begin..=end.
+        def block_comment_in_scope?(node)
+          return false unless node.is_a?(Parser::AST::Node)
+
+          nodes_to_check = [node]
+          nodes_to_check.concat(node.ancestors.to_a)
+          nodes_to_check.any? do |n|
+            next false unless n.respond_to?(:source_range)
+
+            range = n.source_range
+            processed_source.comments.select(&:document?).any? do |c|
+              within?(c.source_range, range)
+            end
           end
         end
 
-        def calculate_range(expr, line_begin_pos, column_delta)
+        def calculate_range(expr, line_begin_pos, column_delta) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           return range_between(line_begin_pos, line_begin_pos) if column_delta.positive?
 
-          starts_with_space = expr.source_buffer.source[line_begin_pos].start_with?(' ')
+          if using_tabs?
+            # For tab removal, target leading whitespace at line start
+            line_start = expr.source_buffer.line_range(
+              expr.source_buffer.line_for_position(line_begin_pos)
+            ).begin_pos
+            chars_to_remove = column_delta.abs
+            source = expr.source_buffer.source
+            line_end = source.index("\n", line_start) || source.length
+            leading = source[line_start...line_end][/\A[ \t]*/]
+            chars_to_remove = [chars_to_remove, leading.length].min
+            return range_between(line_start, line_start) if chars_to_remove.zero?
 
-          if starts_with_space
-            range_between(line_begin_pos, line_begin_pos + column_delta.abs)
+            range_between(line_start, line_start + chars_to_remove)
           else
-            range_between(line_begin_pos - column_delta.abs, line_begin_pos)
+            # Original logic for spaces
+            starts_with_space = expr.source_buffer.source[line_begin_pos].start_with?(' ')
+            if starts_with_space
+              range_between(line_begin_pos, line_begin_pos + column_delta.abs)
+            else
+              range_between(line_begin_pos - column_delta.abs, line_begin_pos)
+            end
           end
+        end
+
+        def configured_indentation_width
+          processed_source.config.for_cop('Layout/IndentationStyle')['IndentationWidth'] ||
+            processed_source.config.for_cop('Layout/IndentationWidth')['Width'] || 2
+        end
+
+        def indent_width
+          return 1 if using_tabs?
+
+          processed_source.config.for_cop('Layout/IndentationWidth')['Width'] || 2
+        end
+
+        def indent_char
+          using_tabs? ? "\t" : ' '
         end
 
         def each_line(expr)
           line_begin_pos = expr.begin_pos
           expr.source.each_line do |line|
-            yield line_begin_pos
+            yield line_begin_pos, line
             line_begin_pos += line.length
           end
         end

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -302,12 +302,14 @@ module RuboCop
           # example.
           body_node = body_node.children.first if body_node.begin_type? && !parentheses?(body_node)
 
+          range = offending_range(body_node, indentation)
+
           # Since autocorrect changes a number of lines, and not only the line
           # where the reported offending range is, we avoid autocorrection if
-          # this cop has already found other offenses is the same
+          # this cop has already found other offenses in the same
           # range. Otherwise, two corrections can interfere with each other,
           # resulting in corrupted code.
-          node = if autocorrect? && other_offense_in_same_range?(body_node)
+          node = if autocorrect? && other_offense_in_same_range?(range)
                    nil
                  else
                    body_node
@@ -316,7 +318,7 @@ module RuboCop
           name = style == 'normal' ? '' : " #{style}"
           message = message(configured_indentation_width, indentation, name)
 
-          add_offense(offending_range(body_node, indentation), message: message) do |corrector|
+          add_offense(range, message: message) do |corrector|
             autocorrect(corrector, node)
           end
         end
@@ -352,16 +354,21 @@ module RuboCop
           )
         end
 
-        # Returns true if the given node is within another node that has
+        # Returns true if the given range overlaps with another range that has
         # already been marked for autocorrection by this cop.
-        def other_offense_in_same_range?(node)
-          expr = node.source_range
+        def other_offense_in_same_range?(range)
           @offense_ranges ||= []
 
-          return true if @offense_ranges.any? { |r| within?(expr, r) }
+          return true if @offense_ranges.any? { |r| ranges_overlap?(range, r) }
 
-          @offense_ranges << expr
+          @offense_ranges << range
           false
+        end
+
+        def ranges_overlap?(range1, range2)
+          return true if range1.begin_pos == range2.begin_pos && range1.end_pos == range2.end_pos
+
+          range1.begin_pos < range2.end_pos && range2.begin_pos < range1.end_pos
         end
 
         def indentation_to_check?(base_loc, body_node)

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -153,16 +153,20 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize
 
-        def unindent(corrector, node)
+        def unindent(corrector, node) # rubocop:disable Metrics/AbcSize
           return unless node.body.children.last
 
           last_child_leading_spaces = leading_spaces(node.body.children.last)
           return if spaces_size(leading_spaces(node)) == spaces_size(last_child_leading_spaces)
 
-          column_delta = configured_indentation_width - spaces_size(last_child_leading_spaces)
-          return if column_delta.zero?
+          # Use per-line deltas: target = level 1, compute delta from leading whitespace
+          target_indent = configured_indentation_width
+          AlignmentCorrector.correct(corrector, processed_source, node, 0) do |_pos, line_content|
+            next 0 unless line_content.start_with?(/\s/)
 
-          AlignmentCorrector.correct(corrector, processed_source, node, column_delta)
+            current_indent = spaces_size(line_content[/\A[ \t]*/])
+            target_indent - current_indent
+          end
         end
 
         def leading_spaces(node)
@@ -177,6 +181,10 @@ module RuboCop
         def tab_indentation_width
           config.for_cop('Layout/IndentationStyle')['IndentationWidth'] ||
             configured_indentation_width
+        end
+
+        def indentation_style
+          config.for_cop('Layout/IndentationStyle')['EnforcedStyle'] || 'spaces'
         end
 
         def check_style(node, body, style)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4144,7 +4144,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
     class SomeClient
     \tconversation_request.get_messages(session_id, time_before).map do |message|
-    \t\t\t\tConversationMessagesResponse.new message
+    \t\tConversationMessagesResponse.new message
     \tend
     end
     RUBY

--- a/spec/rubocop/cop/alignment_corrector_spec.rb
+++ b/spec/rubocop/cop/alignment_corrector_spec.rb
@@ -2,6 +2,10 @@
 
 RSpec.describe RuboCop::Cop::AlignmentCorrector, :config do
   let(:cop_class) { RuboCop::Cop::Test::AlignmentDirective }
+  # AlignmentDirective uses raw column deltas; Width: 1 makes 1 column = 1 character
+  let(:config) do
+    RuboCop::Config.new('Layout/IndentationWidth' => { 'Width' => 1 })
+  end
 
   describe '#correct' do
     context 'simple indentation' do

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
-      it 'detects excessive tab indentation in if statement' do
+      it 'detects and corrects excessive tab indentation in if statement' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         if cond
         \t\tfunc
@@ -109,10 +109,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        if cond
+        \tfunc
+        end
+        RUBY
       end
 
-      it 'detects insufficient tab indentation in class' do
+      it 'detects and corrects insufficient tab indentation in class' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         class A
         def test
@@ -121,10 +125,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        class A
+        \tdef test
+        \tend
+        end
+        RUBY
       end
 
-      it 'detects excessive tab indentation' do
+      it 'detects and corrects excessive tab indentation' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         def test
         \t\t\tputs 'hello'
@@ -132,7 +141,34 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        def test
+        \tputs 'hello'
+        end
+        RUBY
+      end
+
+      context 'with Width 1 (one tab per level)' do
+        let(:width) { 1 }
+
+        it 'corrects excessive tab indentation in nested modules' do
+          expect_offense(<<-RUBY.gsub(/^          /, ''))
+          module Foo
+          \t\tmodule Bar
+          ^^ Use 1 (not 2) tabs for indentation.
+          \t\t\tbaz = 1
+          \t\tend
+          \tend
+          RUBY
+
+          expect_correction(<<-RUBY.gsub(/^          /, ''))
+          module Foo
+          \tmodule Bar
+          \t\tbaz = 1
+          \t\tend
+          \tend
+          RUBY
+        end
       end
     end
 
@@ -1872,7 +1908,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
-      it 'detects excessive tab indentation in if statement' do
+      it 'detects and corrects excessive tab indentation in if statement' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         if cond
         \t\tfunc
@@ -1880,10 +1916,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        if cond
+        \tfunc
+        end
+        RUBY
       end
 
-      it 'detects insufficient tab indentation in class' do
+      it 'detects and corrects insufficient tab indentation in class' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         class A
         def test
@@ -1892,10 +1932,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        class A
+        \tdef test
+        \tend
+        end
+        RUBY
       end
 
-      it 'detects excessive tab indentation' do
+      it 'detects and corrects excessive tab indentation' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         def test
         \t\t\tputs 'hello'
@@ -1903,7 +1948,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        def test
+        \tputs 'hello'
+        end
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -403,23 +403,27 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
-    it 'registers an offense for tab-intended nested children' do
-      expect_offense(<<~RUBY)
-        module A
-               ^ Use compact module/class definition instead of nested style.
-        \tmodule B
-        \t\tmodule C
-        \t\t\tbody
-        \t\tend
-        \tend
-        end
-      RUBY
+    context 'with tab indentation enforced' do
+      let(:other_cops) { { 'Layout/IndentationStyle' => { 'EnforcedStyle' => 'tabs' } } }
 
-      expect_correction(<<~RUBY)
-        module A::B::C
-        \t\t\tbody
-        end
-      RUBY
+      it 'registers an offense for tab-intended nested children' do
+        expect_offense(<<~RUBY)
+          module A
+                 ^ Use compact module/class definition instead of nested style.
+          \tmodule B
+          \t\tmodule C
+          \t\t\tbody
+          \t\tend
+          \tend
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module A::B::C
+          \tbody
+          end
+        RUBY
+      end
     end
 
     context 'with unindented nested nodes' do
@@ -473,6 +477,8 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       end
 
       context 'with tab-intended nested nodes' do
+        let(:other_cops) { { 'Layout/IndentationStyle' => { 'EnforcedStyle' => 'tabs' } } }
+
         it 'registers an offense and autocorrects when 3rd-level module has unintended body' do
           expect_offense(<<~RUBY)
             module A
@@ -487,7 +493,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
 
           expect_correction(<<~RUBY)
             module A::B::C
-            \t\tbody
+            \tbody
             end
           RUBY
         end
@@ -525,7 +531,7 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
 
           expect_correction(<<~RUBY)
             module A::B::C
-            \t\tbody
+            \tbody
             end
           RUBY
         end


### PR DESCRIPTION
- Convert column_delta from display columns to character count when using tabs
- Fix block comment scope: skip correction when node is inside ancestor with block comment
- Update tests to expect corrections instead of expect_no_corrections

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
