### PR TITLE
Fix extension suggestion documentation link

### DIFF
--- a/lib/rubocop/cli/command/suggest_extensions.rb
+++ b/lib/rubocop/cli/command/suggest_extensions.rb
@@ -60,7 +60,7 @@ module RuboCop
         def print_opt_out_instruction
           puts
           puts 'You can opt out of this message by adding the following to your config ' \
-               '(see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions ' \
+               '(see https://docs.rubocop.org/rubocop/plugins.html#plugin-suggestions ' \
                'for more options):'
           puts '  AllCops:'
           puts '    SuggestExtensions: false'


### PR DESCRIPTION
Fixes a broken documentation link in the `SuggestExtensions` opt-out message.

  The old URL points to `extensions.html#extension-suggestions`, which no longer exists after the
  documentation was reorganized around plugins. This updates it to `plugins.html#plugin-suggestions`.

  Tested with:

 ```sh
  bundle exec rspec spec/rubocop/cli/suggest_extensions_spec.rb
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
