### PR TITLE
[Fix #15122] Fix false positive in `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_merge_pull_request_15116_from_20260423015103.md
+++ b/changelog/fix_merge_pull_request_15116_from_20260423015103.md
@@ -1,0 +1,1 @@
+* [#15122](https://github.com/rubocop/rubocop/issues/15122): Fix false positive in `Layout/MultilineMethodCallIndentation` when a line has multiple chained calls before a single-line block. ([@hammadxcm][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -380,7 +380,7 @@ module RuboCop
 
         def find_continuation_node(node)
           receiver = node.receiver
-          return receiver.send_node if single_line_block_receiver?(receiver)
+          return leftmost_call_on_same_line(receiver) if single_line_block_receiver?(receiver)
           return unless receiver.call_type? && receiver.loc.dot
           return receiver if receiver.receiver.begin_type? && node.block_node.single_line?
           return unless receiver.loc.dot.line > receiver.receiver.last_line
@@ -392,9 +392,19 @@ module RuboCop
           receiver.single_line? && receiver.any_block_type?
         end
 
+        def leftmost_call_on_same_line(node)
+          current = node.any_block_type? ? node.send_node : node
+          while current.receiver&.call_type? &&
+                current.receiver.loc?(:dot) &&
+                current.receiver.loc.dot.line == current.loc.dot.line
+            current = current.receiver
+          end
+          current
+        end
+
         def handle_descendant_block(node)
           receiver = node.receiver
-          return receiver.send_node if single_line_block_receiver?(receiver)
+          return leftmost_call_on_same_line(receiver) if single_line_block_receiver?(receiver)
 
           block_node = node.each_descendant(:any_block).first
           return unless block_node&.multiline?

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -1083,6 +1083,40 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts aligned method chain when line has multiple calls before single-line block' do
+      expect_no_offenses(<<~RUBY)
+        users
+          .dup.sort_by { _1.name.lower }
+          .page(params[:page])
+          .per(PER_PAGE)
+      RUBY
+    end
+
+    it 'accepts aligned method chain when line has multiple calls before single-line block with safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        users
+          &.dup&.sort_by { _1.name.lower }
+          &.page(params[:page])
+      RUBY
+    end
+
+    it 'accepts aligned method chain when continuation also has a block' do
+      expect_no_offenses(<<~RUBY)
+        users
+          .dup.sort_by { _1.name }
+          .select { |u| u.active? }
+          .map(&:id)
+      RUBY
+    end
+
+    it 'accepts aligned method chain with three calls before single-line block' do
+      expect_no_offenses(<<~RUBY)
+        users
+          .dup.compact.sort_by { _1.name }
+          .first(10)
+      RUBY
+    end
+
     it 'accepts aligned method chained after single-line block on both calls' do
       expect_no_offenses(<<~RUBY)
         (0..foo).bar { baz }


### PR DESCRIPTION
Fixes #15122.

## Summary

- Fix false positive when a line has multiple chained calls before a single-line block (e.g., `.dup.sort_by { _1.name }`). The cop incorrectly used the block's method (`.sort_by`) as the alignment base instead of the leftmost call on that line (`.dup`).
- Add `leftmost_call_on_same_line` helper that walks up through chained receivers on the same line to find the correct alignment reference.

## Before

```ruby
# This valid code was incorrectly flagged:
users
  .dup.sort_by { _1.name.lower }
  .page(params[:page])       # offense: Align .page with .sort_by on line 2
  .per(PER_PAGE)
```

## After

No offense is reported. All `.` calls are correctly recognized as aligned at column 2.

## Test plan

- [x] Added spec for the exact reproduction case from the issue
- [x] Added spec for safe navigation (`&.`) variant
- [x] Added spec for continuation line that also has a block (`find_continuation_node` path)
- [x] Added spec for three chained calls before a single-line block
- [x] All existing specs pass (275 examples, 0 failures)
- [x] Full `bundle exec rake` passes (0 offenses, 0 failures)