### PR TITLE
[Fix #15148] Fix false positives in `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_in_lint_redundant_safe_navigation_for_rescue_and_ensure.md
+++ b/changelog/fix_false_positives_in_lint_redundant_safe_navigation_for_rescue_and_ensure.md
@@ -1,0 +1,1 @@
+* [#15148](https://github.com/rubocop/rubocop/issues/15148): Fix false positives in `Lint/RedundantSafeNavigation` when safe navigation appears in `rescue` or `ensure` bodies. ([@koic][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -60,9 +60,7 @@ module RuboCop
               return true if _cant_be_nil?(node.expression, receiver)
             end
 
-            # Due to how `if/else` are implemented (`elsif` is a child of `if` or another `elsif`),
-            # using left_siblings will not work correctly for them.
-            if !else_branch?(node) || (node.if_type? && !node.elsif?)
+            if sequentially_reached?(node)
               node.left_siblings.reverse_each do |sibling|
                 next unless sibling.is_a?(AST::Node)
 
@@ -110,6 +108,17 @@ module RuboCop
             return true if condition == node
 
             condition.csend_type? && csend_root_receiver(condition) == node
+          end
+
+          # Whether control reaches `node` by falling through its left siblings rather than by
+          # a non-sequential entry. A `resbody` is entered via an exception, the `ensure` branch
+          # runs even after a partway raise, and the `else` arm of an `if/elsif` chain is reached by
+          # branching (its `if/case` siblings are walked via parent recursion instead).
+          def sequentially_reached?(node)
+            return false if node.resbody_type?
+            return false if node.parent&.ensure_type? && node.parent.branch.equal?(node)
+
+            !else_branch?(node) || (node.if_type? && !node.elsif?)
           end
 
           def else_branch?(node)

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -730,6 +730,119 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
       RUBY
     end
 
+    it 'does not register an offense for safe navigation in a `rescue` body referring to a receiver dereferenced in the `begin` body' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          foo.bar
+        rescue
+          foo&.baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in an `ensure` body referring to a receiver dereferenced in the `begin` body' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          foo.bar
+        ensure
+          foo&.baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in an `ensure` body when paired with a `rescue` clause' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          foo.bar
+        rescue
+          handle
+        ensure
+          foo&.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation in the `else` branch of `begin/rescue/else` when the `begin` body dereferences the receiver' do
+      expect_offense(<<~RUBY)
+        begin
+          foo.bar
+        rescue
+          handle
+        else
+          foo&.baz
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          foo.bar
+        rescue
+          handle
+        else
+          foo.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation in a `rescue` body after a prior dereference within the same `rescue` body' do
+      expect_offense(<<~RUBY)
+        begin
+          do_something
+        rescue
+          foo.bar
+          foo&.baz
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          do_something
+        rescue
+          foo.bar
+          foo.baz
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in modifier `rescue`' do
+      expect_no_offenses(<<~RUBY)
+        foo.bar rescue foo&.baz
+      RUBY
+    end
+
+    it 'does not register an offense for safe navigation in an implicit `rescue` of a method definition' do
+      expect_no_offenses(<<~RUBY)
+        def x
+          foo.bar
+        rescue
+          foo&.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation in the `else` branch of `case/in` when the condition dereferences the receiver' do
+      expect_offense(<<~RUBY)
+        case foo.condition
+        in Integer
+          1
+        else
+          foo&.baz
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo.condition
+        in Integer
+          1
+        else
+          foo.baz
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when method is called in preceding line in assignment with `||`' do
       expect_offense(<<~RUBY)
         x = foo.bar || true


### PR DESCRIPTION
This PR fixes false positives in `Lint/RedundantSafeNavigation` when safe navigation appears in `rescue` or `ensure` bodies.

`NilReceiverChecker#_cant_be_nil?` walked `node.left_siblings` as if every sibling were definitely-prior code. Inside a `resbody`, the rescue's begin body is among those siblings but may have raised partway through; inside an `ensure` branch, the begin body or inner rescue may also have raised partway. Skip the `left_siblings` walk in those positions while preserving the `else` branch of `begin/rescue/else`, which only runs when the body completes successfully.

Fixes #15148.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
