### PR TITLE
[Fix #15144] Fix an error for `Style/SoleNestedConditional`

### DIFF
--- a/changelog/fix_an_error_in_style_sole_nested_conditional.md
+++ b/changelog/fix_an_error_in_style_sole_nested_conditional.md
@@ -1,0 +1,1 @@
+* [#15144](https://github.com/rubocop/rubocop/issues/15144): Fix an error in `Style/SoleNestedConditional` when autocorrecting nested conditionals containing comments. ([@koic][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -65,7 +65,10 @@ module RuboCop
 
           message = format(MSG, conditional_type: node.keyword)
           add_offense(if_branch.loc.keyword, message: message) do |corrector|
+            next if ignored_node?(node)
+
             autocorrect(corrector, node, if_branch)
+            ignore_node(if_branch)
           end
         end
 
@@ -115,9 +118,8 @@ module RuboCop
         end
 
         def correct_node(corrector, node)
-          corrector.replace(node.loc.keyword, 'if') if node.unless? && !part_of_ignored_node?(node)
+          corrector.replace(node.loc.keyword, 'if') if node.unless?
           corrector.replace(node.condition, chainable_condition(node))
-          ignore_node(node)
         end
 
         def correct_for_guard_condition_style(corrector, node, if_branch)

--- a/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
+++ b/spec/rubocop/cop/style/sole_nested_conditional_spec.rb
@@ -609,6 +609,30 @@ RSpec.describe RuboCop::Cop::Style::SoleNestedConditional, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when nested conditionals contain comments at multiple levels' do
+    expect_offense(<<~RUBY)
+      if foo
+        # Comments.
+        if bar
+        ^^ Consider merging nested conditions into outer `if` conditions.
+          # More comments.
+          if baz
+          ^^ Consider merging nested conditions into outer `if` conditions.
+            do_something
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # Comments.
+      # More comments.
+      if foo && bar && baz
+            do_something
+          end
+    RUBY
+  end
+
   it 'registers an offense and corrects when there are outer and inline comments' do
     expect_offense(<<~RUBY)
       # Outer comment.


### PR DESCRIPTION
This PR fixes an error for `Style/SoleNestedConditional` when autocorrecting nested conditionals that contain comments.
The outer correction's range replacement covered the inner `if` keyword position, while the inner correction inserted comments at that same position, triggering `Parser::Source::TreeRewriter detected clobbering`.

The cop now ignores the inner `if_branch` and skips its corrector when an outer offense is being processed, deferring the inner merge to the next autocorrect pass. `ignored_node?` is used (object identity) rather than `part_of_ignored_node?` so stale ignored entries from prior iterations do not interfere with new nodes.

Fixes #15144.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
