### PR TITLE
[Fix #15107] Fix false positives in `Lint/RequireRelativeSelfPath`

### DIFF
--- a/changelog/fix_false_positive_in_lint_require_relative_self_path.md
+++ b/changelog/fix_false_positive_in_lint_require_relative_self_path.md
@@ -1,0 +1,1 @@
+* [#15107](https://github.com/rubocop/rubocop/issues/15107): Fix false positives in `Lint/RequireRelativeSelfPath` when a non-`.rb` file uses `require_relative` with its own basename. ([@koic][])

--- a/lib/rubocop/cop/lint/require_relative_self_path.rb
+++ b/lib/rubocop/cop/lint/require_relative_self_path.rb
@@ -38,6 +38,8 @@ module RuboCop
         private
 
         def same_file?(file_path, required_feature)
+          return false unless File.extname(file_path) == '.rb'
+
           file_path == required_feature || remove_ext(file_path) == required_feature
         end
 

--- a/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
+++ b/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
@@ -48,4 +48,16 @@ RSpec.describe RuboCop::Cop::Lint::RequireRelativeSelfPath, :config do
       Dir['test/**/test_*.rb'].each { |f| require_relative f }
     RUBY
   end
+
+  it 'does not register an offense when a `.rake` file requires a file with the same basename' do
+    expect_no_offenses(<<~RUBY, 'foo.rake')
+      require_relative 'foo'
+    RUBY
+  end
+
+  it 'does not register an offense when a file without an extension requires a file with the same basename' do
+    expect_no_offenses(<<~RUBY, 'Rakefile')
+      require_relative 'Rakefile'
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes false positives in `Lint/RequireRelativeSelfPath` when a non-`.rb` file requires a file with its own basename.

Fixes #15107.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
