### PR TITLE
Fix whitespace handling in `Layout/ClassStructure` autocorrect

### DIFF
--- a/changelog/fix_layout_class_structure_autocorrect_whitespace.md
+++ b/changelog/fix_layout_class_structure_autocorrect_whitespace.md
@@ -1,0 +1,1 @@
+* [#15152](https://github.com/rubocop/rubocop/pull/15152): Fix `Layout/ClassStructure` autocorrect to preserve blank-line separators between groups, move consecutive same-category siblings together, and avoid leaving stray blank lines before the closing `end`. ([@dduugg][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -174,7 +174,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ClassStructure < Base
+      class ClassStructure < Base # rubocop:disable Metrics/ClassLength
         include VisibilityHelp
         include CommentsHelp
         extend AutoCorrector
@@ -205,18 +205,106 @@ module RuboCop
 
         private
 
-        # Autocorrect by swapping between two nodes autocorrecting them
-        def autocorrect(corrector, node)
+        # Autocorrect by moving the offending node (and any consecutive
+        # movable same-category siblings) before its previous out-of-order
+        # sibling, normalizing the surrounding whitespace.
+        def autocorrect(corrector, node) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           previous = node.left_siblings.reverse.find do |sibling|
             !ignore_for_autocorrect?(node, sibling)
           end
           return unless previous
 
-          current_range = source_range_with_comment(node)
-          previous_range = source_range_with_comment(previous)
+          current_block = build_current_block(node)
+          prev_begin, prev_end = lines_bounds(previous, previous)
+          block_begin, block_end = lines_bounds(current_block.first, current_block.last)
+          in_between = buffer.source[prev_end...block_begin]
+          next_sibling = next_relevant_sibling(current_block.last)
+          replace_end =
+            next_sibling ? lines_bounds(next_sibling, next_sibling).first : container_end_pos(node)
 
-          corrector.insert_before(previous_range, current_range.source)
-          corrector.remove(current_range)
+          new_text = buffer.source[block_begin...block_end] +
+                     (blank_separator_needed?(in_between) ? "\n" : '') +
+                     buffer.source[prev_begin...prev_end] +
+                     normalize_in_between(in_between, at_end: !next_sibling)
+
+          corrector.replace(Parser::Source::Range.new(buffer, prev_begin, replace_end), new_text)
+        end
+
+        def lines_bounds(first_node, last_node)
+          first_line = first_line_with_comment(first_node)
+          [buffer.line_range(first_line).begin_pos, line_after_pos(effective_last_line(last_node))]
+        end
+
+        def build_current_block(node)
+          block = [node]
+          classification = classify(node)
+
+          node.right_siblings.each do |sibling|
+            sibling_class = classify(sibling)
+            next if ignore?(sibling, sibling_class)
+            break if sibling_class != classification
+            break if dynamic_constant?(sibling)
+
+            block << sibling
+          end
+          block
+        end
+
+        def next_relevant_sibling(node)
+          node.right_siblings.find do |sibling|
+            !ignore?(sibling, classify(sibling))
+          end
+        end
+
+        def container_end_pos(node)
+          container = node.each_ancestor(:class, :sclass, :module).first
+          return buffer.source.length unless container
+
+          buffer.line_range(container.loc.end.line).begin_pos
+        end
+
+        def line_after_pos(line)
+          if line + 1 <= buffer.last_line
+            buffer.line_range(line + 1).begin_pos
+          else
+            buffer.source.length
+          end
+        end
+
+        def effective_last_line(node)
+          max_line = node.last_line
+          node.each_node(:any_str) do |str_node|
+            next unless str_node.heredoc?
+
+            max_line = [max_line, str_node.location.heredoc_end.line].max
+          end
+          max_line
+        end
+
+        def first_line_with_comment(node)
+          first_line = node.first_line
+          (first_line - 1).downto(1) do |line|
+            break unless processed_source.comment_at_line(line)
+            break unless whole_line_comment_at_line?(line)
+
+            first_line = line
+          end
+          first_line
+        end
+
+        def normalize_in_between(in_between, at_end:)
+          if at_end
+            return '' unless in_between.match?(/\S/)
+
+            in_between.sub(/\n+\z/, "\n")
+          else
+            stripped = in_between.sub(/\n+\z/, '')
+            stripped.empty? ? "\n" : "#{stripped}\n\n"
+          end
+        end
+
+        def blank_separator_needed?(in_between)
+          in_between.start_with?("\n") || in_between.include?("\n\n")
         end
 
         # Classifies a node to match with something in the {expected_order}

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         LIMIT = 10
         CONST = 'wrong place'.freeze
         RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze
+
         def name; end
 
         DYNAMIC_CONST = foo.freeze
@@ -303,6 +304,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     expect_correction(<<~RUBY)
       class Foo
         PUBLIC_CONST = 'public'
+
         def name; end
 
         PRIVATE_CONST1 = 1
@@ -410,10 +412,10 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
             class method
           EOS
         end
+
         def instance_method
           'instance method'
         end
-
       end
     RUBY
   end
@@ -435,9 +437,9 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           public def bar
           end
+
           private def foo
           end
-
         end
       RUBY
     end
@@ -458,9 +460,9 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           def bar
           end
+
           private def foo
           end
-
         end
       RUBY
     end
@@ -483,12 +485,12 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
       expect_correction(<<~RUBY)
         class A
           def bar; end
+
           def qux; end
+
           private def foo; end
 
-
           private def baz; end
-
         end
       RUBY
     end
@@ -510,10 +512,10 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
         class A
           def bar
           end
+
           def foo
           end
           private :foo
-
         end
       RUBY
     end
@@ -539,8 +541,8 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
           def initialize
           end
-          attr_accessor :foo
 
+          attr_accessor :foo
         end
       RUBY
     end


### PR DESCRIPTION
## Summary

Reworks the `Layout/ClassStructure` autocorrect so that swapping out-of-order class elements produces idiomatic whitespace.

The previous implementation used pairwise `insert_before` + `remove`, which left a few rough edges:

- A blank line that should sit between two category groups would slide around as successive iterations swapped pairs, leaving content of the same category split by a blank (e.g. constants ending up as `LIMIT, blank, CONST, blank, RECURSIVE, ...`).
- A blank line was sometimes left dangling before the class's closing `end` after a node was moved away from the end of the body.
- Autocorrecting a heredoc-valued constant produced corrupt output (e.g. `endend`) because the casgn node's `end_position_for` included the trailing `\n` while the swapped def's range did not.

The new implementation constructs the replacement text explicitly and:

1. **Extends the offending node into a "block"** of consecutive movable same-category siblings (skipping ignored ones, stopping at dynamic constants), so `LIMIT`, `CONST`, `RECURSIVE_BASIC_LITERALS_CONST` all move together in a single pass instead of one-per-iteration.
2. **Operates on whole-line ranges** including trailing newlines, with `effective_last_line` extending casgn ranges through the heredoc terminator.
3. **Inserts a blank-line separator** between the moved block and the previous node only when the original source had a blank line between them — preserves the existing "no blank between consecutive single-line defs on the same level" behavior.
4. **Normalizes the in-between content**: when the moved block was the last thing in the class body, trailing blank lines are stripped so the closing `end` isn't preceded by a stray blank.

### Before / after

```ruby
# bad
class Foo
  def name; end

  LIMIT = 10
  CONST = 'wrong place'.freeze
  RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze
  DYNAMIC_CONST = foo.freeze
end

# was autocorrected to
class Foo
  LIMIT = 10
  CONST = 'wrong place'.freeze
  RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze
  def name; end

  DYNAMIC_CONST = foo.freeze
end

# now autocorrected to
class Foo
  LIMIT = 10
  CONST = 'wrong place'.freeze
  RECURSIVE_BASIC_LITERALS_CONST = [1, 2].freeze

  def name; end

  DYNAMIC_CONST = foo.freeze
end
```

## Test plan

- [x] Updated `spec/rubocop/cop/layout/class_structure_spec.rb` to reflect the desired whitespace.
- [x] All 21 examples in `spec/rubocop/cop/layout/class_structure_spec.rb` pass.
- [x] Full `spec/rubocop/cop/layout/` suite passes (4694 examples).
- [x] `bundle exec rubocop --no-server lib/rubocop/cop/layout/class_structure.rb` passes.
- [x] Added changelog entry.
