### PR TITLE
[Style/CollectionQuerying] Preserve semantics for count without block

### DIFF
--- a/changelog/fix_collection_querying_empty_for_falsey.md
+++ b/changelog/fix_collection_querying_empty_for_falsey.md
@@ -1,0 +1,1 @@
+* [#15067](https://github.com/rubocop/rubocop/issues/15067): Fix `Style/CollectionQuerying` to suggest `empty?`/`!empty?` for `count` without block to preserve behavior with falsey elements. ([@wwenrr][]) 

--- a/changelog/fix_collection_querying_empty_for_falsey.md
+++ b/changelog/fix_collection_querying_empty_for_falsey.md
@@ -1,1 +1,1 @@
-* [#15067](https://github.com/rubocop/rubocop/issues/15067): Fix `Style/CollectionQuerying` to suggest `empty?`/`!empty?` for `count` without block to preserve behavior with falsey elements. ([@wwenrr][]) 
+* [#15067](https://github.com/rubocop/rubocop/issues/15067): Fix `Style/CollectionQuerying` to suggest `empty?`/`!empty?` for `count` without block to preserve behavior with falsey elements. ([@wwenrr][])

--- a/lib/rubocop/cop/style/collection_querying.rb
+++ b/lib/rubocop/cop/style/collection_querying.rb
@@ -102,13 +102,24 @@ module RuboCop
         RESTRICT_ON_SEND = %i[positive? > != zero? ==].freeze
 
         REPLACEMENTS = {
-          [:positive?, nil] => :any?,
-          [:>, 0] => :any?,
-          [:!=, 0] => :any?,
-          [:zero?, nil] => :none?,
-          [:==, 0] => :none?,
-          [:==, 1] => :one?,
-          [:>, 1] => :many?
+          with_block: {
+            [:positive?, nil] => 'any?',
+            [:>, 0] => 'any?',
+            [:!=, 0] => 'any?',
+            [:zero?, nil] => 'none?',
+            [:==, 0] => 'none?',
+            [:==, 1] => 'one?',
+            [:>, 1] => 'many?'
+          },
+          without_block: {
+            [:positive?, nil] => '!empty?',
+            [:>, 0] => '!empty?',
+            [:!=, 0] => '!empty?',
+            [:zero?, nil] => 'empty?',
+            [:==, 0] => 'empty?',
+            [:==, 1] => 'one?',
+            [:>, 1] => 'many?'
+          }
         }.freeze
 
         # @!method count_predicate(node)
@@ -132,28 +143,42 @@ module RuboCop
         def on_send(node)
           return unless (count_node = count_predicate(node))
 
-          replacement_method = replacement_method(node)
-
+          replacement_method = replacement_method(node, count_node)
           return unless replacement_supported?(replacement_method)
 
           offense_range = count_node.loc.selector.join(node.source_range.end)
           add_offense(offense_range,
                       message: format(MSG, prefer: replacement_method)) do |corrector|
-            corrector.replace(count_node.loc.selector, replacement_method)
-            corrector.remove(removal_range(node))
+            autocorrect(corrector, node, count_node, replacement_method)
           end
         end
 
         private
 
-        def replacement_method(node)
-          REPLACEMENTS.fetch([node.method_name, node.first_argument&.value])
+        def autocorrect(corrector, node, count_node, replacement_method)
+          if replacement_method.start_with?('!')
+            corrector.insert_before(count_node, '!')
+            corrector.replace(count_node.loc.selector, replacement_method.delete_prefix('!'))
+          else
+            corrector.replace(count_node.loc.selector, replacement_method)
+          end
+          corrector.remove(removal_range(node))
+        end
+
+        def replacement_method(node, count_node)
+          replacement_type = count_with_block?(count_node) ? :with_block : :without_block
+
+          REPLACEMENTS.fetch(replacement_type).fetch([node.method_name, node.first_argument&.value])
+        end
+
+        def count_with_block?(count_node)
+          count_node.parent&.any_block_type? || count_node.arguments.any?(&:block_pass_type?)
         end
 
         def replacement_supported?(method_name)
           return true if active_support_extensions_enabled?
 
-          method_name != :many?
+          method_name != 'many?'
         end
 
         def removal_range(node)

--- a/spec/rubocop/cop/style/collection_querying_spec.rb
+++ b/spec/rubocop/cop/style/collection_querying_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
   it 'registers an offense for `.count.positive?`' do
     expect_offense(<<~RUBY)
       x.count.positive?
-        ^^^^^^^^^^^^^^^ Use `any?` instead.
+        ^^^^^^^^^^^^^^^ Use `!empty?` instead.
     RUBY
 
     expect_correction(<<~RUBY)
-      x.any?
+      !x.empty?
     RUBY
   end
 
@@ -16,13 +16,13 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
     expect_offense(<<~RUBY)
       x
         .count
-         ^^^^^ Use `any?` instead.
+         ^^^^^ Use `!empty?` instead.
         .positive?
     RUBY
 
     expect_correction(<<~RUBY)
-      x
-        .any?
+      !x
+        .empty?
     RUBY
   end
 
@@ -84,11 +84,11 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
   it 'registers an offense for `&.count.positive?`' do
     expect_offense(<<~RUBY)
       x&.count.positive?
-         ^^^^^^^^^^^^^^^ Use `any?` instead.
+         ^^^^^^^^^^^^^^^ Use `!empty?` instead.
     RUBY
 
     expect_correction(<<~RUBY)
-      x&.any?
+      !x&.empty?
     RUBY
   end
 


### PR DESCRIPTION
## Summary
Fixes #15067.

For `Style/CollectionQuerying`, when `count` is used **without a block**, replacing:
- `count.zero?`/`count == 0` with `none?`
- `count.positive?`/`count > 0`/`count != 0` with `any?`
changes behavior for collections containing falsey elements (e.g. `[false]`).

This change keeps block-based replacements as-is (`any?`/`none?`) but updates no-block replacements to:
- `empty?` for zero checks
- `!empty?` for positive/non-zero checks

## What changed
- Update replacement mapping in `Style::CollectionQuerying` to distinguish block vs no-block `count`.
- Handle `!empty?` autocorrection by inserting `!` before the receiver and replacing only method selector with `empty?`.
- Update specs for no-block cases and keep block-based expectations unchanged.
- Add changelog entry.

## Verification
- `bundle exec rspec spec/rubocop/cop/style/collection_querying_spec.rb`
- `bundle exec exe/rubocop lib/rubocop/cop/style/collection_querying.rb spec/rubocop/cop/style/collection_querying_spec.rb`
- Manual run on sample file confirms:
  - `x.count.zero?` -> `x.empty?`
  - `x.count.positive?` -> `!x.empty?`
  - `x.count(&:odd?).zero?` -> `x.none?(&:odd?)`
  - `x.count(&:odd?).positive?` -> `x.any?(&:odd?)`
