### PR TITLE
Add missing expect_correction to Layout cop specs

### DIFF
--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -999,6 +999,12 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
           end
           ^^^ `end` at 3, 2 is not aligned with `var1, var2` at 1, 0.
       RUBY
+
+      expect_correction(<<~RUBY)
+        var1, var2 = lambda do
+          [_1, _2]
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
           # d
           def test; end
         RUBY
+
+        expect_correction(<<~RUBY)
+          # a
+          # b
+          # c
+          # d
+          def test; end
+        RUBY
       end
     end
 
@@ -291,6 +299,28 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def compile_sequence(seq, seq_var)
+          @seq_var = seq_var # Holds the name of the variable holding the AST::Node we are matching
+
+          context.with_temp_variables do |cur_child, cur_index, previous_index|
+            @cur_child_var = cur_child        # To hold the current child node
+            @cur_index_var = cur_index        # To hold the current child index (always >= 0)
+            @prev_index_var = previous_index  # To hold the child index before we enter the looping nodes
+            @cur_index = :seq_head            # Can be any of:
+            #   :seq_head : when the current child is actually the sequence head
+            #   :variadic_mode : child index held by @cur_index_var
+            #   >= 0 : when the current child index is known (from the beginning)
+            #   < 0 : when the index is known from the end, where -1 is *past the end*,
+            #         -2 is the last child, etc...
+            #         This shift of 1 from standard Ruby indices is stored in DELTA
+            @in_sync = false                  # `true` iff `@cur_child_var` and `@cur_index_var` correspond to `@cur_index`
+            # Must be true if `@cur_index` is `:variadic_mode`
+            compile_terms(seq)
+          end
+        end
+      RUBY
     end
   end
 
@@ -365,6 +395,19 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
           end
         # rubocop:enable
         ^^^^^^^^^^^^^^^^ Incorrect indentation detected (column 0 instead of 2).
+        private
+
+          def bar
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          # rubocop:disable
+          def foo
+          end
+          # rubocop:enable
         private
 
           def bar

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -167,6 +167,16 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
                           derp3
                         end
             RUBY
+
+            expect_correction(<<~RUBY)
+              foo.bar = if baz
+                          derp1
+              elsif meh
+                          derp2
+              else
+                          derp3
+                        end
+            RUBY
           end
 
           it 'registers an offense for an if with element assignment' do
@@ -178,6 +188,14 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
                            derp2
                          end
             RUBY
+
+            expect_correction(<<~RUBY)
+              foo[bar] = if baz
+                           derp1
+              else
+                           derp2
+                         end
+            RUBY
           end
 
           it 'registers an offense for an if' do
@@ -186,6 +204,14 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
                       0
                     else
                     ^^^^ Align `else` with `var`.
+                      1
+                    end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              var = if a
+                      0
+              else
                       1
                     end
             RUBY
@@ -356,6 +382,14 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
            func2
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        unless cond
+           func1
+        else
+           func2
+        end
+      RUBY
     end
 
     it 'accepts a correctly aligned else in an otherwise empty unless' do
@@ -384,6 +418,17 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
           e
          else
          ^^^^ Align `else` with `when`.
+          f
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case a
+        when b
+          c
+        when d
+          e
+        else
           f
         end
       RUBY
@@ -426,6 +471,19 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
               baz
              else
              ^^^^ Align `else` with `in`.
+              qux
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case 0
+            in 0
+              foo
+            in -1..1
+              bar
+            in Integer
+              baz
+            else
               qux
             end
           RUBY
@@ -528,6 +586,16 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
                     something_else
                   end
         RUBY
+
+        expect_correction(<<~RUBY)
+          private def test
+                    something
+                  rescue
+                    handling
+          else
+                    something_else
+                  end
+        RUBY
       end
     end
   end
@@ -545,6 +613,23 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
             puts 'wrongly intended error handling'
         else
         ^^^^ Align `else` with `begin`.
+            puts 'wrongly intended normal case handling'
+          ensure
+            puts 'wrongly intended common handling'
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def my_func
+          puts 'do something outside block'
+          begin
+            puts 'do something error prone'
+          rescue SomeException, SomeOther => e
+            puts 'wrongly intended error handling'
+          rescue
+            puts 'wrongly intended error handling'
+          else
             puts 'wrongly intended normal case handling'
           ensure
             puts 'wrongly intended common handling'
@@ -594,6 +679,18 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
           puts 'I love methods that print'
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def my_func(string)
+          puts string
+        rescue => e
+          puts e
+        else
+          puts e
+        ensure
+          puts 'I love methods that print'
+        end
+      RUBY
     end
   end
 
@@ -622,6 +719,18 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
           puts 'error handling'
           else
           ^^^^ Align `else` with `def`.
+          puts 'normal handling'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def my_func
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
           puts 'normal handling'
         end
       RUBY
@@ -697,6 +806,18 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
           puts 'error handling'
           else
           ^^^^ Align `else` with `array_like.each`.
+          puts 'normal handling'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array_like.each do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
           puts 'normal handling'
         end
       RUBY

--- a/spec/rubocop/cop/layout/empty_line_after_multiline_condition_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_multiline_condition_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
         do_something
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if multiline &&
+         condition
+
+        do_something
+      end
+    RUBY
   end
 
   it 'does not register an offense when new line after `if` with multiline condition' do
@@ -34,6 +42,13 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
       do_something if multiline &&
                       ^^^^^^^^^^^^ Use empty line after multiline condition.
                       condition
+      do_something_else
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something if multiline &&
+                      condition
+
       do_something_else
     RUBY
   end
@@ -73,6 +88,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
         do_something_else
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      if condition
+        do_something
+      elsif multiline &&
+         condition
+
+        do_something_else
+      end
+    RUBY
   end
 
   it 'does not register an offense when new line after `elsif` with multiline condition' do
@@ -95,6 +120,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
         do_something
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      while multiline &&
+         condition
+
+        do_something
+      end
+    RUBY
   end
 
   it 'registers an offense when no new line after `until` with multiline condition' do
@@ -102,6 +135,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
       until multiline &&
             ^^^^^^^^^^^^ Use empty line after multiline condition.
          condition
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      until multiline &&
+         condition
+
         do_something
       end
     RUBY
@@ -132,6 +173,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
       end while multiline &&
                 ^^^^^^^^^^^^ Use empty line after multiline condition.
             condition
+      do_something_else
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        do_something
+      end while multiline &&
+            condition
+
       do_something_else
     RUBY
   end
@@ -168,6 +218,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
         do_something
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      case x
+      when foo,
+          bar
+
+        do_something
+      end
+    RUBY
   end
 
   it 'does not register an offense when new line after `when` with multiline condition' do
@@ -197,6 +256,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMultilineCondition, :config d
       rescue FooError,
       ^^^^^^^^^^^^^^^^ Use empty line after multiline condition.
         BarError
+        handle_error
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      begin
+        do_something
+      rescue FooError,
+        BarError
+
         handle_error
       end
     RUBY

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -22,6 +22,25 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      class K
+        def m
+        end
+
+        class J
+          def n
+          end
+
+          def o
+          end
+        end
+
+        # checks something
+        def p
+        end
+      end
+    RUBY
   end
 
   context 'when there are only comments between defs' do
@@ -75,6 +94,22 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           end
           def bar
           ^^^^^^^ Expected 1 empty line between method definitions; found 0.
+            true
+          end
+        else
+          def foo
+            false
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if condition
+          def foo
+            true
+          end
+
+          def bar
             true
           end
         else

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -252,6 +252,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
                 end
               end
             RUBY
+
+            expect_correction(<<~RUBY)
+              included do
+                #{access_modifier}
+
+                def test
+                end
+              end
+            RUBY
           end
         end
 
@@ -313,6 +322,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier, :config do
           class Test
             #{access_modifier}
             #{'^' * access_modifier.size} Keep a blank line after `#{access_modifier}`.
+            end_this!
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Test
+            #{access_modifier}
+
             end_this!
           end
         RUBY

--- a/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb
@@ -256,6 +256,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
         def do_something
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        attr_accessor :foo
+
+        alias foo? foo
+
+        def do_something
+        end
+      RUBY
     end
   end
 
@@ -280,6 +289,15 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAttributeAccessor, :config 
       expect_offense(<<~RUBY)
         attr_accessor :foo
         ^^^^^^^^^^^^^^^^^^ Add an empty line after attribute accessor.
+        private :foo
+
+        def do_something
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        attr_accessor :foo
+
         private :foo
 
         def do_something

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -195,6 +195,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            class Child
+
+              do_something
+
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense for namespace body ending with a blank' do
@@ -209,6 +219,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
           ^{} #{extra_end}
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            class Child
+
+              do_something
+
+            end
+          end
+        RUBY
       end
 
       it 'registers offenses for namespaced class body not starting with a blank' do
@@ -217,6 +237,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             class Child
               do_something
           ^ #{missing_begin}
+
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            class Child
+
+              do_something
 
             end
           end
@@ -231,6 +261,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
               do_something
             end
           ^ #{missing_end}
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            class Child
+
+              do_something
+
+            end
           end
         RUBY
       end
@@ -283,6 +323,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            module Child
+              do_something
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense for namespace body ending with a blank' do
@@ -293,6 +341,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
 
           ^{} #{extra_end}
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+            module Child
+              do_something
+            end
           end
         RUBY
       end
@@ -330,6 +386,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
           end
           ^ #{missing_end}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Parent
+
+            class Mom
+
+              do_something
+
+            end
+            class Dad
+
+            end
+
+          end
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody, :config do
       #{end_offense_annotation}
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def some_method
+        do_something
+      end
+    RUBY
   end
 
   it 'registers an offense for class method body ending with a blank' do
@@ -60,6 +66,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody, :config do
         do_something
 
       #{end_offense_annotation}
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def Test.some_method
+        do_something
       end
     RUBY
   end

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           do_something
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        module SomeModule
+          do_something
+        end
+      RUBY
     end
 
     it 'registers an offense for module body ending with a blank' do
@@ -27,6 +33,12 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           do_something
 
         ^{} #{extra_end}
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module SomeModule
+          do_something
         end
       RUBY
     end
@@ -61,6 +73,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         end
         ^ #{missing_end}
       RUBY
+
+      expect_correction(<<~RUBY)
+        module SomeModule
+
+          do_something
+
+        end
+      RUBY
     end
 
     it 'registers an offense for module body not ending with a blank' do
@@ -68,16 +88,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
         module SomeModule
 
           do_something
-        end
-        ^ #{missing_end}
-      RUBY
-    end
-
-    it 'autocorrects beginning and end' do
-      expect_offense(<<~RUBY)
-        module SomeModule
-          do_something
-        ^ #{missing_begin}
         end
         ^ #{missing_end}
       RUBY
@@ -127,6 +137,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            module Child
+
+              do_something
+
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense for namespace body ending with a blank' do
@@ -141,6 +161,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
           ^{} #{extra_end}
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            module Child
+
+              do_something
+
+            end
+          end
+        RUBY
       end
 
       it 'registers offenses for namespaced module body not starting with a blank' do
@@ -149,6 +179,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             module Child
               do_something
           ^ #{missing_begin}
+
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            module Child
+
+              do_something
 
             end
           end
@@ -163,6 +203,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
               do_something
             end
           ^ #{missing_end}
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            module Child
+
+              do_something
+
+            end
           end
         RUBY
       end
@@ -215,6 +265,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            class SomeClass
+              do_something
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense for namespace body ending with a blank' do
@@ -225,6 +283,14 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
 
           ^{} #{extra_end}
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+            class SomeClass
+              do_something
+            end
           end
         RUBY
       end
@@ -262,6 +328,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
           end
           ^ #{missing_end}
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Parent
+
+            module Mom
+
+              do_something
+
+            end
+            module Dad
+
+            end
+
+          end
         RUBY
       end
     end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -252,6 +252,90 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       RUBY
   }.freeze
 
+  corrections = {
+    'lining up assignments' =>
+      <<~RUBY,
+        website = "example.org"
+        name = "Jill"
+      RUBY
+
+    'lining up assignments with empty lines and comments in between' =>
+      <<~RUBY,
+        a += 1
+
+        # Comment
+        aa = 2
+        bb = 3
+
+        a ||= 1
+      RUBY
+
+    'aligning with the same character' =>
+      <<~RUBY,
+        y, m = (year * 12 + (mon - 1) + n).divmod(12)
+        m, = (m + 1) .divmod(1)
+      RUBY
+
+    'lining up different kinds of assignments' =>
+      <<~RUBY,
+        type_name ||= value.class.name if value
+        type_name = type_name.to_s if type_name
+
+        type_name = value.class.name if value
+        type_name += type_name.to_s unless type_name
+        a += 1
+        aa -= 2
+      RUBY
+
+    'aligning comments on non-adjacent lines' =>
+      <<~RUBY,
+        include_examples 'aligned', 'var = until', 'test'
+
+        include_examples 'unaligned', "var = if", 'test'
+      RUBY
+
+    'aligning tokens with empty line between' =>
+      <<~RUBY,
+        unless nochdir
+          Dir.chdir "/" # Release old working directory.
+        end
+
+        File.umask 0000 # Ensure sensible umask.
+      RUBY
+
+    'aligning long assignment expressions that include line breaks' =>
+      <<~RUBY,
+        size_attribute_name = FactoryGirl.create(:attribute,
+                                                    name: 'Size',
+                                                    values: %w{small large})
+        carrier_attribute_name = FactoryGirl.create(:attribute,
+                                                    name: 'Carrier',
+                                                    values: %w{verizon})
+      RUBY
+
+    'aligning = on lines where there are trailing comments' =>
+      <<~RUBY,
+        a_long_var_name = 100 # this is 100
+        short_name1 = 2
+
+        clear
+
+        short_name2 = 2
+        a_long_var_name = 100 # this is 100
+
+        clear
+
+        short_name3 = 2 # this is 2
+        a_long_var_name = 100 # this is 100
+      RUBY
+
+    'aligning trailing comments' =>
+      <<~RUBY
+        a_long_var_name = 2 # this is 2
+        a_long_var_name = 100 # this is 100
+      RUBY
+  }.freeze
+
   context 'when AllowForAlignment is true' do
     let(:cop_config) { { 'AllowForAlignment' => true, 'ForceEqualSignAlignment' => false } }
 
@@ -294,6 +378,8 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         context "such as #{reason}" do
           it 'registers offense(s)' do
             expect_offense(src)
+
+            expect_correction(corrections[reason])
           end
         end
       end
@@ -346,6 +432,8 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
               else
                 it 'registers offense(s)' do
                   expect_offense(src)
+
+                  expect_correction(corrections[reason])
                 end
               end
             end
@@ -361,6 +449,10 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         expect_offense(<<~RUBY)
           object.method(argument)  # this is a comment
                                  ^ Unnecessary spacing detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          object.method(argument) # this is a comment
         RUBY
       end
 

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -932,6 +932,17 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^^^ Align the keys and values of a hash literal if they span more than one line.
         }
       RUBY
+
+      expect_correction(<<~RUBY)
+        hash1 = {
+          'a'   => 0,
+          'bbb' => 1
+        }
+        hash2 = {
+          a:   0,
+          bbb: 1
+        }
+      RUBY
     end
 
     it 'registers an offense and corrects for misaligned hash keys' do

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -238,6 +238,12 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<`.
           RUBY2
         RUBY
+
+        expect_correction(<<~RUBY)
+          <<~RUBY2
+            foo
+          RUBY2
+        RUBY
       end
 
       it 'displays message to use `<<~` instead of `<<-`' do
@@ -245,6 +251,12 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
           <<-RUBY2
           foo
           ^^^ Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<-`.
+          RUBY2
+        RUBY
+
+        expect_correction(<<~RUBY)
+          <<~RUBY2
+            foo
           RUBY2
         RUBY
       end

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
         __END__
         \tx = 0
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{' ' * 2}x = 0
+        __END__
+        \tx = 0
+      RUBY
     end
 
     it 'accepts a line with a tab other than indentation' do
@@ -135,12 +141,22 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
          \tx = 0
         ^ Space detected in indentation.
       RUBY
+
+      expect_correction(<<~RUBY)
+        \tx = 0
+      RUBY
     end
 
     it 'registers offenses before __END__ but not after' do
       expect_offense(<<~RUBY)
           x = 0
         ^^ Space detected in indentation.
+        __END__
+          x = 0
+      RUBY
+
+      expect_correction(<<~RUBY)
+        \tx = 0
         __END__
           x = 0
       RUBY

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 4 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          if cond
+              func
+          end
+        RUBY
       end
     end
 
@@ -175,6 +181,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          if cond
+            func
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an else body' do
@@ -186,6 +198,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          if cond
+            func1
+          else
+            func2
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an else body when if body contains no code' do
@@ -195,6 +215,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           else
            func2
           ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if cond
+            # nothing here
+          else
+            func2
           end
         RUBY
       end
@@ -211,6 +239,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          if cond
+            # nothing here
+          elsif cond2
+            # nothing here either
+          else
+            func2
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an elsif body' do
@@ -220,6 +258,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           elsif a2
            b2
           ^ Use 2 (not 1) spaces for indentation.
+          else
+            c
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if a1
+            b1
+          elsif a2
+            b2
           else
             c
           end
@@ -235,6 +283,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^^^^^ Use 2 (not 5) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          if a
+            b
+          else
+            x ? y : z
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of modifier if in else' do
@@ -244,6 +300,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           else
              x if y
           ^^^ Use 2 (not 3) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if a
+            b
+          else
+            x if y
           end
         RUBY
       end
@@ -617,6 +681,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^^^^^^^^^^^ Use 2 (not 12) spaces for indentation.
                           end
               RUBY
+
+              expect_correction(<<~RUBY)
+                foo.bar = if baz
+                  derp
+                          end
+              RUBY
             end
 
             it 'registers an offense for an if with element assignment' do
@@ -626,6 +696,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^^^^^^^^^^^^ Use 2 (not 13) spaces for indentation.
                            end
               RUBY
+
+              expect_correction(<<~RUBY)
+                foo[bar] = if baz
+                  derp
+                           end
+              RUBY
             end
 
             it 'registers an offense for an if' do
@@ -633,6 +709,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 var = if a
                         0
                 ^^^^^^^^ Use 2 (not 8) spaces for indentation.
+                      end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                var = if a
+                  0
                       end
               RUBY
             end
@@ -655,6 +737,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^^^^^^^ Use 2 (not 8) spaces for indentation.
                       end
               RUBY
+
+              expect_correction(<<~RUBY)
+                var = while a
+                  b
+                      end
+              RUBY
             end
 
             it 'registers an offense for an until' do
@@ -662,6 +750,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 var = until a
                         b
                 ^^^^^^^^ Use 2 (not 8) spaces for indentation.
+                      end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                var = until a
+                  b
                       end
               RUBY
             end
@@ -675,6 +769,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
                       end
               RUBY
+
+              expect_correction(<<~RUBY)
+                var = if a
+                  0
+                      end
+              RUBY
             end
 
             it 'registers an offense for a while' do
@@ -684,6 +784,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
                       end
               RUBY
+
+              expect_correction(<<~RUBY)
+                var = while a
+                  b
+                      end
+              RUBY
             end
 
             it 'registers an offense for an until' do
@@ -691,6 +797,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 var = until a
                           b
                 ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
+                      end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                var = until a
+                  b
                       end
               RUBY
             end
@@ -726,6 +838,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                   ^ Use 2 (not -4) spaces for indentation.
                 end
               RUBY
+
+              expect_correction(<<~RUBY)
+                var = if a
+                        0
+                end
+              RUBY
             end
 
             it 'registers an offense for a while' do
@@ -733,6 +851,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 var = while a
                   b
                   ^ Use 2 (not -4) spaces for indentation.
+                end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                var = while a
+                        b
                 end
               RUBY
             end
@@ -832,6 +956,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          unless cond
+            func
+          end
+        RUBY
       end
 
       it 'accepts an empty unless' do
@@ -852,6 +982,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          case a
+          when b
+            c
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation in a case/else body' do
@@ -864,6 +1001,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           else
              f
           ^^^ Use 2 (not 3) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case a
+          when b
+            c
+          when d
+            e
+          else
+            f
           end
         RUBY
       end
@@ -940,6 +1088,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          case a
+          in b
+            c
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation in a case/else body' do
@@ -952,6 +1107,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           else
              f
           ^^^ Use 2 (not 3) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case a
+          in b
+            c
+          in d
+            e
+          else
+            f
           end
         RUBY
       end
@@ -1034,6 +1200,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          while cond
+            func
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of begin/end/while' do
@@ -1044,6 +1216,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
              func2
           end while cond
         RUBY
+
+        expect_correction(<<~RUBY)
+          something = begin
+            func1
+             func2
+          end while cond
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an until body' do
@@ -1051,6 +1230,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           until cond
            func
           ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          until cond
+            func
           end
         RUBY
       end
@@ -1069,6 +1254,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           for var in 1..10
            func
           ^ Use 2 (not 1) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          for var in 1..10
+            func
           end
         RUBY
       end
@@ -1091,6 +1282,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                  func2 # No offense registered for this.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            def test
+              func1
+                 func2 # No offense registered for this.
+            end
+          RUBY
         end
 
         it 'registers an offense for bad indentation of a defs body' do
@@ -1098,6 +1296,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             def self.test
                func
             ^^^ Use 2 (not 3) spaces for indentation.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def self.test
+              func
             end
           RUBY
         end
@@ -1147,6 +1351,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               ^^^^^^ Use 2 (not 6) spaces for indentation.
                   end
             RUBY
+
+            expect_correction(<<~RUBY)
+              foo def test
+                something
+                  end
+            RUBY
           end
 
           it 'registers an offense for bad indentation of a defs body' do
@@ -1154,6 +1364,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               foo def self.test
                     something
               ^^^^^^ Use 2 (not 6) spaces for indentation.
+                  end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              foo def self.test
+                something
                   end
             RUBY
           end
@@ -1175,6 +1391,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               ^^^^^^ Use 2 (not 6) spaces for indentation.
               end
             RUBY
+
+            expect_correction(<<~RUBY)
+              public foo def test
+                something
+              end
+            RUBY
           end
 
           it 'registers an offense for bad indentation of a defs body' do
@@ -1182,6 +1404,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               public foo def self.test
                     something
               ^^^^^^ Use 2 (not 6) spaces for indentation.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              public foo def self.test
+                something
               end
             RUBY
           end
@@ -1206,6 +1434,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                     end
                 end.new
               RUBY
+
+              expect_correction(<<~RUBY)
+                obj = Class.new do
+                  private def private_property
+                  end
+                end.new
+              RUBY
             end
 
             it 'registers an offense for bad indentation of a def body' do
@@ -1214,6 +1449,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                   private def private_property
                       "That would be great."
                   ^^^^ Use 2 (not 4) spaces for indentation.
+                  end
+                end.new
+              RUBY
+
+              expect_correction(<<~RUBY)
+                obj = Class.new do
+                  private def private_property
+                    "That would be great."
                   end
                 end.new
               RUBY
@@ -1245,6 +1488,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 ^^ Use 2 (not -2) spaces for indentation.
                   end
             RUBY
+
+            expect_correction(<<~RUBY)
+              foo def test
+                    something
+                  end
+            RUBY
           end
 
           it 'registers an offense for bad indentation of a defs body' do
@@ -1252,6 +1501,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               foo def self.test
                 something
                 ^^ Use 2 (not -2) spaces for indentation.
+                  end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              foo def self.test
+                    something
                   end
             RUBY
           end
@@ -1266,6 +1521,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               def func
           ^^^^ Use 2 (not 4) spaces for indentation.
               end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Test
+            def func
+            end
           end
         RUBY
       end
@@ -1313,6 +1575,17 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 def f
             ^^^^ Use 2 (not 4) spaces for indentation.
                 end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              public
+              def e
+              end
+
+              def f
+              end
             end
           RUBY
         end
@@ -1381,6 +1654,23 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 end
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              def e
+              end
+
+              protected
+
+              def f
+              end
+
+              private
+
+              def g
+              end
+            end
+          RUBY
         end
       end
 
@@ -1423,6 +1713,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               end
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              public
+
+              def e
+              end
+
+              protected
+
+                def f
+                end
+
+              private
+
+                def g
+                end
+            end
+          RUBY
         end
 
         it 'registers an offense for normal non-indented internal methods ' \
@@ -1447,6 +1756,25 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               end
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            class << self
+              public
+
+              def e
+              end
+
+              protected
+
+                def f
+                end
+
+              private
+
+                def g
+                end
+            end
+          RUBY
         end
       end
     end
@@ -1459,6 +1787,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                 def func
             ^^^^ Use 2 (not 4) spaces for indentation.
                 end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module Test
+              def func
+              end
             end
           RUBY
         end
@@ -1498,6 +1833,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
              end
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            module Test
+              def func1
+              end
+              private
+                def func2
+                end
+            end
+          RUBY
         end
 
         it 'accepts normal non-indented internal methods of module functions' do
@@ -1532,6 +1877,23 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             ensure
                 puts 'wrongly indented common handling'
             ^^^^ Use 2 (not 4) spaces for indentation.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_func
+            puts 'do something outside block'
+            begin
+              puts 'do something error prone'
+              rescue SomeException, SomeOther => e
+               puts 'wrongly indented error handling'
+              rescue
+               puts 'wrongly indented error handling'
+              else
+                 puts 'wrongly indented normal case handling'
+              ensure
+                puts 'wrongly indented common handling'
             end
           end
         RUBY
@@ -1575,6 +1937,16 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          foo def self.my_func
+            puts 'do something error prone'
+          rescue SomeException
+            puts 'wrongly indented error handling'
+          rescue
+            puts 'wrongly indented error handling'
+          end
+        RUBY
       end
     end
 
@@ -1597,6 +1969,20 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               end
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            concern :Authenticatable do
+              def foo
+                puts "foo"
+              end
+
+              private
+
+                def bar
+                  puts "bar"
+                end
+            end
+          RUBY
         end
 
         it 'does not register an offense for an empty block body' do
@@ -1615,6 +2001,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           ^ Use 2 (not 1) spaces for indentation.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          a = func do
+            b
+          end
+        RUBY
       end
 
       it 'registers an offense for bad indentation of a {} body' do
@@ -1622,6 +2014,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
           func {
              b
           ^^^ Use 2 (not 3) spaces for indentation.
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func {
+            b
           }
         RUBY
       end
@@ -1660,6 +2058,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             handle_error
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          do_something do
+            foo
+          ensure
+          handle_error
+          end
+        RUBY
       end
 
       context 'when using safe navigation operator' do
@@ -1670,6 +2076,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             ^^^ Use 2 (not 3) spaces for indentation.
             }
           RUBY
+
+          expect_correction(<<~RUBY)
+            func {
+              receiver&.b
+            }
+          RUBY
         end
 
         it 'registers an offense for an if with setter' do
@@ -1677,6 +2089,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             foo&.bar = if baz
                          derp
             ^^^^^^^^^^^^^ Use 2 (not 13) spaces for indentation.
+                       end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo&.bar = if baz
+              derp
                        end
           RUBY
         end
@@ -1690,6 +2108,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             ^^^ Use 2 (not 3) spaces for indentation.
             }
           RUBY
+
+          expect_correction(<<~RUBY)
+            func {
+              _1&.foo
+            }
+          RUBY
         end
 
         it 'registers an offense for bad indentation of a do-end body' do
@@ -1697,6 +2121,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             func do
                _1&.foo
             ^^^ Use 2 (not 3) spaces for indentation.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func do
+              _1&.foo
             end
           RUBY
         end
@@ -1710,6 +2140,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             ^^^ Use 2 (not 3) spaces for indentation.
             }
           RUBY
+
+          expect_correction(<<~RUBY)
+            func {
+              it&.foo
+            }
+          RUBY
         end
 
         it 'registers an offense for bad indentation of a do-end body' do
@@ -1717,6 +2153,12 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             func do
                it&.foo
             ^^^ Use 2 (not 3) spaces for indentation.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            func do
+              it&.foo
             end
           RUBY
         end
@@ -1740,6 +2182,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
             .bar do |x|
           x
           ^{} Use 2 (not 0) spaces for indentation.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo
+            .bar do |x|
+            x
           end
         RUBY
       end
@@ -1791,6 +2240,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
               .bar do |x|
             x
             ^ Use 2 (not -2) spaces for indentation.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo
+              .bar do |x|
+                x
             end
           RUBY
         end

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -190,6 +190,10 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
         #:nodoc:
         ^^^^^^^^ Missing space after `#`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        # :nodoc:
+      RUBY
     end
   end
 
@@ -218,6 +222,13 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
           ^^^^^^^^^^^^^^^^^^^^^^ Missing space after `#`.
           ruby '~> 2.7.0'
         RUBY
+
+        expect_correction(<<~RUBY)
+          # Specific version (comment) will be used by RVM
+          # ruby=2.7.0
+          # ruby-gemset=myproject
+          ruby '~> 2.7.0'
+        RUBY
       end
     end
 
@@ -232,6 +243,13 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
             ^^^^^^^^^^^ Missing space after `#`.
             #ruby-gemset=myproject
             ^^^^^^^^^^^^^^^^^^^^^^ Missing space after `#`.
+            ruby '~> 2.7.0'
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # Specific version (comment) will be used by RVM
+            # ruby=2.7.0
+            # ruby-gemset=myproject
             ruby '~> 2.7.0'
           RUBY
         end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       #{maximum_string}abc
       _{maximum_string}^^^ Line is too long. [83/80]
     RUBY
+
+    expect_no_corrections
   end
 
   it "accepts a line that's 80 characters wide" do
@@ -47,6 +49,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
       __END__
       #{'#' * 200}
     RUBY
+
+    expect_no_corrections
   end
 
   context 'when line is indented with tabs' do
@@ -61,6 +65,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         \t\t\t\t\t\t\t\t\t\t\t\t1
         ^^^^^^^^^^^^^ Line is too long. [25/10]
       RUBY
+
+      expect_no_corrections
     end
   end
 
@@ -74,6 +80,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # See: https://github.com/rubocop/rubocop and then words that are not part of a URL
                                                                                 ^^^^^^^^^^^^^ Line is too long. [93/80]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -124,6 +132,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # See: http://google.com/, http://gmail.com/, https://maps.google.com/, http://plus.google.com/
                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [105/80]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -134,6 +144,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                    ^^^^ Line is too long. [103/80]
           #   http://google.com/
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -144,6 +156,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                      ^^^^ Line is too long. [105/80]
           #   "http://google.com/"
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -154,6 +168,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                      ^^^^ Line is too long. [105/80]
           #   http://google.com/
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -164,6 +180,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                    ^ Line is too long. [100/80]
           #   http://google.com/
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -175,6 +193,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           \t\t\t\t# There is some content http://test.com
                                     ^^^^^^^^^^^^^^^^^ Line is too long. [47/30]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -198,6 +218,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           #{'x' * 40} = 'otherprotocol://a.very.long.line.which.violates.LineLength/sadf'
           #{' ' * 40}                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [108/80]
         RUBY
+
+        expect_no_corrections
       end
 
       context 'and the scheme has been configured' do
@@ -244,6 +266,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # Should call ActiveRecord::Oracle::SchemaStatements::create_table in the end
                                                                                 ^^^^^^^ Line is too long. [87/80]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -286,6 +310,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # Invoke the normal migration method, in oracle envs should end up calling ActiveRecord::Oracle::create_table
                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [119/80]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -295,6 +321,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # Refer ActiveRecord::Migrations, in oracle envs should end up calling ActiveRecord::Oracle::create_table
                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [115/80]
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -305,6 +333,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                         ^^^^ Line is too long. [108/80]
           #   ActiveRecord::Example
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -315,6 +345,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                           ^^^^ Line is too long. [110/80]
           #   "ActiveRecord::Example"
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -325,6 +357,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                           ^^^^ Line is too long. [110/80]
           #   {ActiveRecord::Example}
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -335,6 +369,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                                                                                                         ^ Line is too long. [105/80]
           #   http://google.com/
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -360,6 +396,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # should end up calling ActiveRecord::ConnectionAdapters::OracleEnhanced::SchemaStatements::create_table
                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [114/80]
         RUBY
+
+        expect_no_corrections
       end
     end
   end
@@ -377,6 +415,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           end
         end
       RUBY
+
+      expect_no_corrections
     end
   end
 
@@ -440,6 +480,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [149/80]
           FOO
         RUBY
+
+        expect_no_corrections
       end
     end
   end
@@ -454,6 +496,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           # See: https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
                                                                                 ^^^^^^^^^^^^^^^^^^^ Line is too long. [99/80]
         RUBY
+
+        expect_no_corrections
       end
     end
   end
@@ -468,6 +512,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         def hash
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'registers an offense for a long line with an RBS::Inline annotation on the same line as the code' do
@@ -476,6 +522,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
                   ^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [32/10]
         end
       RUBY
+
+      expect_no_corrections
     end
   end
 
@@ -508,6 +556,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             #{'a' * 80} # rubocop:disable Layout/SomeCop
             #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [113/80]
           RUBY
+
+          expect_no_corrections
         end
       end
 
@@ -517,6 +567,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             #{'a' * 80} ###
             #{' ' * 80}^^^^ Line is too long. [84/80]
           RUBY
+
+          expect_no_corrections
         end
       end
     end
@@ -527,6 +579,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           #{'a' * 80} b # rubocop:disable Metrics/AbcSize
           #{' ' * 80}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [116/80]
         RUBY
+
+        expect_no_corrections
       end
     end
   end
@@ -568,6 +622,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
           #{'a' * 80}bcd # rubocop:enable Style/ClassVars
           #{' ' * 80}^^^ Line is too long. [83/80]
         RUBY
+
+        expect_no_corrections
       end
 
       context 'and the source contains non-directive # as comment' do
@@ -576,6 +632,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             #{'a' * 70} # bbbbbbbbbbbbbb # rubocop:enable Style/ClassVars'
             #{' ' * 70}          ^^^^^^^ Line is too long. [87/80]
           RUBY
+
+          expect_no_corrections
         end
       end
 
@@ -585,6 +643,8 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             LARGE_DATA_STRING_PATTERN = %r{\\A([A-Za-z0-9+/#]*={0,2})#([A-Za-z0-9+/#]*={0,2})#([A-Za-z0-9+/#]*={0,2})\\z} # rubocop:disable Style/ClassVars
             #{' ' * 68}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line is too long. [119/80]
           RUBY
+
+          expect_no_corrections
         end
       end
     end

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           ^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
           5
         RUBY
+
+        expect_correction(<<~RUBY)
+          a, b =
+           4,
+          5
+        RUBY
       end
     end
 
@@ -84,6 +90,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         b = if foo
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        a,
+        b =
+         if foo
+        end
+      RUBY
     end
 
     context 'when supported types is block' do
@@ -94,6 +107,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         expect_offense(<<~RUBY)
           lambda = -> {
           ^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            puts 'hello'
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          lambda =
+           -> {
             puts 'hello'
           }
         RUBY
@@ -179,12 +199,26 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
             _1.bar
           }
         RUBY
+
+        expect_correction(<<~RUBY)
+          bars =
+           foo.map {
+            _1.bar
+          }
+        RUBY
       end
 
       it 'registers an offense for itblock on the same line', :ruby34 do
         expect_offense(<<~RUBY)
           bars = foo.map {
           ^^^^^^^^^^^^^^^^ Right hand side of multi-line assignment is on the same line as the assignment operator `=`.
+            it.bar
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bars =
+           foo.map {
             it.bar
           }
         RUBY
@@ -255,6 +289,11 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           4,
           5
         RUBY
+
+        expect_correction(<<~RUBY)
+          a, b = 4,
+          5
+        RUBY
       end
     end
 
@@ -271,6 +310,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
         ^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
         b =
         if foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a,
+        b = if foo
         end
       RUBY
     end
@@ -292,6 +337,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           lambda =
           ^^^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
             -> {
+              puts 'hello'
+            }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          lambda = -> {
               puts 'hello'
             }
         RUBY
@@ -365,6 +416,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
               _1.bar
             }
         RUBY
+
+        expect_correction(<<~RUBY)
+          bars = foo.map {
+              _1.bar
+            }
+        RUBY
       end
 
       it 'registers an offense for itblock on separate lines', :ruby34 do
@@ -372,6 +429,12 @@ RSpec.describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
           bars =
           ^^^^^^ Right hand side of multi-line assignment is not on the same line as the assignment operator `=`.
             foo.map {
+              it.bar
+            }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          bars = foo.map {
               it.bar
             }
         RUBY

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -441,6 +441,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           ^^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          !0
+            .nil?
+        end
+      RUBY
     end
 
     # We call it semantic alignment when a dot is aligned with the first dot in
@@ -1353,6 +1360,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           ^^^^^ Indent `.nil?` 2 spaces more than `0` on line 2.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          !0
+             .nil?
+        end
+      RUBY
     end
 
     it 'accepts correctly indented methods in operation' do
@@ -1793,6 +1807,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           ^^^^^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          !0
+            .nil?
+        end
+      RUBY
     end
 
     it 'accepts indented method chained after single-line block on both calls' do
@@ -1927,6 +1948,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           #{keyword} receiver
             .nil? &&
             ^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
+            !args.empty?
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} receiver
+              .nil? &&
             !args.empty?
           end
         RUBY
@@ -2240,6 +2268,13 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
             #{keyword} receiver
                 .nil? &&
                 ^^^^^ Use 9 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
+                !args.empty?
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{keyword} receiver
+                     .nil? &&
                 !args.empty?
             end
           RUBY

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -424,11 +424,18 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
       %w[a while],
       %w[an until]
     ].each do |article, keyword|
-      it "registers an offense for misaligned operands in #{keyword} condition" do
+      it "registers an offense and corrects misaligned operands in #{keyword} condition" do
         expect_offense(<<~RUBY)
           #{keyword} a or
               b
               ^ Align the operands of a condition in #{article} `#{keyword}` statement spanning multiple lines.
+            something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} a or
+          #{' ' * keyword.length} b
             something
           end
         RUBY
@@ -564,13 +571,20 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
         RUBY
       end
 
-      it "registers an offense for a 2 space indentation of #{keyword} condition" do
+      it "registers an offense and corrects a 2 space indentation of #{keyword} condition" do
         expect_offense(<<~RUBY)
           #{keyword} receiver.nil? &&
             !args.empty? &&
             ^^^^^^^^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
             FORBIDDEN_METHODS.include?(method_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use 4 (not 2) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} receiver.nil? &&
+              !args.empty? &&
+              FORBIDDEN_METHODS.include?(method_name)
           end
         RUBY
       end
@@ -700,13 +714,20 @@ RSpec.describe RuboCop::Cop::Layout::MultilineOperationIndentation, :config do
           RUBY
         end
 
-        it "registers an offense for a 4 space indentation of #{keyword} condition" do
+        it "registers an offense and corrects a 4 space indentation of #{keyword} condition" do
           expect_offense(<<~RUBY)
             #{keyword} receiver.nil? &&
                 !args.empty? &&
                 ^^^^^^^^^^^^ Use 8 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
                 FORBIDDEN_METHODS.include?(method_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use 8 (not 4) spaces for indenting a condition in #{article} `#{keyword}` statement spanning multiple lines.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{keyword} receiver.nil? &&
+                    !args.empty? &&
+                    FORBIDDEN_METHODS.include?(method_name)
             end
           RUBY
         end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -607,6 +607,10 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             let(:ruby_version) { 2.4 }
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          RSpec.shared_context('ruby 2.4', :ruby24) do let(:ruby_version) { 2.4 } end
+        RUBY
       end
 
       it 'registers an offense when the method call has no arguments' do
@@ -615,6 +619,10 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
           ^^^^^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
             let(:ruby_version) { 2.4 }
           end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          RSpec.shared_context do let(:ruby_version) { 2.4 } end
         RUBY
       end
 
@@ -626,6 +634,10 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             f do
             ^^^^ Redundant line break detected.
             end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f do end
           RUBY
         end
       end
@@ -639,6 +651,10 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
             ^^^^ Redundant line break detected.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            f do end
+          RUBY
         end
 
         it 'reports an offense for a method call chained onto a multiline block' do
@@ -648,17 +664,31 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
               i.cond?
             end.join
           RUBY
+
+          expect_correction(<<~RUBY)
+            e.select do |i| i.cond? end.join
+          RUBY
+
           expect_offense(<<~RUBY)
             a = e.select do |i|
             ^^^^^^^^^^^^^^^^^^^ Redundant line break detected.
               i.cond?
             end.join
           RUBY
+
+          expect_correction(<<~RUBY)
+            a = e.select do |i| i.cond? end.join
+          RUBY
+
           expect_offense(<<~RUBY)
             e.select do |i|
             ^^^^^^^^^^^^^^^ Redundant line break detected.
               i.cond?
             end.join + []
+          RUBY
+
+          expect_correction(<<~RUBY)
+            e.select do |i| i.cond? end.join + []
           RUBY
         end
       end

--- a/spec/rubocop/cop/layout/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_comma_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterComma, :config do
           { foo:bar,}
                    ^ Space missing after comma.
         RUBY
+
+        expect_correction(<<~RUBY)
+          { foo:bar, }
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_empty_lines_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
         x = 0
              ^{} Final newline missing.
       RUBY
+
+      expect_correction("x = 0\n")
     end
 
     it 'registers an offense for no final newline after block comment' do
@@ -71,6 +73,17 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
         third line
         =end
             ^{} Final newline missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        puts 'testing rubocop when final new line is missing
+                                  after block comments'
+
+        =begin
+        first line
+        second line
+        third line
+        =end
       RUBY
     end
 
@@ -104,6 +117,8 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
         x = 0\n
         ^{} Trailing blank line missing.
       RUBY
+
+      expect_correction("x = 0\n\n")
     end
 
     it 'registers an offense for multiple trailing blank lines' do
@@ -141,6 +156,8 @@ RSpec.describe RuboCop::Cop::Layout::TrailingEmptyLines, :config do
         x = 0
              ^{} Final newline missing.
       RUBY
+
+      expect_correction("x = 0\n\n")
     end
 
     it 'accepts final blank line' do

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       x = 0#{trailing_whitespace}
            ^ Trailing whitespace detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      x = 0
+    RUBY
   end
 
   it 'registers an offense for a blank line with space' do
@@ -15,12 +19,18 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       #{trailing_whitespace * 2}
       ^^ Trailing whitespace detected.
     RUBY
+
+    expect_correction("\n")
   end
 
   it 'registers an offense for a line ending with tab' do
     expect_offense(<<~RUBY)
       x = 0\t
            ^ Trailing whitespace detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 0
     RUBY
   end
 
@@ -29,6 +39,10 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       x = :a\u3000
             ^ Trailing whitespace detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      x = :a
+    RUBY
   end
 
   it 'registers an offense for trailing whitespace in a heredoc string' do
@@ -36,6 +50,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       x = <<HEREDOC
         Hi#{trailing_whitespace * 3}
           ^^^ Trailing whitespace detected.
+      HEREDOC
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = <<HEREDOC
+        Hi\#{'   '}
       HEREDOC
     RUBY
   end
@@ -47,6 +67,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       ^ Trailing whitespace detected.
       X
     RUBY
+
+    expect_correction(<<~RUBY)
+      <<~X
+      \#{'	'}
+      X
+    RUBY
   end
 
   it 'registers an offense for a full-width space in a heredoc' do
@@ -54,6 +80,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       <<~X
       \u3000
       ^ Trailing whitespace detected.
+      X
+    RUBY
+
+    expect_correction(<<~RUBY)
+      <<~X
+      \#{'\u3000'}
       X
     RUBY
   end
@@ -64,6 +96,13 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
            ^ Trailing whitespace detected.
       #{trailing_whitespace}
       ^ Trailing whitespace detected.
+      __END__
+      x = 0\t
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 0
+
       __END__
       x = 0\t
     RUBY
@@ -79,6 +118,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       x = 0\t
            ^ Trailing whitespace detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      x = 0
+      =begin
+      __END__
+      =end
+      x = 0
+    RUBY
   end
 
   it 'is not fooled by heredoc containing __END__' do
@@ -91,6 +138,14 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       HEREDOC
       x3 = 0\t
             ^ Trailing whitespace detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x1 = <<HEREDOC
+      __END__
+      x2 = 0\#{'	'}
+      HEREDOC
+      x3 = 0
     RUBY
   end
 
@@ -107,6 +162,16 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       HEREDOC
       x3 = 0\t
             ^ Trailing whitespace detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x1 = <<HEREDOC
+      =begin\#{'  '}
+      __END__
+      =end
+      x2 = 0\#{'	'}
+      HEREDOC
+      x3 = 0
     RUBY
   end
 
@@ -146,6 +211,12 @@ RSpec.describe RuboCop::Cop::Layout::TrailingWhitespace, :config do
       expect_offense(<<~RUBY)
         x = <<HEREDOC#{trailing_whitespace}
                      ^ Trailing whitespace detected.
+          Hi#{trailing_whitespace * 3}
+        HEREDOC
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = <<HEREDOC
           Hi#{trailing_whitespace * 3}
         HEREDOC
       RUBY


### PR DESCRIPTION
Many Layout cop specs tested offense detection via `expect_offense` without verifying the autocorrection output, despite their cops extending `AutoCorrector`. This adds the missing `expect_correction` and `expect_no_corrections` assertions across 24 spec files to ensure autocorrect behavior is properly tested.