### PR TITLE
[Fix #14361] Fix false positive in `file_to_include?` for absolute include patterns

### DIFF
--- a/changelog/fix_false_positive_in_file_to_include_for_absolute_include_patterns.md
+++ b/changelog/fix_false_positive_in_file_to_include_for_absolute_include_patterns.md
@@ -1,0 +1,1 @@
+* [#14361](https://github.com/rubocop/rubocop/issues/14361): Fix false positive in `file_to_include?` when a relative `Include` pattern matches a parent directory name in the absolute file path. ([@jonas054][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -217,6 +217,9 @@ module RuboCop
       for_all_cops['StringLiteralsFrozenByDefault']
     end
 
+    # Returns true if the file matches any include pattern. If a block is given, the block is called
+    # to determine if the pattern is relevant (true returned by the block) or should be skipped
+    # (false returned).
     def file_to_include?(file)
       relative_file_path = path_relative_to_config(file)
 
@@ -228,11 +231,9 @@ module RuboCop
       absolute_file_path = File.expand_path(file)
 
       patterns_to_include.any? do |pattern|
-        if block_given?
-          yield pattern, relative_file_path, absolute_file_path
-        else
-          match_path?(pattern, relative_file_path) || match_path?(pattern, absolute_file_path)
-        end
+        next if block_given? && !yield(pattern)
+
+        match_relative_or_absolute_path?(pattern, relative_file_path, absolute_file_path)
       end
     end
 
@@ -242,10 +243,7 @@ module RuboCop
       # `bundler-console` conveys `Bundler::Console`).
       return true if File.extname(file) == '.gemspec'
 
-      file_to_include?(file) do |pattern, relative_path, absolute_path|
-        /[A-Z]/.match?(pattern.to_s) &&
-          (match_path?(pattern, relative_path) || match_path?(pattern, absolute_path))
-      end
+      file_to_include?(file) { |pattern| /[A-Z]/.match?(pattern.to_s) }
     end
 
     # Returns true if there's a chance that an Include pattern matches hidden
@@ -344,6 +342,12 @@ module RuboCop
     end
 
     private
+
+    def match_relative_or_absolute_path?(pattern, relative_file_path, absolute_file_path)
+      should_use_absolute_path = absolute?(pattern.to_s) || pattern.to_s.start_with?('..') ||
+                                 relative_file_path.start_with?('..')
+      match_path?(pattern, should_use_absolute_path ? absolute_file_path : relative_file_path)
+    end
 
     # @return [Float, nil] The Rails version as a `major.minor` Float.
     def target_rails_version_from_bundler_lock_file

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -588,6 +588,24 @@ RSpec.describe RuboCop::Config do
         expect(configuration).not_to be_file_to_include(file_path)
       end
     end
+
+    context 'when a relative pattern matches a parent directory in the absolute path' do
+      let(:hash) { { 'AllCops' => { 'Include' => ['**/app/**/*.rb'] } } }
+      let(:loaded_path) { '/app/myproject/.rubocop.yml' }
+
+      before do
+        allow(configuration).to receive(:base_dir_for_path_parameters).and_return('/app/myproject')
+      end
+
+      it 'only matches files inside the project' do
+        # This file is in an 'app' subdirectory of the project, so it should match.
+        expect(configuration).to be_file_to_include('/app/myproject/lib/app/file.rb')
+
+        # The file is under '/app' but not in an 'app' subdirectory of the project, so it should not
+        # match.
+        expect(configuration).not_to be_file_to_include('/app/myproject/config/application.rb')
+      end
+    end
   end
 
   describe '#file_to_exclude?' do


### PR DESCRIPTION
Let `file_to_include?` use a new private helper `match_relative_or_absolute_path?` that first selects whether to match against the relative or absolute file path, and then does the matching.

Previously, we allowed each pattern to match either relative or absoute paths. For example, `**/app/**/*.rb` would match files whose absolute path contained the pattern (e.g. `/app/myproject/config/file.rb` matched because `/app/` appears in the absolute path), causing false positives when a parent directory name coincidentally matched a glob segment. Now only the relative path is used for relative patterns, avoiding these spurious matches.

