### PR TITLE
Fix Lint/DuplicateMethods false positives with anonymous classes

### DIFF
--- a/changelog/fix_duplicate_methods_false_positives_anonymous_classes_in_blocks.md
+++ b/changelog/fix_duplicate_methods_false_positives_anonymous_classes_in_blocks.md
@@ -1,0 +1,1 @@
+* [#15055](https://github.com/rubocop/rubocop/pull/15055): Fix `Lint/DuplicateMethods` false positives with anonymous classes inside blocks (e.g. RSpec `let`, `describe`). ([@ShkumbinDelija][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -308,7 +308,7 @@ module RuboCop
         def anonymous_class_block(node)
           first_block = node.each_ancestor(:block).first
           return unless class_or_module_new_block?(first_block)
-          return if first_block.parent&.type?(:lvasgn, :block)
+          return if first_block.parent&.type?(:lvasgn)
           return if node.each_ancestor(:sclass).any? { |s| !s.children.first.self_type? }
 
           first_block
@@ -316,13 +316,18 @@ module RuboCop
 
         def anon_block_scope_id(anon_block)
           parent = anon_block.parent
-          return unless parent&.call_type?
+          return unless parent&.type?(:any_block, :begin, :call)
 
-          if parent.receiver
-            "#{parent.receiver.source}.#{parent.method_name}"
-          else
+          if (receiver = named_receiver(parent))
+            "#{receiver.source}.#{parent.method_name}"
+          elsif !parent.begin_type? || parent.parent&.any_block_type?
             source_location(anon_block)
           end
+        end
+
+        def named_receiver(node)
+          receiver = node.receiver
+          receiver unless class_or_module_new_block?(receiver)
         end
 
         def found_sclass_method(node, name)

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1064,6 +1064,361 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'inside blocks with multiple statements' do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        a = bar
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+
+      foo do
+        b = baz
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'inside blocks with multiple statements' do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        a = bar
+        Class.new do
+          def self.name
+            'Foo'
+          end
+        end
+      end
+
+      foo do
+        b = baz
+        Class.new do
+          def self.name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'inside numblocks with multiple statements', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        _1
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+
+      bar do
+        _1
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'inside numblocks with multiple statements', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        _1
+        Class.new do
+          def self.name
+            'Foo'
+          end
+        end
+      end
+
+      bar do
+        _1
+        Class.new do
+          def self.name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'inside itblocks with multiple statements', :ruby34 do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        it
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+
+      bar do
+        it
+        Class.new do
+          def custom_validation
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'inside itblocks with multiple statements', :ruby34 do
+    expect_no_offenses(<<~RUBY)
+      foo do
+        it
+        Class.new do
+          def self.name
+            'Foo'
+          end
+        end
+      end
+
+      bar do
+        it
+        Class.new do
+          def self.name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks inside blocks' do
+    expect_no_offenses(<<~RUBY)
+      let(:foo_class) do
+        Class.new do
+          def name
+            'Foo'
+          end
+        end
+      end
+
+      let(:bar_class) do
+        Class.new do
+          def name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks inside blocks' do
+    expect_no_offenses(<<~RUBY)
+      let(:foo_class) do
+        Class.new do
+          def self.name
+            'Foo'
+          end
+        end
+      end
+
+      let(:bar_class) do
+        Class.new do
+          def self.name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks inside describe blocks' do
+    expect_no_offenses(<<~RUBY)
+      describe 'something' do
+        Class.new do
+          def foo
+            1
+          end
+        end
+      end
+
+      describe 'other' do
+        Class.new do
+          def foo
+            2
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for duplicate methods inside the same Class.new block inside a block' do
+    expect_offense(<<~RUBY)
+      let(:klass) do
+        Class.new do
+          def foo
+            1
+          end
+          def foo
+          ^^^^^^^ Method `::Object#foo` is defined at both (string):3 and (string):6.
+            2
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for duplicate class methods inside the same Class.new block inside a block' do
+    expect_offense(<<~RUBY)
+      let(:klass) do
+        Class.new do
+          def self.foo
+            1
+          end
+          def self.foo
+          ^^^^^^^^^^^^ Method `::Object.foo` is defined at both (string):3 and (string):6.
+            2
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Module.new blocks inside blocks' do
+    expect_no_offenses(<<~RUBY)
+      let(:foo_mod) do
+        Module.new do
+          def name
+            'Foo'
+          end
+        end
+      end
+
+      let(:bar_mod) do
+        Module.new do
+          def name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Module.new blocks with chained method calls' do
+    expect_no_offenses(<<~RUBY)
+      Module.new { def test; end }
+            .instance_method(:test)
+
+      Module.new { def test; end }
+            .instance_method(:test)
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Module.new blocks ' \
+     'with endless methods and chained calls', :ruby30 do
+    expect_no_offenses(<<~RUBY)
+      Module.new { def test(*one, **two, &block) = super(one, two, yield(block)) }
+            .instance_method(:test)
+            .parameters
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks inside numblocks', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      foo { Class.new(_1) { def name; end } }
+
+      bar { Class.new(_1) { def name; end } }
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks inside numblocks', :ruby27 do
+    expect_no_offenses(<<~RUBY)
+      foo { Class.new(_1) { def self.name; 'Foo'; end } }
+
+      bar { Class.new(_1) { def self.name; 'Bar'; end } }
+    RUBY
+  end
+
+  it 'registers an offense for duplicate methods inside the same Class.new block inside a numblock', :ruby27 do
+    expect_offense(<<~RUBY)
+      foo { Class.new(_1) do
+          def foo
+            1
+          end
+          def foo
+          ^^^^^^^ Method `Object#foo` is defined at both (string):2 and (string):5.
+            2
+          end
+        end
+      }
+    RUBY
+  end
+
+  it 'registers an offense for duplicate class methods inside the same Class.new block inside a numblock', :ruby27 do
+    expect_offense(<<~RUBY)
+      foo { Class.new(_1) do
+          def self.foo
+            1
+          end
+          def self.foo
+          ^^^^^^^^^^^^ Method `Object.foo` is defined at both (string):2 and (string):5.
+            2
+          end
+        end
+      }
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks inside itblocks', :ruby34 do
+    expect_no_offenses(<<~RUBY)
+      foo { Class.new(it) { def name; end } }
+
+      bar { Class.new(it) { def name; end } }
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks inside itblocks', :ruby34 do
+    expect_no_offenses(<<~RUBY)
+      foo { Class.new(it) { def self.name; 'Foo'; end } }
+
+      bar { Class.new(it) { def self.name; 'Bar'; end } }
+    RUBY
+  end
+
+  it 'registers an offense for duplicate methods inside the same Class.new block inside an itblock', :ruby34 do
+    expect_offense(<<~RUBY)
+      foo { Class.new(it) do
+          def foo
+            1
+          end
+          def foo
+          ^^^^^^^ Method `Object#foo` is defined at both (string):2 and (string):5.
+            2
+          end
+        end
+      }
+    RUBY
+  end
+
+  it 'registers an offense for duplicate class methods inside the same Class.new block inside an itblock', :ruby34 do
+    expect_offense(<<~RUBY)
+      foo { Class.new(it) do
+          def self.foo
+            1
+          end
+          def self.foo
+          ^^^^^^^^^^^^ Method `Object.foo` is defined at both (string):2 and (string):5.
+            2
+          end
+        end
+      }
+    RUBY
+  end
+
   it 'does not register an offense when there are same `alias_method` name outside `ensure` scope' do
     expect_no_offenses(<<~RUBY)
       module FooTest


### PR DESCRIPTION
## Summary

Fixes false positives in `Lint/DuplicateMethods` when `Class.new`/`Module.new` blocks are nested inside other blocks like RSpec `let`, `describe`, or any method block.

```ruby
# These were incorrectly flagged as duplicates
let(:foo_class) do
  Class.new do
    def name
      'Foo'
    end
  end
end

let(:bar_class) do
  Class.new do
    def name  # false positive: "Method Object#name is defined at both..."
      'Bar'
    end
  end
end
```

Also fixes the related edge case from https://github.com/rubocop/rubocop/issues/15028#issuecomment-4114266834 where chained calls on `Module.new` blocks caused false positives:

```ruby
# Also incorrectly flagged
Module.new { def test(*one, **two, &block) = super one, two, yield(block) }
      .instance_method(:test)
      .parameters
```

### What changed

- **`anonymous_class_block`** — removed `:block` from the bail-out guard. Previously the method returned `nil` whenever the `Class.new` block's parent was another block (like `let`), which prevented the anonymous class detection path from being used at all.
- **`anon_block_scope_id`** — reworked to handle wrapping blocks and chained calls. When a `Class.new` block is wrapped in another block, the file/line location is used as the scope ID so each block is unique. When the parent is a call with a named receiver (e.g. `A.prepend(Module.new { })`), the receiver-based scope ID is preserved so real duplicates on the same receiver are still caught.

### What's preserved

- Duplicate methods inside the same `Class.new` block are still detected
- `A.prepend(Module.new { def foo; end })` called twice still flags correctly
- `klass = Class.new { }` with local variable assignment still works (scoped by variable)
- All existing tests pass

---
Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
