### PR TITLE
Fix false positives in `Lint/DuplicateMethods`

### DIFF
--- a/changelog/fix_fix_false_positives_in_lint_duplicate_methods.md
+++ b/changelog/fix_fix_false_positives_in_lint_duplicate_methods.md
@@ -1,0 +1,1 @@
+* [#15019](https://github.com/rubocop/rubocop/pull/15019): Fix false positives in `Lint/DuplicateMethods` when the same method is defined in anonymous module blocks passed to different receivers. ([@koic][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -244,7 +244,7 @@ module RuboCop
             found_method(node, "#{enclosing}.#{name}")
           elsif (anon_block = anonymous_class_block(node))
             scope = qualified_name(anon_block.parent_module_name, nil, 'Object')
-            found_method(node, "#{scope}.#{name}")
+            found_method(node, "#{scope}.#{name}", scope_id: anon_block_scope_id(anon_block))
           end
         end
 
@@ -289,7 +289,9 @@ module RuboCop
           elsif (anon_block = anonymous_class_block(node))
             base = qualified_name(anon_block.parent_module_name, nil, 'Object')
             scope = node.each_ancestor(:sclass).any? ? "#<Class:#{base}>" : base
-            found_method(node, "#{humanize_scope(scope)}#{name}")
+            found_method(
+              node, "#{humanize_scope(scope)}#{name}", scope_id: anon_block_scope_id(anon_block)
+            )
           else
             found_sclass_method(node, name)
           end
@@ -306,10 +308,17 @@ module RuboCop
         def anonymous_class_block(node)
           first_block = node.each_ancestor(:block).first
           return unless class_or_module_new_block?(first_block)
-          return if first_block.parent&.type?(:lvasgn, :block, :call)
+          return if first_block.parent&.type?(:lvasgn, :block)
           return if node.each_ancestor(:sclass).any? { |s| !s.children.first.self_type? }
 
           first_block
+        end
+
+        def anon_block_scope_id(anon_block)
+          return unless (parent = anon_block.parent)
+          return unless parent.call_type? && parent.receiver
+
+          "#{parent.receiver.source}.#{parent.method_name}"
         end
 
         def found_sclass_method(node, name)
@@ -322,8 +331,10 @@ module RuboCop
           found_method(node, "#{singleton_receiver_node.method_name}.#{name}")
         end
 
-        def found_method(node, method_name)
+        # rubocop:disable Metrics/AbcSize
+        def found_method(node, method_name, scope_id: nil)
           key = method_key(node, method_name)
+          key = "#{key}@#{scope_id}" if scope_id
           scope = node.each_ancestor(:rescue, :ensure).first&.type
 
           if @definitions.key?(key)
@@ -340,6 +351,7 @@ module RuboCop
             @definitions[key] = node
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         def method_key(node, method_name)
           if (ancestor_def = node.each_ancestor(:any_def).first)

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -964,6 +964,88 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'registers an offense for the same method in anonymous module blocks prepended to the same receiver' do
+    expect_offense(<<~RUBY)
+      A.prepend(
+        Module.new do
+          def foo
+            x
+          end
+        end
+      )
+
+      A.prepend(
+        Module.new do
+          def foo
+          ^^^^^^^ Method `Object#foo` is defined at both (string):3 and (string):11.
+            y
+          end
+        end
+      )
+    RUBY
+  end
+
+  it 'does not register an offense for the same method in anonymous module blocks prepended to different receivers' do
+    expect_no_offenses(<<~RUBY)
+      A.prepend(
+        Module.new do
+          def foo
+            x
+          end
+        end
+      )
+
+      B.prepend(
+        Module.new do
+          def foo
+            y
+          end
+        end
+      )
+    RUBY
+  end
+
+  it 'registers an offense for the same method in anonymous module blocks prepended to the same receiver using safe navigation' do
+    expect_offense(<<~RUBY)
+      A&.prepend(
+        Module.new do
+          def foo
+            x
+          end
+        end
+      )
+
+      A&.prepend(
+        Module.new do
+          def foo
+          ^^^^^^^ Method `Object#foo` is defined at both (string):3 and (string):11.
+            y
+          end
+        end
+      )
+    RUBY
+  end
+
+  it 'does not register an offense for the same method in anonymous module blocks prepended to different receivers using safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      A&.prepend(
+        Module.new do
+          def foo
+            x
+          end
+        end
+      )
+
+      B&.prepend(
+        Module.new do
+          def foo
+            y
+          end
+        end
+      )
+    RUBY
+  end
+
   it 'does not register an offense when there are same `alias_method` name outside `ensure` scope' do
     expect_no_offenses(<<~RUBY)
       module FooTest


### PR DESCRIPTION
The cop incorrectly flagged methods in anonymous module blocks as duplicates when the blocks were passed to different receivers, e.g., `A.prepend(Module.new { def foo; end })` and `B.prepend(Module.new { def foo; end })`.

Introduce `scope_id` to differentiate anonymous blocks by their parent call (e.g., `A.prepend` vs `B.prepend`). This keeps internal keys unique without changing the user-facing offense message, which remains `Object#foo`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
