### PR TITLE
[Fix #15147] Fix false positives in `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_in_lint_redundant_safe_navigation_for_unless.md
+++ b/changelog/fix_false_positives_in_lint_redundant_safe_navigation_for_unless.md
@@ -1,0 +1,1 @@
+* [#15147](https://github.com/rubocop/rubocop/issues/15147): Fix false positives in `Lint/RedundantSafeNavigation` when safe navigation appears in the body of `unless`. ([@koic][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -82,15 +82,17 @@ module RuboCop
             !NIL_METHODS.include?(method_name) && !@additional_nil_methods.include?(method_name)
           end
 
-          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
           def sole_condition_of_parent_if?(node)
             child = node
             parent = node.parent
 
             while parent
               if parent.if_type?
-                condition = parent.condition
-                return true if !child.equal?(condition) && non_nil_condition?(condition, node)
+                unless parent.unless?
+                  condition = parent.condition
+                  return true if !child.equal?(condition) && non_nil_condition?(condition, node)
+                end
 
                 parent = find_top_if(parent) if parent.elsif?
               elsif else_branch?(parent)
@@ -104,7 +106,7 @@ module RuboCop
 
             false
           end
-          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
           def non_nil_condition?(condition, node)
             return true if condition == node

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -473,6 +473,38 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
 
+    it 'does not register an offense for safe navigation in the body of `unless` with a csend condition' do
+      expect_no_offenses(<<~RUBY)
+        unless foo&.ready?
+          foo&.name
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in modifier `unless` with a csend condition' do
+      expect_no_offenses(<<~RUBY)
+        foo&.name unless foo&.ready?
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in the body of `unless` whose condition is the receiver' do
+      expect_no_offenses(<<~RUBY)
+        unless foo
+          foo&.name
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in the body of `unless` with `else`' do
+      expect_no_offenses(<<~RUBY)
+        unless foo&.ready?
+          foo&.name
+        else
+          bar
+        end
+      RUBY
+    end
+
     it 'does not register an offense for chained safe navigation within an if condition' do
       expect_no_offenses(<<~RUBY)
         if foo&.bar&.baz


### PR DESCRIPTION
This PR fixes false positives in `Lint/RedundantSafeNavigation` when safe navigation appears in the body of `unless`

`NilReceiverChecker#sole_condition_of_parent_if?` did not distinguish between `if` and `unless`, so it inferred that the csend root receiver of the condition was non-nil inside the body. For `unless`, the body runs when the condition is falsy, so the receiver may still be `nil`.

Fixes #15147.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
