### PR TITLE
[Fix #14977] Support `AllowedReceivers` for `Style/HashLookupMethod`

### DIFF
--- a/changelog/new_support_allowed_receivers_for_style_hash_lookup_method.md
+++ b/changelog/new_support_allowed_receivers_for_style_hash_lookup_method.md
@@ -1,0 +1,1 @@
+* [#14977](https://github.com/rubocop/rubocop/issues/14977): Support `AllowedReceivers` for `Style/HashLookupMethod`. ([@koic][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -41,8 +41,13 @@ module RuboCop
       #   # good
       #   hash.fetch(key)
       #
+      # @example AllowedReceivers: ['Rails.cache']
+      #   # good
+      #   Rails.cache.fetch(name, options) { block }
+      #
       class HashLookupMethod < Base
         include ConfigurableEnforcedStyle
+        include AllowedReceivers
         extend AutoCorrector
 
         BRACKET_MSG = 'Use `Hash#[]` instead of `Hash#fetch`.'
@@ -51,6 +56,8 @@ module RuboCop
         RESTRICT_ON_SEND = %i[[] fetch].freeze
 
         def on_send(node)
+          return if (receiver = node.receiver) && allowed_receiver?(receiver)
+
           if offense_for_brackets?(node)
             add_offense(node.loc.selector, message: BRACKET_MSG) do |corrector|
               correct_fetch_to_brackets(corrector, node)

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -114,4 +114,14 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
       end
     end
   end
+
+  context "when `AllowedReceivers: ['Rails.cache']`" do
+    let(:cop_config) { { 'AllowedReceivers' => ['Rails.cache'] } }
+
+    it 'does not register an offense for `Rails.cache.fetch(name, options) { block }`' do
+      expect_no_offenses(<<~RUBY)
+        Rails.cache.fetch(name, options) { block }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This follows the same approach as `Lint/UselessDefaultValueArgument`: https://docs.rubocop.org/rubocop/latest/cops_lint.html#examples-lintuselessdefaultvalueargument

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
