### PR TITLE
[Fix #15106] Fix TargetFinder to work correctly inside hidden parent directories

### DIFF
--- a/changelog/fix_fix_target_finder_to_work_correctly_inside_hidden_20260414225805.md
+++ b/changelog/fix_fix_target_finder_to_work_correctly_inside_hidden_20260414225805.md
@@ -1,0 +1,1 @@
+* [#15106](https://github.com/rubocop/rubocop/issues/15106): Fix `TargetFinder` to work correctly inside hidden parent directories. ([@alpaca-tc][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -44,10 +44,10 @@ module RuboCop
       all_files = find_files(base_dir, File::FNM_DOTMATCH)
       base_dir_config = @config_store.for(base_dir)
 
-      target_files = if hidden_path?(base_dir)
+      target_files = if hidden_dir?(base_dir)
                        all_files.select { |file| ruby_file?(file) }
                      else
-                       all_files.select { |file| to_inspect?(file, base_dir_config) }
+                       all_files.select { |file| to_inspect?(file, base_dir, base_dir_config) }
                      end
 
       target_files.sort_by!(&order)
@@ -72,15 +72,22 @@ module RuboCop
 
     private
 
-    def to_inspect?(file, base_dir_config)
+    def to_inspect?(file, base_dir, base_dir_config)
       return false if base_dir_config.file_to_exclude?(file)
-      return true if !hidden_path?(file) && ruby_file?(file)
+      return true if !hidden_file_in_dir?(file, base_dir) && ruby_file?(file)
 
       base_dir_config.file_to_include?(file)
     end
 
-    def hidden_path?(path)
-      path.include?(HIDDEN_PATH_SUBSTRING)
+    def hidden_dir?(dir)
+      basename = File.basename(dir)
+      basename.start_with?('.') && basename != '.' && basename != '..'
+    end
+
+    def hidden_file_in_dir?(file, base_dir)
+      base_dir = "#{base_dir}#{File::SEPARATOR}" unless base_dir.end_with?(File::SEPARATOR)
+      relative = file.delete_prefix(base_dir)
+      relative.start_with?('.') || relative.include?(HIDDEN_PATH_SUBSTRING)
     end
 
     def wanted_dir_patterns(base_dir, exclude_pattern, flags)

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -678,6 +678,18 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when base_dir is inside a hidden parent directory (e.g. worktree)' do
+      let(:base_dir) { File.expand_path('.worktrees/feature') }
+
+      it 'picks Ruby files normally despite the hidden parent' do
+        create_empty_file('.worktrees/feature/lib/ruby6.rb')
+        create_empty_file('.worktrees/feature/lib/.hidden_in_worktree/ruby7.rb')
+        create_empty_file('.worktrees/feature/ruby8.rb')
+
+        expect(found_basenames).to contain_exactly('ruby6.rb', 'ruby8.rb')
+      end
+    end
+
     context 'w/ --fail-fast option' do
       let(:options) { { force_exclusion: force_exclusion, debug: debug, fail_fast: true } }
 


### PR DESCRIPTION
Fixed #15106

`hidden_path?` checked for `/.` anywhere in the absolute path, which caused all files under a hidden parent (e.g. `.worktrees/`) to be treated as hidden. Replace it with `hidden_dir?` for the base directory check and `hidden_file_in_dir?` that only examines the path relative to the base directory.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
