### PR TITLE
[Fix #15041] Remove `mcp` gem from runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'asciidoctor'
 gem 'bump', require: false
 gem 'fiddle', platform: :windows if RUBY_VERSION >= '3.4'
 gem 'irb'
+gem 'mcp', '~> 0.6'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'

--- a/changelog/change_remove_mcp_gem_from_runtime_dependency.md
+++ b/changelog/change_remove_mcp_gem_from_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#15041](https://github.com/rubocop/rubocop/issues/15041): Remove `mcp` gem from runtime dependencies. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/mcp.adoc
+++ b/docs/modules/ROOT/pages/usage/mcp.adoc
@@ -13,6 +13,31 @@ Through MCP, RuboCop operations are initiated by an MCP client, with decisions m
 The MCP server runs as a long-lived process over stdio, allowing an MCP client to request analysis and autocorrection without spawning a new RuboCop process for each request.
 This is based on the same principles as xref:usage/server.adoc[Server Mode] and xref:usage/lsp.adoc[LSP].
 
+== Setup
+
+The `mcp` gem is required but is not included as a dependency of RuboCop. You must install it separately.
+
+If you use Bundler, add the following to your `Gemfile`:
+
+[source,ruby]
+----
+gem 'mcp', '~> 0.6'
+----
+
+Then run:
+
+[source,console]
+----
+$ bundle install
+----
+
+If you do not use Bundler:
+
+[source,console]
+----
+$ gem install mcp
+----
+
 == Available Tools
 
 The MCP server exposes two tools:

--- a/lib/rubocop/mcp/server.rb
+++ b/lib/rubocop/mcp/server.rb
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
-require 'mcp'
+begin
+  require 'mcp'
+
+  required_mcp_version = '0.6.0'
+
+  if Gem::Version.new(required_mcp_version) > Gem::Version.new(MCP::VERSION)
+    # While `mcp` is not a runtime dependency, users may have an outdated version installed.
+    warn <<~MESSAGE
+      Error: `mcp` gem version #{MCP::VERSION} was loaded, but `rubocop --mcp` requires #{required_mcp_version}.
+      - If you're using Bundler and don't yet have `gem 'mcp'` as a dependency, add it now.
+      - If you're using Bundler and already have `gem 'mcp'` as a dependency, update it to the most recent version.
+      - If you don't use Bundler, run `gem update mcp`.
+    MESSAGE
+    exit!
+  end
+rescue LoadError => e
+  raise unless e.path == 'mcp'
+
+  warn <<~MESSAGE
+    Error: Unable to load `mcp` gem. Add `gem 'mcp', '~> 0.6'` to your Gemfile, or run `gem install mcp`.
+  MESSAGE
+
+  exit!
+end
+
 require_relative '../lsp'
 require_relative '../lsp/runtime'
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   # where x.y.z indicates the Language Server Protocol Specification, t is an incrementing number.
   s.add_dependency('language_server-protocol', '~> 3.17.0.2')
   s.add_dependency('lint_roller', '~> 1.1.0')
-  s.add_dependency('mcp', '~> 0.6')
   s.add_dependency('parallel', '~> 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')


### PR DESCRIPTION
The built-in MCP support is still experimental, and not all users need the `mcp` gem at runtime. Remove it from the runtime dependencies and require users of this feature to install it separately, as documented.

Fixes #15041.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
