### PR TITLE
Fix `DuplicateMethods` for anonymous classes in constant assignments and methods

### DIFF
--- a/changelog/fix_duplicate_methods_anonymous_class_scope.md
+++ b/changelog/fix_duplicate_methods_anonymous_class_scope.md
@@ -1,0 +1,1 @@
+* [#15091](https://github.com/rubocop/rubocop/pull/15091): Fix `Lint/DuplicateMethods` false positives for anonymous classes in constant assignments and method return values. ([@eugeneius][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -316,7 +316,7 @@ module RuboCop
 
         def anon_block_scope_id(anon_block)
           parent = anon_block.parent
-          return unless parent&.type?(:any_block, :begin, :call)
+          return unless parent&.type?(:any_block, :begin, :call, :casgn, :any_def)
 
           if (receiver = named_receiver(parent))
             "#{receiver.source}.#{parent.method_name}"

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -942,6 +942,108 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'assigned to different constants' do
+    expect_no_offenses(<<~RUBY)
+      self::A = Class.new do
+        def foo
+          1
+        end
+      end
+      self::B = Class.new do
+        def foo
+          2
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'assigned to different constants' do
+    expect_no_offenses(<<~RUBY)
+      self::A = Class.new do
+        def self.name
+          'Foo'
+        end
+      end
+      self::B = Class.new do
+        def self.name
+          'Bar'
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for duplicate methods inside the same Class.new block assigned to a constant' do
+    expect_offense(<<~RUBY)
+      self::A = Class.new do
+        def foo
+          1
+        end
+        def foo
+        ^^^^^^^ Method `::A#foo` is defined at both (string):2 and (string):5.
+          2
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'returned from different methods' do
+    expect_no_offenses(<<~RUBY)
+      def build_foo
+        Class.new do
+          def name
+            'Foo'
+          end
+        end
+      end
+      def build_bar
+        Class.new do
+          def name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'returned from different methods' do
+    expect_no_offenses(<<~RUBY)
+      def build_foo
+        Class.new do
+          def self.name
+            'Foo'
+          end
+        end
+      end
+      def build_bar
+        Class.new do
+          def self.name
+            'Bar'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for duplicate methods inside the same Class.new block returned from a method' do
+    expect_offense(<<~RUBY)
+      def build_klass
+        Class.new do
+          def name
+            1
+          end
+          def name
+          ^^^^^^^^ Method `Object#name` is defined at both (string):3 and (string):6.
+            2
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'ignores Module.new blocks which are passed as method arguments' do
     expect_no_offenses(<<~RUBY)
       A.prepend(


### PR DESCRIPTION
`anon_block_scope_id` did not generate a unique scope ID when a `Class.new` block's parent was a `:casgn` or `:any_def` node, so methods in separate anonymous classes were flagged as duplicates.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/