### PR TITLE
[Fix #5876] Fix Lint/UnusedMethodArgument false positive when yield is used

### DIFF
--- a/changelog/fix_merge_pull_request_15055_from_20260325140210.md
+++ b/changelog/fix_merge_pull_request_15055_from_20260325140210.md
@@ -1,0 +1,1 @@
+* [#5876](https://github.com/rubocop/rubocop/issues/5876): Fix `Lint/UnusedMethodArgument` false positive when block argument is used via `yield`. ([@dduugg][])

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -95,8 +95,18 @@ module RuboCop
           return unless variable.method_argument?
           return if variable.keyword_argument? && cop_config['AllowUnusedKeywordArguments']
           return if ignored_method?(variable.scope.node.body)
+          return if block_argument_with_yield?(variable)
 
           super
+        end
+
+        def block_argument_with_yield?(variable)
+          return false unless variable.declaration_node.blockarg_type?
+
+          method_body = variable.scope.node.body
+          return false unless method_body
+
+          method_body.yield_type? || method_body.each_descendant(:yield).any?
         end
 
         def ignored_method?(body)

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -221,6 +221,52 @@ RSpec.describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
+    context 'when a trailing block argument is used with yield' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def some_method(&block)
+            yield
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when yield is in a nested block' do
+        expect_no_offenses(<<~RUBY)
+          def some_method(&block)
+            items.each do |item|
+              yield item
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when yield is in a conditional' do
+        expect_no_offenses(<<~RUBY)
+          def some_method(&block)
+            yield if condition
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when yield has arguments' do
+        expect_no_offenses(<<~RUBY)
+          def some_method(&block)
+            yield 1, 2, 3
+          end
+        RUBY
+      end
+    end
+
+    context 'when a trailing block argument is used with block.call' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def some_method(&block)
+            block.call
+          end
+        RUBY
+      end
+    end
+
     context 'when a singleton method argument is unused' do
       it 'registers an offense' do
         message = "Unused method argument - `foo`. If it's necessary, use " \


### PR DESCRIPTION
This PR fixes a false positive in `Lint/UnusedMethodArgument` where block arguments were incorrectly flagged as unused when `yield` is used instead of `block.call`.

The cop now treats `yield` and `block.call` equivalently, which aligns with the `Performance/RedundantBlockCall` cop that recommends rewriting `block.call` to `yield` for better performance. (Although the enforced consistency is more valuable than any performance win, speaking for myself.)

### Before

```ruby
def foo(&block)
  yield
end
# => Offense: Unused method argument - `block`
```

### After

```ruby
def foo(&block)
  yield
end
# => No offense (block is implicitly used by yield)
```

### Changes

- Added `block_argument_with_yield?` method to detect when a block parameter is used via `yield`
- Updated `check_argument` to skip block parameters when `yield` is present in the method body
- Added comprehensive specs covering various yield scenarios (nested blocks, conditionals, with arguments)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/