### PR TITLE
Fix false positives in `Style/Copyright`

### DIFF
--- a/changelog/fix_false_positives_in_style_copyright.md
+++ b/changelog/fix_false_positives_in_style_copyright.md
@@ -1,0 +1,1 @@
+* [#15163](https://github.com/rubocop/rubocop/pull/15163): Fix false positives in `Style/Copyright` when `Notice` pattern starts with `\A#`, uses `\s` metacharacters, or has multiple spaces after `#`. ([@koic][])

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -104,7 +104,7 @@ module RuboCop
         end
 
         def notice_regexp
-          @notice_regexp ||= Regexp.new(notice.sub(/\A\^?#\s?/, ''))
+          @notice_regexp ||= Regexp.new(notice.sub(/\A(?:\\A|\^)?#(?:\\s[*+?]?|\s)*/, ''))
         end
 
         def notice

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -243,6 +243,83 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
     end
   end
 
+  context 'when the `Notice` pattern starts with `\A#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '\A# Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => '# Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'does not register an offense when the notice is present' do
+      expect_no_offenses(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+
+    it 'autocorrects with a single `#` prefix' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
+  context 'when the `Notice` pattern uses `\s+` after `#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '^#\s+Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => '# Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'does not register an offense when the notice is present' do
+      expect_no_offenses(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+
+    it 'autocorrects with a single `#` prefix' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
+  context 'when the `Notice` pattern has multiple literal spaces after `#`' do
+    let(:cop_config) do
+      {
+        'Notice' => '^#  Copyright (\(c\) )?2[0-9]{3} .+',
+        'AutocorrectNotice' => '#  Copyright (c) 2026 My Name'
+      }
+    end
+
+    it 'autocorrects preserving the configured spacing' do
+      expect_offense(<<~RUBY)
+        puts 'Hello world'
+        ^ Include a copyright notice matching [...]
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #  Copyright (c) 2026 My Name
+        puts 'Hello world'
+      RUBY
+    end
+  end
+
   context 'when `Notice` starts with `^#` and AutocorrectNotice has no `#`' do
     let(:cop_config) do
       {


### PR DESCRIPTION
Follow-up to #15132 (which fixed #15130).

This PR fixes false positives in `Style/Copyright` for more `Notice` pattern variations. Broaden the leading anchor and comment-marker stripping in the `Notice` regex derivation to also support:

- `\A`-anchored patterns (e.g. `\A# Copyright …`)
- `\s` metacharacters after `#` (e.g. `^#\s+Copyright …`)
- Multiple literal spaces after `#` (e.g. `^#  Copyright …`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
