### PR TITLE
Fix `Layout/LineLength` with `SplitStrings` enabled

### DIFF
--- a/changelog/fix_layout_line_length_with_split_strings_enabled_20260324194606.md
+++ b/changelog/fix_layout_line_length_with_split_strings_enabled_20260324194606.md
@@ -1,0 +1,1 @@
+* [#15059](https://github.com/rubocop/rubocop/pull/15059): Fix an error in `Layout/LineLength` when `SplitStrings` option is enabled and `__FILE__` is used. ([@jeromedalbert][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -406,9 +406,11 @@ module RuboCop
         end
 
         def string_delimiter(node)
-          delimiter = node.loc.begin
-          delimiter ||= node.parent.loc.begin if node.parent&.dstr_type? && node.parent.loc?(:begin)
-          delimiter = delimiter&.source
+          delimiter = if node.loc?(:begin)
+                        node.loc.begin
+                      elsif node.parent&.dstr_type? && node.parent.loc?(:begin)
+                        node.parent.loc.begin
+                      end&.source
 
           delimiter if %w[' "].include?(delimiter)
         end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -650,6 +650,18 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     end
   end
 
+  context 'when SplitStrings is enabled' do
+    let(:cop_config) { { 'Max' => 80, 'SplitStrings' => true } }
+
+    it 'accepts a line that contains __FILE__' do
+      expect { expect_no_offenses(<<~RUBY) }.not_to raise_error
+        if __FILE__ == $PROGRAM_NAME
+          do_something
+        end
+      RUBY
+    end
+  end
+
   context 'affecting by IndentationWidth from Layout\Tab' do
     shared_examples 'with tabs indentation' do
       it "registers an offense for a line that's including 2 tab with size 2 " \


### PR DESCRIPTION
This fixes a `NoMethodError` that happens when linting a file that contains `__FILE__` and the `SplitStrings` option is enabled for the `Layout/LineLength` cop.

### Error message

```
An error occurred while Layout/LineLength cop was inspecting /Users/jerome/c/my_project/test.rb:1:3.
/Users/jerome/.mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rubocop-1.81.7/lib/rubocop/cop/layout/line_length.rb:403:in 'RuboCop::Cop::Layout::LineLength#string_delimiter': undefined method 'begin' for an instance of Parser::Source::Map (NoMethodError)

          delimiter = node.loc.begin
                              ^^^^^^
	from /Users/jerome/.mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rubocop-1.81.7/lib/rubocop/cop/layout/line_length.rb:151:in 'RuboCop::Cop::Layout:       :LineLength#check_for_breakable_str'
	from /Users/jerome/.mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rubocop-1.81.7/lib/rubocop/cop/layout/line_length.rb:81:in 'RuboCop::Cop::Layout::       LineLength#on_str'
```

### Repro file

```ruby
if __FILE__ == $PROGRAM_NAME
  do_something
end
```