### PR TITLE
[Fix #15136] Fix false positive for `Lint/MissingCopEnableDirective` inside `# rubocop:push`/`# rubocop:pop`

### DIFF
--- a/changelog/fix_lint_missing_cop_enable_directive_with_push_pop.md
+++ b/changelog/fix_lint_missing_cop_enable_directive_with_push_pop.md
@@ -1,0 +1,1 @@
+* [#15136](https://github.com/rubocop/rubocop/issues/15136): Fix false positive for `Lint/MissingCopEnableDirective` when `# rubocop:disable` is wrapped in a `# rubocop:push` / `# rubocop:pop` block. ([@koic][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -95,7 +95,8 @@ module RuboCop
       end
     end
 
-    def analyze # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def analyze
       return {} if @no_directives
 
       analyses = Hash.new { |hash, key| hash[key] = CopAnalysis.new([], nil) }
@@ -103,9 +104,9 @@ module RuboCop
 
       each_directive do |directive|
         if directive.push?
-          resolved = resolve_push_cops(directive)
-          @stack.push(snapshot_cops(analyses, resolved.values.flatten))
-          apply_push(analyses, resolved, directive.line_number)
+          restore_point = analyses.transform_values(&:dup)
+          @stack.push(restore_point)
+          apply_push(analyses, resolve_push_cops(directive), directive.line_number)
         elsif directive.pop?
           pop_state(analyses, directive.line_number) if @stack.any?
         else
@@ -121,10 +122,7 @@ module RuboCop
         hash[cop_name] = cop_line_ranges(analysis)
       end
     end
-
-    def snapshot_cops(analyses, cop_names)
-      cop_names.to_h { |name| [name, analyses[name].dup] }
-    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def resolve_push_cops(directive)
       directive.push_args.transform_values do |names|
@@ -155,13 +153,12 @@ module RuboCop
     end
 
     def pop_state(analyses, line)
-      saved = @stack.pop
-      saved.each do |cop, old|
-        cur = analyses[cop]
-        new_range = cur.start_line_number ? [cur.start_line_number..(line - 1)] : []
-        ranges = cur.line_ranges + new_range
-        new_start = old.start_line_number ? line : nil
-        analyses[cop] = CopAnalysis.new(ranges, new_start)
+      restore_point = @stack.pop
+      (restore_point.keys | analyses.keys).each do |cop|
+        current = analyses[cop]
+        new_range = current.start_line_number ? [current.start_line_number..(line - 1)] : []
+        new_start = restore_point[cop]&.start_line_number ? line : nil
+        analyses[cop] = CopAnalysis.new(current.line_ranges + new_range, new_start)
       end
     end
 

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -758,5 +758,107 @@ RSpec.describe RuboCop::CommentConfig do
         expect(guard_clause_disabled).not_to include(6, 7)
       end
     end
+
+    context 'bare push/pop with disable inside' do
+      let(:source) do
+        <<~RUBY
+          def test
+            # rubocop:push
+            # rubocop:disable Style/RescueStandardError
+          rescue => e
+            print e
+          end
+          # rubocop:pop
+          other
+        RUBY
+      end
+
+      it 'restores the cop after pop even when push has no inline args' do
+        disabled = disabled_lines_of_cop('Style/RescueStandardError')
+
+        expect(disabled).to include(3, 4, 5, 6)
+        expect(disabled).not_to include(1, 2, 7, 8, 9)
+      end
+    end
+
+    context 'bare push/pop preserves outer disable for unrelated cop' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable Style/Not
+          # rubocop:push
+          # rubocop:disable Style/For
+          for x in [1, 2, 3]
+            not x.nil?
+          end
+          # rubocop:pop
+          tail
+        RUBY
+      end
+
+      it 'restores Style/For at pop while leaving Style/Not disabled' do
+        for_disabled = disabled_lines_of_cop('Style/For')
+        not_disabled = disabled_lines_of_cop('Style/Not')
+
+        expect(for_disabled).to include(3, 4, 5, 6)
+        expect(for_disabled).not_to include(7, 8, 9)
+        expect(not_disabled).to include(1, 2, 3, 4, 5, 6, 7, 8, 9)
+      end
+    end
+
+    context 'inline-arg push/pop restores an unrelated cop disabled inside the block' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:push -Style/GuardClause
+          # rubocop:disable Style/For
+          for x in [1, 2, 3]
+            if x.size == 0
+              return x
+            end
+          end
+          # rubocop:pop
+          for y in [4, 5, 6]
+            puts y
+          end
+        RUBY
+      end
+
+      it 'restores Style/For at pop even though it is not named in the push args' do
+        for_disabled = disabled_lines_of_cop('Style/For')
+        guard_clause_disabled = disabled_lines_of_cop('Style/GuardClause')
+
+        expect(for_disabled).to include(2, 3, 4, 5, 6, 7)
+        expect(for_disabled).not_to include(8, 9, 10, 11)
+        expect(guard_clause_disabled).to include(1, 2, 3, 4, 5, 6, 7)
+        expect(guard_clause_disabled).not_to include(8, 9, 10, 11)
+      end
+    end
+
+    context 'bare push/pop with `# rubocop:enable` for a previously disabled cop' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable Style/For
+          for x in [1, 2, 3]
+            puts x
+          end
+          # rubocop:push
+          # rubocop:enable Style/For
+          for y in [4, 5, 6]
+            puts y
+          end
+          # rubocop:pop
+          for z in [7, 8, 9]
+            puts z
+          end
+        RUBY
+      end
+
+      it 'restores the disabled state of Style/For at pop' do
+        disabled = disabled_lines_of_cop('Style/For')
+
+        expect(disabled).to include(1, 2, 3, 4, 5, 6)
+        expect(disabled).not_to include(7, 8, 9)
+        expect(disabled).to include(10, 11, 12, 13)
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -106,6 +106,41 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
     end
   end
 
+  context 'when a `# rubocop:disable` is wrapped in `# rubocop:push` / `# rubocop:pop`' do
+    let(:cop_config) { { 'MaximumRangeSize' => Float::INFINITY } }
+
+    it 'does not register an offense for a bare `push` / `pop` pair' do
+      expect_no_offenses(<<~RUBY)
+        def test
+          # rubocop:push
+          # rubocop:disable Style/RescueStandardError
+        rescue => e
+          print e
+        end
+        # rubocop:pop
+      RUBY
+    end
+
+    it 'does not register an offense when the disable is closed by `# rubocop:pop` before EOF' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:push
+        # rubocop:disable Layout/SpaceAroundOperators
+        x =   0
+        # rubocop:pop
+        y = 1
+      RUBY
+    end
+
+    it 'registers an offense when `# rubocop:push` has no matching `# rubocop:pop`' do
+      expect_offense(<<~RUBY)
+        # rubocop:push
+        # rubocop:disable Layout/SpaceAroundOperators
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:enable` after disabling it.
+        x =   0
+      RUBY
+    end
+  end
+
   context 'when the cop is disabled in the config' do
     let(:other_cops) { { 'Layout/LineLength' => { 'Enabled' => false } } }
 


### PR DESCRIPTION
A bare `# rubocop:push` snapshotted only the cops named in its inline args, so any `# rubocop:disable` written between a bare push and its `# rubocop:pop` was never restored at pop time. The disable range therefore extended to EOF and triggered `Lint/MissingCopEnableDirective`, contradicting the documented "saves the current state of all cop settings" semantics.

Snapshot every cop on push and, on pop, restore every cop seen in either the snapshot or the current analyses.

Fixes #15136.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
