### PR TITLE
Remove obsolete extensions and interpreters from default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,6 @@
 AllCops:
   RubyInterpreters:
     - ruby
-    - macruby
     - rake
     - jruby
   # Include common Ruby source files.
@@ -12,10 +11,8 @@ AllCops:
     - '**/*.arb'
     - '**/*.axlsx'
     - '**/*.builder'
-    - '**/*.fcgi'
     - '**/*.gemfile'
     - '**/*.gemspec'
-    - '**/*.god'
     - '**/*.jb'
     - '**/*.jbuilder'
     - '**/*.mspec'
@@ -24,14 +21,12 @@ AllCops:
     - '**/*.podspec'
     - '**/*.rabl'
     - '**/*.rake'
-    - '**/*.rbuild'
     - '**/*.rbw'
     - '**/*.ru'
     - '**/*.ruby'
     - '**/*.schema'
     - '**/*.spec'
     - '**/*.thor'
-    - '**/*.watchr'
     - '**/.irbrc'
     - '**/.pryrc'
     - '**/.simplecov'
@@ -41,7 +36,6 @@ AllCops:
     - '**/Brewfile'
     - '**/Buildfile'
     - '**/Capfile'
-    - '**/Cheffile'
     - '**/Dangerfile'
     - '**/Deliverfile'
     - '**/Fastfile'
@@ -58,7 +52,6 @@ AllCops:
     - '**/Snapfile'
     - '**/Steepfile'
     - '**/Thorfile'
-    - '**/Vagabondfile'
     - '**/Vagrantfile'
   Exclude:
     - 'node_modules/**/*'

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -7,10 +7,8 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                        .arb
                        .axlsx
                        .builder
-                       .fcgi
                        .gemfile
                        .gemspec
-                       .god
                        .jb
                        .jbuilder
                        .mspec
@@ -19,16 +17,14 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                        .podspec
                        .rabl
                        .rake
-                       .rbuild
                        .rbw
                        .ru
                        .ruby
                        .schema
                        .spec
-                       .thor
-                       .watchr]
+                       .thor]
 
-  ruby_interpreters = %w[ruby macruby rake jruby]
+  ruby_interpreters = %w[ruby rake jruby]
 
   ruby_filenames = %w[.irbrc
                       .pryrc
@@ -38,7 +34,6 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                       Brewfile
                       Buildfile
                       Capfile
-                      Cheffile
                       Dangerfile
                       Deliverfile
                       Fastfile
@@ -54,7 +49,6 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
                       Snapfile
                       Steepfile
                       Thorfile
-                      Vagabondfile
                       Vagrantfile
                       buildfile]
 


### PR DESCRIPTION
Remove dead/unmaintained entries from `AllCops` default configuration:

**Interpreters:**
- `macruby` — dead since 2012, last release was 0.12
- `rbx` (Rubinius) — dead since ~2020

**Extensions:**
- `.fcgi` (FastCGI) — obsolete since ~2009, superseded by Rack-based servers
- `.god` (God process monitor) — unmaintained for years
- `.rbuild` — dead/obscure
- `.rbx` (Rubinius) — see above
- `.watchr` (Watchr) — dead, superseded by Guard

**Filenames:**
- `Cheffile` (Librarian-Chef) — officially deprecated by Chef
- `Vagabondfile` (Vagabond) — dead, never widely adopted

This is a superset of #15013 (which only removes Rubinius).