### PR TITLE
Fix `Style/DocumentDynamicEvalDefinition` on escaped interpolation

### DIFF
--- a/changelog/fix_false_positives_in_style_document_dynamic_eval_definition.md
+++ b/changelog/fix_false_positives_in_style_document_dynamic_eval_definition.md
@@ -1,0 +1,1 @@
+* [#10179](https://github.com/rubocop/rubocop/issues/10179): Fix false positives in `Style/DocumentDynamicEvalDefinition` when the heredoc contains an escaped interpolation (`\#{...}`). ([@eyupcanakman][])

--- a/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
+++ b/lib/rubocop/cop/style/document_dynamic_eval_definition.rb
@@ -161,7 +161,12 @@ module RuboCop
           source = source.gsub(COMMENT_REGEXP, '')
           return if source.blank?
 
-          /\s*#{Regexp.escape(source.strip)}/
+          # Treat `\#` (an escaped interpolation marker in the heredoc) as matching
+          # either `\#` or `#` in the comment, since the comment may show either
+          # the literal source form or the runtime appearance.
+          segments = source.strip.split('\\#', -1).map { |segment| Regexp.escape(segment) }
+
+          /\s*#{segments.join('\\\\?#')}/
         end
       end
     end

--- a/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
+++ b/spec/rubocop/cop/style/document_dynamic_eval_definition_spec.rb
@@ -196,6 +196,38 @@ RSpec.describe RuboCop::Cop::Style::DocumentDynamicEvalDefinition, :config do
       RUBY
     end
 
+    it 'does not register an offense when the heredoc contains an escaped interpolation' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # def something
+          #   puts "escaped \#{interpolation}"
+          # end
+
+          <<~EOT, __FILE__, __LINE__ + 1
+            def \#{my_method}
+              puts "escaped \\\#{interpolation}"
+            end
+          EOT
+        )
+      RUBY
+    end
+
+    it 'does not register an offense when the comment also escapes an interpolation that the heredoc escapes' do
+      expect_no_offenses(<<~RUBY)
+        class_eval(
+          # def something
+          #   puts "escaped \\\#{interpolation}"
+          # end
+
+          <<~EOT, __FILE__, __LINE__ + 1
+            def \#{my_method}
+              puts "escaped \\\#{interpolation}"
+            end
+          EOT
+        )
+      RUBY
+    end
+
     it 'does not register an offense when using inline comments' do
       expect_no_offenses(<<~RUBY)
         class_eval(


### PR DESCRIPTION
Fix a false positive in `Style/DocumentDynamicEvalDefinition` when a heredoc body contains an escaped interpolation (`\#{...}`). `source_to_regexp` runs the heredoc through `Regexp.escape`, which doubles the backslash, so the resulting regexp no longer matches the documenting comment that shows the unescaped runtime form `#{...}`. The escape is now collapsed back to `\#` before matching.

Fixes #10179.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
