### PR TITLE
[Fix #15087] Fix false positive for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_false_positive_for_sytle_redundant_line_continuation.md
+++ b/changelog/fix_false_positive_for_sytle_redundant_line_continuation.md
@@ -1,0 +1,1 @@
+* [#15087](https://github.com/rubocop/rubocop/pull/15087): Fix false positive for `Style/RedundantLineContinuation` when using interpolated string literals. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -82,6 +82,7 @@ module RuboCop
           tIDENTIFIER kBREAK kNEXT kRETURN kSUPER kYIELD
         ].freeze
         ARITHMETIC_OPERATOR_TOKENS = %i[tDIVIDE tDSTAR tMINUS tPERCENT tPLUS tSTAR2].freeze
+        STRING_LITERAL_BEGIN_TOKENS = %i[tSTRING_BEG tXSTRING_BEG tREGEXP_BEG tSYMBEG].freeze
 
         def on_new_investigation
           return unless processed_source.ast
@@ -105,6 +106,7 @@ module RuboCop
             string_concatenation?(range.source_line) ||
             start_with_arithmetic_operator?(range) ||
             inside_string_literal_or_method_with_argument?(range) ||
+            inside_string_literal_with_interpolation?(range) ||
             leading_dot_method_chain_with_blank_line?(range)
         end
 
@@ -130,6 +132,20 @@ module RuboCop
             inside_string_literal?(range, token) ||
               method_with_argument?(line_range, token, next_token)
           end
+        end
+
+        def inside_string_literal_with_interpolation?(range)
+          string_depth = 0
+          processed_source.tokens.each do |token|
+            break if token.pos.begin_pos >= range.begin_pos
+
+            if STRING_LITERAL_BEGIN_TOKENS.include?(token.type)
+              string_depth += 1
+            elsif token.type == :tSTRING_END
+              string_depth -= 1
+            end
+          end
+          string_depth.positive?
         end
 
         def leading_dot_method_chain_with_blank_line?(range)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -428,6 +428,34 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when line continuations for interpolated double quoted string' do
+    expect_no_offenses(<<~'RUBY')
+            "longlong-string \
+      #{a}"
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations for interpolated backtick string' do
+    expect_no_offenses(<<~'RUBY')
+            `longlong-command \
+      #{a}`
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations for interpolated regexp' do
+    expect_no_offenses(<<~'RUBY')
+            /longlong-pattern \
+      #{a}/
+    RUBY
+  end
+
+  it 'does not register an offense when line continuations for interpolated dynamic symbol' do
+    expect_no_offenses(<<~'RUBY')
+            :"longlong-symbol \
+      #{a}"
+    RUBY
+  end
+
   it 'does not register an offense when line continuations for single quoted string' do
     expect_no_offenses(<<~'RUBY')
       foo = 'foo \


### PR DESCRIPTION
This PR fixes false positive for `Style/RedundantLineContinuation` when using interpolated string literals.

Fixes #15087.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
