### PR TITLE
feat: add `disable-next-line` comment to allow disabling cops with directive comment

### DIFF
--- a/changelog/new_disable_cops_on_next_line_with_directive_comment_20260510080320.md
+++ b/changelog/new_disable_cops_on_next_line_with_directive_comment_20260510080320.md
@@ -1,1 +1,1 @@
-* [#x](https://github.com/rubocop/rubocop/pull/x): Add new comment that allows you to disable cops on the next line. ([@nzlaura][])
+* [#15159](https://github.com/rubocop/rubocop/pull/15159): Add new comment that allows you to disable cops on the next line. ([@nzlaura][])

--- a/changelog/new_disable_cops_on_next_line_with_directive_comment_20260510080320.md
+++ b/changelog/new_disable_cops_on_next_line_with_directive_comment_20260510080320.md
@@ -1,0 +1,1 @@
+* [#x](https://github.com/rubocop/rubocop/pull/x): Add new comment that allows you to disable cops on the next line. ([@nzlaura][])

--- a/docs/modules/ROOT/pages/usage/source_code_directives.adoc
+++ b/docs/modules/ROOT/pages/usage/source_code_directives.adoc
@@ -53,6 +53,14 @@ comment.
 for x in (0..19) # rubocop:disable Style/For
 ----
 
+If you want to disable a cop on the next line, you can do so with a `disable-next-line` comment.
+
+[source,ruby]
+----
+# rubocop:disable-next-line Style/For
+for x in (0..19)
+----
+
 If you want to disable a cop that inspects comments, you can do so by
 adding an "inner comment" on the comment line.
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -3,6 +3,7 @@
 module RuboCop
   # This class parses the special `rubocop:disable` comments in a source
   # and provides a way to check if each cop is enabled at arbitrary line.
+  # rubocop:disable-next-line Metrics/ClassLength
   class CommentConfig
     extend SimpleForwardable
 
@@ -175,6 +176,8 @@ module RuboCop
       # Disabling cops after comments like `#=SomeDslDirective` does not related to single line
       if !comment_only_line?(directive.line_number) || directive.single_line?
         analyze_single_line(analysis, directive)
+      elsif directive.disabled_next_line?
+        analyze_next_line(analysis, directive)
       elsif directive.disabled?
         analyze_disabled(analysis, directive)
       else
@@ -186,6 +189,11 @@ module RuboCop
       return analysis unless directive.disabled?
 
       line = directive.line_number
+      CopAnalysis.new(analysis.line_ranges + [(line..line)], analysis.start_line_number)
+    end
+
+    def analyze_next_line(analysis, directive)
+      line = directive.line_number + 1
       CopAnalysis.new(analysis.line_ranges + [(line..line)], analysis.start_line_number)
     end
 
@@ -245,6 +253,8 @@ module RuboCop
     # so that `Lint/RedundantCopEnableDirective` can register offenses correctly.
     def handle_switch(directive, names, extras)
       directive.cop_names.each do |name|
+        next if directive.disabled_next_line?
+
         if directive.disabled?
           names[name] += 1
         elsif names[name].positive?

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -46,7 +46,7 @@ module RuboCop
         COMMON_MSG = 'Malformed directive comment detected.'
 
         MISSING_MODE_NAME_MSG = 'The mode name is missing.'
-        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, `todo`, `push`, or `pop`.' # rubocop:disable Layout/LineLength
+        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, `disable-next-line`, `todo`, `push`, or `pop`.' # rubocop:disable Layout/LineLength
         MISSING_COP_NAME_MSG = 'The cop name is missing.'
         MALFORMED_COP_NAMES_MSG = 'Cop names must be separated by commas. ' \
                                   'Comment in the directive must start with `--`.'

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -114,7 +114,7 @@ module RuboCop
           line_ranges.each_with_index do |line_range, line_range_index|
             next if should_skip_line_range?(cop, line_range)
 
-            comment = processed_source.comment_at_line(line_range.begin)
+            comment = comment_for_line(line_range.begin)
             next if skip_directive?(comment)
 
             next_range = line_ranges[line_range_index + 1]
@@ -152,7 +152,7 @@ module RuboCop
             # whether there are offenses or not.
             next unless followed_ranges?(previous_range, range)
 
-            comment = processed_source.comment_at_line(range.begin)
+            comment = comment_for_line(range.begin)
 
             next unless comment
             # Comments disabling all cops don't count since it's reasonable
@@ -327,6 +327,11 @@ module RuboCop
         def ends_its_line?(range)
           line = range.source_buffer.source_line(range.last_line)
           (line =~ /\s*\z/) == range.last_column
+        end
+
+        # For `disable-next-line`, the comment is on the line before the disabled line
+        def comment_for_line(line)
+          processed_source.comment_at_line(line) || processed_source.comment_at_line(line - 1)
         end
 
         def department_marker?(department)

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -24,7 +24,7 @@ module RuboCop
     # @api private
     PUSH_POP_ARGS_PATTERN = "([+\\-]#{COP_NAME_PATTERN_NC}(?:\\s+[+\\-]#{COP_NAME_PATTERN_NC})*)"
     # @api private
-    AVAILABLE_MODES = %w[disable enable todo push pop].freeze
+    AVAILABLE_MODES = %w[disable-next-line disable enable todo push pop].freeze
     # @api private
     DIRECTIVE_MARKER_PATTERN = '# rubocop : '
     # @api private
@@ -112,6 +112,11 @@ module RuboCop
       %w[disable todo].include?(mode)
     end
 
+    # Checks if this directive disables cops only on the next line
+    def disabled_next_line?
+      mode == 'disable-next-line'
+    end
+
     # Checks if this directive enables cops
     def enabled?
       mode == 'enable'
@@ -134,12 +139,12 @@ module RuboCop
 
     # Checks if this directive enables all cops
     def enabled_all?
-      !disabled? && all_cops?
+      enabled? && all_cops?
     end
 
     # Checks if this directive disables all cops
     def disabled_all?
-      disabled? && all_cops?
+      (disabled? || disabled_next_line?) && all_cops?
     end
 
     # Checks if all cops specified in this directive

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe RuboCop::CommentConfig do
         # rubocop:disable RSpec/Rails/HttpStatus
         it { is_expected.to have_http_status 200 }                          # 52
         # rubocop:enable RSpec/Rails/HttpStatus
+
+        # rubocop:disable-next-line Style/EmptyMethod
+        def foo                                                             # 56
+        end
       RUBY
       # rubocop:enable Lint/EmptyExpression, Lint/EmptyInterpolation
     end
@@ -171,6 +175,10 @@ RSpec.describe RuboCop::CommentConfig do
     it 'supports disabling cops on a comment line with an EOL comment' do
       expect(disabled_lines_of_cop('Layout/LeadingCommentSpace')).to eq([7, 8, 9, 50])
     end
+
+    it 'supports disabling cops on next line' do
+      expect(disabled_lines_of_cop('Style/EmptyMethod')).to eq([7, 8, 9, 56])
+    end
   end
 
   describe '#cop_disabled_line_ranges' do
@@ -192,6 +200,21 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'collects line ranges by disabled cops' do
       expect(range).to eq({ 'Metrics/MethodLength' => [1..5], 'Security/Eval' => [8..8] })
+    end
+
+    context 'with disable-next-line' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable-next-line Metrics/MethodLength
+          def some_method
+            puts 'foo'
+          end
+        RUBY
+      end
+
+      it 'collects a single-line range for the next line' do
+        expect(range).to eq({ 'Metrics/MethodLength' => [2..2] })
+      end
     end
   end
 
@@ -217,6 +240,68 @@ RSpec.describe RuboCop::CommentConfig do
     it 'has values as arrays of extra enabled cops' do
       expect(extra.values.first).to eq ['Metrics/MethodLength', 'Security/Eval']
     end
+
+    shared_examples 'has extra_enabled_comments' do |ctx, src|
+      context ctx do
+        let(:source) { src }
+
+        it 'has extra_enabled_comments' do
+          expect(extra.values.first).to eq ['Metrics/MethodLength']
+        end
+      end
+    end
+
+    it_behaves_like 'has extra_enabled_comments',
+                    'with `rubocop:enable`',
+                    <<~RUBY
+                      # rubocop:enable Metrics/MethodLength
+                      def some_method; end
+                    RUBY
+
+    it_behaves_like 'has extra_enabled_comments',
+                    'with `rubocop:disable-next-line` and `rubocop:enable`',
+                    <<~RUBY
+                      # rubocop:disable-next-line Metrics/MethodLength
+                      def some_method; end
+                      # rubocop:enable Metrics/MethodLength
+                    RUBY
+
+    it_behaves_like 'has extra_enabled_comments',
+                    'with `rubocop:disable` for line and `rubocop:enable`',
+                    <<~RUBY
+                      def some_method; end # rubocop:disable Metrics/MethodLength
+                      # rubocop:enable Metrics/MethodLength
+                    RUBY
+
+    shared_examples 'has no extra_enabled_comments' do |ctx, src|
+      context ctx do
+        let(:source) { src }
+
+        it 'has no extra_enabled_comments' do
+          expect(extra).to eq({})
+        end
+      end
+    end
+
+    it_behaves_like 'has no extra_enabled_comments',
+                    'with `rubocop:disable-next-line`',
+                    <<~RUBY
+                      # rubocop:disable-next-line Metrics/MethodLength
+                      def some_method; end
+                    RUBY
+
+    it_behaves_like 'has no extra_enabled_comments',
+                    'with `rubocop:disable`',
+                    <<~RUBY
+                      # rubocop:disable Metrics/MethodLength
+                      def some_method; end
+                    RUBY
+
+    it_behaves_like 'has no extra_enabled_comments',
+                    'with `rubocop:disable` for line',
+                    <<~RUBY
+                      def some_method; end # rubocop:disable Metrics/MethodLength
+                    RUBY
 
     context 'with push directive disabling Style/GuardClause' do
       let(:source) do
@@ -858,6 +943,151 @@ RSpec.describe RuboCop::CommentConfig do
         expect(disabled).to include(1, 2, 3, 4, 5, 6)
         expect(disabled).not_to include(7, 8, 9)
         expect(disabled).to include(10, 11, 12, 13)
+      end
+    end
+  end
+
+  describe 'disable-next-line directives' do
+    def disabled_lines_of_cop(cop)
+      (1..source.size).each_with_object([]) do |line_number, disabled_lines|
+        enabled = comment_config.cop_enabled_at_line?(cop, line_number)
+        disabled_lines << line_number unless enabled
+      end
+    end
+
+    context 'basic disable-next-line' do
+      let(:source) do
+        <<~RUBY
+          foo
+          # rubocop:disable-next-line Style/For
+          for x in (0..19)
+            puts x
+          end
+        RUBY
+      end
+
+      it 'disables the cop only on the next line' do
+        disabled = disabled_lines_of_cop('Style/For')
+        expect(disabled).to include(3)
+        expect(disabled).not_to include(1, 2, 4, 5)
+      end
+    end
+
+    context 'disable-next-line with multiple cops' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable-next-line Style/For, Style/Not
+          for x in (not true)
+            puts x
+          end
+        RUBY
+      end
+
+      it 'disables all listed cops only on the next line' do
+        expect(disabled_lines_of_cop('Style/For')).to eq([2])
+        expect(disabled_lines_of_cop('Style/Not')).to eq([2])
+      end
+    end
+
+    context 'disable-next-line does not affect subsequent lines' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable-next-line Style/For
+          for x in (0..9)
+            puts x
+          end
+          for y in (0..9)
+            puts y
+          end
+        RUBY
+      end
+
+      it 'only disables the immediately following line' do
+        disabled = disabled_lines_of_cop('Style/For')
+        expect(disabled).to eq([2])
+      end
+    end
+
+    context 'disable-next-line at end of file' do
+      let(:source) do
+        <<~RUBY
+          foo
+          # rubocop:disable-next-line Style/For
+        RUBY
+      end
+
+      it 'disables the cop on the line after the comment (even if it does not exist)' do
+        disabled = disabled_lines_of_cop('Style/For')
+        expect(disabled).to include(3)
+        expect(disabled).not_to include(1, 2)
+      end
+    end
+
+    context 'multiple disable-next-line comments for different lines' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable-next-line Style/For
+          for x in (0..9)
+            puts x
+          end
+          # rubocop:disable-next-line Style/For
+          for y in (0..9)
+            puts y
+          end
+        RUBY
+      end
+
+      it 'disables the cop on each respective next line' do
+        disabled = disabled_lines_of_cop('Style/For')
+        expect(disabled).to eq([2, 6])
+      end
+    end
+
+    context 'disable-next-line combined with regular disable/enable' do
+      let(:source) do
+        <<~RUBY
+          # rubocop:disable-next-line Style/For
+          for x in (0..9)
+            puts x
+          end
+          # rubocop:disable Style/For
+          for y in (0..9)
+            puts y
+          end
+          # rubocop:enable Style/For
+          for z in (0..9)
+            puts z
+          end
+        RUBY
+      end
+
+      it 'handles both directive types independently' do
+        disabled = disabled_lines_of_cop('Style/For')
+        expect(disabled).to include(2)
+        expect(disabled).not_to include(3, 4)
+        expect(disabled).to include(5, 6, 7, 8, 9)
+        expect(disabled).not_to include(10, 11, 12)
+      end
+    end
+
+    context 'disable-next-line with all cops' do
+      let(:source) do
+        <<~RUBY
+          foo
+          # rubocop:disable-next-line all
+          bar
+          baz
+        RUBY
+      end
+
+      it 'disables all cops only on the next line' do
+        excluded = [RuboCop::Cop::Lint::RedundantCopDisableDirective, RuboCop::Cop::Lint::Syntax]
+        cops = RuboCop::Cop::Registry.all - excluded
+        cops.each do |cop|
+          disabled = disabled_lines_of_cop(cop)
+          expect(disabled).to include(3), "expected #{cop} to be disabled on line 3"
+          expect(disabled).not_to include(4), "expected #{cop} to be enabled on line 4"
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -37,6 +37,37 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
     RUBY
   end
 
+  it 'does not register an offense for disable-next-line directives' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable-next-line Layout/LineLength
+    RUBY
+  end
+
+  it 'does not register an offense for disable-next-line with multiple cops' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable-next-line Layout/LineLength, Style/Encoding
+    RUBY
+  end
+
+  it 'does not register an offense for disable-next-line all' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable-next-line all
+    RUBY
+  end
+
+  it 'does not register an offense for disable-next-line with trailing comment' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable-next-line Layout/LineLength -- This is a good comment.
+    RUBY
+  end
+
+  it 'registers an offense for disable-next-line without cop name' do
+    expect_offense(<<~RUBY)
+      # rubocop:disable-next-line
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The cop name is missing.
+    RUBY
+  end
+
   it 'registers an offense for multiple cops a without comma' do
     expect_offense(<<~RUBY)
       # rubocop:disable Layout/LineLength Style/Encoding
@@ -61,7 +92,7 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
   it 'registers an offense for incorrect mode' do
     expect_offense(<<~RUBY)
       # rubocop:disabled Layout/LineLength
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, `todo`, `push`, or `pop`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The mode name must be one of `enable`, `disable`, `disable-next-line`, `todo`, `push`, or `pop`.
     RUBY
   end
 

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -823,5 +823,101 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
         RUBY
       end
     end
+
+    context 'when cop disabled with `disable-next-line`' do
+      context 'and there is an offense' do
+        let(:offenses) do
+          [
+            RuboCop::Cop::Offense.new(:convention,
+                                      FakeLocation.new(line: 2, column: 0),
+                                      'Class has too many lines.',
+                                      'Metrics/ClassLength')
+          ]
+        end
+
+        it 'returns no offenses' do
+          expect_no_offenses(<<~RUBY)
+            # rubocop:disable-next-line Metrics/ClassLength
+            class Foo
+            end
+          RUBY
+        end
+
+        context 'and cop disabled again with line directive' do
+          it 'returns an offense for the redundant inline disable' do
+            expect_offense(<<~RUBY)
+              # rubocop:disable-next-line Metrics/ClassLength
+              class Foo # rubocop:disable Metrics/ClassLength
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+              end
+            RUBY
+
+            expect_correction(<<~RUBY)
+              # rubocop:disable-next-line Metrics/ClassLength
+              class Foo
+              end
+            RUBY
+          end
+        end
+      end
+
+      context 'and there are no offenses' do
+        it 'removes the comment' do
+          expect_offense(<<~RUBY)
+            # rubocop:disable-next-line Metrics/ClassLength
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+            class Foo
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Foo
+            end
+          RUBY
+        end
+      end
+
+      context 'with multiple cops and one has an offense' do
+        let(:offenses) do
+          [
+            RuboCop::Cop::Offense.new(:convention,
+                                      FakeLocation.new(line: 2, column: 0),
+                                      'Class has too many lines.',
+                                      'Metrics/ClassLength')
+          ]
+        end
+
+        it 'returns an offense for the cop without offenses' do
+          expect_offense(<<~RUBY)
+            # rubocop:disable-next-line Metrics/ClassLength, Metrics/MethodLength
+                                                             ^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
+            class Foo
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # rubocop:disable-next-line Metrics/ClassLength
+            class Foo
+            end
+          RUBY
+        end
+      end
+
+      context 'with all cops disabled and no offenses' do
+        it 'removes the comment' do
+          expect_offense(<<~RUBY)
+            # rubocop:disable-next-line all
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of all cops.
+            class Foo
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class Foo
+            end
+          RUBY
+        end
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -378,4 +378,20 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
       RUBY
     end
   end
+
+  context 'when cop disabled with `disable-next-line` and enabled again' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable-next-line Layout/LineLength
+        foo
+        # rubocop:enable Layout/LineLength
+                         ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/LineLength.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable-next-line Layout/LineLength
+        foo
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -335,6 +335,12 @@ RSpec.describe RuboCop::DirectiveComment do
 
       it { is_expected.to be(false) }
     end
+
+    context 'when disable-next-line all cops' do
+      let(:text) { '# rubocop:disable-next-line all' }
+
+      it { is_expected.to be(false) }
+    end
   end
 
   describe '#disabled_all?' do
@@ -360,6 +366,18 @@ RSpec.describe RuboCop::DirectiveComment do
 
     context 'when disabled specific cops' do
       let(:text) { '# rubocop:disable Foo/Bar' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when disable-next-line all cops' do
+      let(:text) { '# rubocop:disable-next-line all' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when disable-next-line specific cops' do
+      let(:text) { '# rubocop:disable-next-line Foo/Bar' }
 
       it { is_expected.to be(false) }
     end
@@ -440,6 +458,48 @@ RSpec.describe RuboCop::DirectiveComment do
       let(:text) { '# rubocop:enable Foo' }
 
       it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#disabled_next_line?' do
+    subject { directive_comment.disabled_next_line? }
+
+    shared_examples 'checks disabled_next_line?' do |explanation, comment, result|
+      context explanation do
+        let(:text) { comment }
+
+        it { is_expected.to eq result }
+      end
+    end
+
+    it_behaves_like 'checks disabled_next_line?',
+                    'when disabled next line', '# rubocop:disable-next-line all', true
+    it_behaves_like 'checks disabled_next_line?',
+                    'when disabled current line', 'def foo # rubocop:disable all', false
+    it_behaves_like 'checks disabled_next_line?',
+                    'when disabled few lines', '# rubocop:disable Foo/Bar', false
+    it_behaves_like 'checks disabled_next_line?', 'when enabled', '# rubocop:enable Foo/Bar', false
+  end
+
+  describe '#match_captures with disable-next-line' do
+    subject { directive_comment.match_captures }
+
+    context 'when disable-next-line' do
+      let(:text) { '# rubocop:disable-next-line Foo/Bar' }
+
+      it { is_expected.to eq(['disable-next-line', 'Foo/Bar']) }
+    end
+
+    context 'when disable-next-line all' do
+      let(:text) { '# rubocop:disable-next-line all' }
+
+      it { is_expected.to eq(%w[disable-next-line all]) }
+    end
+
+    context 'when disable-next-line with multiple cops' do
+      let(:text) { '# rubocop:disable-next-line Foo/Bar, Baz/Qux' }
+
+      it { is_expected.to eq(['disable-next-line', 'Foo/Bar, Baz/Qux']) }
     end
   end
 


### PR DESCRIPTION
This PR adds support for a `rubocop:disable-next-line` directive comment. 

It has been discussed in a previously closed issue: https://github.com/rubocop/rubocop/issues/9505

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
