### PR TITLE
[Fix #10822] Don't cache if there are warnings

### DIFF
--- a/changelog/fix_warnings_with_cache.md
+++ b/changelog/fix_warnings_with_cache.md
@@ -1,0 +1,1 @@
+* [#10822](https://github.com/rubocop/rubocop/issues/10822): Don't store results in cache if there are warnings. ([@jonas054][])

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -16,7 +16,7 @@ module RuboCop
     end
 
     # Registry that tracks all cops by their badge and department.
-    class Registry
+    class Registry # rubocop:disable Metrics/ClassLength
       include Enumerable
 
       def self.all
@@ -46,7 +46,7 @@ module RuboCop
         global.qualify_badge(badge).first == badge
       end
 
-      attr_reader :options
+      attr_reader :options, :warnings
 
       def initialize(cops = [], options = {})
         @registry = {}
@@ -58,6 +58,7 @@ module RuboCop
 
         @enabled_cache = {}.compare_by_identity
         @disabled_cache = {}.compare_by_identity
+        @warnings = {}
       end
 
       def enlist(cop)
@@ -132,7 +133,7 @@ module RuboCop
       # @return [String] Qualified cop name
       def qualified_cop_name(name, path, warn: true)
         badge = Badge.parse(name)
-        print_warning(name, path) if warn && department_missing?(badge, name)
+        print_department_missing_warning(name, path) if warn && department_missing?(badge, name)
         return name if registered?(badge)
 
         potential_badges = qualify_badge(badge)
@@ -148,12 +149,12 @@ module RuboCop
         !badge.qualified? && unqualified_cop_names.include?(name)
       end
 
-      def print_warning(name, path)
-        message = "#{path}: Warning: no department given for #{name}."
+      def print_department_missing_warning(name, path)
+        message = "no department given for #{name}."
         if path.end_with?('.rb')
           message += ' Run `rubocop -a --only Migration/DepartmentName` to fix.'
         end
-        warn message
+        emit_warning(path, message)
       end
 
       def unqualified_cop_names
@@ -274,6 +275,10 @@ module RuboCop
         attr_reader :global
       end
 
+      def warnings?(path)
+        @warnings[path]
+      end
+
       private
 
       def initialize_copy(reg)
@@ -297,16 +302,18 @@ module RuboCop
       end
 
       def resolve_badge(given_badge, real_badge, source_path, warn: true)
-        unless given_badge.match?(real_badge)
-          path = PathUtil.smart_path(source_path)
-
-          if warn
-            warn("#{path}: #{given_badge} has the wrong namespace - " \
-                 "replace it with #{given_badge.with_department(real_badge.department)}")
-          end
+        if warn && !given_badge.match?(real_badge)
+          emit_warning(source_path,
+                       "#{given_badge} has the wrong namespace - " \
+                       "replace it with #{given_badge.with_department(real_badge.department)}")
         end
 
         real_badge.to_s
+      end
+
+      def emit_warning(path, message)
+        Registry.global.warnings[path] = true
+        warn "#{PathUtil.smart_path(path)}: Warning: #{message}"
       end
 
       def registered?(badge)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -194,7 +194,7 @@ module RuboCop
 
       if real_run_needed
         offenses = yield
-        save_in_cache(cache, offenses)
+        save_in_cache(cache, offenses) unless Cop::Registry.global.warnings?(file)
       end
 
       offenses

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           1 file inspected, 2 offenses detected, 1 offense autocorrectable
       RESULT
       expect($stderr.string).to eq(<<~RESULT)
-        #{abs('.rubocop.yml')}: Warning: no department given for EndOfLine.
+        .rubocop.yml: Warning: no department given for EndOfLine.
       RESULT
     end
   end
@@ -547,7 +547,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                    'end'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stderr.string)
-        .to eq(['example.rb: Style/LineLength has the wrong ' \
+        .to eq(['example.rb: Warning: Style/LineLength has the wrong ' \
                 'namespace - replace it with Layout/LineLength',
                 ''].join("\n"))
       # 2 real cops were disabled, and 1 that was incorrect
@@ -590,8 +590,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                      'y("123") # rubocop:disable StringLiterals'])
         expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
         expect($stderr.string).to eq(<<~OUTPUT)
-          #{abs('example.rb')}: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
-          #{abs('example.rb')}: Warning: no department given for StringLiterals. Run `rubocop -a --only Migration/DepartmentName` to fix.
+          example.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
+          example.rb: Warning: no department given for StringLiterals. Run `rubocop -a --only Migration/DepartmentName` to fix.
         OUTPUT
         expect($stdout.string)
           .to eq(<<~RESULT)
@@ -680,8 +680,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
             create_file('.rubocop.yml', config)
             expect(cli.run(['--format', 'emacs'])).to eq(1)
             expect($stderr.string).to eq(<<~OUTPUT)
-              #{abs('example.rb')}: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
-              #{abs('example.rb')}: Warning: no department given for ClassLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
+              example.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
+              example.rb: Warning: no department given for ClassLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
             OUTPUT
             expect($stdout.string)
               .to eq(<<~RESULT)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1019,7 +1019,7 @@ RSpec.describe RuboCop::ConfigLoader do
           expect { described_class.configuration_from_file('.rubocop.yml') }
             .to output(
               a_string_including(
-                '.rubocop.yml: Custom/Loop has the ' \
+                '.rubocop.yml: Warning: Custom/Loop has the ' \
                 "wrong namespace - replace it with Lint/Loop\n"
               )
             ).to_stderr

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::Registry do
     end
 
     it 'emits a warning when namespace is incorrect' do
-      warning = '/app/.rubocop.yml: Style/MethodLength has the wrong ' \
+      warning = '/app/.rubocop.yml: Warning: Style/MethodLength has the wrong ' \
                 "namespace - replace it with Metrics/MethodLength\n"
       qualified = nil
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -251,23 +251,40 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       end
     end
 
-    context 'if a cop crashes' do
+    context 'when results should not be saved to the cache' do
       before do
         # The cache responds that it's not valid, which means that new results
-        # should normally be collected and saved...
+        # should normally be collected and saved.
         cache = instance_double(RuboCop::ResultCache, 'valid?' => false)
-        # ... but there's a crash in one cop.
-        runner.errors = ['An error occurred in ...']
 
         allow(RuboCop::ResultCache).to receive(:new) { cache }
       end
 
-      let(:source) { '' }
+      context 'if a cop crashes' do
+        before { runner.errors = ['An error occurred in ...'] }
 
-      it 'does not call ResultCache#save' do
-        # The double doesn't define #save, so we'd get an error if it were
-        # called.
-        expect(runner.run([])).to be true
+        let(:source) { '' }
+
+        it 'does not call ResultCache#save' do
+          # The double doesn't define #save, so we'd get an error if it were
+          # called.
+          expect(runner.run([])).to be true
+        end
+      end
+
+      context 'if a warning is emitted for a file' do
+        include_context 'cli spec behavior'
+
+        let(:source) { 'x = 3 # rubocop:disable UselessAssignment' }
+
+        it 'does not call ResultCache#save' do
+          # The double doesn't define #save, so we'd get an error if it were called.
+          expect(runner.run([])).to be false
+
+          expect($stderr.string.chomp).to eq('example.rb: Warning: no department given for ' \
+                                             'UselessAssignment. Run `rubocop -a --only ' \
+                                             'Migration/DepartmentName` to fix.')
+        end
       end
     end
 


### PR DESCRIPTION
Warnings are similar to reported offenses from the users' point of view. They expect to get the same warnings reported in each run, even if the cache is turned on.

We add a hash for warnings per file in the global registry. If warnings have been emitted for a certain file, we don't store the inspection results in the cache, thus ensuring that the same warnings are printed in each run.

We were already using smart (relative) path for outputting one kind of warning. It makes sense to use the same kind of paths consistently in the registry.
