### PR TITLE
Make `Style/OneClassPerFile` exclude `test/**/*` by default

### DIFF
--- a/changelog/change_make_style_one_class_per_file_exclude_spec_by_default.md
+++ b/changelog/change_make_style_one_class_per_file_exclude_spec_by_default.md
@@ -1,1 +1,1 @@
-* [#15005](https://github.com/rubocop/rubocop/issues/15005): Make `Style/OneClassPerFile` exclude `spec/**/*` by default. ([@koic][])
+* [#15005](https://github.com/rubocop/rubocop/issues/15005): Make `Style/OneClassPerFile` exclude `spec/**/*` and `test/**/*` by default. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5115,6 +5115,7 @@ Style/OneClassPerFile:
   AllowedClasses: []
   Exclude:
     - 'spec/**/*'
+    - 'test/**/*'
 
 Style/OneLineConditional:
   Description: >-


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/15064 and https://github.com/rubocop/rubocop/issues/15005#issuecomment-4175798987.

This PR makes `Style/OneClassPerFile` exclude `test/**/*` by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
