### PR TITLE
Extend `Style/WhileUntilModifier` to skip any conditional body

### DIFF
--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -59,7 +59,7 @@ module RuboCop
         private
 
         def non_eligible_body?(body)
-          body&.if_type? || super
+          body&.conditional? || super
         end
       end
     end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -57,4 +57,76 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilModifier, :config do
       RUBY
     end
   end
+
+  context 'when the body is a nested `while`' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          bar while baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          bar while baz
+        end
+      RUBY
+    end
+  end
+
+  context 'when the body is a nested `until`' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          bar until baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          bar until baz
+        end
+      RUBY
+    end
+  end
+
+  context 'when the body is a single-line `case`' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          case x; when 42 then a; end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          case x; when 42 then a; end
+        end
+      RUBY
+    end
+  end
+
+  context 'when the body is a single-line `case` match' do
+    it 'does not register an offense for while' do
+      expect_no_offenses(<<~RUBY)
+        while foo
+          case x; in 42 then a; end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for until' do
+      expect_no_offenses(<<~RUBY)
+        until foo
+          case x; in 42 then a; end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Widen the body check from `if_type?` to `conditional?` so that nested `while`, `until`, `case`, and `case` match bodies are also exempt from the offense. This matches the changelog wording ("when the body is a conditional") and prevents the same readability issue in those forms.

This is a follow-up to https://github.com/rubocop/rubocop/pull/15101, so no changelog entry is added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
