### PR TITLE
[Cop lazy loading] Refactor registry implementation

### DIFF
--- a/lib/rubocop/cli/command/show_docs_url.rb
+++ b/lib/rubocop/cli/command/show_docs_url.rb
@@ -25,10 +25,10 @@ module RuboCop
           puts Cop::Documentation.default_base_url if cops_array.empty?
 
           cops_array.each do |cop_name|
-            cop = registry_hash[cop_name]
-            next if cop.empty?
+            cop = Cop::Registry.global.find_by_cop_name(cop_name)
+            next unless cop
 
-            url = Cop::Documentation.url_for(cop.first, @config)
+            url = Cop::Documentation.url_for(cop, @config)
             puts url if url
           end
 
@@ -37,10 +37,6 @@ module RuboCop
 
         def cops_array
           @cops_array ||= @options[:show_docs_url]
-        end
-
-        def registry_hash
-          @registry_hash ||= Cop::Registry.global.to_h
         end
       end
     end

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -49,9 +49,8 @@ module RuboCop
       attr_reader :options, :warnings
 
       def initialize(cops = [], options = {})
-        @registry = {}
-        @departments = {}
-        @cops_by_cop_name = Hash.new { |hash, key| hash[key] = [] }
+        @departments = Set.new
+        @cops_by_badge = {}
 
         @enrollment_queue = cops
         @options = options
@@ -72,22 +71,17 @@ module RuboCop
       # @return [Array<Symbol>] list of departments for current cops.
       def departments
         clear_enrollment_queue
-        @departments.keys
+        @departments.to_a
       end
 
       # @return [Registry] Cops for that specific department.
       def with_department(department)
-        clear_enrollment_queue
-        with(@departments.fetch(department, []))
+        with(cops.select { |cop| cop.department == department })
       end
 
       # @return [Registry] Cops not for a specific department.
       def without_department(department)
-        clear_enrollment_queue
-        without_department = @departments.dup
-        without_department.delete(department)
-
-        with(without_department.values.flatten)
+        with(cops.reject { |cop| cop.department == department })
       end
 
       # @return [Boolean] Checks if given name is department
@@ -160,31 +154,31 @@ module RuboCop
       def unqualified_cop_names
         clear_enrollment_queue
         @unqualified_cop_names ||=
-          Set.new(@cops_by_cop_name.keys.map { |qn| File.basename(qn) }) <<
+          Set.new(@cops_by_badge.keys.map { |badge| File.basename(badge.to_s) }) <<
           'RedundantCopDisableDirective'
       end
 
       def qualify_badge(badge)
         clear_enrollment_queue
         @departments
-          .map { |department, _| badge.with_department(department) }
+          .map { |department| badge.with_department(department) }
           .select { |potential_badge| registered?(potential_badge) }
       end
 
       # @return [Hash{String => Array<Class>}]
       def to_h
         clear_enrollment_queue
-        @cops_by_cop_name
+        @cops_by_badge.to_h { |_badge, cop| [cop.cop_name, [cop]] }
       end
 
       def cops
         clear_enrollment_queue
-        @registry.values
+        @cops_by_badge.values
       end
 
       def length
         clear_enrollment_queue
-        @registry.size
+        @cops_by_badge.size
       end
 
       def enabled(config)
@@ -219,7 +213,8 @@ module RuboCop
       end
 
       def names
-        cops.map(&:cop_name)
+        clear_enrollment_queue
+        @cops_by_badge.keys.map(&:to_s)
       end
 
       def cops_for_department(department)
@@ -236,7 +231,7 @@ module RuboCop
 
       def sort!
         clear_enrollment_queue
-        @registry = @registry.sort_by { |badge, _| badge.cop_name }.to_h
+        @cops_by_badge = @cops_by_badge.sort_by { |badge, _cop| badge.cop_name }.to_h
 
         self
       end
@@ -252,7 +247,9 @@ module RuboCop
       # @param [String] cop_name
       # @return [Class, nil]
       def find_by_cop_name(cop_name)
-        to_h[cop_name].first
+        clear_enrollment_queue
+        badge = Badge.parse(cop_name)
+        @cops_by_badge[badge]
       end
 
       # When a cop name is given returns a single-element array with the cop class.
@@ -289,10 +286,8 @@ module RuboCop
         return if @enrollment_queue.empty?
 
         @enrollment_queue.each do |cop|
-          @registry[cop.badge] = cop
-          @departments[cop.department] ||= []
-          @departments[cop.department] << cop
-          @cops_by_cop_name[cop.cop_name] << cop
+          @cops_by_badge[cop.badge] = cop
+          @departments << cop.department
         end
         @enrollment_queue = []
       end
@@ -318,7 +313,7 @@ module RuboCop
 
       def registered?(badge)
         clear_enrollment_queue
-        @registry.key?(badge)
+        @cops_by_badge.key?(badge)
       end
     end
   end

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -23,7 +23,6 @@ module RuboCop
         RuboCop::LSP.enable
 
         @runner = RuboCop::Lsp::StdinRunner.new(config_store)
-        @cop_registry = RuboCop::Cop::Registry.global.to_h
 
         @safe_autocorrect = true
         @lint_mode = false
@@ -63,7 +62,7 @@ module RuboCop
           document_encoding,
           offense,
           path,
-          @cop_registry[offense.cop_name]&.first,
+          RuboCop::Cop::Registry.global.find_by_cop_name(offense.cop_name),
           processed_source
         ).to_lsp_diagnostic(config)
       end


### PR DESCRIPTION
Refactors `RuboCop::Cop::Registry` internals to prepare it for addition of lazy loaded cops (https://github.com/rubocop/rubocop/issues/14983).

The main change in this PR is the repurposing of instance variables and simplifying them to just `@cops_by_badge` and `@departments`:
- `@cops_by_badge` is a Hash mapping a badge to a cop class
- `@departments` is a Set with all unique cop departments in the registry

The public API of the Registry has remained the same.

In the next PR, a new instance variable `@lazy_loaded_cops_by_badge` will be added as a Hash mapping a badge to the fully qualified name of the cop. It will also update registry logic to first look up a cop in `@cops_by_badge`, or fall back to loading the constant from `@lazy_loaded_cops_by_badge`. You can see this already in my [PoC implementation](https://github.com/lovro-bikic/rubocop/compare/90c795960da9c7fbd40b16f3b245eb26a6d564fa...3909cc5efad1adfc25605dfca63434468b6b6fa0#diff-dc00dfc3fe3e605382e6da43bf62ffda83cf5f54df0bbf4d2ab986b7f072a070) (the names might be a bit different).

This PR also refactors two places which use `Registry#to_h` to instead use `Registry#find_by_cop_name`. `#to_h` requires loading all cops, so in the future this will be an issue because it will trigger the loading of all lazy-loaded cops, effectively nullifying the benefits of lazy loading.

## Performance benchmark

To benchmark performance, I ran different registry methods 10 times on the master branch and 10 times on this branch. The results are below:

```
Registry.all

# before
all:
  runs:   0.00076200, 0.00074600, 0.00074400, 0.00080300, 0.00074200, 0.00074500, 0.00073800, 0.00081800, 0.00074200, 0.00074700 s
  avg:    0.00075870 s
  stddev: 0.00002679 s

# after
all:
  runs:   0.00053700, 0.00052500, 0.00052800, 0.00052500, 0.00052300, 0.00052700, 0.00054200, 0.00052800, 0.00052200, 0.00053000 s
  avg:    0.00052870 s
  stddev: 0.00000597 s
```

There's a speed-up here because of `.all`'s implementation, which is: `global.without_department(:Test).cops`. `.without_department` returns a new instance of registry with the cops saved in the enrollment queue, and then `.cops` clears the enrollment queue. Because the internals have been simplified, `#clear_enrollment_queue` has less work to do.

This is a win because [`Registry.all` is used in the Runner](https://github.com/rubocop/rubocop/blob/e4673357d34fad1f10e8f84e0dbcb9a19d34e331/lib/rubocop/runner.rb#L415), for example.

<br />

```
Registry#find_by_cop_name

# before
find_by_cop_name:
  runs:   0.00000400, 0.00000100, 0.00000000, 0.00000100, 0.00000000, 0.00000100, 0.00000000, 0.00000100, 0.00000000, 0.00000000 s
  avg:    0.00000080 s
  stddev: 0.00000117 s

# after
find_by_cop_name:
  runs:   0.00000500, 0.00000100, 0.00000100, 0.00000100, 0.00000000, 0.00000100, 0.00000100, 0.00000100, 0.00000100, 0.00000100 s
  avg:    0.00000130 s
  stddev: 0.00000127 s
```

No significant change after accounting for std dev.

<br />

```
Registry#with_department and Registry#without_department

# before
with_department:
  runs:   0.00000500, 0.00000200, 0.00000100, 0.00000100, 0.00000100, 0.00000200, 0.00000200, 0.00000200, 0.00000100, 0.00000200 s
  avg:    0.00000190 s
  stddev: 0.00000114 s

without_department:
  runs:   0.00004600, 0.00004200, 0.00004200, 0.00004200, 0.00004200, 0.00004200, 0.00004200, 0.00004600, 0.00004400, 0.00004300 s
  avg:    0.00004310 s
  stddev: 0.00000158 s

# after
with_department:
  runs:   0.00010800, 0.00010300, 0.00010500, 0.00010700, 0.00010600, 0.00010500, 0.00010400, 0.00010400, 0.00010400, 0.00010400 s
  avg:    0.00010500 s
  stddev: 0.00000148 s

without_department:
  runs:   0.00011200, 0.00011100, 0.00011000, 0.00011000, 0.00011100, 0.00011000, 0.00011000, 0.00011300, 0.00013500, 0.00011700 s
  avg:    0.00011390 s
  stddev: 0.00000733 s
```

There's an obvious regression here, and it's due to a lack of memoization to look-up cops by department (the new implementation instead filters an array of all cops). However, this seems acceptable to me for two reasons:
1. even with the regression, the methods run in a tenth of a millisecond
2. `with_department` and `without_department` are directly used only in `CopsDocumentationGenerator` (used for development), in CLI commands `list-enabled-cops-for` and `show-cops`, and in `Registry.all` (where there's actually a performance increase, even with this regression)

If this doesn't seem acceptable to you, let me know, and I'll think about memoizing cops by department (though it will come at a cost of more complex internals once lazy loaded cops are added).
