### PR TITLE
Fix incorrect autocorrect in `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_in_style_if_with_semicolon.md
+++ b/changelog/fix_incorrect_autocorrect_in_style_if_with_semicolon.md
@@ -1,0 +1,1 @@
+* [#15039](https://github.com/rubocop/rubocop/pull/15039): Fix incorrect autocorrect in `Style/IfWithSemicolon` when `return` with value is in the `else` branch. ([@koic][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -71,7 +71,7 @@ module RuboCop
         end
 
         def use_return_with_argument?(node)
-          node.if_branch&.return_type? && node.if_branch&.arguments&.any?
+          node.branches.compact.any? { |branch| branch.return_type? && branch.arguments.any? }
         end
 
         def replacement(node)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -321,6 +321,30 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
       RUBY
     end
 
+    it 'registers an offense when using `return` with value in `else` branch of `if` with a semicolon' do
+      expect_offense(<<~RUBY)
+        if cond; run else return value end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a newline instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if cond
+         run else return value end
+      RUBY
+    end
+
+    it 'registers an offense when using `return` with value in `else` branch of `unless` with a semicolon' do
+      expect_offense(<<~RUBY)
+        unless cond; run else return value end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if cond;` - use a newline instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        unless cond
+         run else return value end
+      RUBY
+    end
+
     it 'registers an offense when using `return` without value in `if` with a semicolon is used' do
       expect_offense(<<~RUBY)
         if cond; return end


### PR DESCRIPTION
This PR fixes incorrect autocorrect in `Style/IfWithSemicolon` when `return` with value is in the `else` branch.

`use_return_with_argument?` only checked `if_branch`, missing `return value` in the `else` branch. This caused invalid ternary output like `cond ? run : return value`. Now checks both branches.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
