### PR TITLE
[Fix #15115] Fix an incorrect autocorrect in `Style/RegexpLiteral`

### DIFF
--- a/changelog/fix_regexp_literal_autocorrect_breaks_syntax_with_curly_braces.md
+++ b/changelog/fix_regexp_literal_autocorrect_breaks_syntax_with_curly_braces.md
@@ -1,0 +1,1 @@
+* [#15115](https://github.com/rubocop/rubocop/issues/15115): Fix an incorrect autocorrect in `Style/RegexpLiteral` when the regexp contains unbalanced braces that conflict with the preferred `%r` delimiters. ([@koic][])

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -98,7 +98,16 @@ module RuboCop
         MSG_USE_SLASHES = 'Use `//` around regular expression.'
         MSG_USE_PERCENT_R = 'Use `%r` around regular expression.'
 
+        PAIR_DELIMITER_PATTERNS = {
+          ['(', ')'] => /\\.|[()]/,
+          ['[', ']'] => /\\.|[\[\]]/,
+          ['{', '}'] => /\\.|[{}]/,
+          ['<', '>'] => /\\.|[<>]/
+        }.freeze
+
         def on_regexp(node)
+          return if slash_literal?(node) && percent_r_delimiters_conflict?(node)
+
           message = if slash_literal?(node)
                       MSG_USE_PERCENT_R unless allowed_slash_literal?(node)
                     else
@@ -114,6 +123,26 @@ module RuboCop
         end
 
         private
+
+        def percent_r_delimiters_conflict?(node)
+          opening, closing = preferred_delimiters
+          return false unless (pattern = PAIR_DELIMITER_PATTERNS[[opening, closing]])
+
+          !balanced_delimiters?(node_body(node), opening, closing, pattern)
+        end
+
+        def balanced_delimiters?(text, opening, closing, pattern)
+          depth = 0
+          text.scan(pattern) do |match|
+            if match == opening
+              depth += 1
+            elsif match == closing
+              depth -= 1
+              return false if depth.negative?
+            end
+          end
+          depth.zero?
+        end
 
         def allowed_slash_literal?(node)
           (style == :slashes && !contains_disallowed_slash?(node)) || allowed_mixed_slash?(node)

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -68,6 +68,71 @@ RSpec.describe RuboCop::Cop::Style::RegexpLiteral, :config do
     end
   end
 
+  describe 'when `%r` delimiters would produce unbalanced braces in the content' do
+    let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
+
+    it 'does not register an offense for an unbalanced opening brace' do
+      expect_no_offenses('x = /{\\//')
+    end
+
+    it 'does not register an offense for an unbalanced closing brace' do
+      expect_no_offenses('x = /}\\//')
+    end
+
+    it 'registers an offense when the braces in the content are balanced' do
+      expect_offense(<<~'RUBY')
+        x = /{foo}\//
+            ^^^^^^^^^ Use `%r` around regular expression.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = %r{{foo}/}
+      RUBY
+    end
+
+    it 'registers an offense when the braces in the content are escaped' do
+      expect_offense(<<~'RUBY')
+        x = /\{foo\//
+            ^^^^^^^^^ Use `%r` around regular expression.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = %r{\{foo/}
+      RUBY
+    end
+
+    it 'registers an offense when braces appear only inside interpolation' do
+      expect_offense(<<~'RUBY')
+        x = /\/\A#{"{"}\z/
+            ^^^^^^^^^^^^^^ Use `%r` around regular expression.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = %r{/\A#{"{"}\z}
+      RUBY
+    end
+
+    it 'does not register an offense when an escaped backslash precedes an unbalanced brace' do
+      expect_no_offenses('x = /\\\\{\\//')
+    end
+
+    context 'when PercentLiteralDelimiters is configured with angle brackets' do
+      let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%r' => '<>' } } }
+
+      it 'does not register an offense for an unbalanced `<`' do
+        expect_no_offenses('x = /<\\//')
+      end
+    end
+
+    context 'when PercentLiteralDelimiters is configured with square brackets' do
+      let(:percent_literal_delimiters_config) { { 'PreferredDelimiters' => { '%r' => '[]' } } }
+
+      it 'does not register an offense for an unbalanced `]`' do
+        expect_no_offenses('x = /[abc]]\\//')
+      end
+    end
+  end
+
   context 'when EnforcedStyle is set to slashes' do
     let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
 


### PR DESCRIPTION
This PR fixes an incorrect autocorrect in `Style/RegexpLiteral` when the regexp contains unbalanced braces that conflict with the preferred `%r` delimiters.

Skip the offense when converting a `//` regexp to `%r` would place the preferred paired delimiters (`{}`, `()`, `[]`, `<>`) unbalanced in the regexp content, which would otherwise produce a syntax error.

Fixes #15115.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
