### PR TITLE
[Fix #14665] Cache plugin integration in CopHelper to avoid repeated loading

### DIFF
--- a/changelog/fix_cache_plugin_integration_in_cop_helper_to_avoid_20260327201556.md
+++ b/changelog/fix_cache_plugin_integration_in_cop_helper_to_avoid_20260327201556.md
@@ -1,0 +1,1 @@
+* [#14665](https://github.com/rubocop/rubocop/issues/14665): Cache plugin integration in CopHelper to avoid repeated loading. ([@55728][])

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -6,6 +6,12 @@ require 'tempfile'
 module CopHelper
   extend RSpec::SharedContext
 
+  @integrated_plugins = false
+
+  class << self
+    attr_accessor :integrated_plugins
+  end
+
   let(:ruby_version) do
     # The minimum version Prism can parse is 3.3.
     ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : RuboCop::TargetRuby::DEFAULT_VERSION
@@ -18,11 +24,13 @@ module CopHelper
 
   before(:all) do
     next if ENV['RUBOCOP_CORE_DEVELOPMENT']
+    next if CopHelper.integrated_plugins
 
     plugins = Gem.loaded_specs.filter_map do |feature_name, feature_specification|
       feature_name if feature_specification.metadata['default_lint_roller_plugin']
     end
     RuboCop::Plugin.integrate_plugins(RuboCop::Config.new, plugins)
+    CopHelper.integrated_plugins = true
   end
 
   def inspect_source(source, file = nil)


### PR DESCRIPTION
## Description

Cache plugin integration in `CopHelper#before(:all)` to run `Plugin.integrate_plugins` only once per process instead of once per example group.

Fixes #14665

## Root Cause

`rubocop/rspec/support` globally includes `CopHelper` via `config.include CopHelper`, which means the `before(:all)` hook fires for every `describe` block in the test suite. Each invocation calls `Plugin.integrate_plugins`, which loads and integrates all plugins from scratch — scanning `Gem.loaded_specs`, requiring gems, and merging configuration.

In large test suites with hundreds of `describe` blocks, this repeated integration adds significant overhead to examples that don't test cops at all.

## Changes

Add a module-level `plugins_integrated` flag to `CopHelper` that ensures `Plugin.integrate_plugins` runs only once per process. Subsequent `before(:all)` invocations hit `next if CopHelper.plugins_integrated` and return immediately.

This is safe because plugin integration is idempotent:
- Gem `require` is a no-op if already loaded
- Cop registry entries are not duplicated
- Configuration merging produces the same result

## Design Note

The root cause is that `CopHelper` is globally included rather than scoped to cop-testing examples (e.g., via `config.include CopHelper, :cop_test`). A metadata-based approach would be a more fundamental fix but would be a breaking change for existing users of `rubocop/rspec/support`. This caching approach resolves the performance issue without breaking the public API.

## Test Results

```
bundle exec rake spec
31,246 examples, 0 failures

bundle exec rubocop
1,704 files inspected, no offenses detected
```
