### PR TITLE
[Fix #15137] Fix incorrect "does not support `IndentationWidth` parameter" warning

### DIFF
--- a/changelog/fix_false_positive_warning_for_layout_closing_parenthesis_indentation_and_layout_comment_indentation.md
+++ b/changelog/fix_false_positive_warning_for_layout_closing_parenthesis_indentation_and_layout_comment_indentation.md
@@ -1,0 +1,1 @@
+* [#15137](https://github.com/rubocop/rubocop/issues/15137): Fix incorrect "does not support IndentationWidth parameter" warning for `Layout/ClosingParenthesisIndentation` and `Layout/CommentIndentation`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -529,6 +529,10 @@ Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '<<next>>'
+  # By default the indentation width from `Layout/IndentationWidth` is used,
+  # but it can be overridden by setting this parameter.
+  IndentationWidth: ~
 
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
@@ -537,7 +541,10 @@ Layout/CommentIndentation:
   # with a comment on the preceding line.
   AllowForAlignment: false
   VersionAdded: '0.49'
-  VersionChanged: '1.24'
+  VersionChanged: '<<next>>'
+  # By default the indentation width from `Layout/IndentationWidth` is used,
+  # but it can be overridden by setting this parameter.
+  IndentationWidth: ~
 
 Layout/ConditionPosition:
   Description: >-

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
         expect(todo_contents).to eq(<<~YAML)
           # Offense count: 1
           # This cop supports safe autocorrection (--autocorrect).
-          # Configuration parameters: AllowForAlignment.
+          # Configuration parameters: AllowForAlignment, IndentationWidth.
           Layout/CommentIndentation:
             Exclude:
               - 'example1.rb'
@@ -869,7 +869,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# Offense count: 1',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, IndentationWidth.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
@@ -972,7 +972,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          '',
          '# Offense count: 1',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, IndentationWidth.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",
@@ -1173,7 +1173,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
 
         # Offense count: 1
         # This cop supports safe autocorrection (--autocorrect).
-        # Configuration parameters: AllowForAlignment.
+        # Configuration parameters: AllowForAlignment, IndentationWidth.
         Layout/CommentIndentation:
           Exclude:
             - 'example2.rb'
@@ -1278,7 +1278,7 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
          'again.',
          '',
          '# This cop supports safe autocorrection (--autocorrect).',
-         '# Configuration parameters: AllowForAlignment.',
+         '# Configuration parameters: AllowForAlignment, IndentationWidth.',
          'Layout/CommentIndentation:',
          '  Exclude:',
          "    - 'example2.rb'",

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -525,4 +525,28 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation, :config do
       end
     RUBY
   end
+
+  context 'when the cop is configured with `IndentationWidth`' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/ClosingParenthesisIndentation' => { 'IndentationWidth' => 1 },
+        'Layout/IndentationWidth' => { 'Width' => 2 }
+      )
+    end
+
+    it 'uses the per-cop `IndentationWidth` to determine the expected column' do
+      expect_offense(<<~RUBY)
+        some_method(
+          a
+        )
+        ^ Indent `)` to column 1 (not 0)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        some_method(
+          a
+         )
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -416,4 +416,23 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
       RUBY
     end
   end
+
+  context 'when the cop is configured with `IndentationWidth`' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/CommentIndentation' => { 'IndentationWidth' => 1 },
+        'Layout/IndentationWidth' => { 'Width' => 2 }
+      )
+    end
+
+    it 'uses the per-cop `IndentationWidth` over `Layout/IndentationWidth`' do
+      expect_no_offenses(<<~RUBY)
+        if foo
+         # comment indented by 1 to align with the keyword `else` below
+        else
+          bar
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Both `Layout/ClosingParenthesisIndentation` and `Layout/CommentIndentation` include the `Alignment` mixin and read `IndentationWidth` from `cop_config`, but the parameter was not declared in `config/default.yml`, causing the config validator to print "does not support IndentationWidth parameter" even though the cops honor the value.

Declare `IndentationWidth: ~` for both cops so the validator recognizes the supported parameter.

Fixes #15137.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
