### PR TITLE
[Fix #15084] Handle heredocs with methods calls correctly when fixing guard clauses

### DIFF
--- a/changelog/fix_handle_heredocs_with_methods_calls_correctly_when_20260405205502.md
+++ b/changelog/fix_handle_heredocs_with_methods_calls_correctly_when_20260405205502.md
@@ -1,0 +1,1 @@
+* [#15084](https://github.com/rubocop/rubocop/issues/15084): Handle heredocs with methods calls correctly when fixing guard clauses. ([@G-Rath][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -224,15 +224,18 @@ module RuboCop
         end
 
         def find_heredoc_argument(node)
-          return unless node&.call_type?
+          return unless node
 
-          last_arg = node.last_argument
+          node = node.children.first while node.begin_type?
+          return node if heredoc?(node)
+          return unless node.call_type?
 
-          if heredoc?(last_arg)
-            last_arg
-          elsif last_arg&.call_type?
-            find_heredoc_argument(last_arg)
+          node.arguments.reverse_each do |argument|
+            heredoc_argument = find_heredoc_argument(argument)
+            return heredoc_argument if heredoc_argument
           end
+
+          find_heredoc_argument(node.receiver)
         end
 
         def autocorrect_heredoc_argument(corrector, node, heredoc_node, leave_branch, guard)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -488,6 +488,32 @@ RSpec.describe RuboCop::Cop::Style::GuardClause, :config do
     RUBY
   end
 
+  it 'registers an offense when using heredoc with a method call as an argument of raise in `then` branch' do
+    expect_offense(<<~RUBY)
+      def func
+        if condition
+        ^^ Use a guard clause (`raise <<~MESSAGE.strip unless condition`) instead of wrapping the code inside a conditional expression.
+          foo
+        else
+          raise <<~MESSAGE.strip
+            oops
+          MESSAGE
+        end
+      end
+    RUBY
+
+    # NOTE: Let `Layout/HeredocIndentation`, `Layout/ClosingHeredocIndentation`, and
+    #       `Layout/IndentationConsistency` cops autocorrect inconsistent indentations.
+    expect_correction(<<~RUBY)
+      def func
+        raise <<~MESSAGE.strip unless condition
+            oops
+          MESSAGE
+      foo
+      end
+    RUBY
+  end
+
   it 'registers an offense when using heredoc as an argument of method call of raise in `else` branch' do
     expect_offense(<<~RUBY)
       def func


### PR DESCRIPTION
This updates `GuardClause` to walk call chains when autofixing so that heredocs with method calls like `MSG.strip` are not missed.

Fixes #15084

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
