### PR TITLE
Fix false positives in Lint/DuplicateMethods

### DIFF
--- a/changelog/fix_false_positive_in_duplicate_methods_20260317095831.md
+++ b/changelog/fix_false_positive_in_duplicate_methods_20260317095831.md
@@ -1,0 +1,1 @@
+* [#15028](https://github.com/rubocop/rubocop/issues/15028): Fix a false positive for `Lint/DuplicateMethods` when the same method is defined in different anonymous module blocks passed to a no-receiver call (e.g. `stub_const`). ([@Darhazer][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -315,10 +315,14 @@ module RuboCop
         end
 
         def anon_block_scope_id(anon_block)
-          return unless (parent = anon_block.parent)
-          return unless parent.call_type? && parent.receiver
+          parent = anon_block.parent
+          return unless parent&.call_type?
 
-          "#{parent.receiver.source}.#{parent.method_name}"
+          if parent.receiver
+            "#{parent.receiver.source}.#{parent.method_name}"
+          else
+            source_location(anon_block)
+          end
         end
 
         def found_sclass_method(node, name)

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1046,6 +1046,24 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'does not register an offense for the same method in different Module.new blocks passed to a no-receiver call' do
+    expect_no_offenses(<<~RUBY)
+      stub_const('Foo',
+                 Module.new { def self.underscore(_); end })
+      stub_const('Bar',
+                 Module.new { def self.underscore(_); end })
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Module.new blocks passed to a no-receiver call' do
+    expect_no_offenses(<<~RUBY)
+      stub_const('Foo',
+                 Module.new { def underscore(_); end })
+      stub_const('Bar',
+                 Module.new { def underscore(_); end })
+    RUBY
+  end
+
   it 'does not register an offense when there are same `alias_method` name outside `ensure` scope' do
     expect_no_offenses(<<~RUBY)
       module FooTest


### PR DESCRIPTION
Fixes #15028 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
