### PR TITLE
[Fix #15034] Fix incorrect autocorrect in `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_merge_pull_request_15030_from_20260319170625.md
+++ b/changelog/fix_merge_pull_request_15030_from_20260319170625.md
@@ -1,0 +1,1 @@
+* [#15034](https://github.com/rubocop/rubocop/issues/15034): Fix incorrect autocorrection in `Style/IfWithSemicolon` when using single-line `unless` / `;` / `end`. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -17,9 +17,9 @@ module RuboCop
         include OnNormalIfUnless
         extend AutoCorrector
 
-        MSG_IF_ELSE = 'Do not use `if %<expr>s;` - use `if/else` instead.'
-        MSG_NEWLINE = 'Do not use `if %<expr>s;` - use a newline instead.'
-        MSG_TERNARY = 'Do not use `if %<expr>s;` - use a ternary operator instead.'
+        MSG_IF_ELSE = 'Do not use `%<keyword>s %<expr>s;` - use `if/else` instead.'
+        MSG_NEWLINE = 'Do not use `%<keyword>s %<expr>s;` - use a newline instead.'
+        MSG_TERNARY = 'Do not use `%<keyword>s %<expr>s;` - use a ternary operator instead.'
 
         def on_normal_if_unless(node)
           return if node.parent&.if_type?
@@ -49,7 +49,7 @@ module RuboCop
                        MSG_TERNARY
                      end
 
-          format(template, expr: node.condition.source)
+          format(template, keyword: node.keyword, expr: node.condition.source)
         end
 
         def autocorrect(corrector, node)
@@ -79,6 +79,8 @@ module RuboCop
 
           then_code = node.if_branch ? build_expression(node.if_branch) : 'nil'
           else_code = node.else_branch ? build_expression(node.else_branch) : 'nil'
+
+          then_code, else_code = else_code, then_code if node.unless?
 
           "#{node.condition.source} ? #{then_code} : #{else_code}"
         end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -348,4 +348,62 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
       RUBY
     end
   end
+
+  context 'when using `unless`' do
+    it 'registers an offense and corrects for single-line `unless/;/end`' do
+      expect_offense(<<~RUBY)
+        unless cond; run end
+        ^^^^^^^^^^^^^^^^^^^^ Do not use `unless cond;` - use a ternary operator instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? nil : run
+      RUBY
+    end
+
+    it 'registers an offense and corrects for single-line `unless/;/else/end`' do
+      expect_offense(<<~RUBY)
+        unless cond; run else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `unless cond;` - use a ternary operator instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? dont : run
+      RUBY
+    end
+
+    it 'registers an offense and corrects for single-line `unless/;/end` without then body' do
+      expect_offense(<<~RUBY)
+        unless cond; else dont end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `unless cond;` - use a ternary operator instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? dont : nil
+      RUBY
+    end
+
+    it 'registers an offense and corrects a single-line `unless/;/end` when the then body contains a method call with an argument' do
+      expect_offense(<<~RUBY)
+        unless cond; do_something arg end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `unless cond;` - use a ternary operator instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        cond ? nil : do_something(arg)
+      RUBY
+    end
+
+    it 'registers an offense when using multiple expressions in the `else` branch of `unless`' do
+      expect_offense(<<~RUBY)
+        unless cond; foo else bar'arg'; baz end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `unless cond;` - use a newline instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless cond
+         foo else bar'arg'; baz end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes incorrect autocorrect in `Style/IfWithSemicolon` when using single-line `unless` / `;` / `end`.

Fixes #15034.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
