### PR TITLE
Fix infinite loop in `Layout/EndAlignment` when `end` is followed by `||` or `&&`

### DIFF
--- a/changelog/fix_infinite_loop_error_in_layout_end_alignment.md
+++ b/changelog/fix_infinite_loop_error_in_layout_end_alignment.md
@@ -1,0 +1,1 @@
+* [#15009](https://github.com/rubocop/rubocop/pull/15009): Fix infinite loop in `Layout/EndAlignment` when `end` is followed by `||` or `&&`. ([@koic][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -129,8 +129,9 @@ module RuboCop
           # we check if it's an if/unless/while/until.
           return unless (rhs = first_part_of_call_chain(rhs))
 
-          # If `rhs` is a `begin` node, find the first non-`begin` child.
-          rhs = rhs.child_nodes.first while rhs.begin_type?
+          # If `rhs` is a `begin` node or a logical operator,
+          # unwrap to find the leading conditional.
+          rhs = rhs.child_nodes.first while rhs.type?(:begin, :or, :and)
 
           return unless rhs.conditional?
           return if rhs.if_type? && rhs.ternary?

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -696,6 +696,52 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         it_behaves_like 'aligned', 'var = case', 'a; in b', '      end'
         it_behaves_like 'aligned', 'var[0] = case', 'a; in b', '         end'
       end
+
+      it 'registers an offense and corrects `if...end || ""` with `end` not aligned to keyword' do
+        expect_offense(<<~RUBY)
+          var = if test
+                  foo
+          end || ""
+          ^^^ `end` at 3, 0 is not aligned with `if` at 1, 6.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = if test
+                  foo
+                end || ""
+        RUBY
+      end
+
+      it 'does not register an offense for `if...end || ""` with `end` aligned to keyword' do
+        expect_no_offenses(<<~RUBY)
+          var = if test
+                  foo
+                end || ""
+        RUBY
+      end
+
+      it 'registers an offense and corrects `if...end && ""` with `end` not aligned to keyword' do
+        expect_offense(<<~RUBY)
+          var = if test
+                  foo
+          end && ""
+          ^^^ `end` at 3, 0 is not aligned with `if` at 1, 6.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = if test
+                  foo
+                end && ""
+        RUBY
+      end
+
+      it 'does not register an offense for `if...end && ""` with `end` aligned to keyword' do
+        expect_no_offenses(<<~RUBY)
+          var = if test
+                  foo
+                end && ""
+        RUBY
+      end
     end
 
     context 'when EnforcedStyleAlignWith is variable' do
@@ -717,6 +763,52 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       it_behaves_like 'aligned', "var =\n  if",  'test', '  end'
       context 'Ruby >= 2.7', :ruby27 do
         it_behaves_like 'aligned', 'var = case', 'a; in b', 'end'
+      end
+
+      it 'does not register an offense for `if...end || ""` with `end` aligned to variable' do
+        expect_no_offenses(<<~RUBY)
+          var = if test
+                  foo
+          end || ""
+        RUBY
+      end
+
+      it 'registers an offense and corrects `if...end || ""` with `end` not aligned to variable' do
+        expect_offense(<<~RUBY)
+          var = if test
+                  foo
+                end || ""
+                ^^^ `end` at 3, 6 is not aligned with `var = if` at 1, 0.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = if test
+                  foo
+          end || ""
+        RUBY
+      end
+
+      it 'does not register an offense for `if...end && ""` with `end` aligned to variable' do
+        expect_no_offenses(<<~RUBY)
+          var = if test
+                  foo
+          end && ""
+        RUBY
+      end
+
+      it 'registers an offense and corrects `if...end && ""` with `end` not aligned to variable' do
+        expect_offense(<<~RUBY)
+          var = if test
+                  foo
+                end && ""
+                ^^^ `end` at 3, 6 is not aligned with `var = if` at 1, 0.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          var = if test
+                  foo
+          end && ""
+        RUBY
       end
 
       it_behaves_like 'misaligned', <<~RUBY, :keyword


### PR DESCRIPTION
This PR fixes infinite loop in `Layout/EndAlignment` when `end` is followed by `||` or `&&`.

When code like `var = if cond; ...; end || ""` was autocorrected with `EnforcedStyleAlignWith: variable`, `check_assignment` failed to recognize the conditional inside the `or`/`and` wrapper, causing a mismatch between offense detection and autocorrection that resulted in an infinite loop. Unwrap `or`/`and` nodes in `check_assignment` so the conditional is properly handled via `check_asgn_alignment`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
