### PR TITLE
Disable `Style/RedundantStructKeywordInit` by default

### DIFF
--- a/changelog/change_update_examples_in_style_one_class_per_file_cop_20260327124301.md
+++ b/changelog/change_update_examples_in_style_one_class_per_file_cop_20260327124301.md
@@ -1,0 +1,1 @@
+* [#15063](https://github.com/rubocop/rubocop/pull/15063): Disable `Style/RedundantStructKeywordInit` cop by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5557,9 +5557,10 @@ Style/RedundantStringEscape:
 
 Style/RedundantStructKeywordInit:
   Description: 'Checks for redundant `keyword_init` option for `Struct.new`.'
-  Enabled: pending
+  Enabled: false
   SafeAutoCorrect: false
   VersionAdded: '1.85'
+  VersionChanged: '<<next>>'
 
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'

--- a/lib/rubocop/cop/style/redundant_struct_keyword_init.rb
+++ b/lib/rubocop/cop/style/redundant_struct_keyword_init.rb
@@ -9,6 +9,16 @@ module RuboCop
       # Therefore, this cop detects and autocorrects redundant `keyword_init: nil`
       # and `keyword_init: true` in `Struct.new`.
       #
+      # This cop is disabled by default because `keyword_init: true` is not purely
+      # redundant. It changes behavior in the following ways:
+      #
+      # - `Struct#keyword_init?` returns `true` instead of `nil`.
+      # - A `Struct` with `keyword_init: true` accepts a `Hash` argument and
+      #   expands it as keyword arguments, whereas without it the `Hash` is
+      #   treated as a positional argument.
+      # - `keyword_init: true` raises an `ArgumentError` for positional arguments,
+      #   enforcing keyword-only initialization.
+      #
       # @safety
       #   This autocorrect is unsafe because when the value of `keyword_init` changes
       #   from `true` to `nil`, the return value of `Struct#keyword_init?` changes.


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/13501#issuecomment-4127100327.

`keyword_init: true` is not purely redundant in Ruby 3.2+ because it changes behavior in the following ways:

- `Struct#keyword_init?` returns `true` instead of `nil`.
- A `Struct` with `keyword_init: true` accepts a `Hash` argument and expands it as keyword arguments, whereas without it the `Hash` is treated as a positional argument.
- `keyword_init: true` raises an `ArgumentError` for positional arguments, enforcing keyword-only initialization.

This PR disables `Style/RedundantStructKeywordInit` by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
