### PR TITLE
Return tool execution errors instead of protocol errors in MCP server

### DIFF
--- a/changelog/fix_return_tool_execution_errors_instead_of_protocol.md
+++ b/changelog/fix_return_tool_execution_errors_instead_of_protocol.md
@@ -1,0 +1,1 @@
+* [#15093](https://github.com/rubocop/rubocop/pull/15093): Return tool execution errors instead of protocol errors in MCP server. ([@koic][])

--- a/lib/rubocop/mcp/server.rb
+++ b/lib/rubocop/mcp/server.rb
@@ -190,6 +190,8 @@ module RuboCop
           result = yield(path, source_code, safety)
 
           ::MCP::Tool::Response.new([{ type: 'text', text: result }])
+        rescue RuboCop::Error => e
+          ::MCP::Tool::Response.new([{ type: 'text', text: e.message }], error: true)
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists


### PR DESCRIPTION
Since `mcp` gem v0.11.0, unhandled exceptions in tool blocks are converted to JSON-RPC protocol errors. Handle `RuboCop::Error` within the MCP tool block so that file I/O errors (permission denied, no space left, read-only FS) are returned as tool execution errors (`isError: true`) per the MCP specification.

Existing tests cover this change, so no new tests are added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
