### PR TITLE
[Fix #13755] Let auto_gen_config run in parallel

### DIFF
--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -50,7 +50,7 @@ module RuboCop
         def auto_gen_tmp_dir
           @auto_gen_tmp_dir ||= Pathname.new(
             RuboCop::CacheConfig.root_dir_from_toplevel_config
-          ).join('auto-gen-tmp').tap do |path|
+          ).join("auto-gen-tmp-#{Digest::SHA1.hexdigest(Dir.pwd)}").tap do |path|
             path.mkpath
             # Set the temp directory path for ExcludeLimit to use
             RuboCop::ExcludeLimit.tmp_dir = path

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -250,11 +250,13 @@ module RuboCop
       end
 
       def config_to_allow_offenses
-        Formatter::DisabledConfigFormatter.config_to_allow_offenses[cop_name] ||= {}
+        Formatter::DisabledConfigFormatter.config_to_allow_offenses[cop_name] ||=
+          Formatter::DisabledConfigFormatter::ConfigToAllowHash.new(cop_name)
       end
 
       def config_to_allow_offenses=(hash)
-        Formatter::DisabledConfigFormatter.config_to_allow_offenses[cop_name] = hash
+        Formatter::DisabledConfigFormatter.config_to_allow_offenses[cop_name] =
+          Formatter::DisabledConfigFormatter::ConfigToAllowHash.new(cop_name, hash)
       end
 
       def target_ruby_version

--- a/lib/rubocop/cop/mixin/array_min_size.rb
+++ b/lib/rubocop/cop/mixin/array_min_size.rb
@@ -6,6 +6,22 @@ module RuboCop
     # `Style/SymbolArray` and `Style/WordArray`, which check for use of the
     # relevant percent literal syntax such as `%i[...]` and `%w[...]`
     module ArrayMinSize
+      # Merge lambdas for parallel --auto-gen-config.
+      # When workers see different subsets of files, these lambdas specify
+      # how to combine each config option from _config_overrides.
+      module ClassMethods
+        def config_to_allow_offenses_mergers
+          {
+            'EnforcedStyle' => ->(_a, _b) { 'percent' },
+            'MinSize' => ->(a, b) { [a, b].max }
+          }.freeze
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
       private
 
       def below_array_length?(node)
@@ -16,7 +32,7 @@ module RuboCop
         cop_config['MinSize']
       end
 
-      def array_style_detected(style, ary_size) # rubocop:todo Metrics/AbcSize
+      def array_style_detected(style, ary_size) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
         cfg = config_to_allow_offenses
         return if cfg['Enabled'] == false
 
@@ -29,10 +45,28 @@ module RuboCop
           cfg['EnforcedStyle'] = style.to_s
         elsif smallest_percent <= largest_brackets
           self.config_to_allow_offenses = { 'Enabled' => false }
+          cfg = config_to_allow_offenses
         else
           cfg['EnforcedStyle'] = 'percent'
           cfg['MinSize'] = largest_brackets + 1
         end
+
+        persist_config_overrides(cfg, largest_brackets)
+      end
+
+      # Persist a fallback config for parallel merge resolution.
+      # When workers see different subsets of files, they may resolve
+      # to different styles. This provides the "most permissive" config
+      # (percent with a MinSize that accommodates all observed bracket
+      # arrays) so the merge can reconstruct the correct result.
+      def persist_config_overrides(cfg, largest_brackets)
+        return unless largest_brackets > -Float::INFINITY
+
+        cfg.set_metadata(
+          '_config_overrides',
+          'EnforcedStyle' => 'percent',
+          'MinSize' => largest_brackets + 1
+        )
       end
 
       def largest_brackets_size(style, ary_size)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+require 'json'
+
 module RuboCop
   module Formatter
     # This formatter displays a YAML configuration file where all cops that
@@ -37,8 +40,212 @@ module RuboCop
       @config_to_allow_offenses = {}
       @detected_styles = {}
 
+      # A Hash wrapper that automatically persists to a tmp file on mutation.
+      # This enables cross-process aggregation when running --auto-gen-config
+      # in parallel: each forked worker writes its state to a PID-keyed file,
+      # and the parent merges all workers' files before generating the todo.
+      class ConfigToAllowHash
+        extend Forwardable
+
+        def_delegators :@data, :[], :key?, :==, :empty?, :each, :each_key, :merge
+
+        def initialize(cop_name, data = {})
+          @cop_name = cop_name
+          @data = data.dup
+          @metadata = {}
+          persist! unless @data.empty?
+        end
+
+        def to_h
+          @data.dup
+        end
+
+        def []=(key, value)
+          return if @data[key] == value
+
+          @data[key] = value
+          persist!
+        end
+
+        # Stores metadata that is serialized to the JSON tmp file for
+        # cross-process communication but not included in the config hash.
+        def set_metadata(key, value)
+          return if @metadata[key] == value
+
+          @metadata[key] = value
+          persist!
+        end
+
+        def clear
+          return if @data.empty? && @metadata.empty?
+
+          @data.clear
+          @metadata.clear
+          persist!
+        end
+
+        private
+
+        def persist!
+          tmp_dir = ExcludeLimit.tmp_dir
+          return unless tmp_dir
+
+          dir = tmp_dir.join('config_to_allow', @cop_name.tr('/', '-'))
+          dir.mkpath
+
+          serialized = @data.dup
+          @metadata.each { |k, v| serialized[k] = v }
+          detected = Formatter::DisabledConfigFormatter.detected_styles[@cop_name]
+          serialized['_detected_styles'] = detected if detected
+
+          dir.join("#{Process.pid}.json").write(JSON.dump(serialized))
+        end
+      end
+
+      # Encapsulates the logic for merging per-worker cop config state
+      # collected during parallel --auto-gen-config runs.
+      module ConfigMerger
+        DISABLED = { 'Enabled' => false }.freeze
+
+        module_function
+
+        def accumulate_worker_configs(cop_dir, cop_class = nil)
+          worker_data = cop_dir.children.sort.filter_map do |filepath|
+            next unless filepath.file?
+
+            parse_worker_file(filepath)
+          end
+
+          worker_data.inject do |(acc_cfg, acc_meta), (cfg, meta)|
+            merged_meta = merge_metadata(acc_meta, meta, cop_class)
+            merged_cfg = merge_cop_config(acc_cfg, cfg, merged_meta[:detected_styles])
+            [merged_cfg, merged_meta]
+          end
+        end
+
+        def parse_worker_file(filepath)
+          raw = JSON.parse(filepath.read)
+          meta = {
+            detected_styles: raw.delete('_detected_styles'),
+            config_overrides: raw.delete('_config_overrides')
+          }
+          [raw, meta]
+        end
+
+        def merge_metadata(meta_a, meta_b, cop_class = nil)
+          {
+            detected_styles: intersect_styles(meta_a[:detected_styles], meta_b[:detected_styles]),
+            config_overrides: merge_config_overrides(
+              meta_a[:config_overrides],
+              meta_b[:config_overrides],
+              cop_class
+            )
+          }
+        end
+
+        # Merges _config_overrides from multiple workers using cop-defined
+        # merge lambdas. Each cop/module can define how its config options
+        # should be combined by implementing config_to_allow_offenses_mergers.
+        def merge_config_overrides(override_a, override_b, cop_class = nil)
+          return override_a unless override_b
+          return override_b unless override_a
+
+          mergers = cop_config_mergers(cop_class)
+          override_a.merge(override_b) do |key, a_val, b_val|
+            next a_val if a_val == b_val
+
+            mergers[key]&.call(a_val, b_val) || a_val
+          end
+        end
+
+        def cop_config_mergers(cop_class)
+          return {} unless cop_class.respond_to?(:config_to_allow_offenses_mergers)
+
+          cop_class.config_to_allow_offenses_mergers
+        end
+
+        def intersect_styles(style_a, style_b)
+          Array(style_a) & Array(style_b)
+        end
+
+        def disabled_config?(existing, incoming)
+          existing == DISABLED || incoming == DISABLED
+        end
+
+        def merge_cop_config(existing, incoming, detected_styles = nil)
+          return DISABLED if disabled_config?(existing, incoming)
+          return existing if existing == incoming
+
+          merged = existing.merge(incoming)
+          if merged.all? { |k, v| existing.fetch(k, v) == v }
+            merged
+          elsif detected_styles&.any?
+            resolve_with_detected_styles(existing, incoming, detected_styles)
+          else
+            DISABLED
+          end
+        end
+
+        def resolve_with_detected_styles(existing, incoming, detected_styles)
+          resolved_conflict = false
+          (existing.keys | incoming.keys).each_with_object({}) do |key, result|
+            e_val = existing[key]
+            i_val = incoming[key]
+            next result[key] = i_val if e_val.nil?
+            next result[key] = e_val if i_val.nil? || e_val == i_val
+            # detected_styles can only resolve a single style parameter;
+            # a second conflicting key cannot be resolved.
+            return DISABLED if resolved_conflict
+
+            resolved_conflict = true
+            result[key] = detected_styles.first
+          end
+        end
+      end
+
       class << self
         attr_accessor :config_to_allow_offenses, :detected_styles
+
+        # Reads per-cop config_to_allow state from all per-worker tmp files
+        # and merges them. Called before outputting the todo configuration.
+        def merge_config_from_tmp
+          config_dir = ExcludeLimit.tmp_dir&.join('config_to_allow')
+          return unless config_dir&.directory?
+
+          config_dir.children.sort.each do |cop_dir|
+            next unless cop_dir.directory?
+
+            cop_name = cop_dir.basename.to_s.tr('-', '/')
+            merge_cop_config_from_dir(cop_name, cop_dir)
+          end
+        end
+
+        private
+
+        def merge_cop_config_from_dir(cop_name, cop_dir)
+          cop_class = Cop::Registry.global.find_by_cop_name(cop_name)
+          result = ConfigMerger.accumulate_worker_configs(cop_dir, cop_class)
+          return unless result
+
+          accumulated_cfg, accumulated_meta = result
+          accumulated_cfg = apply_config_overrides_fallback(
+            accumulated_cfg, accumulated_meta, cop_class
+          )
+
+          existing = @config_to_allow_offenses[cop_name]
+          existing = existing.to_h if existing.is_a?(ConfigToAllowHash)
+          @config_to_allow_offenses[cop_name] =
+            existing ? ConfigMerger.merge_cop_config(existing, accumulated_cfg) : accumulated_cfg
+        end
+
+        def apply_config_overrides_fallback(cfg, meta, cop_class)
+          if cfg == ConfigMerger::DISABLED && meta[:config_overrides] &&
+             cop_class.respond_to?(:config_to_allow_offenses_mergers)
+            meta[:config_overrides]
+          else
+            cfg
+          end
+        end
       end
 
       def initialize(output, options = {})
@@ -63,6 +270,8 @@ module RuboCop
       end
 
       def finished(_inspected_files)
+        self.class.merge_config_from_tmp
+
         output.puts format(HEADING, command: command, timestamp: timestamp)
 
         # Syntax isn't a real cop and it can't be disabled.
@@ -118,7 +327,7 @@ module RuboCop
 
       def output_cop(cop_name, offense_count)
         output.puts
-        cfg = self.class.config_to_allow_offenses[cop_name] || {}
+        cfg = self.class.config_to_allow_offenses.fetch(cop_name, {}).to_h
         set_max(cfg, cop_name)
 
         # To avoid malformed YAML when potentially reading the config in
@@ -220,6 +429,7 @@ module RuboCop
         # limit is exceeded.
         rejected_keys = ['Enabled']
         rejected_keys << /\AEnforcedStyle\w*/ unless auto_gen_enforced_style?
+        rejected_keys << /\A_/ # Strip internal keys used for parallel merge
         cfg.reject { |key| include_or_match?(rejected_keys, key) }
       end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -163,7 +163,6 @@ module RuboCop
     end
 
     def run_in_parallel?(files)
-      return false if @options[:auto_gen_config]
       return false unless @options[:parallel]
 
       if files.size <= 1

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -244,6 +244,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
 
       context 'when specifying `--auto-gen-config`' do
+        before do
+          RuboCop::Formatter::DisabledConfigFormatter.config_to_allow_offenses = {}
+          RuboCop::Formatter::DisabledConfigFormatter.detected_styles = {}
+        end
+
         it 'uses parallel inspection' do
           create_file('example1.rb', <<~RUBY)
             # frozen_string_literal: true
@@ -252,6 +257,29 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           RUBY
           expect(cli.run(['--debug', '--auto-gen-config'])).to eq(0)
           expect($stdout.string).to include('Use parallel by default.')
+        end
+
+        it 'generates EnforcedStyle when multiple files have the same style' do
+          create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)'])
+          create_file('example2.rb', ['# frozen_string_literal: true', '', 'h(:b => 2)'])
+
+          expect(cli.run(['--auto-gen-config'])).to eq(0)
+          todo = File.readlines('.rubocop_todo.yml').drop_while do |line|
+            line.start_with?('#')
+          end.join
+          expect(todo).to include("Style/HashSyntax:\n  EnforcedStyle: hash_rockets")
+        end
+
+        it 'generates Exclude when files have conflicting styles' do
+          create_file('example1.rb', ['# frozen_string_literal: true', '', 'h(:a => 1)'])
+          create_file('example2.rb', ['# frozen_string_literal: true', '', 'h(b: 2)'])
+
+          expect(cli.run(['--auto-gen-config'])).to eq(0)
+          todo = File.readlines('.rubocop_todo.yml').drop_while do |line|
+            line.start_with?('#')
+          end.join
+          expect(todo).to include('Style/HashSyntax:')
+          expect(todo).not_to match %r{Style/HashSyntax:\n\s+EnforcedStyle:}
         end
       end
 

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -254,6 +254,286 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
+  describe '.merge_cop_config' do
+    def merge(existing, incoming, detected_styles = nil)
+      described_class::ConfigMerger.merge_cop_config(existing, incoming, detected_styles)
+    end
+
+    context 'when both sides have identical scalar values' do
+      it 'returns the existing config' do
+        result = merge({ 'EnforcedStyle' => 'space' }, { 'EnforcedStyle' => 'space' })
+        expect(result).to eq({ 'EnforcedStyle' => 'space' })
+      end
+    end
+
+    context 'when scalar values differ without detected_styles' do
+      it 'disables the cop' do
+        result = merge({ 'EnforcedStyle' => 'space' }, { 'EnforcedStyle' => 'no_space' })
+        expect(result).to eq({ 'Enabled' => false })
+      end
+    end
+
+    context 'when scalar values differ with non-empty detected_styles intersection' do
+      it 'resolves using the detected_styles intersection' do
+        result = merge({ 'EnforcedStyle' => 'space' }, { 'EnforcedStyle' => 'no_space' },
+                       %w[no_space])
+        expect(result).to eq({ 'EnforcedStyle' => 'no_space' })
+      end
+    end
+
+    context 'when scalar values differ with empty detected_styles' do
+      it 'disables the cop' do
+        result = merge({ 'EnforcedStyle' => 'space' }, { 'EnforcedStyle' => 'no_space' }, [])
+        expect(result).to eq({ 'Enabled' => false })
+      end
+    end
+
+    context 'when one side is already disabled' do
+      it 'disables the cop' do
+        result = merge({ 'Enabled' => false }, { 'EnforcedStyle' => 'space' })
+        expect(result).to eq({ 'Enabled' => false })
+      end
+    end
+
+    context 'when one side has keys the other lacks' do
+      it 'merges both sides' do
+        result = merge({ 'EnforcedStyle' => 'space' }, { 'MinSize' => 5 })
+        expect(result).to eq({ 'EnforcedStyle' => 'space', 'MinSize' => 5 })
+      end
+    end
+  end
+
+  describe '.merge_config_overrides' do
+    def merge_overrides(override_a, override_b, cop_class = nil)
+      described_class::ConfigMerger.merge_config_overrides(override_a, override_b, cop_class)
+    end
+
+    context 'when one side is nil' do
+      it 'returns the other side' do
+        expect(merge_overrides({ 'MinSize' => 4 }, nil)).to eq({ 'MinSize' => 4 })
+        expect(merge_overrides(nil, { 'MinSize' => 3 })).to eq({ 'MinSize' => 3 })
+      end
+    end
+
+    context 'when both sides have identical values' do
+      it 'returns the values unchanged' do
+        result = merge_overrides({ 'EnforcedStyle' => 'percent', 'MinSize' => 4 },
+                                 { 'EnforcedStyle' => 'percent', 'MinSize' => 4 })
+        expect(result).to eq({ 'EnforcedStyle' => 'percent', 'MinSize' => 4 })
+      end
+    end
+
+    context 'when values differ and cop defines merge lambdas' do
+      let(:cop_class) do
+        Class.new do
+          def self.config_to_allow_offenses_mergers
+            {
+              'EnforcedStyle' => ->(_a, _b) { 'percent' },
+              'MinSize' => ->(a, b) { [a, b].max }
+            }
+          end
+        end
+      end
+
+      it 'uses the lambdas to resolve conflicts' do
+        result = merge_overrides({ 'EnforcedStyle' => 'percent', 'MinSize' => 4 },
+                                 { 'EnforcedStyle' => 'brackets', 'MinSize' => 3 },
+                                 cop_class)
+        expect(result).to eq({ 'EnforcedStyle' => 'percent', 'MinSize' => 4 })
+      end
+    end
+
+    context 'when values differ and cop has no merge lambdas' do
+      it 'keeps the left-side value' do
+        result = merge_overrides({ 'EnforcedStyle' => 'ruby19' },
+                                 { 'EnforcedStyle' => 'hash_rockets' })
+        expect(result).to eq({ 'EnforcedStyle' => 'ruby19' })
+      end
+    end
+  end
+
+  describe '.merge_config_from_tmp' do
+    around do |example|
+      tmp_dir = Pathname.new(Dir.mktmpdir('rubocop-auto-gen'))
+      original_tmp_dir = RuboCop::ExcludeLimit.tmp_dir
+      RuboCop::ExcludeLimit.tmp_dir = tmp_dir
+      original_config = described_class.config_to_allow_offenses.dup
+      described_class.config_to_allow_offenses = {}
+      begin
+        example.run
+      ensure
+        RuboCop::ExcludeLimit.tmp_dir = original_tmp_dir
+        described_class.config_to_allow_offenses = original_config
+        tmp_dir.rmtree if tmp_dir.exist?
+      end
+    end
+
+    def write_worker_config(cop_name, pid, data)
+      dir = RuboCop::ExcludeLimit.tmp_dir.join('config_to_allow', cop_name.tr('/', '-'))
+      dir.mkpath
+      dir.join("#{pid}.json").write(JSON.dump(data))
+    end
+
+    context 'when workers report overlapping detected_styles' do
+      before do
+        # Layout/FirstHashElementIndentation supports: consistent,
+        # special_inside_parentheses, align_braces.
+        #
+        # A hash literal NOT inside parentheses is ambiguous between
+        # consistent and special_inside_parentheses (both indent
+        # relative to start-of-line). So ambiguous_style_detected
+        # is called with both.
+        #
+        # Worker 1 only saw such hashes, so it persists
+        # EnforcedStyle: consistent (.first) with both possibilities.
+        write_worker_config('Layout/FirstHashElementIndentation', 1001,
+                            'EnforcedStyle' => 'consistent',
+                            '_detected_styles' => %w[consistent special_inside_parentheses])
+        # Worker 2 saw a hash inside parentheses that uniquely matches
+        # special_inside_parentheses, narrowing to a single style.
+        write_worker_config('Layout/FirstHashElementIndentation', 1002,
+                            'EnforcedStyle' => 'special_inside_parentheses',
+                            '_detected_styles' => %w[special_inside_parentheses])
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'uses the detected_styles intersection to resolve the conflict' do
+        cfg = described_class.config_to_allow_offenses['Layout/FirstHashElementIndentation']
+        expect(cfg).to eq('EnforcedStyle' => 'special_inside_parentheses')
+      end
+    end
+
+    context 'when workers report non-overlapping detected_styles' do
+      before do
+        write_worker_config('Style/HashSyntax', 2001,
+                            'EnforcedStyle' => 'ruby19',
+                            '_detected_styles' => ['ruby19'])
+        write_worker_config('Style/HashSyntax', 2002,
+                            'EnforcedStyle' => 'hash_rockets',
+                            '_detected_styles' => ['hash_rockets'])
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'disables the cop' do
+        cfg = described_class.config_to_allow_offenses['Style/HashSyntax']
+        expect(cfg).to eq('Enabled' => false)
+      end
+    end
+
+    context 'when three workers progressively narrow the intersection' do
+      before do
+        write_worker_config('Layout/SpaceInsideHashLiteralBraces', 3001,
+                            'EnforcedStyle' => 'space',
+                            '_detected_styles' => %w[space no_space compact])
+        write_worker_config('Layout/SpaceInsideHashLiteralBraces', 3002,
+                            'EnforcedStyle' => 'no_space',
+                            '_detected_styles' => %w[no_space compact])
+        write_worker_config('Layout/SpaceInsideHashLiteralBraces', 3003,
+                            'EnforcedStyle' => 'compact',
+                            '_detected_styles' => %w[compact])
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'narrows to the common intersection' do
+        cfg = described_class.config_to_allow_offenses['Layout/SpaceInsideHashLiteralBraces']
+        expect(cfg).to eq('EnforcedStyle' => 'compact')
+      end
+    end
+
+    context 'when workers have no detected_styles (scalar-only)' do
+      before do
+        write_worker_config('Style/HashSyntax', 4001, 'EnforcedStyle' => 'ruby19')
+        write_worker_config('Style/HashSyntax', 4002, 'EnforcedStyle' => 'hash_rockets')
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'falls back to disabling the cop' do
+        cfg = described_class.config_to_allow_offenses['Style/HashSyntax']
+        expect(cfg).to eq('Enabled' => false)
+      end
+    end
+
+    context 'when workers produce conflicting MinSize with _config_overrides (ArrayMinSize cop)' do
+      before do
+        # Worker 1 saw brackets of size 3 → percent + MinSize 4
+        write_worker_config('Style/SymbolArray', 5001,
+                            'EnforcedStyle' => 'percent',
+                            'MinSize' => 4,
+                            '_config_overrides' => {
+                              'EnforcedStyle' => 'percent',
+                              'MinSize' => 4
+                            })
+        # Worker 2 saw brackets of size 2 → percent + MinSize 3
+        write_worker_config('Style/SymbolArray', 5002,
+                            'EnforcedStyle' => 'percent',
+                            'MinSize' => 3,
+                            '_config_overrides' => {
+                              'EnforcedStyle' => 'percent',
+                              'MinSize' => 3
+                            })
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'uses cop-defined merge lambdas to take the max MinSize' do
+        cfg = described_class.config_to_allow_offenses['Style/SymbolArray']
+        expect(cfg).to eq('EnforcedStyle' => 'percent', 'MinSize' => 4)
+      end
+    end
+
+    context 'when one worker disabled and another has config, both with _config_overrides' do
+      before do
+        # Worker 1 disabled: smallest_percent <= largest_brackets
+        write_worker_config('Style/SymbolArray', 6001,
+                            'Enabled' => false,
+                            '_config_overrides' => {
+                              'EnforcedStyle' => 'percent',
+                              'MinSize' => 4
+                            })
+        # Worker 2 resolved to percent+MinSize
+        write_worker_config('Style/SymbolArray', 6002,
+                            'EnforcedStyle' => 'percent',
+                            'MinSize' => 3,
+                            '_config_overrides' => {
+                              'EnforcedStyle' => 'percent',
+                              'MinSize' => 3
+                            })
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'uses merged overrides as fallback instead of disabling' do
+        cfg = described_class.config_to_allow_offenses['Style/SymbolArray']
+        expect(cfg).to eq('EnforcedStyle' => 'percent', 'MinSize' => 4)
+      end
+    end
+
+    context 'when only one worker provides _config_overrides' do
+      before do
+        # Worker 1 saw only brackets → EnforcedStyle: brackets, with overrides
+        write_worker_config('Style/WordArray', 7001,
+                            'EnforcedStyle' => 'brackets',
+                            '_config_overrides' => {
+                              'EnforcedStyle' => 'percent',
+                              'MinSize' => 5
+                            })
+        # Worker 2 saw only percent → EnforcedStyle: percent, no overrides
+        write_worker_config('Style/WordArray', 7002, 'EnforcedStyle' => 'percent')
+
+        described_class.merge_config_from_tmp
+      end
+
+      it 'uses the single override as fallback' do
+        cfg = described_class.config_to_allow_offenses['Style/WordArray']
+        expect(cfg).to eq('EnforcedStyle' => 'percent', 'MinSize' => 5)
+      end
+    end
+  end
+
   context 'with autocorrect supported cop', :restore_registry do
     before do
       stub_cop_class('Test::Cop3') { extend RuboCop::Cop::AutoCorrector }


### PR DESCRIPTION
Re-enables `--auto-gen-config` running in parallel after it was reverted by #15110 (which introduced true runner parallelism but dropped auto-gen-config parallel support).

## Approach

Introduces `ConfigToAllowHash`, a Hash wrapper that automatically persists `config_to_allow_offenses` state to PID-keyed tmp files on mutation. This enables cross-process aggregation when running `--auto-gen-config` in parallel:

- Each forked worker writes its `config_to_allow_offenses` mutations to disk (JSON files keyed by PID under the existing `ExcludeLimit.tmp_dir`).
- `detected_styles` are persisted alongside `config_to_allow_offenses` so that ambiguous style conflicts (e.g. from `ambiguous_style_detected`) can be resolved via intersection rather than unnecessarily disabling the cop.
- The parent merges all workers' persisted state before generating the todo YAML.
- Uses `Forwardable` to delegate read-only Hash methods, keeping only the mutating methods (`[]=`, `clear`) explicit so they can trigger persistence.

### Cop-specific merge semantics

For `ArrayMinSize` cops (`Style/SymbolArray`, `Style/WordArray`), defines `config_to_allow_offenses_mergers` — cop-specific lambda methods that tell `ConfigMerger` how to combine each config option across workers. This keeps merge semantics in the cop where they belong: `EnforcedStyle` always resolves to `'percent'`, and `MinSize` takes the maximum.

### Metadata support

Adds `set_metadata` to `ConfigToAllowHash` for storing cross-process data (like `_config_overrides`) that is serialized to the JSON tmp file but excluded from the live config hash used by cops and output formatting.

## Context

#15007 originally fixed #13755 by enabling parallel auto-gen-config. Then #15110 replaced the two-pass parallel approach with true single-pass parallelism, but reverted auto-gen-config parallel support because "modifying shared formatter state across parallel processes proved incompatible."

This PR restores parallel auto-gen-config by taking a different approach to the state-sharing problem: instead of relying on in-memory state being shared, each forked worker writes its mutations to disk, and the parent merges them before outputting the todo. This reuses the same tmp-dir mechanism that `ExcludeLimit` already uses for `Max`/`MinDigits` values.

## Tests

- New spec: verifies `EnforcedStyle` is correctly generated when multiple files share the same style.
- New spec: verifies `Exclude` is generated (instead of `EnforcedStyle`) when files have conflicting styles.
- Existing spec: verifies `--auto-gen-config` uses parallel inspection.
- New specs for `ConfigToAllowHash` serialization, merging, and metadata persistence.
- New specs for `ArrayMinSize` cop-specific mergers.

I did not add a changelog entry, since one already exists from #15007.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/