### PR TITLE
[Fix #15155] Fix false negatives in `Style/RedundantSelf`

### DIFF
--- a/changelog/fix_false_negative_in_style_redundant_self_for_or_asgn.md
+++ b/changelog/fix_false_negative_in_style_redundant_self_for_or_asgn.md
@@ -1,0 +1,1 @@
+* [#15155](https://github.com/rubocop/rubocop/issues/15155): Fix false negatives in `Style/RedundantSelf` when an explicit `self` receiver in one scope matches the LHS of an `||=`, `&&=`, or `op_asgn` in another scope. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -59,7 +59,7 @@ module RuboCop
 
         def initialize(config = nil, options = nil)
           super
-          @allowed_send_nodes = []
+          @allowed_send_nodes = Set.new.compare_by_identity
           @local_variables_scopes = Hash.new { |hash, key| hash[key] = [] }.compare_by_identity
         end
 
@@ -187,7 +187,7 @@ module RuboCop
         def allow_self(node)
           return unless node.send_type? && node.self_receiver?
 
-          @allowed_send_nodes << node
+          @allowed_send_nodes.add(node)
         end
 
         def add_lhs_to_local_variables_scopes(rhs, lhs)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
     expect_no_offenses('self.logger ||= Rails.logger')
   end
 
+  it 'registers an offense when a self receiver follows an or-assignment with the same left-hand side' do
+    expect_offense(<<~RUBY)
+      self.x ||= 42
+      self.x
+      ^^^^ Redundant `self` detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      self.x ||= 42
+      x
+    RUBY
+  end
+
   it 'accepts a self receiver on an lvalue of an and-assignment' do
     expect_no_offenses('self.flag &&= value')
   end


### PR DESCRIPTION
This PR fixes false negatives in `Style/RedundantSelf` when an explicit `self.x` receiver in one scope matches the LHS of an `||=`, `&&=`, or `op_asgn` (e.g. `+=`) elsewhere in the file.

The cop tracks "allowed" `self` send nodes (LHS of those compound assignments) in an `Array`. `Array#include?` compares with `==`, but `Parser::AST::Node#==` is structural, so two distinct `self.x` send nodes are considered equal. As a result, `self.x` in another `def` body was treated as already allowed and never flagged. Switching the container to `Set.new.compare_by_identity` makes the membership check identity-based and restores the offense.

Fixes #15155.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
