### PR TITLE
[Fix #13794] Fix Layout/LineLength autocorrection for endless methods with blocks

### DIFF
--- a/changelog/fix_line_length_endless_method_blocks_20260424174203.md
+++ b/changelog/fix_line_length_endless_method_blocks_20260424174203.md
@@ -1,0 +1,1 @@
+* [#13794](https://github.com/rubocop/rubocop/issues/13794): Fix `Layout/LineLength` autocorrection for endless methods with block bodies. ([@hervetatche][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -65,6 +65,7 @@ module RuboCop
         include AllowedPattern
         include RangeHelp
         include LineLengthHelp
+        include EndlessMethodRewriter
         extend AutoCorrector
 
         exclude_limit 'Max'
@@ -92,8 +93,15 @@ module RuboCop
         alias on_hash on_potential_breakable_node
         alias on_send on_potential_breakable_node
         alias on_csend on_potential_breakable_node
-        alias on_def on_potential_breakable_node
-        alias on_defs on_potential_breakable_node
+
+        def on_def(node)
+          if node.endless?
+            track_endless_method(node)
+          else
+            check_for_breakable_node(node)
+          end
+        end
+        alias on_defs on_def
 
         def on_new_investigation
           return unless processed_source.raw_source.include?(';')
@@ -110,6 +118,70 @@ module RuboCop
         private
 
         attr_accessor :breakable_range
+
+        def track_endless_method(node)
+          line_index = node.first_line - processed_source.buffer.first_line
+          endless_methods_by_line[line_index] = node
+        end
+
+        def handle_endless_method_line(line, line_index)
+          if require_endless_methods?
+            return register_required_endless_method_offense(line, line_index)
+          end
+
+          register_endless_method_offense(line, line_index)
+        end
+
+        def require_endless_methods?
+          config.cop_enabled?('Style/EndlessMethod') &&
+            config.for_cop('Style/EndlessMethod')['EnforcedStyle'] == 'require_always'
+        end
+
+        def register_endless_method_offense(line, line_index)
+          message = format(MSG, length: line_length(line), max: max)
+          loc = excess_range(nil, line, line_index)
+
+          add_offense(loc, message: message) do |corrector|
+            self.max = line_length(line)
+
+            correct_to_multiline(corrector, endless_methods_by_line[line_index])
+          end
+        end
+
+        def register_required_endless_method_offense(line, line_index)
+          node = endless_methods_by_line[line_index]
+          loc = excess_range(nil, line, line_index)
+
+          add_offense(loc, message: format(MSG, length: line_length(line), max: max)) do |corrector|
+            self.max = line_length(line)
+
+            if correctable_endless_method_block?(node)
+              correct_endless_method_block_to_multiline(corrector, node)
+            end
+          end
+        end
+
+        def correctable_endless_method_block?(node)
+          block_node = node.body
+
+          block_node&.type?(:any_block) &&
+            block_node.braces? &&
+            block_node.single_line? &&
+            block_node.body &&
+            !receiver_contains_heredoc?(block_node)
+        end
+
+        def correct_endless_method_block_to_multiline(corrector, node)
+          block_node = node.body
+          block_arguments = block_node.arguments? ? " #{block_node.arguments.source}" : ''
+          replacement = [
+            "#{block_node.send_node.source} do#{block_arguments}",
+            "#{indent(node, offset: 2)}#{block_node.body.source}",
+            "#{indent(node)}end"
+          ].join("\n")
+
+          corrector.replace(block_node, replacement)
+        end
 
         def check_for_breakable_node(node)
           breakable_node = extract_breakable_node(node, max)
@@ -237,6 +309,10 @@ module RuboCop
           @breakable_range_by_line_index ||= {}
         end
 
+        def endless_methods_by_line
+          @endless_methods_by_line ||= {}
+        end
+
         def breakable_string_delimiters
           @breakable_string_delimiters ||= {}
         end
@@ -252,10 +328,15 @@ module RuboCop
           [max - indentation_difference(line), 0].max
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_line(line, line_index)
           return if line_length(line) <= max
           return if allowed_line?(line, line_index)
+
+          if endless_methods_by_line.key?(line_index)
+            return handle_endless_method_line(line, line_index)
+          end
+
           if allow_rbs_inline_annotation? && rbs_inline_annotation_on_source_line?(line_index)
             return
           end
@@ -267,7 +348,7 @@ module RuboCop
 
           register_offense(excess_range(nil, line, line_index), line, line_index)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def allowed_line?(line, line_index)
           matches_allowed_pattern?(line) ||

--- a/lib/rubocop/cop/mixin/endless_method_rewriter.rb
+++ b/lib/rubocop/cop/mixin/endless_method_rewriter.rb
@@ -5,19 +5,27 @@ module RuboCop
     # Common functionality for rewriting endless methods to normal method definitions
     module EndlessMethodRewriter
       def correct_to_multiline(corrector, node)
-        replacement = <<~RUBY.strip
-          def #{node.method_name}#{arguments(node)}
-            #{node.body.source}
-          end
-        RUBY
+        replacement = [
+          "def #{receiver(node)}#{node.method_name}#{arguments(node)}",
+          "#{indent(node, offset: configured_indentation_width)}#{node.body.source}",
+          "#{indent(node)}end"
+        ].join("\n")
 
         corrector.replace(node, replacement)
       end
 
       private
 
+      def receiver(node)
+        node.receiver ? "#{node.receiver.source}#{node.loc.operator.source}" : ''
+      end
+
       def arguments(node, missing = '')
         node.arguments.any? ? node.arguments.source : missing
+      end
+
+      def configured_indentation_width
+        cop_config['IndentationWidth'] || config.for_cop('Layout/IndentationWidth')['Width'] || 2
       end
     end
   end

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -206,16 +206,6 @@ module RuboCop
           body.each_descendant(:str).any?(&:heredoc?)
         end
 
-        def correct_to_multiline(corrector, node)
-          replacement = <<~RUBY.strip
-            def #{receiver(node)}#{node.method_name}#{arguments(node)}
-              #{node.body.source}
-            end
-          RUBY
-
-          corrector.replace(node, replacement)
-        end
-
         def endless_replacement(node)
           <<~RUBY.strip
             def #{receiver(node)}#{node.method_name}#{arguments(node)} = #{node.body.source}

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
   include_context 'with exclude limit tracking'
 
   let(:cop_config) { { 'Max' => 80, 'AllowedPatterns' => nil } }
+  let(:other_cops) { {} }
 
   let(:config) do
     RuboCop::Config.new(
-      'Layout/LineLength' => { 'URISchemes' => %w[http https] }.merge(cop_config),
-      'Layout/IndentationStyle' => { 'IndentationWidth' => 2 }
+      {
+        'Layout/LineLength' => { 'URISchemes' => %w[http https] }.merge(cop_config),
+        'Layout/IndentationStyle' => { 'IndentationWidth' => 2 }
+      }.merge(other_cops)
     )
   end
 
@@ -1369,6 +1372,150 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             def: "100000", ghi: "100000", jkl: "100000", mno: "100000")
             end
           RUBY
+        end
+      end
+    end
+
+    context 'endless method definition', :ruby30 do
+      let(:cop_config) { super().merge('Max' => 80) }
+
+      context 'when under limit' do
+        it 'does not add any offenses' do
+          expect_no_offenses(<<~RUBY)
+            def foo(bar) = bar.length
+          RUBY
+        end
+      end
+
+      context 'when over limit' do
+        context 'with a simple expression' do
+          it 'adds an offense and autocorrects to multiline definition' do
+            expect_offense(<<~RUBY)
+              def very_long_method_name = some_long_expression_here_that_exceeds_maximum_line_length_configuration
+                                                                                              ^^^^^^^^^^^^^^^^^^^^ Line is too long. [100/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def very_long_method_name
+                some_long_expression_here_that_exceeds_maximum_line_length_configuration
+              end
+            RUBY
+          end
+        end
+
+        context 'with a block expression' do
+          it 'adds an offense and autocorrects to multiline definition' do
+            expect_offense(<<~RUBY)
+              def citations = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                                                                                              ^^^^^^^^ Line is too long. [88/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def citations
+                a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+              end
+            RUBY
+          end
+        end
+
+        context 'with a class method definition' do
+          it 'adds an offense and autocorrects to multiline definition' do
+            expect_offense(<<~RUBY)
+              def self.citations = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                                                                                              ^^^^^^^^^^^^^ Line is too long. [93/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def self.citations
+                a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+              end
+            RUBY
+          end
+        end
+
+        context 'when nested inside a class' do
+          it 'adds an offense and preserves indentation when autocorrecting to multiline definition' do
+            expect_offense(<<~RUBY)
+              class Foo
+                def citations = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                                                                                              ^^^^^^^^^^ Line is too long. [90/80]
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              class Foo
+                def citations
+                  a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                end
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'when Style/EndlessMethod requires endless methods' do
+        let(:other_cops) do
+          { 'Style/EndlessMethod' => { 'Enabled' => true, 'EnforcedStyle' => 'require_always' } }
+        end
+
+        context 'when over limit' do
+          it 'adds an offense and converts block braces to do/end' do
+            expect_offense(<<~RUBY)
+              def citations = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                                                                                              ^^^^^^^^ Line is too long. [88/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def citations = a_method_call[1..].filter_map do |argument|
+                some_other_method(argument)
+              end
+            RUBY
+          end
+
+          it 'adds an offense and converts numblock braces to do/end' do
+            expect_offense(<<~RUBY)
+              def nums = a_method_call[1..].filter_map { _1.some_other_method(long_argument_name) }
+                                                                                              ^^^^^ Line is too long. [85/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def nums = a_method_call[1..].filter_map do
+                _1.some_other_method(long_argument_name)
+              end
+            RUBY
+          end
+
+          it 'adds an offense and converts itblock braces to do/end', :ruby34 do
+            expect_offense(<<~RUBY)
+              def its = a_method_call[1..].filter_map { it.some_other_method(long_argument_name) }
+                                                                                              ^^^^ Line is too long. [84/80]
+            RUBY
+
+            expect_correction(<<~RUBY)
+              def its = a_method_call[1..].filter_map do
+                it.some_other_method(long_argument_name)
+              end
+            RUBY
+          end
+
+          context 'when nested inside a class' do
+            it 'adds an offense and preserves indentation when converting block braces to do/end' do
+              expect_offense(<<~RUBY)
+                class Foo
+                  def citations = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
+                                                                                                ^^^^^^^^^^ Line is too long. [90/80]
+                end
+              RUBY
+
+              expect_correction(<<~RUBY)
+                class Foo
+                  def citations = a_method_call[1..].filter_map do |argument|
+                    some_other_method(argument)
+                  end
+                end
+              RUBY
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
A fix for https://github.com/rubocop/rubocop/issues/13794 was attempted last year but it finally [staled](https://github.com/rubocop/rubocop/pull/13940). I wanted to try to make a contribution to a Rails OSS project and though that this issue was a good one to get started since I already had some code to piggy back on. This said, it being my first, be aware that some of it might not be quite right!

```ruby
  def under_limit(bar) = bar.length

  def over_limit_with_block = a_method_call[1..].filter_map { |argument| some_other_method(argument) }

  def over_limit_simple_expression = some_long_expression_here_that_exceeds_maximum_line_length_configuration

  def over_limit_numblock = a_method_call[1..].filter_map { _1.some_other_method(long_argument_name) }

  def over_limit_itblock = a_method_call[1..].filter_map { it.some_other_method(long_argument_name) }

  def self.over_limit_class_method = a_method_call[1..].filter_map { |argument| some_other_method(argument) }
```

```yaml
Layout/LineLength:
  Max: 80
Style/EndlessMethod:
  Enabled: true
```

```ruby
  def under_limit(bar) = bar.length

  def over_limit_with_block
    a_method_call[1..].filter_map { |argument| some_other_method(argument) }
  end

  def over_limit_simple_expression
    some_long_expression_here_that_exceeds_maximum_line_length_configuration
  end

  def over_limit_numblock
    a_method_call[1..].filter_map { _1.some_other_method(long_argument_name) }
  end

  def over_limit_itblock
    a_method_call[1..].filter_map { it.some_other_method(long_argument_name) }
  end

  def self.over_limit_class_method
    a_method_call[1..].filter_map { |argument| some_other_method(argument) }
  end
```

```yaml
Layout/LineLength:
  Max: 80
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_always
```

```ruby
  def under_limit(bar) = bar.length

  def over_limit_with_block = a_method_call[1..].filter_map do |argument|
    some_other_method(argument)
  end

  def over_limit_simple_expression = some_long_expression_here_that_exceeds_maximum_line_length_configuration

  def over_limit_numblock = a_method_call[1..].filter_map do
    _1.some_other_method(long_argument_name)
  end

  def over_limit_itblock = a_method_call[1..].filter_map do
    it.some_other_method(long_argument_name)
  end

  def self.over_limit_class_method = a_method_call[1..].filter_map do |argument|
    some_other_method(argument)
  end
```

Fixes https://github.com/rubocop/rubocop/issues/13794

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
