### PR TITLE
[Fix #14971] Don't suggest modifier form when the body is a conditional

### DIFF
--- a/changelog/fix_while_until_modifier_conditional_body.md
+++ b/changelog/fix_while_until_modifier_conditional_body.md
@@ -1,0 +1,1 @@
+* [#14971](https://github.com/rubocop/rubocop/issues/14971): Fix false positive for `Style/WhileUntilModifier` when the body is a conditional. ([@fujitanisora][])

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -16,6 +16,11 @@ module RuboCop
       #   # good
       #   x += 1 while x < 10
       #
+      #   # good
+      #   while x < 10
+      #     y += 1 if x.odd?
+      #   end
+      #
       #   # bad
       #   until x > 10
       #     x += 1
@@ -23,6 +28,11 @@ module RuboCop
       #
       #   # good
       #   x += 1 until x > 10
+      #
+      #   # good
+      #   until x > 10
+      #     y += 1 unless x.even?
+      #   end
       #
       #   # bad
       #   x += 100 while x < 500 # a long comment that makes code too long if it were a single line
@@ -45,6 +55,12 @@ module RuboCop
           end
         end
         alias on_until on_while
+
+        private
+
+        def non_eligible_body?(body)
+          body&.if_type? || super
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -3,4 +3,58 @@
 RSpec.describe RuboCop::Cop::Style::WhileUntilModifier, :config do
   it_behaves_like 'condition modifier cop', :while
   it_behaves_like 'condition modifier cop', :until
+
+  context 'when the body is a modifier if' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          bar if baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          bar if baz
+        end
+      RUBY
+    end
+  end
+
+  context 'when the body is a modifier unless' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          bar unless baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          bar unless baz
+        end
+      RUBY
+    end
+  end
+
+  context 'when the body is a ternary' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          x.odd? ? do_a : do_b
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          x.odd? ? do_a : do_b
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/WhileUntilModifier` suggests converting `while`/`until` loops to modifier form even when the body contains a conditional (`if`/`unless` modifier or ternary). This produces hard-to-read double-modifier code:

```ruby
# before (readable)
while $stdin.read
  warn 'message' if Time.now.to_i.odd?
end

# after autocorrect (confusing double-modifier)
warn 'message' if Time.now.to_i.odd? while $stdin.read
```

This PR overrides `non_eligible_body?` in `WhileUntilModifier` to skip bodies that are `:if` type nodes (modifier `if`, modifier `unless`, and ternary operators), following the same pattern used by `Style/IfUnlessModifier` which handles nested conditionals via `non_eligible_node?`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/