### PR TITLE
fix(layout): avoid IndentationStyle false positive on tab+space alignment

### DIFF
--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -67,7 +67,7 @@ module RuboCop
           match = if style == :spaces
                     line.match(/\A\s*\t+/)
                   else
-                    line.match(/\A\s* +/)
+                    line.match(/\A +/)
                   end
           return unless match
 

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -186,6 +186,13 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       expect_no_offenses("x = <<HELLO\n\thello\n\t\n\t\t\nhello\nHELLO")
     end
 
+    it 'accepts a line with tab indentation followed by spaces for alignment' do
+      expect_no_offenses(<<~RUBY)
+        \ts.description = 'Use foo' \\
+        \t                ' as bar.'
+      RUBY
+    end
+
     it 'registers and corrects an offense for a line indented with fractional number of' \
        'indentation groups by rounding down' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Closes #7884

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
rubocop/rubocop

## Issue
https://github.com/rubocop/rubocop/issues/7884

## Root cause
In `Layout/IndentationStyle` with `EnforcedStyle: tabs`, the offense detection regex `/\A\s* +/` matches any leading whitespace ending in spaces. This incorrectly flags spaces used for alignment after a tab indent (e.g. `\t                'continued'` for a continued/aligned string), producing a false positive.

## Fix
Restrict the tabs-style offense regex to leading spaces only (`/\A +/`). Spaces that follow tabs in the indentation are treated as alignment, not indentation, and are no longer reported. Existing behavior (flagging space-only or space-before-tab indents) is preserved.

## Regression test
`spec/rubocop/cop/layout/indentation_style_spec.rb` — new example "accepts a line with tab indentation followed by spaces for alignment" exercises the exact pattern from the issue (tab indent followed by aligned spaces on a continuation line).

## Risk
low

## Verification
Ran `bundle exec rspec spec/rubocop/cop/layout/indentation_style_spec.rb` → 26 examples, 0 failures (includes pre-existing tests + new regression test).
