### PR TITLE
[Fix #15081] Relax `parallel` dependency to `>= 1.10`

### DIFF
--- a/changelog/change_parallel_dependency_constraint.md
+++ b/changelog/change_parallel_dependency_constraint.md
@@ -1,0 +1,1 @@
+* [#15081](https://github.com/rubocop/rubocop/issues/15081): Relax `parallel` dependency to `>= 1.10`. ([@koic][])

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   # where x.y.z indicates the Language Server Protocol Specification, t is an incrementing number.
   s.add_dependency('language_server-protocol', '~> 3.17.0.2')
   s.add_dependency('lint_roller', '~> 1.1.0')
-  s.add_dependency('parallel', '~> 1.10')
+  s.add_dependency('parallel', '>= 1.10')
   s.add_dependency('parser', '>= 3.3.0.2')
   s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('regexp_parser', '>= 2.9.3', '< 3.0')


### PR DESCRIPTION
The pessimistic constraint `~> 1.10` prevented upgrading to `parallel` 2.0.0. The 2.0.0 release contains no API changes that affect RuboCop (it only raises the minimum Ruby version to 3.3 and adds Ractor support), so relax the constraint to `>= 1.10`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
