### PR TITLE
[Fix #15021] Fix false positives in `Layout/EmptyLineAfterGuardClause`

### DIFF
--- a/changelog/fix_false_positives_in_layout_empty_line_after_guard_clause.md
+++ b/changelog/fix_false_positives_in_layout_empty_line_after_guard_clause.md
@@ -1,0 +1,1 @@
+* [#15021](https://github.com/rubocop/rubocop/issues/15021): Fix false positives in `Layout/EmptyLineAfterGuardClause` when using a guard clause followed by a multi-line guard clause with `raise`, `fail`, `return`, `break`, or `next`. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -60,6 +60,11 @@ module RuboCop
         END_OF_HEREDOC_LINE = 1
         SIMPLE_DIRECTIVE_COMMENT_PATTERN = /\A# *:nocov:\z/.freeze
 
+        # @!method guard_clause_branch?(node)
+        def_node_matcher :guard_clause_branch?, <<~PATTERN
+          {(send nil? {:raise :fail} ...) return break next}
+        PATTERN
+
         def on_if(node)
           return if correct_style?(node)
           return if multiple_statements_on_line?(node)
@@ -97,14 +102,16 @@ module RuboCop
         end
 
         def correct_style?(node)
-          !contains_guard_clause?(node) ||
+          !node.if_branch&.guard_clause? ||
             next_line_rescue_or_ensure?(node) ||
             next_sibling_parent_empty_or_else?(node) ||
             next_sibling_empty_or_guard_clause?(node)
         end
 
         def contains_guard_clause?(node)
-          node.if_branch&.guard_clause?
+          return false unless (branch = node.if_branch)
+
+          guard_clause_branch?(branch)
         end
 
         def next_line_empty_or_allowed_directive_comment?(line)

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -399,6 +399,97 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'accepts a guard clause followed by a multi-line guard clause with `raise`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        return if something?
+        if something_else?
+          raise bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause followed by a multi-line guard clause with `fail`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        return if something?
+        if something_else?
+          fail bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause followed by a multi-line guard clause with `return`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        return if something?
+        if something_else?
+          return bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause followed by a multi-line guard clause with `break`' do
+    expect_no_offenses(<<~RUBY)
+      collection.each do |item|
+        break if something?
+        if something_else?
+          break bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause followed by a multi-line guard clause with `next`' do
+    expect_no_offenses(<<~RUBY)
+      collection.each do |item|
+        next if something?
+        if something_else?
+          next bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a guard clause followed by a multi-line if with non-guard body' do
+    expect_offense(<<~RUBY)
+      def foo
+        return if something?
+        ^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        if something_else?
+          bar(
+            baz
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        return if something?
+
+        if something_else?
+          bar(
+            baz
+          )
+        end
+      end
+    RUBY
+  end
+
   it 'accepts a modifier if when the next line is `end`' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
This PR fixes false positives in `Layout/EmptyLineAfterGuardClause` when using a guard clause followed by a multi-line guard clause with `raise`, `fail`, `return`, `break`, or `next`.

Fixes #15021.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
