### PR TITLE
[Fix #15117] Add `AllowConsecutiveConditionals` option to `Style/IfUnlessModifier`

### DIFF
--- a/changelog/new_allow_consecutive_conditionals_in_if_unless_modifier.md
+++ b/changelog/new_allow_consecutive_conditionals_in_if_unless_modifier.md
@@ -1,0 +1,1 @@
+* [#15117](https://github.com/rubocop/rubocop/issues/15117): Add new `AllowConsecutiveConditionals` option to `Style/IfUnlessModifier`. ([@hammadxcm][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4441,7 +4441,8 @@ Style/IfUnlessModifier:
   StyleGuide: '#if-as-a-modifier'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.30'
+  VersionChanged: '<<next>>'
+  AllowConsecutiveConditionals: false
 
 Style/IfUnlessModifierOfIfUnless:
   Description: >-

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -72,6 +72,37 @@ module RuboCop
       #     do_something
       #   end
       #
+      # @example AllowConsecutiveConditionals: false (default)
+      #   # bad
+      #   if foo
+      #     do_foo # a long comment that prevents the modifier form
+      #   end
+      #
+      #   if bar
+      #     do_bar
+      #   end
+      #
+      # @example AllowConsecutiveConditionals: true
+      #   # good
+      #   if foo
+      #     do_foo # a long comment that prevents the modifier form
+      #   end
+      #
+      #   if bar
+      #     do_bar
+      #   end
+      #
+      #   # bad
+      #   if foo
+      #     do_foo # a long comment that prevents the modifier form
+      #   end
+      #
+      #   do_something
+      #
+      #   if bar
+      #     do_bar
+      #   end
+      #
       class IfUnlessModifier < Base # rubocop:disable Metrics/ClassLength
         include StatementModifier
         include LineLengthHelp
@@ -92,6 +123,8 @@ module RuboCop
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
           return if endless_method?(node.body) || node.ancestors.any?(&:dstr_type?)
+          return if allowed_consecutive_conditionals? &&
+                    consecutive_conditionals?(node.parent, node)
 
           condition = node.condition
           return if defined_nodes(condition).any? { |n| defined_argument_is_undefined?(node, n) } ||
@@ -355,6 +388,22 @@ module RuboCop
 
         def remove_comment(corrector, _node, comment)
           corrector.remove(range_with_surrounding_space(range: comment.source_range, side: :left))
+        end
+
+        def allowed_consecutive_conditionals?
+          cop_config.fetch('AllowConsecutiveConditionals', false)
+        end
+
+        def consecutive_conditionals?(parent, node)
+          return false unless parent
+
+          siblings = parent.each_child_node.to_a
+          index = siblings.index(node)
+          return false unless index
+
+          prev_sibling = index.positive? ? siblings[index - 1] : nil
+          next_sibling = siblings[index + 1]
+          [prev_sibling, next_sibling].compact.any?(&:if_type?)
         end
       end
     end

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
+              # Configuration parameters: AllowConsecutiveConditionals.
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -219,6 +220,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
+              # Configuration parameters: AllowConsecutiveConditionals.
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'
@@ -269,6 +271,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
               # Offense count: 1
               # This cop supports safe autocorrection (--autocorrect).
+              # Configuration parameters: AllowConsecutiveConditionals.
               Style/IfUnlessModifier:
                 Exclude:
                   - 'example.rb'

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -1546,4 +1546,99 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       end
     end
   end
+
+  context 'AllowConsecutiveConditionals' do
+    context 'when `false` (default)' do
+      let(:cop_config) { { 'AllowConsecutiveConditionals' => false } }
+
+      it 'registers an offense for consecutive `if` blocks that fit on a single line' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_foo
+          end
+
+          if bar
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_bar
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_foo if foo
+
+          do_bar if bar
+        RUBY
+      end
+    end
+
+    context 'when `true`' do
+      let(:cop_config) { { 'AllowConsecutiveConditionals' => true } }
+
+      it 'does not register an offense when the preceding sibling is also an `if` block' do
+        expect_no_offenses(<<~RUBY)
+          if foo
+            do_foo
+          end
+
+          if bar
+            do_bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the preceding sibling is an `unless` block' do
+        expect_no_offenses(<<~RUBY)
+          unless foo
+            do_foo
+          end
+
+          if bar
+            do_bar
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the following sibling is also an `if` block' do
+        expect_no_offenses(<<~RUBY)
+          def func
+            do_something
+
+            if foo
+              do_foo
+            end
+
+            if bar
+              do_bar
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for each isolated `if` when a non-conditional statement breaks the chain' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_foo
+          end
+
+          do_something
+
+          if bar
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_bar
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a solitary `if` block' do
+        expect_offense(<<~RUBY)
+          if foo
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            do_foo
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #15117.

Adds a new `AllowConsecutiveConditionals` (default: `false`) configuration option to `Style/IfUnlessModifier`, mirroring the existing option of the same name on `Style/GuardClause`. When enabled, `if`/`unless` blocks that are adjacent to another `if`/`unless` block (at the same AST depth) are skipped so that visual symmetry is preserved when at least one of the blocks cannot be rewritten in modifier form.

The check is bidirectional (preceding *or* following sibling), so every member of a consecutive chain is exempted, not just trailing ones. This differs slightly from `Style/GuardClause`'s helper, which only looks at the preceding sibling — necessary here because `Style/IfUnlessModifier` can flag any block in the chain, not only the final one.

### Example

```ruby
# With AllowConsecutiveConditionals: true — no offenses, symmetry preserved

if params[:foo]
  process(params[:foo]) # long comment that prevents the modifier form
end

if params[:bar]
  process(params[:bar])
end
```

## Test plan

- [x] New RSpec context covering `AllowConsecutiveConditionals: false` (default) and `true`, including `if`/`unless` mixing, chain-breaking by a non-conditional statement, and isolated `if` blocks.
- [x] Existing `spec/rubocop/cli/auto_gen_config_spec.rb` fixtures updated to reflect the new `# Configuration parameters:` comment emitted by `--auto-gen-config`.
- [x] `bundle exec rake` passes end-to-end (codespell + doc syntax + full spec suite + self-lint).
- [x] Changelog entry added.