### PR TITLE
[Fix #15102] Fix `FrozenError` in `DisabledConfigFormatter`

### DIFF
--- a/changelog/fix_frozen-error_in_formatter_disabled_config_formatter.md
+++ b/changelog/fix_frozen-error_in_formatter_disabled_config_formatter.md
@@ -1,0 +1,1 @@
+* [#15102](https://github.com/rubocop/rubocop/issues/15102): Fix `FrozenError` in `DisabledConfigFormatter` for frozen array config parameters. ([@koic][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -192,7 +192,7 @@ module RuboCop
           next unless value.is_a?(Array)
           next if value.empty?
 
-          value.map! { |v| v.nil? ? '~' : v } # Change nil back to ~ as in the YAML file.
+          value = value.map { |v| v.nil? ? '~' : v } # Change nil back to ~ as in the YAML file.
           output_buffer.puts "# #{param}: #{value.uniq.join(', ')}"
         end
       end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -232,6 +232,28 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
+  context 'when a cop has a frozen array config parameter' do
+    before do
+      default_config = RuboCop::ConfigLoader.default_configuration
+      allow(default_config).to receive(:[]).with('Test/Cop1').and_return(
+        {
+          'Enabled' => true,
+          'AllowedOperators' => %w[* + & | ^].freeze
+        }
+      )
+      allow(default_config).to receive(:[]).with('Test/Cop2').and_return({})
+
+      formatter.started(['test_a.rb'])
+      formatter.file_started('test_a.rb', options)
+      formatter.file_finished('test_a.rb', offenses)
+      formatter.finished(['test_a.rb'])
+    end
+
+    it 'does not raise a `FrozenError`' do
+      expect(output.string).to include('# AllowedOperators: *, +, &, |, ^')
+    end
+  end
+
   context 'with autocorrect supported cop', :restore_registry do
     before do
       stub_cop_class('Test::Cop3') { extend RuboCop::Cop::AutoCorrector }


### PR DESCRIPTION
This PR fixes `FrozenError` in `DisabledConfigFormatter` for frozen array config parameters.

Fixes #15102.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
