### PR TITLE
Memoize cop config lookups to reduce GC pressure

### DIFF
--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -185,7 +185,7 @@ module RuboCop
         end
 
         def empty_line_between_macros
-          cop_config.fetch('DefLikeMacros', []).map(&:to_sym)
+          @empty_line_between_macros ||= cop_config.fetch('DefLikeMacros', []).map(&:to_sym).freeze
         end
 
         def macro_candidate?(node)

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -52,7 +52,7 @@ module RuboCop
         end
 
         def allowed_non_ascii_chars
-          cop_config['AllowedChars'] || []
+          @allowed_non_ascii_chars ||= (cop_config['AllowedChars'] || []).freeze
         end
       end
     end

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -448,7 +448,11 @@ module RuboCop
         end
 
         def functional_method?(method_name)
-          cop_config['FunctionalMethods'].map(&:to_sym).include?(method_name)
+          functional_methods.include?(method_name)
+        end
+
+        def functional_methods
+          @functional_methods ||= cop_config['FunctionalMethods'].to_set(&:to_sym).freeze
         end
 
         def functional_block?(node)
@@ -460,7 +464,11 @@ module RuboCop
         end
 
         def procedural_method?(method_name)
-          cop_config['ProceduralMethods'].map(&:to_sym).include?(method_name)
+          procedural_methods.include?(method_name)
+        end
+
+        def procedural_methods
+          @procedural_methods ||= cop_config['ProceduralMethods'].to_set(&:to_sym).freeze
         end
 
         def return_value_used?(node)

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -57,7 +57,7 @@ module RuboCop
         ].map(&:to_sym)
 
         def user_vars
-          cop_config['AllowedVariables'].map(&:to_sym)
+          @user_vars ||= cop_config['AllowedVariables'].map(&:to_sym).freeze
         end
 
         def allowed_var?(global_var)

--- a/lib/rubocop/cop/style/ip_addresses.rb
+++ b/lib/rubocop/cop/style/ip_addresses.rb
@@ -48,8 +48,7 @@ module RuboCop
         private
 
         def allowed_addresses
-          allowed_addresses = cop_config['AllowedAddresses']
-          Array(allowed_addresses).map(&:downcase)
+          @allowed_addresses ||= Array(cop_config['AllowedAddresses']).map(&:downcase).freeze
         end
 
         def potential_ip?(str)

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -299,7 +299,7 @@ module RuboCop
         end
 
         def supported_capitalizations
-          cop_config['SupportedCapitalizations'].map(&:to_sym)
+          @supported_capitalizations ||= cop_config['SupportedCapitalizations'].map(&:to_sym).freeze
         end
       end
     end

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/require_parentheses.rb
@@ -33,16 +33,18 @@ module RuboCop
           end
 
           def included_macros_list
-            cop_config.fetch('IncludedMacros', []).map(&:to_sym)
+            @included_macros_list ||= cop_config.fetch('IncludedMacros', []).map(&:to_sym).freeze
           end
 
           def included_macro_patterns
-            cop_config.fetch('IncludedMacroPatterns', [])
+            @included_macro_patterns ||=
+              cop_config.fetch('IncludedMacroPatterns', [])
+                        .map { |pattern| Regexp.new(pattern) }.freeze
           end
 
           def matches_included_macro_pattern?(method_name)
             included_macro_patterns.any? do |pattern|
-              Regexp.new(pattern).match?(method_name.to_s)
+              pattern.match?(method_name.to_s)
             end
           end
 

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def allowed_numbers
-          cop_config.fetch('AllowedNumbers', []).map(&:to_s)
+          @allowed_numbers ||= cop_config.fetch('AllowedNumbers', []).map(&:to_s).freeze
         end
 
         def allowed_patterns

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -89,7 +89,7 @@ module RuboCop
         end
 
         def method_names
-          methods.map { |method| method_name(method).to_sym }
+          @method_names ||= methods.map { |method| method_name(method).to_sym }.freeze
         end
 
         def method_name(method)

--- a/lib/rubocop/cop/style/yoda_expression.rb
+++ b/lib/rubocop/cop/style/yoda_expression.rb
@@ -76,7 +76,7 @@ module RuboCop
         end
 
         def supported_operators
-          Array(cop_config['SupportedOperators'])
+          @supported_operators ||= Array(cop_config['SupportedOperators']).freeze
         end
 
         def offended_ancestor?(node)


### PR DESCRIPTION
Profiling showed that ~34% of RuboCop's execution time is spent in GC. Several cops were calling `cop_config[...].map(...)` on every node visit, creating throwaway arrays/sets each time. These small allocations add up across hundreds of cops and thousands of AST nodes.

This memoizes config-derived collections with `@var ||=` in 10 cops:

- `Style/BlockDelimiters` — `FunctionalMethods`/`ProceduralMethods` (converted to `Set` for O(1) lookup)
- `Style/IpAddresses` — `AllowedAddresses`
- `Style/GlobalVars` — `AllowedVariables`
- `Style/NumericLiterals` — `AllowedNumbers`
- `Style/SingleLineBlockParams` — `Methods`
- `Style/AsciiComments` — `AllowedChars`
- `Style/YodaExpression` — `SupportedOperators`
- `Style/MagicCommentFormat` — `SupportedCapitalizations`
- `Style/MethodCallWithArgsParentheses` — `IncludedMacros` + `IncludedMacroPatterns` (also avoids re-creating `Regexp` objects)
- `Layout/EmptyLineBetweenDefs` — `DefLikeMacros`

## Profiling data

Benchmark: `bundle exec rubocop lib/` (914 files, cache disabled), 3 runs each, Apple M1.

|  | Before | After |
|--|--------|-------|
| Wall time (avg) | 17.29s | 16.21s (~6% faster) |
| Object allocations | 25,122,653 | 25,119,423 (~3K fewer) |

The allocation reduction is modest when profiling against RuboCop's own codebase (which doesn't heavily exercise all these cops). The wall time improvement is more significant and likely comes from reduced GC pressure and the `Set`-based lookups in `BlockDelimiters` (which fires on every block node). The impact would be proportionally larger on codebases with more blocks, string literals with IPs, global variables, etc.