### PR TITLE
Fix false positives in `Style/RedundantParentheses`

### DIFF
--- a/changelog/fix_false_positives_in_style_redundant_parentheses_cop.md
+++ b/changelog/fix_false_positives_in_style_redundant_parentheses_cop.md
@@ -1,0 +1,1 @@
+* [#15074](https://github.com/rubocop/rubocop/pull/15074): Fix false positives in `Style/RedundantParentheses` when using parentheses around an endless range in assignment. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -272,9 +272,10 @@ module RuboCop
 
         # rubocop:disable Metrics/CyclomaticComplexity
         def body_range?(begin_node, node)
+          return false if begin_node.chained?
           return false unless node.range_type?
           return false unless (parent = begin_node.parent)
-          return false if parent.pair_type? || begin_node.chained?
+          return false unless parent.begin_type?
 
           (node.begin.nil? && begin_node == parent.children.first) ||
             (node.end.nil? && begin_node == parent.children.last)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -1034,6 +1034,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'accepts parentheses around an endless range in an assignment' do
+    expect_no_offenses(<<~RUBY)
+      var = (a..)
+      x
+    RUBY
+  end
+
   it 'accepts parentheses around a beginless range with chained method call' do
     expect_no_offenses(<<~RUBY)
       (..1).cover?(0)


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14988#issuecomment-4124869436.

This PR fixes false positives in `Style/RedundantParentheses` when using parentheses around an endless range in assignment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
