### PR TITLE
Add missing expect_correction to Lint and Style cop specs

### DIFF
--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics/MethodLength
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
               RUBY
+
+              expect_correction('')
             end
 
             describe 'when that cop was previously enabled' do
@@ -53,6 +55,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   # rubocop:disable Metrics/MethodLength
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
                 RUBY
+
+                expect_correction('')
               end
             end
           end
@@ -67,6 +71,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics
                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics` department.
               RUBY
+
+              expect_correction('')
             end
 
             it 'returns an offense when cop from this department is disabled' do
@@ -74,6 +80,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics/MethodLength
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
               RUBY
+
+              expect_correction('')
             end
           end
 
@@ -150,6 +158,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ <
                 Unnecessary disabling of `Metrics/ClassLength`, `Metrics/MethodLength`.
               RUBY
+
+              expect_correction('')
             end
           end
 
@@ -223,10 +233,18 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   # offense here
                 RUBY
 
+                expect_correction(<<~RUBY)
+                  puts 1
+                  # rubocop:disable MethodLength
+                  #
+                  # offense here
+                RUBY
+
                 expect($stderr.string).to eq(<<~OUTPUT)
                   (string): Warning: no department given for MethodLength.
                   (string): Warning: no department given for ClassLength.
                   (string): Warning: no department given for Debugger.
+                  (string): Warning: no department given for MethodLength.
                 OUTPUT
               end
             end
@@ -251,6 +269,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   #
                   # offense here
                 RUBY
+
+                expect_correction(<<~RUBY)
+                  puts 1
+                  # rubocop:disable Metrics/MethodLength
+                  #
+                  # offense here
+                RUBY
               end
             end
           end
@@ -265,6 +290,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop:disable Metrics/MethodLenght, KlassLength
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
               RUBY
+
+              expect_correction('')
             end
 
             context 'when the department starts with a lowercase letter' do
@@ -296,6 +323,8 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # rubocop : disable all
                 ^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of all cops.
               RUBY
+
+              expect_correction('')
             end
           end
 
@@ -344,6 +373,18 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   # rubocop:enable Style/ClassVars
                 end
               RUBY
+
+              expect_correction(<<~RUBY)
+                class One
+                  # rubocop:disable Style/ClassVars
+                  @@class_var = 1  # offense here
+                end
+
+                class Two
+                  @@class_var = 2  # offense and here
+                  # rubocop:enable Style/ClassVars
+                end
+              RUBY
             end
           end
 
@@ -355,6 +396,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 class One
                   # rubocop:disable Style/ClassVars
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Style/ClassVars`.
+                  # rubocop:disable all
+                  @@class_var = 1
+                  # offense here
+                end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                class One
                   # rubocop:disable all
                   @@class_var = 1
                   # offense here
@@ -393,6 +442,15 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 # 4
                 # rubocop:disable Layout/IndentationStyle
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Layout/IndentationStyle`.
+                #
+                # rubocop:enable Layout/IndentationStyle
+              RUBY
+
+              expect_correction(<<~RUBY)
+                # 1
+                # 2
+                # 3, offense here
+                # 4
                 #
                 # rubocop:enable Layout/IndentationStyle
               RUBY
@@ -689,6 +747,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           end
           # rubocop:enable Metrics
         RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          class One
+            @@class_var = 1  # offense here
+          end
+          # rubocop:enable Metrics
+        RUBY
       end
 
       it 'removes department duplicated by department on previous line' do
@@ -697,6 +763,13 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           class One
           @@class_var = 1  # rubocop:disable Metrics
                            ^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics` department.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          class One
+          @@class_var = 1
           end
         RUBY
       end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -553,6 +553,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{keyword} A
+          #{modifier == 'private' ? 'protected' : 'private'}
+          def method1
+          end
+          #{modifier}
+          def method2
+          end
+        end
+      RUBY
     end
   end
 
@@ -616,6 +627,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{keyword} A
+          def method1
+          end
+          def method2
+          end
+        end
+      RUBY
     end
   end
 
@@ -632,6 +652,21 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             %{modifier}
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+            def method2
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{keyword} A
+          #{modifier == 'private' ? 'protected' : 'private'}
+          def blah
+          end
+          begin
+            def method1
+            end
+            #{modifier}
             def method2
             end
           end
@@ -792,6 +827,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
+            class << self
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense if no method is defined after the modifier' do
@@ -805,6 +847,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
+            class << self
+              def method1
+              end
+            end
+          end
+        RUBY
       end
 
       it 'registers an offense even if a non-singleton-class method is defined' do
@@ -815,6 +866,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             class << self
               %{modifier}
               ^{modifier} Useless `#{modifier}` access modifier.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
+            def method1
+            end
+            class << self
             end
           end
         RUBY
@@ -839,6 +899,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             ^{modifier} Useless `#{modifier}` access modifier.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class << A
+          end
+        RUBY
       end
 
       it 'registers an offense if no method is defined after the modifier' do
@@ -848,6 +913,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             end
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class << A
+            def method1
+            end
           end
         RUBY
       end
@@ -872,6 +944,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        A.class_eval do
+        end
+      RUBY
     end
 
     context 'inside a class' do
@@ -880,6 +957,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           class A
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+            A.class_eval do
+              def method1
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A
             A.class_eval do
               def method1
               end
@@ -896,6 +982,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             A.class_eval do
               %{modifier}
               ^{modifier} Useless `#{modifier}` access modifier.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A
+            A.class_eval do
             end
           end
         RUBY
@@ -921,6 +1014,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        #{klass}.new do
+        end
+      RUBY
     end
   end
 
@@ -942,6 +1040,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           ^{modifier} Useless `#{modifier}` access modifier.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        A.instance_eval do
+        end
+      RUBY
     end
 
     context 'inside a class' do
@@ -951,6 +1054,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           class A
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+            self.instance_eval do
+              def method1
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A
             self.instance_eval do
               def method1
               end
@@ -967,6 +1079,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             self.instance_eval do
               %{modifier}
               ^{modifier} Useless `#{modifier}` access modifier.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class A
+            self.instance_eval do
             end
           end
         RUBY
@@ -1004,6 +1123,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             end
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
+            #{keyword} B
+            end
+          end
+        RUBY
       end
 
       it "registers an offense when outside a nested #{keyword}" do
@@ -1011,6 +1137,15 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           #{keyword} A
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+            #{keyword} B
+              def method1
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
             #{keyword} B
               def method1
               end
@@ -1025,6 +1160,13 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             #{keyword} B
               %{modifier}
               ^{modifier} Useless `#{modifier}` access modifier.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{keyword} A
+            #{keyword} B
             end
           end
         RUBY
@@ -1062,6 +1204,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             ^{modifier} Useless `#{modifier}` access modifier.
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          Data.define do
+          end
+        RUBY
       end
 
       it 'registers an offense if no method is defined in `::Data.define` with block' do
@@ -1069,6 +1216,11 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           ::Data.define do
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          ::Data.define do
           end
         RUBY
       end
@@ -1081,6 +1233,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
             do_something(_1)
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          Data.define do
+            do_something(_1)
+          end
+        RUBY
       end
 
       it 'registers an offense if no method is defined in `Data.define` with itblock', :ruby34 do
@@ -1088,6 +1246,12 @@ RSpec.describe RuboCop::Cop::Lint::UselessAccessModifier, :config do
           Data.define do
             %{modifier}
             ^{modifier} Useless `#{modifier}` access modifier.
+            do_something(it)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          Data.define do
             do_something(it)
           end
         RUBY

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -587,6 +587,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           }
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          1
+          foo = 2
+          bar {
+            foo = 3
+          }
+        end
+      RUBY
     end
   end
 
@@ -2017,6 +2027,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           foo
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo in { bar: bar }
+          baz { qux - 1 }
+          foo
+        end
+      RUBY
     end
   end
 
@@ -2039,6 +2057,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
           foo => { bar: bar }
           baz { qux -= 1 }
                 ^^^ Useless assignment to variable - `qux`. Use `-` instead of `-=`.
+          foo
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def some_method
+          foo => { bar: bar }
+          baz { qux - 1 }
           foo
         end
       RUBY
@@ -2459,6 +2485,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             p foo
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          while
+            1
+            foo = 1
+            p foo
+          end
+        RUBY
       end
     end
 
@@ -2469,6 +2503,16 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
             (
               foo = 1
               ^^^ Useless assignment to variable - `foo`.
+              foo = 1
+            )
+            p foo
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          while
+            (
+              1
               foo = 1
             )
             p foo

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -650,6 +650,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         baz
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def something
+        baz
+      end
+    RUBY
   end
 
   it 'registers an offense for a nested array literal composed entirely of literals in a method definition' do
@@ -657,6 +663,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def something
         [1, 2, [3]]
         ^^^^^^^^^^^ Literal `[1, 2, [3]]` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
         baz
       end
     RUBY
@@ -670,6 +682,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
         baz
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def something
+        baz
+      end
+    RUBY
   end
 
   it 'registers an offense for a literal frozen via safe navigation in a method definition' do
@@ -677,6 +695,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def something
         'foo'&.freeze
         ^^^^^^^^^^^^^ Literal `'foo'&.freeze` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
         baz
       end
     RUBY
@@ -696,6 +720,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def something
         [1, ['foo'.freeze]]
         ^^^^^^^^^^^^^^^^^^^ Literal `[1, ['foo'.freeze]]` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
         baz
       end
     RUBY
@@ -792,6 +822,12 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       def something
         {[1, 2] => :foo}
         ^^^^^^^^^^^^^^^^ Literal `{[1, 2] => :foo}` used in void context.
+        baz
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def something
         baz
       end
     RUBY

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
             ].freeze
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class ToBeDone
+            ITEMS = [
+              '', # TODO: Item 1
+              '', # TODO: Item 2
+            ].freeze
+          end
+        RUBY
       end
     end
 
@@ -148,6 +157,12 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         expect_offense(<<~RUBY)
           # TODO line 1
             ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+          # TODO line 2
+          # TODO line 3
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # TODO: line 1
           # TODO line 2
           # TODO line 3
         RUBY
@@ -162,6 +177,10 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
           expect_offense(<<~RUBY, keyword: keyword)
             # #{keyword} blah blah blah
               ^{keyword}^ Annotation keywords like `#{keyword}` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # #{keyword.upcase}: blah blah blah
           RUBY
         end
       end
@@ -291,6 +310,15 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
             ].freeze
           end
         RUBY
+
+        expect_correction(<<~RUBY)
+          class ToBeDone
+            ITEMS = [
+              '', # TODO Item 1
+              '', # TODO Item 2
+            ].freeze
+          end
+        RUBY
       end
     end
 
@@ -299,6 +327,12 @@ RSpec.describe RuboCop::Cop::Style::CommentAnnotation, :config do
         expect_offense(<<~RUBY)
           # TODO: line 1
             ^^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a space, then a note describing the problem.
+          # TODO: line 2
+          # TODO: line 3
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # TODO line 1
           # TODO: line 2
           # TODO: line 3
         RUBY

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -550,6 +550,12 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             ^^^^ Redundant `else`-clause.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              statement
+            end
+          RUBY
         end
       end
 
@@ -561,6 +567,12 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             else
             ^^^^ Redundant `else`-clause.
               nil
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              statement
             end
           RUBY
         end
@@ -601,6 +613,14 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             ^^^^ Redundant `else`-clause.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
+            end
+          RUBY
         end
       end
 
@@ -614,6 +634,14 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             else
             ^^^^ Redundant `else`-clause.
               nil
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            if condition
+              foo
+            elsif condition2
+              bar
             end
           RUBY
         end
@@ -668,6 +696,12 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             ^^^^ Redundant `else`-clause.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            unless condition
+              statement
+            end
+          RUBY
         end
       end
 
@@ -679,6 +713,12 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             else
             ^^^^ Redundant `else`-clause.
               nil
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            unless condition
+              statement
             end
           RUBY
         end
@@ -730,6 +770,13 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             ^^^^ Redundant `else`-clause.
             end
           RUBY
+
+          expect_correction(<<~RUBY)
+            case a
+            when condition
+              statement
+            end
+          RUBY
         end
       end
 
@@ -742,6 +789,13 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse, :config do
             else
             ^^^^ Redundant `else`-clause.
               nil
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            case a
+            when condition
+              statement
             end
           RUBY
         end

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
                     ^^ Prefer [...]
                        ^^ Prefer [...]
           RUBY
+
+          expect_no_corrections
         end
       else
         it 'does not register offenses for dual unannotated' do
@@ -454,6 +456,8 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           redirect("%{foo}", bye: foo("%{foo}"))
                                        ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -465,6 +469,8 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           redirect("%{foo}")
                     ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -488,6 +494,8 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           redirect("%{foo}", bye: foo("%{foo}"))
                                        ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -499,6 +507,8 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
           redirect("%{foo}")
                     ^^^^^^ Prefer annotated tokens (like `%<foo>s`) over template tokens (like `%{foo}`).
         RUBY
+
+        expect_no_corrections
       end
     end
   end
@@ -547,6 +557,11 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
             end
 
             if style != given_style
+              corrected_string = case style
+                                 when :annotated then '%<greetings>s'
+                                 when :template then '%{greetings}'
+                                 end
+
               %i[printf sprintf format].each do |method|
                 context "as an argument to `#{method}`" do
                   it 'registers an offense' do
@@ -554,6 +569,14 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
                       %{method}('%{string}', *vars)
                       _{method}  ^{string} Prefer [...]
                     RUBY
+
+                    if corrected_string && given_style != :unannotated
+                      expect_correction(<<~RUBY)
+                        #{method}('#{corrected_string}', *vars)
+                      RUBY
+                    else
+                      expect_no_corrections
+                    end
                   end
                 end
               end
@@ -564,6 +587,14 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
                     '#{string}' % vars
                      ^{string} Prefer [...]
                   RUBY
+
+                  if corrected_string && given_style != :unannotated
+                    expect_correction(<<~RUBY)
+                      '#{corrected_string}' % vars
+                    RUBY
+                  else
+                    expect_no_corrections
+                  end
                 end
               end
             end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -784,6 +784,18 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          if foo?
+            work
+          end
+
+          return unless bar?
+            work
+         #{trailing_whitespace}
+        end
+      RUBY
     end
   end
 
@@ -819,6 +831,20 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
           ^^ Use a guard clause (`return unless bar?`) instead of wrapping the code inside a conditional expression.
             work
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          if foo?
+            work
+          end
+
+          do_something
+
+          return unless bar?
+            work
+         #{trailing_whitespace}
         end
       RUBY
     end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -590,6 +590,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                                ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"t o" => 0, :b => 1 }
+          RUBY
         end
 
         it 'accepts hash rockets when keys have special symbols in them' do
@@ -602,6 +606,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                                ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"\tab" => 1, :b => 1 }
+          RUBY
         end
 
         it 'accepts hash rockets when keys start with a digit' do
@@ -614,6 +622,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                              ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"1" => 1, :b => 1 }
+          RUBY
         end
       end
 
@@ -770,6 +782,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                                ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"t o" => 0, :b => 1 }
+          RUBY
         end
 
         it 'accepts hash rockets when keys have special symbols in them' do
@@ -782,6 +798,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                                ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"\tab" => 1, :b => 1 }
+          RUBY
         end
 
         it 'accepts hash rockets when keys start with a digit' do
@@ -794,6 +814,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                              ^^ Don't mix styles in the same hash.
           RUBY
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+
+          expect_correction(<<~RUBY)
+            x = { :"1" => 1, :b => 1 }
+          RUBY
         end
       end
 

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       0.times { foo.it() }
                       ^^ Do not use parentheses for method calls with no arguments.
     RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { foo.it }
+    RUBY
   end
 
   it 'registers an offense when using `foo&.it()` in a single line block' do
@@ -49,6 +53,10 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
     expect_offense(<<~RUBY)
       0.times { foo&.it() }
                        ^^ Do not use parentheses for method calls with no arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { foo&.it }
     RUBY
   end
 
@@ -70,6 +78,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
           ^^ Do not use parentheses for method calls with no arguments.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        it
+      end
+    RUBY
   end
 
   it 'registers an offense when using `it` without arguments in the block with empty block parameter' do
@@ -79,6 +93,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
           ^^ Do not use parentheses for method calls with no arguments.
       }
     RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { ||
+        it
+      }
+    RUBY
   end
 
   it 'registers an offense when using `it` without arguments in the block with useless block parameter' do
@@ -86,6 +106,12 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
       0.times { |_n|
         it()
           ^^ Do not use parentheses for method calls with no arguments.
+      }
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { |_n|
+        it
       }
     RUBY
   end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -131,6 +131,15 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
               bar
             HERE
           RUBY
+
+          expect_correction(<<~'RUBY')
+            # frozen_string_literal: true
+
+            CONST = <<~HERE.freeze
+              foo #{use_interpolation}
+              bar
+            HERE
+          RUBY
         end
 
         it 'does not register an offense when using a multiline string' do
@@ -149,6 +158,13 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
             CONST = "#{foo}" \
                     ^^^^^^^^^^ Freeze mutable objects assigned to constants.
                     'bar'
+          RUBY
+
+          expect_correction(<<~'RUBY')
+            # frozen_string_literal: true
+
+            CONST = "#{foo}" \
+                    'bar'.freeze
           RUBY
         end
       end
@@ -333,6 +349,11 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           Y = [4, 5, 6]
               ^^^^^^^^^ Freeze mutable objects assigned to constants.
         RUBY
+
+        expect_correction(<<~RUBY)
+          X = [1, 2, 3].freeze # shareable_constant_value: literal
+          Y = [4, 5, 6].freeze
+        RUBY
       end
 
       it 'raises offense only for shareable_constant_value as none when set in the order of: literal, none and experimental_everything' do
@@ -342,6 +363,15 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
           # shareable_constant_value: none
           Y = [4, 5, 6]
               ^^^^^^^^^ Freeze mutable objects assigned to constants.
+          # shareable_constant_value: experimental_everything
+          Z = [7, 8, 9]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # shareable_constant_value: literal
+          X = [1, 2, 3]
+          # shareable_constant_value: none
+          Y = [4, 5, 6].freeze
           # shareable_constant_value: experimental_everything
           Z = [7, 8, 9]
         RUBY

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -234,6 +234,10 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
         1234
         ^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
       RUBY
+
+      expect_correction(<<~RUBY)
+        1_234
+      RUBY
     end
   end
 
@@ -251,6 +255,10 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
         1234
         ^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
       RUBY
+
+      expect_correction(<<~RUBY)
+        1_234
+      RUBY
     end
   end
 
@@ -267,6 +275,10 @@ RSpec.describe RuboCop::Cop::Style::NumericLiterals, :config do
       expect_offense(<<~RUBY)
         1234_56_78_9012
         ^^^^^^^^^^^^^^^ Use underscores(_) as thousands separator and separate every 3 digits with them.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        123_456_789_012
       RUBY
     end
 

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -479,6 +479,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
                     ^ Redundant line continuation.
         baz)
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo("\#{bar}",#{trailing_whitespace}
+        baz)
+    RUBY
   end
 
   it 'does not register an offense when using line concatenation and calling a method without parentheses' do
@@ -992,6 +997,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
                ^ Redundant line continuation.
         %i[baz quux])
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo(bar,#{trailing_whitespace}
+        %i[baz quux])
+    RUBY
   end
 
   it 'registers an offense for a method call with a line continuation and no following arguments' do
@@ -1001,6 +1011,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
             ^ Redundant line continuation.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar#{trailing_whitespace}
+      end
+    RUBY
   end
 
   it 'registers an offense for `super` with a line continuation and no following arguments' do
@@ -1008,6 +1024,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
       def foo
         super \
               ^ Redundant line continuation.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        super#{trailing_whitespace}
       end
     RUBY
   end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -683,6 +683,11 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
                ^^^^^^ Don't use parentheses around a method call.
       }.qux)
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo bar: baz {
+      }.qux
+    RUBY
   end
 
   it 'registers an offense for parentheses around a method chain with `{`...`}` numblock in keyword argument' do
@@ -691,6 +696,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
                ^^^^^^ Don't use parentheses around a method call.
         do_something(_1)
       }.qux)
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo bar: baz {
+        do_something(_1)
+      }.qux
     RUBY
   end
 
@@ -1211,6 +1222,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       if x; y else (1) end
                    ^^^ Don't use parentheses around a literal.
     RUBY
+
+    expect_correction(<<~RUBY)
+      if x; y else 1 end
+    RUBY
   end
 
   it 'accepts parentheses when enclosed in parentheses at `while-post`' do
@@ -1490,6 +1505,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
         x(({ y: 1 }), z)
           ^^^^^^^^^^ Don't use parentheses around a literal.
       RUBY
+
+      expect_correction(<<~RUBY)
+        x({ y: 1 }, z)
+      RUBY
     end
   end
 
@@ -1498,6 +1517,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       expect_offense(<<~RUBY)
         x ({ y: 1 }), ({ y: 1 })
                       ^^^^^^^^^^ Don't use parentheses around a literal.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x ({ y: 1 }), { y: 1 }
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -89,12 +89,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
       a = x if self.b
                ^^^^ Redundant `self` detected.
     RUBY
+
+    expect_correction(<<~RUBY)
+      a = x if b
+    RUBY
   end
 
   it 'reports an offense when a different masgn name is used in `if`' do
     expect_offense(<<~RUBY)
       a, b, c = x if self.d
                      ^^^^ Redundant `self` detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a, b, c = x if d
     RUBY
   end
 
@@ -384,6 +392,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
         ^^^^ Redundant `self` detected.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        it
+      end
+    RUBY
   end
 
   it 'registers an offense when using `it` without arguments in the block with empty block parameter' do
@@ -393,6 +407,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
         ^^^^ Redundant `self` detected.
       }
     RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { ||
+        it
+      }
+    RUBY
   end
 
   it 'registers an offense when using `it` without arguments in the block with useless block parameter' do
@@ -400,6 +420,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
       0.times { |_n|
         self.it
         ^^^^ Redundant `self` detected.
+      }
+    RUBY
+
+    expect_correction(<<~RUBY)
+      0.times { |_n|
+        it
       }
     RUBY
   end
@@ -476,6 +502,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
             in ^foo, *bar
               self.foo + self.bar + foo + bar
               ^^^^ Redundant `self` detected.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = 17
+          case pattern
+            in ^foo, *bar
+              foo + self.bar + foo + bar
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
         %r_ls_
         ^^^^^^ Use `//` around regular expression.
       RUBY
+
+      expect_correction(<<~RUBY)
+        /ls/
+      RUBY
     end
   end
 
@@ -503,6 +507,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           do_something %r/regexp/
                        ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
+
+        expect_correction(<<~RUBY)
+          do_something /regexp/
+        RUBY
       end
 
       it 'registers an offense when used as a safe navigation method argument' do
@@ -510,12 +518,20 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           foo&.do_something %r/regexp/
                             ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.do_something /regexp/
+        RUBY
       end
 
       it 'registers an offense when not used as a method argument' do
         expect_offense(<<~RUBY)
           %r/regexp/
           ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          /regexp/
         RUBY
       end
 
@@ -535,6 +551,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect_offense(<<~RUBY)
           %r/ regexp/
           ^^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          / regexp/
         RUBY
       end
 
@@ -553,6 +573,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           do_something %r/regexp/
                        ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
+
+        expect_correction(<<~RUBY)
+          do_something /regexp/
+        RUBY
       end
 
       it 'registers an offense when used as a safe navigation method argument' do
@@ -560,12 +584,20 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           foo&.do_something %r/regexp/
                             ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
+
+        expect_correction(<<~RUBY)
+          foo&.do_something /regexp/
+        RUBY
       end
 
       it 'registers an offense when not used as a method argument' do
         expect_offense(<<~RUBY)
           %r/regexp/
           ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          /regexp/
         RUBY
       end
 
@@ -585,6 +617,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect_offense(<<~RUBY)
           %r/ regexp/
           ^^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          / regexp/
         RUBY
       end
     end
@@ -613,6 +649,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
           %r/regexp/
           ^^^^^^^^^^ Use `//` around regular expression.
         RUBY
+
+        expect_correction(<<~RUBY)
+          /regexp/
+        RUBY
       end
     end
 
@@ -635,6 +675,10 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect_offense(<<~RUBY)
           %r/regexp/
           ^^^^^^^^^^ Use `//` around regular expression.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          /regexp/
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/super_arguments_spec.rb
+++ b/spec/rubocop/cop/style/super_arguments_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
         ^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        super
+      end
+    RUBY
   end
 
   it 'registers an offense for nested declarations' do
@@ -118,6 +124,15 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
         end
         super(a)
         ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo(a)
+        def bar(b:)
+          super
+        end
+        super
       end
     RUBY
   end
@@ -287,6 +302,12 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
           ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(a)
+          super.foo
+        end
+      RUBY
     end
 
     it 'registers an offense for unneeded arguments when the method has a block' do
@@ -296,6 +317,12 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
           ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(a)
+          super.foo { x }
+        end
+      RUBY
     end
 
     it 'registers an offense for unneeded arguments when the method has a numblock', :ruby27 do
@@ -303,6 +330,12 @@ RSpec.describe RuboCop::Cop::Style::SuperArguments, :config do
         def foo(a)
           super(a).foo { _1 }
           ^^^^^^^^ Call `super` without arguments and parentheses when the signature is identical.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(a)
+          super.foo { _1 }
         end
       RUBY
     end


### PR DESCRIPTION
Companion to #15004. Many Lint and Style cop specs tested offense detection via `expect_offense` without verifying the autocorrection output, despite their cops extending `AutoCorrector`. This adds the missing `expect_correction` and `expect_no_corrections` assertions across 17 spec files.

Files updated:
- `lint/redundant_cop_disable_directive_spec.rb`
- `lint/useless_access_modifier_spec.rb`
- `lint/useless_assignment_spec.rb`
- `lint/void_spec.rb`
- `style/comment_annotation_spec.rb`
- `style/empty_else_spec.rb`
- `style/format_string_token_spec.rb`
- `style/guard_clause_spec.rb`
- `style/hash_syntax_spec.rb`
- `style/method_call_without_args_parentheses_spec.rb`
- `style/mutable_constant_spec.rb`
- `style/numeric_literals_spec.rb`
- `style/redundant_line_continuation_spec.rb`
- `style/redundant_parentheses_spec.rb`
- `style/redundant_self_spec.rb`
- `style/regexp_literal_spec.rb`
- `style/super_arguments_spec.rb`