### PR TITLE
Memoize ResultCache class methods called per file

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -85,13 +85,21 @@ module RuboCop
     end
 
     def self.cache_root(config_store, cache_root_override = nil)
-      CacheConfig.root_dir do
+      return @cache_root if @cache_root && !cache_root_override
+
+      result = CacheConfig.root_dir do
         cache_root_override || config_store.for_pwd.for_all_cops['CacheRootDirectory']
       end
+      @cache_root = result unless cache_root_override
+      result
     end
 
     def self.allow_symlinks_in_cache_location?(config_store)
       config_store.for_pwd.for_all_cops['AllowSymlinksInCacheRootDirectory']
+    end
+
+    def self.reset_config_cache
+      @cache_root = nil
     end
 
     attr_reader :path

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -26,11 +26,15 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
       begin
         FileUtils.mkdir_p(working_dir)
 
-        Dir.chdir(working_dir) { example.run }
+        Dir.chdir(working_dir) do
+          RuboCop::ResultCache.reset_config_cache
+          example.run
+        end
       ensure
         ENV['HOME'] = original_home
         ENV['XDG_CONFIG_HOME'] = original_xdg_config_home
 
+        RuboCop::ResultCache.reset_config_cache
         RuboCop::ConfigLoader.clear_options # This also resets RuboCop::FileFinder.root_level
       end
     end


### PR DESCRIPTION
`ResultCache.cache_root` and `ResultCache.allow_symlinks_in_cache_location?` were called for every inspected file but always return the same value during a run. `cache_root` in particular calls through `CacheConfig.root_dir` which involves env var lookups, `Dir.home`, and `File.realpath` — all unnecessary to repeat 914 times.

## Profiling data

Benchmark: `bundle exec rubocop lib/` (914 files), 3 runs each, Apple M1.

**Cold cache (first run, writes cache for every file):**

|  | Before | After |
|--|--------|-------|
| Wall time (avg) | 17.76s | 16.52s (~7% faster) |

**Warm cache (typical incremental run):**

|  | Before | After |
|--|--------|-------|
| Wall time (avg) | 0.146s | 0.125s (~14% faster) |

The warm-cache improvement is proportionally larger because `ResultCache#initialize` (which calls these methods) dominates the warm-cache code path — the actual inspection is skipped entirely.