### PR TITLE
Fix bug where specifying `--out` disables parallelization

### DIFF
--- a/changelog/fix_fix_bug_where_specifying_out_disables_20260507172228.md
+++ b/changelog/fix_fix_bug_where_specifying_out_disables_20260507172228.md
@@ -1,0 +1,1 @@
+* [#15154](https://github.com/rubocop/rubocop/pull/15154): Fix bug where specifying `--out` disables parallelization. ([@deivid-rodriguez][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -13,7 +13,7 @@ module RuboCop
     DEFAULT_PARALLEL_OPTIONS = %i[
       color config debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed editor_mode except extra_details fail_level fix_layout format formatters
-      ignore_disable_comments lint only only_guide_cops require safe
+      ignore_disable_comments lint only only_guide_cops out require safe
       autocorrect safe_autocorrect autocorrect_all
       auto_gen_config regenerate_todo
     ].freeze


### PR DESCRIPTION
We run into a big performance regression after changing our rubocop command in CI to use `--format json --out foo`. We eventually identified the regression as rubocop no longer running in parallel.

The output generated seems to be the same, so I guess this is safe.

This is the same as https://github.com/rubocop/rubocop/pull/14339, but for `--out`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
