### PR TITLE
[Fix #15042] Add `DisallowedCops` option to `Style/DisableCopsWithinSourceCodeDirective`

### DIFF
--- a/changelog/new_add_disallowed_cops_option_20260323210952.md
+++ b/changelog/new_add_disallowed_cops_option_20260323210952.md
@@ -1,0 +1,1 @@
+* [#15042](https://github.com/rubocop/rubocop/issues/15042): Add `DisallowedCops` configuration option to `Style/DisableCopsWithinSourceCodeDirective`. ([@hammadxcm][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3909,8 +3909,9 @@ Style/DisableCopsWithinSourceCodeDirective:
                  Forbids disabling/enabling cops within source code.
   Enabled: false
   VersionAdded: '0.82'
-  VersionChanged: '1.9'
+  VersionChanged: '<<next>>'
   AllowedCops: []
+  DisallowedCops: []
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -12,6 +12,13 @@ module RuboCop
       # Specific cops can be allowed with the `AllowedCops` configuration. Note that
       # if this configuration is set, `rubocop:disable all` is still disallowed.
       #
+      # Alternatively, specific cops can be disallowed with the `DisallowedCops`
+      # configuration. When `DisallowedCops` is set, only directives for the listed
+      # cops (and `all`) will be flagged. This is useful when you want
+      # to protect a small set of critical cops from being disabled rather than
+      # allowlisting all other cops. `AllowedCops` and `DisallowedCops` should not
+      # both be set at the same time; if `DisallowedCops` is set, it takes precedence.
+      #
       # @example
       #   # bad
       #   # rubocop:disable Metrics/AbcSize
@@ -30,6 +37,17 @@ module RuboCop
       #   end
       #   # rubocop:enable Metrics/AbcSize
       #
+      # @example DisallowedCops: [Lint/Void]
+      #   # bad
+      #   # rubocop:disable Lint/Void
+      #   foo
+      #   # rubocop:enable Lint/Void
+      #
+      #   # good
+      #   # rubocop:disable Metrics/AbcSize
+      #   foo
+      #   # rubocop:enable Metrics/AbcSize
+      #
       class DisableCopsWithinSourceCodeDirective < Base
         extend AutoCorrector
 
@@ -40,7 +58,7 @@ module RuboCop
         def on_new_investigation
           processed_source.comments.each do |comment|
             directive_cops = directive_cops(comment)
-            disallowed_cops = directive_cops - allowed_cops
+            disallowed_cops = compute_disallowed_cops(directive_cops)
 
             next unless disallowed_cops.any?
 
@@ -50,8 +68,20 @@ module RuboCop
 
         private
 
+        def compute_disallowed_cops(directive_cops)
+          if disallowed_cops_config.any?
+            if directive_cops.include?('all')
+              directive_cops
+            else
+              directive_cops & disallowed_cops_config
+            end
+          else
+            directive_cops - allowed_cops
+          end
+        end
+
         def register_offense(comment, directive_cops, disallowed_cops)
-          message = if any_cops_allowed?
+          message = if any_cops_allowed? || disallowed_cops_config.any?
                       format(MSG_FOR_COPS, cops: "`#{disallowed_cops.join('`, `')}`")
                     else
                       MSG
@@ -80,6 +110,10 @@ module RuboCop
 
         def any_cops_allowed?
           allowed_cops.any?
+        end
+
+        def disallowed_cops_config
+          @disallowed_cops_config ||= Array(cop_config['DisallowedCops'])
         end
       end
     end

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -93,4 +93,114 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       end
     end
   end
+
+  context 'with DisallowedCops' do
+    let(:cop_config) { { 'DisallowedCops' => ['Lint/Void', 'Security/Eval'] } }
+
+    context 'when a disallowed cop is disabled' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:disable Lint/Void
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `Lint/Void` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo#{trailing_whitespace}
+        RUBY
+      end
+    end
+
+    context 'when a non-disallowed cop is disabled' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo # rubocop:disable Metrics/AbcSize
+          end
+        RUBY
+      end
+    end
+
+    context 'when enabling all cops' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:enable all
+              ^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `all` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo#{trailing_whitespace}
+        RUBY
+      end
+    end
+
+    context 'when disabling all cops' do
+      # `rubocop:disable all` disables this cop as well, so its offense is suppressed.
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo # rubocop:disable all
+        RUBY
+      end
+    end
+
+    context 'when a mix of disallowed and non-disallowed cops are disabled' do
+      it 'registers an offense only for the disallowed cops and corrects' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:disable Metrics/AbcSize, Lint/Void, Style/AndOr
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `Lint/Void` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo # rubocop:disable Metrics/AbcSize, Style/AndOr
+        RUBY
+      end
+    end
+
+    context 'when multiple disallowed cops are disabled along with allowed ones' do
+      it 'registers an offense for all disallowed cops and corrects' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:disable Lint/Void, Metrics/AbcSize, Security/Eval
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `Lint/Void`, `Security/Eval` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo # rubocop:disable Metrics/AbcSize
+        RUBY
+      end
+    end
+
+    context 'when a non-disallowed cop is enabled' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:enable Metrics/AbcSize
+        RUBY
+      end
+    end
+
+    context 'when using leading source comment' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          # comment
+
+          class Foo
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when both AllowedCops and DisallowedCops are set' do
+    let(:cop_config) do
+      { 'AllowedCops' => ['Lint/Void'], 'DisallowedCops' => ['Security/Eval'] }
+    end
+
+    it 'gives DisallowedCops precedence and ignores AllowedCops' do
+      expect_offense(<<~RUBY)
+        foo # rubocop:disable Lint/Void, Security/Eval
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `Security/Eval` are not permitted.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo # rubocop:disable Lint/Void
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/15042

## Summary

- Adds a `DisallowedCops` configuration option to `Style/DisableCopsWithinSourceCodeDirective`, the inverse of the existing `AllowedCops`.
- When `DisallowedCops` is set, only directives for the listed cops (and `rubocop:disable all`) are flagged — all other cops can be freely disabled.
- This is useful when you want to protect a small set of critical cops (e.g. `Lint/Void`) from being disabled rather than allowlisting hundreds of cops.

### Context

This addresses a different use case from #14598. Where #14598 is about preventing `Style/DisableCopsWithinSourceCodeDirective` itself from being disabled, this feature is about selectively protecting a small set of critical cops without needing to allowlist every other cop. See the discussion in #14598 and the prior PR #14705 for background.

### Example configuration

```yaml
Style/DisableCopsWithinSourceCodeDirective:
  Enabled: true
  DisallowedCops:
    - Lint/Void
    - Security/Eval
```

With this config, `# rubocop:disable Lint/Void` is flagged, but `# rubocop:disable Metrics/AbcSize` is allowed.

## Test plan

- [x] Added specs for `DisallowedCops`: single disallowed cop, non-disallowed cop, mixed directives, multiple disallowed cops, `rubocop:enable all`, and leading source comments
- [x] Verified all existing `AllowedCops` specs still pass (no regressions)
- [x] `bundle exec rake` passes (all specs + self-lint + doc syntax check)

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/