### PR TITLE
Fix Style/RedundantParentheses handling of beginless ranges

### DIFF
--- a/changelog/fix_fix_style_redundant_parentheses_handling_of_20260323145406.md
+++ b/changelog/fix_fix_style_redundant_parentheses_handling_of_20260323145406.md
@@ -1,0 +1,1 @@
+* [#15051](https://github.com/rubocop/rubocop/pull/15051): Fix `Style/RedundantParentheses` handling of beginless ranges. ([@oggy][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -270,14 +270,16 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def body_range?(begin_node, node)
           return false unless node.range_type?
           return false unless (parent = begin_node.parent)
-          return false if parent.pair_type?
+          return false if parent.pair_type? || begin_node.chained?
 
           (node.begin.nil? && begin_node == parent.children.first) ||
             (node.end.nil? && begin_node == parent.children.last)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def disallowed_one_line_pattern_matching?(begin_node, node)
           if (parent = begin_node.parent)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1034,6 +1034,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses around a beginless range with chained method call' do
+    expect_no_offenses(<<~RUBY)
+      (..1).cover?(0)
+    RUBY
+  end
+
+  it 'accepts parentheses around an endless range with chained method call' do
+    expect_no_offenses(<<~RUBY)
+      (1..).cover?(42)
+    RUBY
+  end
+
   it 'registers an offense when the use of parentheses around `&&` expressions in assignment' do
     expect_offense(<<~RUBY)
       var = (foo && bar)


### PR DESCRIPTION
This was being spuriously flagged:

```
rubocop_test.rb:1:1: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around block body.
(..1).cover?(0)
^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
