### PR TITLE
Consolidate first_argument? matchers in RedundantParentheses

### DIFF
--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -114,7 +114,7 @@ module RuboCop
         def first_arg_begins_with_hash_literal?(node)
           # Don't flag `method ({key: value})` or `method ({key: value}.method)`
           hash_literal = method_chain_begins_with_hash_literal(node.children.first)
-          if (root_method = node.each_ancestor(:send).to_a.last)
+          if (root_method = node.each_ancestor(:call).to_a.last)
             parenthesized = root_method.parenthesized_call?
           end
           hash_literal && first_argument?(node) && !parentheses?(hash_literal) && !parenthesized
@@ -332,28 +332,15 @@ module RuboCop
         end
 
         def first_argument?(node)
-          if first_send_argument?(node) ||
-             first_super_argument?(node) ||
-             first_yield_argument?(node)
-            return true
-          end
+          return true if first_call_argument?(node)
 
           node.each_ancestor.any? { |ancestor| first_argument?(ancestor) }
         end
 
-        # @!method first_send_argument?(node)
-        def_node_matcher :first_send_argument?, <<~PATTERN
-          ^(send _ _ equal?(%0) ...)
-        PATTERN
-
-        # @!method first_super_argument?(node)
-        def_node_matcher :first_super_argument?, <<~PATTERN
-          ^(super equal?(%0) ...)
-        PATTERN
-
-        # @!method first_yield_argument?(node)
-        def_node_matcher :first_yield_argument?, <<~PATTERN
-          ^(yield equal?(%0) ...)
+        # @!method first_call_argument?(node)
+        def_node_matcher :first_call_argument?, <<~PATTERN
+          {^(call _ _ equal?(%0) ...)
+           ^({super yield} equal?(%0) ...)}
         PATTERN
 
         def call_chain_starts_with_int?(begin_node, send_node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1599,6 +1599,10 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
       expect_no_offenses('x ({ y: 1 }.merge({ y: 2 }).merge({ y: 3 })), z')
     end
 
+    it 'accepts parentheses if the argument list is not parenthesized with safe navigation' do
+      expect_no_offenses('x&.y ({ z: 1 }), w')
+    end
+
     it 'registers an offense if the argument list is parenthesized' do
       expect_offense(<<~RUBY)
         x(({ y: 1 }), z)


### PR DESCRIPTION
Replaced three near-identical matchers (`first_send_argument?`, `first_super_argument?`, `first_yield_argument?`) with a single `first_call_argument?` using a union pattern. Also adds `csend` coverage that was previously missing.