### PR TITLE
[Fix #15070] Fix false positive for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_in_lint_redundant_safe_navigation.md
+++ b/changelog/fix_false_positives_in_lint_redundant_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#15070](https://github.com/rubocop/rubocop/issues/15070): Fix false positive for `Lint/RedundantSafeNavigation` when chained safe navigation is used in a conditional expression with `InferNonNilReceiver` enabled. ([@koic][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -84,14 +84,13 @@ module RuboCop
 
           # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           def sole_condition_of_parent_if?(node)
+            child = node
             parent = node.parent
 
             while parent
               if parent.if_type?
                 condition = parent.condition
-                if condition == node || (condition.csend_type? && !condition.receiver.equal?(node))
-                  return true
-                end
+                return true if !child.equal?(condition) && non_nil_condition?(condition, node)
 
                 parent = find_top_if(parent) if parent.elsif?
               elsif else_branch?(parent)
@@ -99,12 +98,19 @@ module RuboCop
                 parent = parent.parent
               end
 
+              child = parent
               parent = parent&.parent
             end
 
             false
           end
           # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+          def non_nil_condition?(condition, node)
+            return true if condition == node
+
+            condition.csend_type? && csend_root_receiver(condition) == node
+          end
 
           def else_branch?(node)
             node.parent&.if_type? && node.parent.else_branch == node
@@ -114,6 +120,14 @@ module RuboCop
             node = node.parent while node.elsif?
 
             node
+          end
+
+          def csend_root_receiver(node)
+            return unless (receiver = node.receiver)
+
+            receiver = receiver.receiver while receiver.call_type? && receiver.receiver
+
+            receiver
           end
         end
       end

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -465,6 +465,52 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
 
+    it 'does not register an offense for chained safe navigation within an unless condition' do
+      expect_no_offenses(<<~RUBY)
+        unless foo&.bar&.baz
+          qux
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for chained safe navigation within an if condition' do
+      expect_no_offenses(<<~RUBY)
+        if foo&.bar&.baz
+          foo.bar.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation in the true branch when condition is a chained csend' do
+      expect_offense(<<~RUBY)
+        if foo&.bar&.baz
+          foo&.qux
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo&.bar&.baz
+          foo.qux
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation in the true branch when condition is a mixed send/csend chain' do
+      expect_offense(<<~RUBY)
+        if foo.bar&.baz
+          foo&.qux
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo.bar&.baz
+          foo.qux
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when method is called on receiver in lhs of condition' do
       expect_offense(<<~RUBY)
         if foo.condition? && other_condition


### PR DESCRIPTION
This PR fixes false positive for `Lint/RedundantSafeNavigation` when chained safe navigation is used in a conditional expression with `InferNonNilReceiver` enabled.

Fixes #15070.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
