### PR TITLE
Remove Rubinius (rbx) from default configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,6 @@ TAGS
 # For redcar:
 #.redcar
 
-# For rubinius:
-#*.rbc
-
 # For bundle binstubs
 bin/*
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,6 @@ AllCops:
     - macruby
     - rake
     - jruby
-    - rbx
   # Include common Ruby source files.
   Include:
     - '**/*.rb'
@@ -27,7 +26,6 @@ AllCops:
     - '**/*.rake'
     - '**/*.rbuild'
     - '**/*.rbw'
-    - '**/*.rbx'
     - '**/*.ru'
     - '**/*.ruby'
     - '**/*.schema'

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                        .rake
                        .rbuild
                        .rbw
-                       .rbx
                        .ru
                        .ruby
                        .schema
@@ -29,7 +28,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                        .thor
                        .watchr]
 
-  ruby_interpreters = %w[ruby macruby rake jruby rbx]
+  ruby_interpreters = %w[ruby macruby rake jruby]
 
   ruby_filenames = %w[.irbrc
                       .pryrc

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -414,14 +414,6 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
         end
       end
 
-      context 'when .ruby-version contains a Rbx version' do
-        let(:ruby_version) { 'rbx-3.42' }
-
-        it 'uses the default target ruby version' do
-          expect(target_ruby.version).to eq default_version
-        end
-      end
-
       context 'when .ruby-version contains "system" version' do
         let(:ruby_version) { 'system' }
 
@@ -610,34 +602,6 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
                 bump
                 bundler (~> 1.3)
                 ruby-extensions (~> 1.9.0)
-
-              BUNDLED WITH
-                1.16.1
-            HEREDOC
-            create_file(lock_file_path, content)
-            expect(target_ruby.version).to eq default_version
-          end
-
-          it "uses the default Ruby when rbx is in #{file_name}" do
-            content = <<~HEREDOC
-              GEM
-                remote: https://rubygems.org/
-                specs:
-                  addressable (2.5.2)
-                    public_suffix (>= 2.0.2, < 4.0)
-                  ast (2.4.0)
-                  bump (0.5.4)
-
-              PLATFORMS
-                ruby
-
-              DEPENDENCIES
-                bump
-                bundler (~> 1.3)
-                ruby-extensions (~> 1.9.0)
-
-              RUBY VERSION
-                  ruby 2.0.0p0 (rbx 3.42)
 
               BUNDLED WITH
                 1.16.1


### PR DESCRIPTION
Rubinius has been effectively dead since ~2020 and the `.rbx` extension is no longer relevant. This removes all Rubinius references from the default configuration and related specs:

- Remove `rbx` from `AllCops: RubyInterpreters`
- Remove `**/*.rbx` from `AllCops: Include`
- Remove Rubinius-related specs in `target_finder_spec` and `target_ruby_spec`
- Remove Rubinius entry from `.gitignore`

Closes #14999