### PR TITLE
[Cop lazy loading] Add lazy load support to Registry

### DIFF
--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -51,6 +51,7 @@ module RuboCop
       def initialize(cops = [], options = {})
         @departments = Set.new
         @cops_by_badge = {}
+        @lazy_loaded_cops_by_badge = {}
 
         @enrollment_queue = cops
         @options = options
@@ -58,6 +59,12 @@ module RuboCop
         @enabled_cache = {}.compare_by_identity
         @disabled_cache = {}.compare_by_identity
         @warnings = {}
+      end
+
+      def lazy_load(cop_name, constant_name)
+        badge = Badge.parse(cop_name)
+        @departments << badge.department
+        @lazy_loaded_cops_by_badge[badge] = constant_name
       end
 
       def enlist(cop)
@@ -154,8 +161,8 @@ module RuboCop
       def unqualified_cop_names
         clear_enrollment_queue
         @unqualified_cop_names ||=
-          Set.new(@cops_by_badge.keys.map { |badge| File.basename(badge.to_s) }) <<
-          'RedundantCopDisableDirective'
+          (@cops_by_badge.keys | @lazy_loaded_cops_by_badge.keys)
+          .to_set { |badge| File.basename(badge.to_s) } << 'RedundantCopDisableDirective'
       end
 
       def qualify_badge(badge)
@@ -168,17 +175,19 @@ module RuboCop
       # @return [Hash{String => Array<Class>}]
       def to_h
         clear_enrollment_queue
+        load_all_lazy_cops
         @cops_by_badge.to_h { |_badge, cop| [cop.cop_name, [cop]] }
       end
 
       def cops
         clear_enrollment_queue
+        load_all_lazy_cops
         @cops_by_badge.values
       end
 
       def length
         clear_enrollment_queue
-        @cops_by_badge.size
+        @cops_by_badge.size + @lazy_loaded_cops_by_badge.size
       end
 
       def enabled(config)
@@ -214,7 +223,7 @@ module RuboCop
 
       def names
         clear_enrollment_queue
-        @cops_by_badge.keys.map(&:to_s)
+        @cops_by_badge.keys.map(&:to_s) | @lazy_loaded_cops_by_badge.keys.map(&:to_s)
       end
 
       def cops_for_department(department)
@@ -231,6 +240,7 @@ module RuboCop
 
       def sort!
         clear_enrollment_queue
+        load_all_lazy_cops
         @cops_by_badge = @cops_by_badge.sort_by { |badge, _cop| badge.cop_name }.to_h
 
         self
@@ -249,7 +259,7 @@ module RuboCop
       def find_by_cop_name(cop_name)
         clear_enrollment_queue
         badge = Badge.parse(cop_name)
-        @cops_by_badge[badge]
+        @cops_by_badge[badge] || load_lazy_cop(badge)
       end
 
       # When a cop name is given returns a single-element array with the cop class.
@@ -262,6 +272,7 @@ module RuboCop
 
       def freeze
         clear_enrollment_queue
+        load_all_lazy_cops
         unqualified_cop_names # build cache
         super
       end
@@ -292,6 +303,17 @@ module RuboCop
         @enrollment_queue = []
       end
 
+      def load_all_lazy_cops
+        @lazy_loaded_cops_by_badge.each_key { |badge| load_lazy_cop(badge) }
+      end
+
+      def load_lazy_cop(badge)
+        constant_name = @lazy_loaded_cops_by_badge.delete(badge)
+        return unless constant_name
+
+        @cops_by_badge[badge] = Kernel.const_get(constant_name)
+      end
+
       def with(cops)
         self.class.new(cops)
       end
@@ -313,7 +335,7 @@ module RuboCop
 
       def registered?(badge)
         clear_enrollment_queue
-        @cops_by_badge.key?(badge)
+        @cops_by_badge.key?(badge) || @lazy_loaded_cops_by_badge.key?(badge)
       end
     end
   end

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -154,24 +154,49 @@ RSpec.describe RuboCop::Cop::Registry do
       end
     end
 
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'returns the qualified cop name' do
+        result = registry.qualified_cop_name('LazyLoad/Foo', origin)
+        expect(result).to eql('LazyLoad/Foo')
+      end
+    end
+
     it 'returns the provided name if no namespace is found' do
       expect(registry.qualified_cop_name('NotReal', origin)).to eql('NotReal')
     end
   end
 
-  it 'exposes a mapping of cop names to cop classes' do
-    expect(registry.to_h).to eql(
-      'Lint/BooleanSymbol' => [RuboCop::Cop::Lint::BooleanSymbol],
-      'Lint/DuplicateMethods' => [RuboCop::Cop::Lint::DuplicateMethods],
-      'Layout/FirstArrayElementIndentation' => [
-        RuboCop::Cop::Layout::FirstArrayElementIndentation
-      ],
-      'Metrics/MethodLength' => [RuboCop::Cop::Metrics::MethodLength],
-      'Test/FirstArrayElementIndentation' => [
-        RuboCop::Cop::Test::FirstArrayElementIndentation
-      ],
-      'RSpec/Foo' => [RuboCop::Cop::RSpec::Foo]
-    )
+  describe '#to_h' do
+    it 'exposes a mapping of cop names to cop classes' do
+      expect(registry.to_h).to eql(
+        'Lint/BooleanSymbol' => [RuboCop::Cop::Lint::BooleanSymbol],
+        'Lint/DuplicateMethods' => [RuboCop::Cop::Lint::DuplicateMethods],
+        'Layout/FirstArrayElementIndentation' => [
+          RuboCop::Cop::Layout::FirstArrayElementIndentation
+        ],
+        'Metrics/MethodLength' => [RuboCop::Cop::Metrics::MethodLength],
+        'Test/FirstArrayElementIndentation' => [
+          RuboCop::Cop::Test::FirstArrayElementIndentation
+        ],
+        'RSpec/Foo' => [RuboCop::Cop::RSpec::Foo]
+      )
+    end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'loads them' do
+        expect(registry.to_h['LazyLoad/Foo']).to eq([RuboCop::Cop::LazyLoad::Foo])
+      end
+    end
   end
 
   describe '#cops' do
@@ -193,10 +218,34 @@ RSpec.describe RuboCop::Cop::Registry do
         )
       end
     end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'includes them in the list' do
+        expect(registry.cops).to include(RuboCop::Cop::LazyLoad::Foo)
+      end
+    end
   end
 
-  it 'exposes the number of stored cops' do
-    expect(registry.length).to be(6)
+  describe '#length' do
+    it 'exposes the number of stored cops' do
+      expect(registry.length).to be(6)
+    end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'includes them' do
+        expect(registry.length).to be(7)
+      end
+    end
   end
 
   describe '#enabled' do
@@ -319,17 +368,30 @@ RSpec.describe RuboCop::Cop::Registry do
     end
   end
 
-  it 'exposes a list of cop names' do
-    expect(registry.names).to eql(
-      [
-        'Lint/BooleanSymbol',
-        'Lint/DuplicateMethods',
-        'Layout/FirstArrayElementIndentation',
-        'Metrics/MethodLength',
-        'RSpec/Foo',
-        'Test/FirstArrayElementIndentation'
-      ]
-    )
+  describe '#names' do
+    it 'exposes a list of cop names' do
+      expect(registry.names).to eql(
+        [
+          'Lint/BooleanSymbol',
+          'Lint/DuplicateMethods',
+          'Layout/FirstArrayElementIndentation',
+          'Metrics/MethodLength',
+          'RSpec/Foo',
+          'Test/FirstArrayElementIndentation'
+        ]
+      )
+    end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'includes them in the list' do
+        expect(registry.names).to include('LazyLoad/Foo')
+      end
+    end
   end
 
   describe '#department?' do
@@ -346,6 +408,86 @@ RSpec.describe RuboCop::Cop::Registry do
     it 'returns array of cops for specified department' do
       expect(registry.names_for_department('Lint'))
         .to eq %w[Lint/BooleanSymbol Lint/DuplicateMethods]
+    end
+  end
+
+  describe '#find_by_cop_name' do
+    it 'returns cop class when it exists in the registry' do
+      expect(registry.find_by_cop_name('Lint/BooleanSymbol')).to eq(RuboCop::Cop::Lint::BooleanSymbol)
+    end
+
+    it 'returns nil when it does not exist in the registry' do
+      expect(registry.find_by_cop_name('Foo/Bar')).to be_nil
+    end
+
+    context 'when the cop is lazy-loaded' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'loads it' do
+        expect(registry.find_by_cop_name('LazyLoad/Foo')).to eq(RuboCop::Cop::LazyLoad::Foo)
+      end
+    end
+  end
+
+  describe '#unqualified_cop_names' do
+    it 'returns a set of cop names without the department' do
+      expect(registry.unqualified_cop_names)
+        .to eq(Set['BooleanSymbol', 'DuplicateMethods',
+                   'FirstArrayElementIndentation', 'MethodLength',
+                   'Foo', 'RedundantCopDisableDirective'])
+    end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::LazyLoadedCop', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/LazyLoadedCop', 'RuboCop::Cop::LazyLoad::LazyLoadedCop')
+      end
+
+      it 'includes them' do
+        expect(registry.unqualified_cop_names).to include('LazyLoadedCop')
+      end
+    end
+  end
+
+  describe '#lazy_load' do
+    before do
+      stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+    end
+
+    it 'adds lazy-loaded cop to departments' do
+      expect do
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end.to change { registry.departments.include?(:LazyLoad) }.from(false).to(true)
+    end
+  end
+
+  describe '#sort!' do
+    it 'sorts the cops by cop name' do
+      expected_order = cops.sort_by { |cop| cop.badge.cop_name }
+
+      expect(cops).not_to eq(expected_order)
+
+      expect do
+        registry.sort!
+      end.to change(registry, :cops).from(cops).to(expected_order)
+    end
+
+    context 'when there are lazy-loaded cops' do
+      before do
+        stub_const('RuboCop::Cop::LazyLoad::Foo', Class.new(RuboCop::Cop::Base))
+        registry.lazy_load('LazyLoad/Foo', 'RuboCop::Cop::LazyLoad::Foo')
+      end
+
+      it 'loads them' do
+        expected_order = (cops + [RuboCop::Cop::LazyLoad::Foo]).sort_by { |cop| cop.badge.cop_name }
+
+        expect do
+          registry.sort!
+        end.to change(registry, :cops).to(expected_order)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds public API to `RuboCop::Cop::Registry` to support cop lazy-loading (`#lazy_load` method). Implements lazy-loading internals. Existing registry methods have been modified so that they take into account already loaded cops (`@cops_by_badge`) and lazy-loaded cops (`@lazy_loaded_cops_by_badge`).

When a lazy-loaded cop's class needs to be used, its constant name is evaluated using `Kernel.const_get`, and the cop is moved from `@lazy_loaded_cops_by_badge` to `@cops_by_badge`.

The PR also adds tests for registry methods which previously haven't been tested directly.

Note that this PR only implements the API, existing cop departments will use it in future PRs. To illustrate how I imagined this to work, I'll use the `Migration` department as an example:

```ruby
module RuboCop
  module Cop
    module Migration
      extend CopLazyLoader

      register_cop :DepartmentName, 'rubocop/cop/migration/department_name'
    end
  end
end
``` 

`CopLazyLoader` module will have a method `register_cop` which accepts cop/class name and the path to require. When called, it will do the following (based on the above example):
```ruby
RuboCop::Cop::Migration.autoload :DepartmentName, 'rubocop/cop/migration/department_name'
RuboCop::Cop::Registry.global.lazy_load 'Migration/DepartmentName', 'RuboCop::Cop::Migration::DepartmentName'
```

This functionality will be implemented in the next PR, I'm just giving an example here to show how `Registry#lazy_load` will be used. (For reference, [here is the PoC](https://github.com/lovro-bikic/rubocop/compare/90c795960da9c7fbd40b16f3b245eb26a6d564fa...3909cc5efad1adfc25605dfca63434468b6b6fa0) which already has this implemented)

Proposal: https://github.com/rubocop/rubocop/issues/14983