### PR TITLE
[Fix #15130] Fix incorrect autocorrect in `Style/Copyright`

### DIFF
--- a/changelog/fix_style_copyright_autocorrect_with_or_without_hash_prefix.md
+++ b/changelog/fix_style_copyright_autocorrect_with_or_without_hash_prefix.md
@@ -1,0 +1,1 @@
+* [#15130](https://github.com/rubocop/rubocop/issues/15130): Fix incorrect autocorrect in `Style/Copyright` when `AutocorrectNotice` lacks a `#` prefix or `Notice` pattern starts with `^#`. ([@koic][])

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -46,15 +46,16 @@ module RuboCop
           token = insert_notice_before(processed_source)
           range = token.nil? ? range_between(0, 0) : token.pos
 
-          corrector.insert_before(range, "#{autocorrect_notice}\n")
+          corrector.insert_before(range, "#{normalized_autocorrect_notice}\n")
         end
 
-        def notice
-          cop_config['Notice']
-        end
+        def normalized_autocorrect_notice
+          autocorrect_notice.lines.map do |line|
+            next line if line.start_with?('#')
+            next "#\n" if line.chomp.empty?
 
-        def autocorrect_notice
-          cop_config['AutocorrectNotice']
+            "# #{line}"
+          end.join
         end
 
         def verify_autocorrect_notice!
@@ -62,8 +63,7 @@ module RuboCop
             raise Warning, "#{cop_name}: #{AUTOCORRECT_EMPTY_WARNING}"
           end
 
-          regex = Regexp.new(notice)
-          return if autocorrect_notice.gsub(/^# */, '').match?(regex)
+          return if normalized_autocorrect_notice.gsub(/^# */, '').match?(notice_regexp)
 
           message = "AutocorrectNotice '#{autocorrect_notice}' must match Notice /#{notice}/"
           raise Warning, "#{cop_name}: #{message}"
@@ -91,17 +91,28 @@ module RuboCop
         end
 
         def notice_found?(processed_source)
-          notice_regexp = Regexp.new(notice.lines.map(&:strip).join)
           multiline_notice = +''
           processed_source.tokens.each do |token|
             break unless token.comment?
 
-            multiline_notice << token.text.sub(/\A# */, '')
+            multiline_notice << token.text.sub(/\A# */, '') << "\n"
 
             break if notice_regexp.match?(token.text)
           end
 
           multiline_notice.match?(notice_regexp)
+        end
+
+        def notice_regexp
+          @notice_regexp ||= Regexp.new(notice.sub(/\A\^?#\s?/, ''))
+        end
+
+        def notice
+          cop_config['Notice']
+        end
+
+        def autocorrect_notice
+          cop_config['AutocorrectNotice']
         end
       end
     end

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -194,6 +194,110 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
     end
   end
 
+  context 'when `AutocorrectNotice` does not start with a `#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '^Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => 'Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'inserts the notice as a comment line' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
+  context 'when the `Notice` pattern starts with `^#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '^# Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => '# Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'does not register an offense when the notice is present' do
+      expect_no_offenses(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+
+    it 'autocorrects with a single `#` prefix' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
+  context 'when `Notice` starts with `^#` and AutocorrectNotice has no `#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '^# Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => 'Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'autocorrects to a single `#`-prefixed comment' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
+  context 'when `AutocorrectNotice` spans multiple lines without `#` prefixes' do
+    let(:cop_config) do
+      {
+        'Notice' => <<~'COPYRIGHT',
+          Copyright (\(c\) )?2026 Acme Inc.
+
+          License details\.\.\.
+        COPYRIGHT
+        'AutocorrectNotice' => <<~COPYRIGHT
+          Copyright (c) 2026 Acme Inc.
+
+          License details...
+        COPYRIGHT
+      }
+    end
+
+    it 'prefixes each line with `# ` and emits blank lines as `#`' do
+      expect_offense(<<~RUBY)
+        class Foo
+        ^ Include a copyright notice matching [...]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 Acme Inc.
+        #
+        # License details...
+
+        class Foo
+        end
+      RUBY
+    end
+  end
+
   context 'when the copyright notice is missing and ' \
           'the source code file starts with shebang and ' \
           'an encoding comment' do


### PR DESCRIPTION
Fix incorrect autocorrect in `Style/Copyright` when `AutocorrectNotice` lacks a `#` prefix or `Notice` pattern starts with `^#`.

Fixes #15130.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
