### PR TITLE
[Fix #15144]Fix an error for Style/SoleNestedConditional when nested conditionals have comments

### DIFF
--- a/changelog/fix_an_error_for_style_sole_nested_conditional_with_nested_comments.md
+++ b/changelog/fix_an_error_for_style_sole_nested_conditional_with_nested_comments.md
@@ -1,0 +1,1 @@
+* [#15144](https://github.com/rubocop/rubocop/issues/15144): Fix an error for `Style/SoleNestedConditional` when autocorrecting nested conditionals with comments. ([@5hun-s][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -157,12 +157,21 @@ module RuboCop
         end
 
         def correct_for_comment(corrector, node, if_branch)
-          comments = processed_source.ast_with_comments[if_branch].select do |comment|
-            comment.loc.line < if_branch.condition.first_line
-          end
+          return if ignored_nodes.any? { |outer| outer.if_branch.equal?(node) }
+
+          comments = collect_nested_comments(if_branch)
           comment_text = comments.map(&:text).join("\n") << "\n"
 
           corrector.insert_before(node.loc.keyword, comment_text) unless comments.empty?
+        end
+
+        def collect_nested_comments(if_branch)
+          comments = processed_source.ast_with_comments[if_branch].select do |comment|
+            comment.loc.line < if_branch.condition.first_line
+          end
+
+          nested = if_branch.if_branch
+          comments + (offending_branch?(if_branch, nested) ? collect_nested_comments(nested) : [])
         end
 
         def chainable_condition(node)

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -736,6 +736,30 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     end
   end
 
+  it 'registers an offense and corrects when using nested conditional and branch contains comments before each inner condition' do
+    expect_offense(<<~RUBY)
+      if foo
+        # Comments.
+        if bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          # More comments.
+          if baz
+          ^^ Consider merging nested conditions into outer `if` conditions.
+            do_something
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Comments.
+      # More comments.
+      if foo && bar && baz
+            do_something
+          end
+    RUBY
+  end
+
   it 'registers an offense and corrects when using guard conditional with outer comment' do
     expect_offense(<<~RUBY)
       # Comment.


### PR DESCRIPTION
When each nested conditional had a comment before its condition,
`correct_for_comment` was called multiple times for the same node,
causing a `Parser::ClobberingError` due to conflicting source rewrites.

Extract `collect_nested_comments` to gather all comments
from nested conditionals and insert them together at the top of the
corrected block. 

Fixes #15144.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
