### PR TITLE
[Fix #15040] Exclude `constants` from `Style/ModuleMemberExistenceCheck`

### DIFF
--- a/changelog/fix_exclude_constants_from_style_module_member_existence_check.md
+++ b/changelog/fix_exclude_constants_from_style_module_member_existence_check.md
@@ -1,0 +1,1 @@
+* [#15040](https://github.com/rubocop/rubocop/issues/15040): Exclude `constants` from `Style/ModuleMemberExistenceCheck`. ([@t-daisuke][])

--- a/lib/rubocop/cop/style/module_member_existence_check.rb
+++ b/lib/rubocop/cop/style/module_member_existence_check.rb
@@ -13,6 +13,12 @@ module RuboCop
       # array, while `method_defined?` will do direct method lookup, which is much
       # faster and consumes less memory.
       #
+      # NOTE: `constants.include?` is not handled by this cop because
+      # `Module#const_defined?` has different lookup behavior than
+      # `Module#constants` - `const_defined?` searches up to `Object`
+      # (top-level constants like `String`, `Integer`, etc.) while
+      # `constants` does not, which can cause behavior changes after autocorrection.
+      #
       # @example
       #   # bad
       #   Array.instance_methods.include?(:size)
@@ -28,14 +34,12 @@ module RuboCop
       #
       #   # bad
       #   Array.class_variables.include?(:foo)
-      #   Array.constants.include?(:foo)
       #   Array.private_instance_methods.include?(:foo)
       #   Array.protected_instance_methods.include?(:foo)
       #   Array.public_instance_methods.include?(:foo)
       #
       #   # good
       #   Array.class_variable_defined?(:foo)
-      #   Array.const_defined?(:foo)
       #   Array.private_method_defined?(:foo)
       #   Array.protected_method_defined?(:foo)
       #   Array.public_method_defined?(:foo)
@@ -55,7 +59,6 @@ module RuboCop
 
         METHOD_REPLACEMENTS = {
           class_variables: :class_variable_defined?,
-          constants: :const_defined?,
           instance_methods: :method_defined?,
           private_instance_methods: :private_method_defined?,
           protected_instance_methods: :protected_method_defined?,

--- a/spec/rubocop/cop/style/module_member_existence_check_spec.rb
+++ b/spec/rubocop/cop/style/module_member_existence_check_spec.rb
@@ -136,7 +136,13 @@ RSpec.describe RuboCop::Cop::Style::ModuleMemberExistenceCheck, :config do
   end
 
   it_behaves_like 'module member inclusion', :class_variables, :class_variable_defined?, false
-  it_behaves_like 'module member inclusion', :constants, :const_defined?
+
+  it 'does not register an offense when using `.constants.include?`' do
+    expect_no_offenses(<<~RUBY)
+      x.constants.include?(:String)
+    RUBY
+  end
+
   it_behaves_like 'module member inclusion', :instance_methods, :method_defined?
   it_behaves_like 'module member inclusion', :private_instance_methods, :private_method_defined?
   it_behaves_like 'module member inclusion', :protected_instance_methods, :protected_method_defined?


### PR DESCRIPTION
Fixes #15040.

Exclude `constants` from `Style/ModuleMemberExistenceCheck` because
`Module#const_defined?` searches up to `Object` while `Module#constants` does not.

This follows the same approach as #15038 for `included_modules`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/