### PR TITLE
[Fix #14979] Fix false positive in `Layout/BlockAlignment` when block follows multi-line arguments

### DIFF
--- a/changelog/fix_layout_block_alignment_false_positive_multiline_args.md
+++ b/changelog/fix_layout_block_alignment_false_positive_multiline_args.md
@@ -1,0 +1,1 @@
+* [#14979](https://github.com/rubocop/rubocop/issues/14979): Fix false positive in `Layout/BlockAlignment` when a block's `{` or `do` falls on a continuation line after multi-line method arguments. For the default `EnforcedStyleAlignWith: either`, the cop now uses the method call's line as the alignment reference instead of the argument continuation line. ([@55728][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -202,15 +202,40 @@ module RuboCop
           # the "end" to be aligned with the start of the line where the "do"
           # is, which is a style some people use in multi-line chains of
           # blocks.
-          match = /\S.*/.match(do_loc.source_line)
+          # When the {/do is on a continuation line (e.g., after multi-line
+          # arguments), use the method call's line for alignment instead,
+          # since the continuation line's indentation reflects argument
+          # alignment rather than the block's logical start.
+          reference_loc = block_start_reference_loc(node, do_loc)
+          match = /\S.*/.match(reference_loc.source_line)
           indentation_of_do_line = match.begin(0)
           return unless end_loc.column != indentation_of_do_line || style == :start_of_line
 
           {
             source: match[0],
-            line: do_loc.line,
+            line: reference_loc.line,
             column: indentation_of_do_line
           }
+        end
+
+        def block_start_reference_loc(node, do_loc)
+          # For start_of_block style, always use the do/{ line as-is,
+          # since the user explicitly wants alignment with that line.
+          return do_loc if style == :start_of_block
+
+          reference_loc = method_call_reference_loc(node)
+          return do_loc unless reference_loc && do_loc.line != reference_loc.line
+
+          reference_loc
+        end
+
+        def method_call_reference_loc(node)
+          # `selector` exists for send/csend; `keyword` covers super/zsuper.
+          loc = node.send_node&.loc
+          return unless loc
+
+          (loc.selector if loc.respond_to?(:selector)) ||
+            (loc.keyword if loc.respond_to?(:keyword))
         end
 
         def loc_to_source_line_column(loc)

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -215,6 +215,60 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end
       RUBY
     end
+
+    # Example from issue 14979 of rubocop/rubocop on github:
+    it 'accepts end aligned with the method call when block follows multi-line arguments' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+      RUBY
+    end
+
+    it 'accepts end aligned with the method call when do...end follows multi-line arguments' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) do
+            process(scheme.constraint)
+          end
+      RUBY
+    end
+
+    it 'accepts end aligned with the method call when block with multi-line arguments is chained' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }.to_s
+      RUBY
+    end
+
+    it 'accepts end aligned with the `super` keyword when super follows multi-line arguments' do
+      expect_no_offenses(<<~RUBY)
+        def call
+          super(a,
+                b) {
+            process
+          }
+        end
+      RUBY
+    end
+
+    it 'does not crash on misaligned end after multi-line `super` arguments' do
+      expect_offense(<<~RUBY)
+        def call
+          super(a,
+                b) {
+            process
+            }
+            ^ `}` at 5, 4 is not aligned with `super(a,` at 2, 2.
+        end
+      RUBY
+    end
   end
 
   context 'when variables of a mass assignment spans several lines' do
@@ -807,6 +861,25 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         RUBY
       end
     end
+
+    it 'registers an offense for end not aligned with start of line when block follows multi-line arguments' do
+      expect_offense(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+          ^ `}` at 5, 2 is not aligned with `out` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+        }
+      RUBY
+    end
   end
 
   context 'with `EnforcedStyle: start_of_block`' do
@@ -980,6 +1053,25 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
           end
         RUBY
       end
+    end
+
+    it 'registers an offense for end not aligned with block start line when block follows multi-line arguments' do
+      expect_offense(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+          ^ `}` at 5, 2 is not aligned with `rgt: foo) {` at 3, 12.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+                    }
+      RUBY
     end
   end
 


### PR DESCRIPTION
## Description

Fix false positive in `Layout/BlockAlignment` when a block `{`/`do` follows multi-line arguments. The cop incorrectly uses the continuation line's indentation for alignment checking.

Fixes #14979

## Root Cause

`compute_do_source_line_column` uses `do_loc.source_line` to determine the indentation of the line where `{`/`do` appears. When arguments span multiple lines, the `{`/`do` falls on a continuation line whose indentation reflects argument alignment rather than the block's logical start.

```ruby
out
  .brackets(lft: foo,
            rgt: foo) {   # cop sees this line → first non-space at col 12 (rgt:)
    process(scheme.constraint)
  }                        # } at col 2 — doesn't match col 0 or col 12 → false positive
```

The `}` at column 2 is correctly aligned with `.brackets` at column 2, but the cop was comparing against `rgt: foo) {` at column 12.

## Changes

### `block_start_reference_loc` / `method_call_reference_loc` methods (new)

Detect when the `{`/`do` is on a different line than the method call, and use the call's line for the alignment reference instead:

- For `start_of_block` style → always use `do_loc` as-is, since this style explicitly aligns with the `{`/`do` line
- For send/csend → use `loc.selector` (e.g., `.brackets`)
- For `super`/`zsuper` → use `loc.keyword` (the `super` keyword position)
- If `{`/`do` is on the same line as the reference → use `do_loc` as before
- `respond_to?(:selector)` / `respond_to?(:keyword)` guards prevent `NoMethodError` for block forms whose `loc` does not expose `selector` (e.g., `super` blocks whose `loc` is `Parser::Source::Map::Keyword`)

### Tests

7 test cases covering all three `EnforcedStyleAlignWith` options:

| Style | Test | Expected |
| --- | --- | --- |
| `either` | brace block with multi-line args | no offense |
| `either` | `do...end` with multi-line args | no offense |
| `either` | chained method after block (`.to_s`) | no offense |
| `either` | `super` with multi-line args | no offense |
| `either` | misaligned `}` after multi-line `super` args | offense (regression test for crash) |
| `start_of_line` | `}` not aligned with expression start | offense + autocorrect |
| `start_of_block` | `}` not aligned with `{` line | offense + autocorrect |

## Test Results

```
bundle exec rspec spec/rubocop/cop/layout/block_alignment_spec.rb
85 examples, 0 failures

bundle exec rake spec
0 failures

bundle exec rubocop
no offenses detected
```
