### PR TITLE
[Fix #11828] Fix brace corrector for EOL comments

### DIFF
--- a/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
+++ b/lib/rubocop/cop/correctors/multiline_literal_brace_corrector.rb
@@ -59,11 +59,7 @@ module RuboCop
       end
 
       def content_if_comment_present(corrector, node)
-        range = range_with_surrounding_space(
-          children(node).last.source_range,
-          side: :right
-        ).end.resize(1)
-        if range.source == '#'
+        if processed_source.comment_at_line(children(node).last.last_line)
           select_content_to_be_inserted_after_last_element(corrector, node)
         else
           node.loc.end.source

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2659,6 +2659,52 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects closing brace placement when last element has a trailing comma before an EOL comment' do
+    source_file = Pathname('example.rb')
+    create_file(source_file, <<~RUBY)
+      # frozen_string_literal: true
+
+      CONFIG = {
+        allowlist: { 'a' => true, # EOL A
+                     'b' => true, # EOL B
+        },
+        blocklist: { 'c' => true }
+      }.freeze
+
+      my_hash = {
+        'something'  => { :toto => ['titi'],
+                        },
+        'other'      => { :clone => 'yes',
+                          :pp => ['no'],
+                          :qq => 'yolo', # Alright this is valid
+                        },
+        'dry'        => { :ploup => ['plip'] },
+      }
+      puts my_hash
+    RUBY
+
+    status = cli.run(%w[--autocorrect])
+    expect(source_file.read).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      CONFIG = {
+        allowlist: { 'a' => true, # EOL A
+                     'b' => true }, # EOL B
+        blocklist: { 'c' => true }
+      }.freeze
+
+      my_hash = {
+        'something' => { toto: ['titi'] },
+        'other' => { clone: 'yes',
+                     pp: ['no'],
+                     qq: 'yolo' }, # Alright this is valid
+        'dry' => { ploup: ['plip'] }
+      }
+      puts my_hash
+    RUBY
+    expect(status).to eq(0)
+  end
+
   it 'corrects TrailingCommaIn(Array|Hash)Literal and Multiline(Array|Hash)BraceLayout offenses' do
     create_file('.rubocop.yml', <<~YAML)
       Style/TrailingCommaInArrayLiteral:


### PR DESCRIPTION
When `MultilineHashBraceLayout` (or `MultilineArrayBraceLayout`) moves a closing brace to the same line as the last element, `MultilineLiteralBraceCorrector` detects any end-of-line comment and delegates to `select_content_to_be_inserted_after_last_element`, which repositions the brace together with any following outer separator comma as a unit.

The comment-detection logic in `content_if_comment_present` checked whether the character immediately after the last element (skipping whitespace) was `#`. This worked when the comment followed the element directly, but failed when a trailing comma appeared first (`'b' => true, # EOL B`): the next character was `,`, not `#`, so the comment branch was bypassed. Only `}` was moved to the previous line while the outer `,` from `},` was left orphaned after the comment, producing malformed output such as `'b' => true} # EOL B,`.

Fix by using `processed_source.comment_at_line` for comment detection.