### PR TITLE
[Fix #15043] Fix an error for `Lint/UselessDefaultValueArgument`

### DIFF
--- a/changelog/fix_merge_pull_request_14984_from_20260321150822.md
+++ b/changelog/fix_merge_pull_request_14984_from_20260321150822.md
@@ -1,0 +1,1 @@
+* [#15043](https://github.com/rubocop/rubocop/issues/15043): Fix an error for `Lint/UselessDefaultValueArgument` when `fetch` without a receiver is inside a `fetch` block. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_default_value_argument.rb
+++ b/lib/rubocop/cop/lint/useless_default_value_argument.rb
@@ -67,6 +67,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless node.receiver
+
           unless (prev_arg_node, default_value_node = default_value_argument_and_block(node.parent))
             return
           end

--- a/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
+++ b/spec/rubocop/cop/lint/useless_default_value_argument_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessDefaultValueArgument, :config do
       RUBY
     end
 
+    it 'registers an offense for `x.fetch(key, default_value) { fetch(arg) }`' do
+      expect_offense(<<~RUBY)
+        x.fetch(key, default_value) { fetch(arg) }
+                     ^^^^^^^^^^^^^ Block supersedes default value argument.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.fetch(key) { fetch(arg) }
+      RUBY
+    end
+
     it 'registers an offense for `x.fetch(key, default_value) { _1 }`' do
       expect_offense(<<~RUBY)
         x.fetch(key, default_value) { _1 }


### PR DESCRIPTION
`on_send` was triggered for a `fetch` call without a receiver inside a `fetch` block (e.g. `cache.fetch("key", 3600) { fetch(id) }`). The parent block matched the node pattern, then `allowed_receiver?` was called with `nil` receiver, causing `NoMethodError`.

Fixes #15043.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
