### PR TITLE
Fix an error for `Style/ReduceToHash` cop

### DIFF
--- a/changelog/fix_an_error_for_style_reduce_to_hash.md
+++ b/changelog/fix_an_error_for_style_reduce_to_hash.md
@@ -1,0 +1,1 @@
+* [#15161](https://github.com/rubocop/rubocop/pull/15161): Fix an error for `Style/ReduceToHash` when nested `each_with_object`/`inject`/`reduce` calls would build hashes. ([@koic][])

--- a/lib/rubocop/cop/style/reduce_to_hash.rb
+++ b/lib/rubocop/cop/style/reduce_to_hash.rb
@@ -99,6 +99,7 @@ module RuboCop
                        end
           return unless key
           return if accumulator_used_in_expressions?(block_node, key, value)
+          return if nested_match?(key) || nested_match?(value)
 
           register_offense(node, block_node, key, value)
         end
@@ -106,6 +107,21 @@ module RuboCop
         def accumulator_used_in_expressions?(block_node, key, value)
           acc_name = accumulator_name(block_node)
           references_variable?(key, acc_name) || references_variable?(value, acc_name)
+        end
+
+        def nested_match?(node)
+          node.each_node(:call).any? do |send_node|
+            next false unless RESTRICT_ON_SEND.include?(send_node.method_name)
+
+            inner_block = send_node.block_node
+            next false unless inner_block
+
+            if send_node.method?(:each_with_object)
+              each_with_object_to_hash?(inner_block)
+            else
+              inject_to_hash?(inner_block)
+            end
+          end
         end
 
         def accumulator_name(block_node)

--- a/spec/rubocop/cop/style/reduce_to_hash_spec.rb
+++ b/spec/rubocop/cop/style/reduce_to_hash_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe RuboCop::Cop::Style::ReduceToHash, :config do
         RUBY
       end
 
+      it 'registers an offense for the inner call when nested without raising a clobbering error' do
+        expect_offense(<<~RUBY)
+          tables.each_with_object({}) { |table, h|
+            h[table.node] = table.columns.each_with_object({}) { |column, i| i[column.name] = column.alias }
+                                          ^^^^^^^^^^^^^^^^ Use `to_h { ... }` instead of `each_with_object`.
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          tables.to_h { |table| [table.node, table.columns.to_h { |column| [column.name, column.alias] }] }
+        RUBY
+      end
+
       it 'registers an offense and corrects with do...end block' do
         expect_offense(<<~RUBY)
           array.each_with_object({}) do |elem, hash|


### PR DESCRIPTION
This fixes an error caused by `Parser::ClobberingError` when `Style/ReduceToHash` autocorrects nested `each_with_object`, `inject`, or `reduce` calls that both build hashes (for example, when the value of an outer `each_with_object` is itself an `each_with_object` block). The outer offense is now skipped while a matching inner call is still present; once the inner call is corrected on the next iteration, the outer offense is reported.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
