### PR TITLE
[Fix #11398] Fix incorrect Include path when local config overrides

### DIFF
--- a/changelog/fix_include_path_when_local_config_overrides_inherited_include_20260328090737.md
+++ b/changelog/fix_include_path_when_local_config_overrides_inherited_include_20260328090737.md
@@ -1,0 +1,1 @@
+* [#11398](https://github.com/rubocop/rubocop/issues/11398): Fix incorrect `Include` path adjustment when local config overrides an inherited `Include`. ([@jonas054][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -45,6 +45,7 @@ module RuboCop
         base_config.each do |k, v|
           next unless v.is_a?(Hash)
 
+          only_base_has_include = v.key?('Include') && !hash.dig(k, 'Include')
           if hash.key?(k)
             v = merge(v, hash[k],
                       cop_name: k, file: file, debug: debug,
@@ -52,7 +53,7 @@ module RuboCop
                       inherit_mode: determine_inherit_mode(hash, k))
           end
           hash[k] = v
-          fix_include_paths(base_config.loaded_path, hash, path, k, v) if v.key?('Include')
+          fix_include_paths(base_config.loaded_path, hash, path, k, v) if only_base_has_include
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1312,6 +1312,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         create_file('child/grandkid/.rubocop.yml', <<~YAML)
           inherit_from:
             - ../../.rubocop.yml
+          Style/FrozenStringLiteralComment:
+            Include:
+              - '*.rb'
         YAML
       end
 
@@ -1329,6 +1332,34 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           Dir.chdir('child/grandkid') { expect(cli.run(['-L'])).to eq(0) }
           expect($stdout.string).to eq("file.rbi\n")
         end
+      end
+    end
+
+    context 'when a .rubocop.yml is inherited from a parent directory' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            DisabledByDefault: true
+          Style/FrozenStringLiteralComment:
+            Enabled: true
+        YAML
+        create_file('child/.rubocop.yml', <<~YAML)
+          inherit_from: ../.rubocop.yml
+          Style/FrozenStringLiteralComment:
+            Include:
+              - '*.rb'
+        YAML
+      end
+
+      it 'keeps the include pattern from the local configuration' do
+        Dir.chdir('child') do
+          expect(cli.run(['--show-cops', 'Style/FrozenStringLiteralComment'])).to eq(0)
+        end
+        expect($stderr.string).to eq('')
+        expect($stdout.string.lines.last(3).map(&:strip).join("\n")).to eq(<<~TEXT)
+          Include:
+          - "*.rb"
+        TEXT
       end
     end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -334,7 +334,12 @@ RSpec.describe RuboCop::ConfigLoader do
               - dir/**/*.rb
         YAML
 
-        create_file(file_path, ['inherit_from: ../.rubocop.yml'])
+        create_file(file_path, <<~YAML)
+          inherit_from: ../.rubocop.yml
+          Style/FrozenStringLiteralComment:
+            Include:
+              - '*.rb'
+        YAML
       end
 
       it 'gets an absolute AllCops/Exclude' do
@@ -344,6 +349,8 @@ RSpec.describe RuboCop::ConfigLoader do
 
       it 'gets an Include that is relative to the subdirectory' do
         expect(configuration_from_file['Style/StringLiterals']['Include']).to eq(['**/*.rb'])
+        expect(configuration_from_file['Style/FrozenStringLiteralComment']['Include'])
+          .to eq(['*.rb'])
       end
 
       it 'ignores parent AllCops/Exclude if ignore_parent_exclusion is true' do
@@ -362,6 +369,18 @@ RSpec.describe RuboCop::ConfigLoader do
         excludes = configuration['AllCops']['Exclude']
         expect(excludes).not_to include(File.expand_path('vendor/**'))
         expect(excludes).to include(File.expand_path('vendor/foo'))
+      end
+
+      context 'when rubocop is run in a subdirectory' do
+        subject(:configuration_from_subdirectory) do
+          Dir.chdir('dir') { described_class.configuration_from_file('.rubocop.yml') }
+        end
+
+        it 'handles paths' do
+          expect(
+            configuration_from_subdirectory['Style/FrozenStringLiteralComment']['Include']
+          ).to eq(['*.rb'])
+        end
       end
     end
 


### PR DESCRIPTION
### Bug

When a child `.rubocop.yml` inherited from a parent and defined its own `Include`, `fix_include_paths` was always called and incorrectly rewrote the local `Include` paths relative to the parent dir (e.g. `*.rb` to `../*.rb`).

### Fix
`fix_include_paths` is now only called when the base config has `Include` and the local config does not.