### PR TITLE
Fix false positives in `Style/RedundantParentheses`

### DIFF
--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -273,6 +273,7 @@ module RuboCop
         def body_range?(begin_node, node)
           return false unless node.range_type?
           return false unless (parent = begin_node.parent)
+          return false if parent.pair_type?
 
           (node.begin.nil? && begin_node == parent.children.first) ||
             (node.end.nil? && begin_node == parent.children.last)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -897,6 +897,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'does not register an offense for parens around an endless irange in a keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      foo bar: (baz..)
+      qux
+    RUBY
+  end
+
+  it 'does not register an offense for parens around an endless erange in a keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      foo bar: (baz...)
+      qux
+    RUBY
+  end
+
   it 'registers parentheses around an irange inside a block' do
     expect_offense(<<~RUBY)
       something do


### PR DESCRIPTION
When an endless range is used as the last keyword argument in a method call without parentheses, omitting the parentheses causes the expression on the following line to be treated as the value. Therefore, the parentheses cannot be omitted. In this case, the parentheses should be kept for safety.

Note that the changelog is not included due to a regression related to the unreleased #14988.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
