### PR TITLE
[Fix #15048] Fix issue where the url_for is missing for Cops without instance methods

### DIFF
--- a/changelog/fix_fix_issue_where_the_url_for_is_missing_for_cops_20260323111148.md
+++ b/changelog/fix_fix_issue_where_the_url_for_is_missing_for_cops_20260323111148.md
@@ -1,0 +1,1 @@
+* [#15048](https://github.com/rubocop/rubocop/pull/15048): Fix issue where the url_for is missing for Cops without instance methods. ([@Fryguy][])

--- a/lib/rubocop/cop/documentation.rb
+++ b/lib/rubocop/cop/documentation.rb
@@ -55,10 +55,9 @@ module RuboCop
 
       # @api private
       def builtin?(cop_class)
-        # any custom method will do
-        return false unless (m = cop_class.instance_methods(false).first)
+        return false unless (name = cop_class.name)
 
-        path, _line = cop_class.instance_method(m).source_location
+        path, _line = Module.const_source_location(name)
         path.start_with?(__dir__)
       end
     end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe RuboCop::Cop::Cop, :config do
 
         it { is_expected.to be_nil }
       end
+
+      describe 'for a builtin cop class with only private methods' do
+        let(:cop_class) { RuboCop::Cop::Layout::AssignmentIndentation }
+
+        it 'returns the documentation URL' do
+          expect(cop_class.instance_methods(false)).to be_empty
+          expect(url).to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutassignmentindentation'
+        end
+      end
+
+      describe 'for an anonymous class' do
+        it 'is not considered builtin' do
+          expect(RuboCop::Cop::Documentation).not_to be_builtin(Class.new)
+        end
+      end
     end
 
     context 'when passing a config' do


### PR DESCRIPTION
Due to the way RuboCop::Cop::Documentation#builtin? checks for the source location by looking at non-inherited instance methods, some cops were not being detected properly as built-in. These cops are

Layout/AssignmentIndentation
Lint/UnusedBlockArgument
Metrics/CyclomaticComplexity
Metrics/AbcSize
Metrics/PerceivedComplexity
Style/HashExcept
Style/HashSlice

This PR changes the detection to look at the const_source_location instead.

Fixes #15048

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
