### PR TITLE
Partially revert auto-gen-config in parallel

### DIFF
--- a/changelog/new_run_auto_gen_config_in_parallel_20260310234345.md
+++ b/changelog/new_run_auto_gen_config_in_parallel_20260310234345.md
@@ -1,1 +1,0 @@
-* [#13755](https://github.com/rubocop/rubocop/issues/13755): Run --auto-gen-config and --regenerate-todo in parallel. ([@bquorning][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -15,7 +15,6 @@ module RuboCop
       display_only_failed editor_mode except extra_details fail_level fix_layout format formatters
       ignore_disable_comments lint only only_guide_cops require safe
       autocorrect safe_autocorrect autocorrect_all
-      auto_gen_config regenerate_todo
     ].freeze
 
     class Finished < StandardError; end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -243,18 +243,6 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      context 'when specifying `--auto-gen-config`' do
-        it 'uses parallel inspection' do
-          create_file('example1.rb', <<~RUBY)
-            # frozen_string_literal: true
-
-            puts 'hello'
-          RUBY
-          expect(cli.run(['--debug', '--auto-gen-config'])).to eq(0)
-          expect($stdout.string).to include('Use parallel by default.')
-        end
-      end
-
       context 'when specifying `--debug` and `-a` options`' do
         it 'uses parallel inspection when correcting the file' do
           create_file('example1.rb', <<~RUBY)


### PR DESCRIPTION
The work to run auto-gen-config in parallel was affected by the true parallelism work done in #15110. So this commit partially reverts 0b48d73c32f6ccc328a2cef2664f374bbbc50e78, so that auto-gen-config will not (try to) run in parallel by default, and the changelog will also not claim that it does.

The other changes are left in, so the runner no longer complains if you try using the `--parallel` flag along with `--auto-gen-config` or `--regenerate-todo`. This way it's easier for to [continue working on the feature](https://github.com/rubocop/rubocop/pull/15114) also after the next release.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
