### PR TITLE
[Fix #15135] Fix `Style/RedundantParentheses` autocorrect swallowing chained methods into trailing comments

### DIFF
--- a/changelog/fix_redundant_parentheses_swallowing_chained_methods.md
+++ b/changelog/fix_redundant_parentheses_swallowing_chained_methods.md
@@ -1,0 +1,1 @@
+* [#15135](https://github.com/rubocop/rubocop/issues/15135): Fix incorrect autocorrect for `Style/RedundantParentheses` that swallowed chained method calls into a trailing inline comment on the line above the closing parenthesis. ([@hammadxcm][])

--- a/lib/rubocop/cop/correctors/parentheses_corrector.rb
+++ b/lib/rubocop/cop/correctors/parentheses_corrector.rb
@@ -13,8 +13,7 @@ module RuboCop
           buffer = node.source_range.source_buffer
           corrector.remove(range_with_surrounding_space(range: node.loc.begin, buffer: buffer,
                                                         side: :right, whitespace: true))
-          corrector.remove(range_with_surrounding_space(range: node.loc.end, buffer: buffer,
-                                                        side: :left))
+          remove_close_paren(corrector, node, buffer)
           handle_orphaned_comma(corrector, node)
 
           return unless ternary_condition?(node) && next_char_is_question_mark?(node)
@@ -23,6 +22,38 @@ module RuboCop
         end
 
         private
+
+        # When the line above `)` ends with a comment and a chained call follows `)`,
+        # crossing the newline would pull the chain into the comment. Preserve the newline.
+        def remove_close_paren(corrector, node, buffer)
+          newlines = !comment_above_close_paren_swallows_chain?(node, buffer)
+          corrector.remove(range_with_surrounding_space(range: node.loc.end, buffer: buffer,
+                                                        side: :left, newlines: newlines))
+        end
+
+        def comment_above_close_paren_swallows_chain?(node, buffer)
+          last_child = node.children.last
+          return false unless last_child
+
+          body_end = last_child.source_range.end_pos
+          close_paren_begin = node.loc.end.begin_pos
+          return false if body_end >= close_paren_begin
+
+          source_between = buffer.source[body_end...close_paren_begin]
+          return false unless source_between.match?(/#[^\n]*\n/)
+
+          chained_after_close_paren?(node)
+        end
+
+        def chained_after_close_paren?(node)
+          close_paren = node.loc.end
+          line_text = close_paren.source_line
+          after_paren = line_text[(close_paren.column + 1)..]
+          return false if after_paren.nil?
+
+          trimmed = after_paren.lstrip
+          !trimmed.empty? && !trimmed.start_with?('#')
+        end
 
         def ternary_condition?(node)
           node.parent&.if_type? && node.parent.ternary?

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -404,6 +404,49 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     expect_no_offenses('def foo((bar, baz)); end')
   end
 
+  context 'with a chained call after a multiline parenthesized expression ending with a comment' do
+    it 'preserves the chained call by keeping it on its own line' do
+      expect_offense(<<~RUBY)
+        member_ids = (
+                     ^ Don't use parentheses around a method call.
+          [1, 2, 3].map { |i| i } # comment
+        ).uniq
+      RUBY
+
+      expect_correction(<<~RUBY)
+        member_ids = [1, 2, 3].map { |i| i } # comment
+        .uniq
+      RUBY
+    end
+
+    it 'preserves the chained call when the closing paren is indented' do
+      expect_offense(<<~RUBY)
+        member_ids = (
+                     ^ Don't use parentheses around a method call.
+          [1, 2, 3].map { |i| i } # comment
+          ).uniq
+      RUBY
+
+      expect_correction(<<~RUBY)
+        member_ids = [1, 2, 3].map { |i| i } # comment
+        .uniq
+      RUBY
+    end
+
+    it 'still removes the newline when no chained call follows the closing paren' do
+      expect_offense(<<~RUBY)
+        x = (
+            ^ Don't use parentheses around a method call.
+          foo.bar # comment
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = foo.bar # comment
+      RUBY
+    end
+  end
+
   it 'registers an offense for parens around parenthesized conditional assignment' do
     expect_offense(<<~RUBY)
       if ((var = 42))


### PR DESCRIPTION
### Summary

Fixes #15135.

`Style/RedundantParentheses` autocorrect blindly removed the newline preceding the closing parenthesis. When the line above ended with an inline comment, the trailing chained method on the `)` line was pulled up into the comment, breaking the code and invalidating any `# rubocop:disable …` directive.

#### Before

```ruby
member_ids = (
  [1, 2, 3].map { |i| i } # rubocop:disable Style/SymbolProc
).uniq
```

was autocorrected to (broken — `.uniq` becomes part of the comment):

```ruby
member_ids = [1, 2, 3].map { |i| i } # rubocop:disable Style/SymbolProc.uniq
```

#### After

```ruby
member_ids = [1, 2, 3].map { |i| i } # rubocop:disable Style/SymbolProc
.uniq
```

The chain stays valid (Ruby's leading-`.` line continuation), and the directive comment remains intact.

### Implementation

`ParenthesesCorrector` now inspects the source between the body's last child and `)`. When that span contains a `#`-style comment **and** there is non-comment content after `)` on its line, the corrector preserves the newline before `)` (passes `newlines: false`). All existing behavior is preserved otherwise.

### Before submitting the PR I made sure to

- [x] Add an entry to `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] Created tests which fail without the change (if possible).
- [x] Run `bundle exec rake` (1706 files, 0 failures, 0 offenses).