### PR TITLE
[Fix #15142] Fix unbreakable range bug for autocorrect

### DIFF
--- a/changelog/fix_infinite_loop_for_line_length_offense.md
+++ b/changelog/fix_infinite_loop_for_line_length_offense.md
@@ -1,0 +1,1 @@
+* [#15142](https://github.com/rubocop/rubocop/issues/15142): Fix infinite loop for `--disable-uncorrectable` and offense near heredoc. ([@jonas054][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -50,7 +50,8 @@ module RuboCop
 
       def disable_offense(offense_range)
         unbreakable_range = multiline_ranges(offense_range)&.find do |range|
-          eol_comment_would_be_inside_literal?(offense_range, range)
+          offense_range.overlaps?(range) &&
+            eol_comment_would_be_inside_literal?(offense_range, range)
         end
 
         if unbreakable_range

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -306,6 +306,42 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         end
       end
 
+      context 'and the offense is preceded by a heredoc' do
+        it 'adds before-and-after the offending line and not around the heredoc' do
+          create_file('.rubocop.yml', <<~YAML)
+            Layout/LineLength:
+              Max: 40
+          YAML
+          create_file('example.rb', <<~RUBY)
+            # frozen_string_literal: true
+
+            puts <<~INPUT
+              111, 138
+            INPUT
+
+            puts 'A line that is longer than the LineLength limit'
+          RUBY
+          expect(exit_code).to eq(0)
+          expect($stdout.string).to eq(<<~OUTPUT)
+            == example.rb ==
+            C:  7: 41: [Todo] Layout/LineLength: Line is too long. [54/40]
+
+            1 file inspected, 1 offense detected, 1 offense corrected
+          OUTPUT
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            puts <<~INPUT
+              111, 138
+            INPUT
+
+            # rubocop:todo Layout/LineLength
+            puts 'A line that is longer than the LineLength limit'
+            # rubocop:enable Layout/LineLength
+          RUBY
+        end
+      end
+
       context 'and the offense is inside a percent array' do
         before do
           create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
The algorithm, which was designed to find ranges where a rubocop:todo comment could not be added (such as a heredoc), didn't check if these ranges had anything to do with the offense being fixed. This is obviously wrong.