### PR TITLE
[Fix #15035] Exclude `included_modules` from `Style/ModuleMemberExistenceCheck`

### DIFF
--- a/changelog/fix_exclude_included_modules_from_style_module_member_existence_check.md
+++ b/changelog/fix_exclude_included_modules_from_style_module_member_existence_check.md
@@ -1,0 +1,1 @@
+* [#15035](https://github.com/rubocop/rubocop/pull/15035): Exclude `included_modules` from `Style/ModuleMemberExistenceCheck`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4794,7 +4794,6 @@ Style/ModuleMemberExistenceCheck:
   Description: 'Checks for usage of `Module` methods returning arrays that can be replaced with equivalent predicates.'
   Enabled: pending
   VersionAdded: '1.82'
-  AllowedMethods: []
 
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'

--- a/lib/rubocop/cop/style/module_member_existence_check.rb
+++ b/lib/rubocop/cop/style/module_member_existence_check.rb
@@ -32,7 +32,6 @@ module RuboCop
       #   Array.private_instance_methods.include?(:foo)
       #   Array.protected_instance_methods.include?(:foo)
       #   Array.public_instance_methods.include?(:foo)
-      #   Array.included_modules.include?(:foo)
       #
       #   # good
       #   Array.class_variable_defined?(:foo)
@@ -40,15 +39,8 @@ module RuboCop
       #   Array.private_method_defined?(:foo)
       #   Array.protected_method_defined?(:foo)
       #   Array.public_method_defined?(:foo)
-      #   Array.include?(:foo)
-      #
-      # @example AllowedMethods: [included_modules]
-      #
-      #   # good
-      #   Array.included_modules.include?(:foo)
       #
       class ModuleMemberExistenceCheck < Base
-        include AllowedMethods
         extend AutoCorrector
 
         MSG = 'Use `%<replacement>s` instead.'
@@ -64,14 +56,13 @@ module RuboCop
         METHOD_REPLACEMENTS = {
           class_variables: :class_variable_defined?,
           constants: :const_defined?,
-          included_modules: :include?,
           instance_methods: :method_defined?,
           private_instance_methods: :private_method_defined?,
           protected_instance_methods: :protected_method_defined?,
           public_instance_methods: :public_method_defined?
         }.freeze
 
-        METHODS_WITHOUT_INHERIT_PARAM = Set[:class_variables, :included_modules].freeze
+        METHODS_WITHOUT_INHERIT_PARAM = Set[:class_variables].freeze
         METHODS_WITH_INHERIT_PARAM =
           (METHOD_REPLACEMENTS.keys.to_set - METHODS_WITHOUT_INHERIT_PARAM).freeze
 
@@ -81,7 +72,6 @@ module RuboCop
           return unless (parent = node.parent)
           return unless module_member_inclusion?(parent)
           return unless simple_method_argument?(node) && simple_method_argument?(parent)
-          return if allowed_method?(node.method_name)
 
           offense_range = node.location.selector.join(parent.source_range.end)
           replacement = replacement_for(node, parent)

--- a/spec/rubocop/cop/style/module_member_existence_check_spec.rb
+++ b/spec/rubocop/cop/style/module_member_existence_check_spec.rb
@@ -133,21 +133,10 @@ RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
         x.#{array_returning_method}(*foo).include?(method)
       RUBY
     end
-
-    context "when #{array_returning_method} is in AllowedMethods" do
-      let(:cop_config) { { 'AllowedMethods' => [array_returning_method.to_s] } }
-
-      it "does not register an offense when using `.#{array_returning_method}.include?(method)`" do
-        expect_no_offenses(<<~RUBY)
-          x.#{array_returning_method}.include?(method)
-        RUBY
-      end
-    end
   end
 
   it_behaves_like 'module member inclusion', :class_variables, :class_variable_defined?, false
   it_behaves_like 'module member inclusion', :constants, :const_defined?
-  it_behaves_like 'module member inclusion', :included_modules, :include?, false
   it_behaves_like 'module member inclusion', :instance_methods, :method_defined?
   it_behaves_like 'module member inclusion', :private_instance_methods, :private_method_defined?
   it_behaves_like 'module member inclusion', :protected_instance_methods, :protected_method_defined?


### PR DESCRIPTION
`Array.included_modules.include?(:foo)` and `Array.include?(:foo)` are not guaranteed to be interchangeable, and the risk of false positives is higher.

For this reason, providing a configuration option such as `AllowedMethods: [included_modules]` to specify target methods for detection does not make much sense.

Based on this, `included_modules` will no longer be handled by this cop, and the redundant `AllowedMethods` configuration option will be removed.

Although removing `AllowedMethods` may raise backward compatibility concerns, the feature was introduced relatively recently, so removal was chosen in this case.

Fixes #15035.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
