### PR TITLE
Fix an error for `Style/HashLookupMethod` cop

### DIFF
--- a/changelog/fix_an_error_for_style_hash_lookup_method.md
+++ b/changelog/fix_an_error_for_style_hash_lookup_method.md
@@ -1,0 +1,1 @@
+* [#15156](https://github.com/rubocop/rubocop/pull/15156): Fix an error for `Style/HashLookupMethod` when chaining `fetch` (or `[]`) calls on the same expression. ([@koic][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -82,18 +82,23 @@ module RuboCop
         end
 
         def correct_fetch_to_brackets(corrector, node)
-          receiver = node.receiver.source
           key = node.first_argument.source
-          replacement = "#{receiver}[#{key}]"
-          replacement = "(#{replacement})" if node.csend_type?
-          corrector.replace(node, replacement)
+
+          if node.csend_type?
+            corrector.replace(node, "(#{node.receiver.source}[#{key}])")
+          else
+            corrector.replace(node.loc.dot.join(node.source_range.end), "[#{key}]")
+          end
         end
 
         def correct_brackets_to_fetch(corrector, node)
-          receiver = node.receiver.source
           key = node.first_argument.source
-          operator = node.csend_type? ? '&.' : '.'
-          corrector.replace(node, "#{receiver}#{operator}fetch(#{key})")
+
+          if node.csend_type?
+            corrector.replace(node.loc.dot.join(node.source_range.end), "&.fetch(#{key})")
+          else
+            corrector.replace(node.loc.selector.join(node.source_range.end), ".fetch(#{key})")
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
       expect_no_offenses('hash[key]')
     end
 
+    it 'registers an offense for chained fetch calls without raising a clobbering error' do
+      expect_offense(<<~RUBY)
+        result.fetch(:foo).fetch(:bar)
+               ^^^^^ Use `Hash#[]` instead of `Hash#fetch`.
+                           ^^^^^ Use `Hash#[]` instead of `Hash#fetch`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        result[:foo][:bar]
+      RUBY
+    end
+
     it 'accepts fetch with default value' do
       expect_no_offenses('hash.fetch(key, default)')
     end
@@ -99,6 +111,18 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
 
     it 'does not flag bracket access with multiple arguments' do
       expect_no_offenses('array[1, 2]')
+    end
+
+    it 'registers an offense for chained bracket access without raising a clobbering error' do
+      expect_offense(<<~RUBY)
+        result[:foo][:bar]
+        ^^^^^^^^^^^^^^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+        ^^^^^^^^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        result.fetch(:foo).fetch(:bar)
+      RUBY
     end
 
     context 'when using safe navigation operator' do


### PR DESCRIPTION
This fixes an error caused by `Parser::ClobberingError` when `Style/HashLookupMethod` autocorrects chained `fetch` (or `[]`) calls such as `hash.fetch(:foo).fetch(:bar)`. Previously the cop replaced the entire send node, so two nested replacements overlapped. Now only the `.fetch(...)` (or `[...]`) portion is replaced, allowing nested corrections to coexist.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
