### PR TITLE
Fix incorrect autocorrect for `Gemspec/RequireMFA` causing an infinite loop

### DIFF
--- a/changelog/fix_infinite_loop_for_gemspec_require_mfa.md
+++ b/changelog/fix_infinite_loop_for_gemspec_require_mfa.md
@@ -1,0 +1,1 @@
+* [#15141](https://github.com/rubocop/rubocop/pull/15141): Fix incorrect autocorrect for `Gemspec/RequireMFA` causing an infinite loop when `rubygems_mfa_required` metadata uses a symbol key. ([@koic][])

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -70,7 +70,7 @@ module RuboCop
         def_node_matcher :metadata, <<~PATTERN
           `{
             (send _ :metadata= $_)
-            (send (send _ :metadata) :[]= (str "rubygems_mfa_required") $_)
+            (send (send _ :metadata) :[]= {(str "rubygems_mfa_required") (sym :rubygems_mfa_required)} $_)
           }
         PATTERN
 
@@ -78,13 +78,13 @@ module RuboCop
         def_node_search :metadata_assignment, <<~PATTERN
           `{
             (send _ :metadata= _)
-            (send (send _ :metadata) :[]= (str _) _)
+            (send (send _ :metadata) :[]= {str sym} _)
           }
         PATTERN
 
         # @!method rubygems_mfa_required(node)
         def_node_search :rubygems_mfa_required, <<~PATTERN
-          (pair (str "rubygems_mfa_required") $_)
+          (pair {(str "rubygems_mfa_required") (sym :rubygems_mfa_required)} $_)
         PATTERN
 
         # @!method true_string?(node)

--- a/spec/rubocop/cop/gemspec/require_mfa_spec.rb
+++ b/spec/rubocop/cop/gemspec/require_mfa_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
           end
         RUBY
       end
+
+      it 'does not register an offense when the key is a symbol' do
+        expect_no_offenses(<<~RUBY, 'my.gemspec')
+          Gem::Specification.new do |spec|
+            spec.metadata = {
+              foo: 'bar',
+              rubygems_mfa_required: 'true',
+              baz: 'quux'
+            }
+          end
+        RUBY
+      end
     end
 
     context 'and `rubygems_mfa_required` is not included' do
@@ -100,6 +112,15 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
           Gem::Specification.new do |spec|
             spec.metadata['foo'] = 'bar'
             spec.metadata['rubygems_mfa_required'] = 'true'
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the key is a symbol' do
+        expect_no_offenses(<<~RUBY, 'my.gemspec')
+          Gem::Specification.new do |spec|
+            spec.metadata[:foo] = 'bar'
+            spec.metadata[:rubygems_mfa_required] = 'true'
           end
         RUBY
       end
@@ -150,6 +171,16 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
         Gem::Specification.new do |spec|
           spec.metadata = {
             'rubygems_mfa_required' => 'true'
+          }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the key is a symbol' do
+      expect_no_offenses(<<~RUBY, 'my.gemspec')
+        Gem::Specification.new do |spec|
+          spec.metadata = {
+            rubygems_mfa_required: 'true'
           }
         end
       RUBY


### PR DESCRIPTION
This makes `Gemspec/RequireMFA` recognize a symbol key for `rubygems_mfa_required` in addition to a string key, so that the cop does not keep inserting a duplicate `'rubygems_mfa_required' => 'true'` pair when other cops (e.g., `Style/StringHashKeys`, `Style/HashSyntax`) convert the key to a symbol with shorthand syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
