### PR TITLE
[Fix #15054] Fix false positive for `Layout/MultilineMethodCallIndentation` in hash pair values

### DIFF
--- a/changelog/fix_layout_multiline_method_call_indentation_hash_pair_dot_alignment.md
+++ b/changelog/fix_layout_multiline_method_call_indentation_hash_pair_dot_alignment.md
@@ -1,0 +1,1 @@
+* [#15054](https://github.com/rubocop/rubocop/issues/15054): Fix false positive for `Layout/MultilineMethodCallIndentation` when a dot-aligned method chain is inside a hash pair value. ([@nicolas-finary][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -158,7 +158,7 @@ module RuboCop
           @base = find_hash_pair_alignment_base(node)
           return false if !@base && inside_multiline_chain_arg?(node)
 
-          @base ||= lhs.source_range
+          @base ||= first_dot_alignment_base(node, rhs) || lhs.source_range
           return if aligned_with_first_line_dot?(node, rhs)
 
           calculate_column_delta_offense(rhs, @base.column)
@@ -170,6 +170,31 @@ module RuboCop
 
           first_call = first_call_has_a_dot(node)
           first_call.loc.dot.join(first_call.loc.selector)
+        end
+
+        def first_dot_alignment_base(node, rhs)
+          return unless rhs.source.start_with?('.', '&.')
+
+          first_call = first_call_has_a_dot(node)
+          dot = first_call.loc.dot
+          return unless dot
+          return if first_call == node
+
+          after_block_base = after_multiline_block_base(first_call, node)
+          return after_block_base if after_block_base
+
+          return unless same_line?(dot, first_call.receiver.source_range)
+
+          dot.join(first_call.loc.selector)
+        end
+
+        def after_multiline_block_base(first_call, node)
+          return unless first_call.block_node&.multiline?
+
+          after_block = first_call.block_node.parent
+          return unless after_block&.call_type? && after_block.loc?(:dot) && after_block != node
+
+          after_block.loc.dot.join(after_block.loc.selector)
         end
 
         def inside_multiline_chain_arg?(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -454,21 +454,21 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
     # a chain of calls, and that first dot does not begin its line.
     context 'for semantic alignment' do
       context 'when inside a hash pair without block receiver' do
-        it 'accepts method chain aligned with receiver start inside hash pair' do
+        it 'accepts dot-aligned method chain inside hash pair' do
           expect_no_offenses(<<~RUBY)
             {
               key: Foo.bar
-                   .baz
+                      .baz
             }
           RUBY
         end
 
-        it 'accepts method chain aligned with receiver start inside hash pair with multiple chains' do
+        it 'accepts dot-aligned method chain with multiple chains inside hash pair' do
           expect_no_offenses(<<~RUBY)
             {
               key: Foo.bar
-                   .baz
-                   .qux
+                      .baz
+                      .qux
             }
           RUBY
         end
@@ -478,7 +478,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
             {
               outer: {
                 inner: Foo.bar
-                       .baz
+                          .baz
               }
             }
           RUBY
@@ -488,7 +488,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           expect_no_offenses(<<~RUBY)
             method_call(
               key: Foo.bar
-                   .baz
+                      .baz
             )
           RUBY
         end
@@ -516,23 +516,16 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           RUBY
         end
 
-        it 'accepts multi-dot chain aligned with receiver start in hash pair' do
-          expect_no_offenses(<<~RUBY)
-            method(key: value.foo.bar
-                        .baz)
-          RUBY
-        end
-
         it 'registers an offense for misaligned multi-dot chain in hash pair' do
           expect_offense(<<~RUBY)
             method(key: value.foo.bar
                           .baz)
-                          ^^^^ Align `.baz` with `value.foo.bar` on line 1.
+                          ^^^^ Align `.baz` with `.foo` on line 1.
           RUBY
 
           expect_correction(<<~RUBY)
             method(key: value.foo.bar
-                        .baz)
+                             .baz)
           RUBY
         end
 
@@ -553,15 +546,15 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           expect_offense(<<~RUBY)
             {
               key: Foo.bar
-                      .baz
-                      ^^^^ Align `.baz` with `Foo.bar` on line 2.
+                   .baz
+                   ^^^^ Align `.baz` with `.bar` on line 2.
             }
           RUBY
 
           expect_correction(<<~RUBY)
             {
               key: Foo.bar
-                   .baz
+                      .baz
             }
           RUBY
         end
@@ -624,12 +617,45 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           expect_offense(<<~RUBY)
             Foo.where(id: Bar.select(:id)
                                     .joins(:bar))
-                                    ^^^^^^ Align `.joins` with `Bar.select(:id)` on line 1.
+                                    ^^^^^^ Align `.joins` with `.select` on line 1.
           RUBY
 
           expect_correction(<<~RUBY)
             Foo.where(id: Bar.select(:id)
-                          .joins(:bar))
+                             .joins(:bar))
+          RUBY
+        end
+
+        it 'accepts dot-aligned chain inside hash pair in same-line method call' do
+          expect_no_offenses(<<~RUBY)
+            timeseries.push(
+              {
+                value: timeseries_snapshots.pluck(:membership_gross_value)
+                                           .compact_sum
+                                           .to_f,
+              },
+            )
+          RUBY
+        end
+
+        it 'accepts dot-aligned chain inside hash pair in standalone hash' do
+          expect_no_offenses(<<~RUBY)
+            {
+              alpha_beta_count: @handler.retrieve_all_by(alpha: alpha)
+                                        .authorized.count,
+              beta_count: @handler.retrieve_all.authorized.count
+            }
+          RUBY
+        end
+
+        it 'accepts dot-aligned chain in hash pair inside lambda' do
+          expect_no_offenses(<<~RUBY)
+            filter :season, apply: lambda { |records, values, _options|
+              return records if values.blank?
+
+              records.joins(:match)
+                     .where(matches: { season_id: values })
+            }
           RUBY
         end
       end
@@ -639,7 +665,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           expect_no_offenses(<<~RUBY)
             {
               key: Foo.bar { |x| x }
-                   .baz
+                      .baz
             }
           RUBY
         end
@@ -650,7 +676,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
               key: Foo.bar do |x|
                 x
               end.baz
-                   .qux
+                 .qux
             }
           RUBY
         end
@@ -661,8 +687,8 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
               key: Foo.bar do |x|
                 x
               end.baz
-                 .qux
-                 ^^^^ Align `.qux` with `Foo.bar do |x|` on line 2.
+                    .qux
+                    ^^^^ Align `.qux` with `.baz` on line 4.
             }
           RUBY
 
@@ -671,7 +697,7 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
               key: Foo.bar do |x|
                 x
               end.baz
-                   .qux
+                 .qux
             }
           RUBY
         end


### PR DESCRIPTION
Since 1.84.1, `Layout/MultilineMethodCallIndentation` (aligned style) incorrectly flags dot-aligned method chains inside hash pair values. The cop uses the receiver's column as alignment base instead of the first dot's column, causing false positives and inconsistent autocorrect.

```ruby
# Correctly aligned — but flagged as offense since 1.84.1
timeseries.push(
  {
    value: snapshots.pluck(:gross_value)
                    .compact_sum
                    .to_f,
  },
)

# Autocorrect produces inconsistent indentation (.compact_sum moved, .to_f not)
timeseries.push(
  {
    value: snapshots.pluck(:gross_value)
           .compact_sum
                    .to_f,
  },
)
```

Root cause: `check_hash_pair_indentation` falls back to `lhs.source_range` (the receiver's column) when `find_hash_pair_alignment_base` returns `nil` for non-hash-literal receivers.

Fix: add `first_dot_alignment_base` to use the first dot in the chain as alignment target when the dot is on the same line as its receiver. Falls back to `lhs.source_range` for multiline receivers and single-link chains.

Fixes #15054

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html