### PR TITLE
Fix `EmptyLineAfterGuardClause` for consecutive `and return` guards

### DIFF
--- a/changelog/fix_false_positives_for_empty_line_after_guard_clause_with_and_return.md
+++ b/changelog/fix_false_positives_for_empty_line_after_guard_clause_with_and_return.md
@@ -1,0 +1,1 @@
+* [#15090](https://github.com/rubocop/rubocop/pull/15090): Fix false positives for `Layout/EmptyLineAfterGuardClause` when consecutive guard clauses use `and return`. ([@eugeneius][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -111,7 +111,7 @@ module RuboCop
         def contains_guard_clause?(node)
           return false unless (branch = node.if_branch)
 
-          guard_clause_branch?(branch)
+          branch.guard_clause? || guard_clause_branch?(branch)
         end
 
         def next_line_empty_or_allowed_directive_comment?(line)

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -399,6 +399,17 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'accepts multiple guard clauses using `and return`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        render :bar and return if condition1?
+        render :baz and return if condition2?
+
+        foobar
+      end
+    RUBY
+  end
+
   it 'accepts a guard clause followed by a multi-line guard clause with `raise`' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/15023 introduced a regression where consecutive guard clauses using `and return` were no longer treated as a group, requiring blank lines between them. Fix by also checking `Node#guard_clause?` which already handles compound guard clauses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/