### PR TITLE
Simplify SafeNavigation chain walking and method checks

### DIFF
--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -367,13 +367,13 @@ module RuboCop
         def unsafe_method_used?(node, method_chain, method)
           return true if unsafe_method?(node, method)
 
-          method.each_ancestor(:send).any? do |ancestor|
-            break true unless config.cop_enabled?('Lint/SafeNavigationChain')
-
-            break true if unsafe_method?(node, ancestor)
-            break true if nil_methods.include?(ancestor.method_name)
-            break false if ancestor == method_chain
+          method.each_ancestor(:send) do |ancestor|
+            return true unless config.cop_enabled?('Lint/SafeNavigationChain')
+            return true if unsafe_method?(node, ancestor)
+            return true if nil_methods.include?(ancestor.method_name)
+            return false if ancestor == method_chain
           end
+          false
         end
 
         def unsafe_method?(node, send_node)
@@ -409,7 +409,7 @@ module RuboCop
                                                  start_method,
                                                  method_chain)
           start_method.each_ancestor do |ancestor|
-            break unless %i[send block].include?(ancestor.type)
+            break unless ancestor.type?(:call, :any_block)
             next if !ancestor.send_type? || ancestor.operator_method?
 
             corrector.insert_before(ancestor.loc.dot, '&')

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -328,6 +328,28 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
         RUBY
       end
 
+      it 'registers an offense for a chained method call with numblock safeguarded with a check for the object', :ruby27 do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.one.two(baz) { _1.qux } if %{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.one&.two(baz) { _1.qux }
+        RUBY
+      end
+
+      it 'registers an offense for a chained method call with itblock safeguarded with a check for the object', :ruby34 do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable}.one.two(baz) { it.qux } if %{variable}
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{variable} Use safe navigation (`&.`) instead [...]
+        RUBY
+
+        expect_correction(<<~RUBY)
+          #{variable}&.one&.two(baz) { it.qux }
+        RUBY
+      end
+
       it 'registers an offense for a method call safeguarded with a ' \
          'negative check for the object' do
         expect_offense(<<~RUBY, variable: variable)


### PR DESCRIPTION
Two improvements to SafeNavigation:

- `add_safe_nav_to_all_methods_in_chain` used a hardcoded `%i[send block]` type list that missed `csend`, `numblock`, and `itblock`. Replaced with `type?(:call, :any_block)` which covers all call and block types.
- `unsafe_method_used?` used `break true`/`break false` inside `any?`, which is semantically misleading. Replaced with a plain loop using explicit returns.