### PR TITLE
Fix Style/AccessModifierDeclarations inline autocorrect dropping comments

### DIFF
--- a/changelog/fix_access_modifier_declarations_inline_drops_comments.md
+++ b/changelog/fix_access_modifier_declarations_inline_drops_comments.md
@@ -1,0 +1,1 @@
+* [#11051](https://github.com/rubocop/rubocop/issues/11051): Fix `Style/AccessModifierDeclarations` inline autocorrect dropping comments between the access modifier and the following method definition. ([@dduugg][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -348,8 +348,20 @@ module RuboCop
 
         def remove_modifier_node_within_begin(corrector, modifier_node, begin_node)
           def_node = begin_node.children[begin_node.children.index(modifier_node) + 1]
-          range = modifier_node.source_range.begin.join(def_node.source_range.begin)
-          corrector.remove(range)
+          # Stop the removal range at the first comment that precedes the def, if
+          # any exist. Without this, comments between the modifier and the def are
+          # dropped because they fall inside the removed range.
+          end_pos = first_comment_or_node_start(def_node)
+          corrector.remove(modifier_node.source_range.begin.join(end_pos))
+        end
+
+        def first_comment_or_node_start(node)
+          preceding = processed_source.ast_with_comments[node].select do |comment|
+            comment.loc.line < node.loc.line
+          end
+          return node.source_range.begin if preceding.empty?
+
+          preceding.first.source_range.begin
         end
 
         def def_source(node, def_nodes)

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -905,6 +905,85 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
             #{access_modifier} def foo; end; some_method; #{access_modifier} def bar; end
           RUBY
         end
+
+        it 'preserves a comment between the modifier and the method definition' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+
+              # Computes the foo.
+              def foo; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              # Computes the foo.
+              #{access_modifier} def foo; end
+            end
+          RUBY
+        end
+
+        it 'preserves multiple comments between the modifier and the method definition' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+
+              # First comment line.
+              # Second comment line.
+              def foo; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              # First comment line.
+              # Second comment line.
+              #{access_modifier} def foo; end
+            end
+          RUBY
+        end
+
+        it 'preserves the comment on the first method when autocorrecting multiple grouped methods' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+
+              # Docs for foo.
+              def foo; end
+
+              def bar; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              # Docs for foo.
+              #{access_modifier} def foo; end
+
+              #{access_modifier} def bar; end
+            end
+          RUBY
+        end
+
+        it 'preserves correct output when `def` has a trailing comment' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class Test
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+              def foo; end # trailing
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Test
+              #{access_modifier} def foo; end # trailing
+            end
+          RUBY
+        end
       end
 
       it_behaves_like 'always accepted', access_modifier


### PR DESCRIPTION
When `EnforcedStyle: inline` autocorrects a standalone access modifier to the inline form, it deletes any comments that appear between the modifier and the first method definition following it. For example:

```ruby
# before autocorrect
private

# Computes the foo.
def foo; end

# after autocorrect (broken)
private def foo; end   # comment is gone

# after autocorrect (with fix)
# Computes the foo.
private def foo; end
```

The bug is in `remove_modifier_node_within_begin`, which builds a removal range from the start of the modifier node all the way to the start of the def node. Any comments between them fall inside that range and are deleted. The fix introduces `first_comment_or_node_start`, which returns the start of the first comment associated with the def node via `processed_source.ast_with_comments`, and stops the removal range there. When there are no comments the behaviour is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/