### PR TITLE
Fix a false positive for Lint/DuplicateMethods

### DIFF
--- a/changelog/fix_false_positive_for_lint_duplicate_methods.md
+++ b/changelog/fix_false_positive_for_lint_duplicate_methods.md
@@ -1,0 +1,1 @@
+* [#15010](https://github.com/rubocop/rubocop/issues/15010): Fix a false positive for `Lint/DuplicateMethods` when modules blocks are passed as method arguments. ([@5hun-s][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -306,7 +306,7 @@ module RuboCop
         def anonymous_class_block(node)
           first_block = node.each_ancestor(:block).first
           return unless class_or_module_new_block?(first_block)
-          return if first_block.parent&.type?(:lvasgn, :block)
+          return if first_block.parent&.type?(:lvasgn, :block, :call)
           return if node.each_ancestor(:sclass).any? { |s| !s.children.first.self_type? }
 
           first_block

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -942,6 +942,28 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'ignores Module.new blocks which are passed as method arguments' do
+    expect_no_offenses(<<~RUBY)
+      A.prepend(
+        Module.new { def foo; end }
+      )
+      B.prepend(
+        Module.new { def foo; end }
+      )
+    RUBY
+  end
+
+  it 'ignores Module.new blocks which are passed as safe navigation method arguments' do
+    expect_no_offenses(<<~RUBY)
+      A&.prepend(
+        Module.new { def foo; end }
+      )
+      B&.prepend(
+        Module.new { def foo; end }
+      )
+    RUBY
+  end
+
   it 'does not register an offense when there are same `alias_method` name outside `ensure` scope' do
     expect_no_offenses(<<~RUBY)
       module FooTest


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop/issues/15010

This PR fixes a false positive for Lint/DuplicateMethods when modules blocks are passed as method arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
