### PR TITLE
Fix `Layout/EndAlignment` cop error on an empty `begin`

### DIFF
--- a/changelog/fix_layout_end_alignment_cop_error_on_empty_begin_20260407042644.md
+++ b/changelog/fix_layout_end_alignment_cop_error_on_empty_begin_20260407042644.md
@@ -1,0 +1,1 @@
+* [#15092](https://github.com/rubocop/rubocop/pull/15092): Fix `Layout/EndAlignment` cop error on an empty `begin`. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -123,6 +123,7 @@ module RuboCop
           AlignmentCorrector.align_end(corrector, processed_source, node, alignment_node(node))
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def check_assignment(node, rhs)
           # If there are method calls chained to the right hand side of the
           # assignment, we let rhs be the receiver of those method calls before
@@ -131,13 +132,14 @@ module RuboCop
 
           # If `rhs` is a `begin` node or a logical operator,
           # unwrap to find the leading conditional.
-          rhs = rhs.child_nodes.first while rhs.type?(:begin, :or, :and)
+          rhs = rhs.child_nodes.first while rhs&.type?(:begin, :or, :and)
 
-          return unless rhs.conditional?
+          return unless rhs&.conditional?
           return if rhs.if_type? && rhs.ternary?
 
           check_asgn_alignment(node, rhs)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check_asgn_alignment(outer_node, inner_node)
           align_with = {

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -742,6 +742,12 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
                 end && ""
         RUBY
       end
+
+      it 'does not register an offense for an empty `begin`' do
+        expect_no_offenses(<<~RUBY)
+          foo = ()
+        RUBY
+      end
     end
 
     context 'when EnforcedStyleAlignWith is variable' do


### PR DESCRIPTION
```shell
$ echo 'foo = ()' | bundle exec rubocop --stdin /dev/stdin --only Layout/EndAlignment -d
For /dev: An error occurred while Layout/EndAlignment cop was inspecting /dev/stdin:1:0.
rubocop/lib/rubocop/cop/layout/end_alignment.rb:134:in 'RuboCop::Cop::Layout::EndAlignment#check_assignment': undefined method 'type?' for nil (NoMethodError)

          rhs = rhs.child_nodes.first while rhs.type?(:begin, :or, :and)
                                               ^^^^^^
	from rubocop/lib/rubocop/cop/mixin/check_assignment.rb:8:in 'RuboCop::Cop::CheckAssignment#on_lvasgn'
	from rubocop/lib/rubocop/cop/commissioner.rb:107:in 'Kernel#public_send'
	from rubocop/lib/rubocop/cop/commissioner.rb:107:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
	from rubocop/lib/rubocop/cop/commissioner.rb:171:in 'RuboCop::Cop::Commissioner#with_cop_error_handling'
	from rubocop/lib/rubocop/cop/commissioner.rb:106:in 'block in RuboCop::Cop::Commissioner#trigger_responding_cops'
	from rubocop/lib/rubocop/cop/commissioner.rb:105:in 'Array#each'
	from rubocop/lib/rubocop/cop/commissioner.rb:105:in 'RuboCop::Cop::Commissioner#trigger_responding_cops'
	from rubocop/lib/rubocop/cop/commissioner.rb:69:in 'RuboCop::Cop::Commissioner#on_lvasgn'
	from rubocop-ast-1.49.0/lib/rubocop/ast/traversal.rb:20:in 'RuboCop::AST::Traversal#walk'
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
