### PR TITLE
fix space/typo in EnforcedStyleForLeadingUnderscores docs header

### DIFF
--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -945,7 +945,7 @@ end
 ----
 
 [#enforcedstyleforleadingunderscores-_optional-namingmemoizedinstancevariablename]
-==== EnforcedStyleForLeadingUnderscores :optional
+==== EnforcedStyleForLeadingUnderscores: optional
 
 [source,ruby]
 ----

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -109,7 +109,7 @@ module RuboCop
       #     @_foo = calculate_expensive_thing
       #   end
       #
-      # @example EnforcedStyleForLeadingUnderscores :optional
+      # @example EnforcedStyleForLeadingUnderscores: optional
       #   # bad
       #   def foo
       #     @something ||= calculate_expensive_thing


### PR DESCRIPTION
just noticed that space is on the wrong side of the colon

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
