### PR TITLE
Add `Recursive` option to `Style/MutableConstant`

### DIFF
--- a/changelog/new_recursive_option_for_style_mutable_constant.md
+++ b/changelog/new_recursive_option_for_style_mutable_constant.md
@@ -1,0 +1,1 @@
+* [#15166](https://github.com/rubocop/rubocop/pull/15166): Add a new `Recursive` option to `Style/MutableConstant`. When enabled, the cop checks and freezes mutable literals nested inside arrays and hashes. The option is disabled by default to preserve existing behavior. ([@paracycle][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4874,7 +4874,7 @@ Style/MutableConstant:
   Description: 'Do not assign mutable objects to constants.'
   Enabled: true
   VersionAdded: '0.34'
-  VersionChanged: '1.8'
+  VersionChanged: "<<next>>"
   SafeAutoCorrect: false
   EnforcedStyle: literals
   SupportedStyles:
@@ -4886,6 +4886,9 @@ Style/MutableConstant:
     # no harm in freezing an already frozen object.
     - literals
     - strict
+  # When `true`, recursively check and freeze mutable literals nested inside
+  # arrays and hashes (e.g. `[{a: []}]` becomes `[{a: [].freeze}.freeze].freeze`).
+  Recursive: false
 
 Style/NegatedIf:
   Description: >-

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -6,6 +6,14 @@ module RuboCop
       # Checks whether some constant value isn't a
       # mutable literal (e.g. array or hash).
       #
+      # When the `Recursive` option is enabled, mutable literals nested inside
+      # arrays and hashes are also frozen, so an offense on the outermost
+      # unfrozen literal will autocorrect every nested mutable literal as well.
+      # When the outer literal already has `.freeze` appended, the cop descends
+      # into it and reports each outermost unfrozen literal underneath. The
+      # option is disabled by default to preserve existing behavior; opt in to
+      # get strict nested freezing.
+      #
       # Strict mode can be used to freeze all constants, rather than
       # just literals.
       # Strict mode is considered an experimental feature. It has not been
@@ -48,6 +56,17 @@ module RuboCop
       #   # good
       #   CONST = Something.new
       #
+      #
+      # @example Recursive: false (default)
+      #   # good - only the outer container needs to be frozen
+      #   CONST = [{ a: [], b: 'foo' }].freeze
+      #
+      # @example Recursive: true
+      #   # bad - nested mutable literals must be frozen too
+      #   CONST = [{ a: [], b: 'foo' }].freeze
+      #
+      #   # good
+      #   CONST = [{ a: [].freeze, b: 'foo'.freeze }.freeze].freeze
       #
       # @example EnforcedStyle: strict
       #   # bad
@@ -138,10 +157,30 @@ module RuboCop
         private
 
         def on_assignment(value)
-          if style == :strict
-            strict_check(value)
+          nodes = mutable_nodes(value) do |node|
+            if style == :strict
+              strict_check(node)
+            else
+              literal_check(node)
+            end
+          end
+
+          nodes.each do |node|
+            add_offense(node) { |corrector| autocorrect(corrector, node) }
+          end
+        end
+
+        def mutable_nodes(value, &block)
+          if recursive? && explicitly_frozen_literal?(value)
+            literal_children(value.receiver).flat_map { |c| mutable_nodes(c, &block) }
           else
-            check(value)
+            node_offending = yield(value)
+
+            if node_offending
+              [value]
+            else
+              []
+            end
           end
         end
 
@@ -151,18 +190,20 @@ module RuboCop
           return if frozen_string_literal?(value)
           return if shareable_constant_value?(value)
 
-          add_offense(value) { |corrector| autocorrect(corrector, value) }
+          true
         end
 
-        def check(value)
-          range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
-          return unless mutable_literal?(value) ||
-                        (target_ruby_version <= 2.7 && range_enclosed_in_parentheses)
-
+        def literal_check(value)
+          return unless mutable_or_unfrozen_range?(value)
           return if frozen_string_literal?(value)
           return if shareable_constant_value?(value)
 
-          add_offense(value) { |corrector| autocorrect(corrector, value) }
+          true
+        end
+
+        def mutable_or_unfrozen_range?(value)
+          mutable_literal?(value) ||
+            (target_ruby_version <= 2.7 && range_enclosed_in_parentheses?(value))
         end
 
         def autocorrect(corrector, node)
@@ -171,13 +212,66 @@ module RuboCop
           splat_value = splat_value(node)
           if splat_value
             correct_splat_expansion(corrector, expr, splat_value)
-          elsif node.array_type? && !node.bracketed?
+            corrector.insert_after(expr, '.freeze')
+            return
+          end
+
+          if node.array_type? && !node.bracketed?
             corrector.wrap(expr, '[', ']')
           elsif requires_parentheses?(node)
             corrector.wrap(expr, '(', ')')
           end
 
           corrector.insert_after(expr, '.freeze')
+
+          freeze_nested_literals(corrector, node) if recursive?
+        end
+
+        # Recursively freezes every nested mutable literal inside an array or
+        # hash literal. Already-frozen subtrees are not re-frozen, but their
+        # children are still inspected for unfrozen literals deeper down.
+        def freeze_nested_literals(corrector, node)
+          literal_children(node).each do |child|
+            if explicitly_frozen_literal?(child)
+              freeze_nested_literals(corrector, child.receiver)
+            elsif freezable_nested_literal?(child)
+              autocorrect(corrector, child)
+            end
+          end
+        end
+
+        def freezable_nested_literal?(node)
+          return false if frozen_string_literal?(node)
+          return false if shareable_constant_value?(node)
+
+          mutable_literal?(node)
+        end
+
+        # Returns the child literals of an array or hash node that may
+        # themselves need freezing. For hashes, both keys and values are
+        # included. Percent-literal arrays (e.g. `%w(a b)`) are skipped because
+        # `.freeze` cannot be appended to their contents.
+        def literal_children(node)
+          case node.type
+          when :array
+            return [] if node.percent_literal?
+
+            node.children
+          when :hash
+            node.children.flat_map { |child| child.pair_type? ? child.children : [] }
+          else
+            []
+          end
+        end
+
+        def explicitly_frozen_literal?(node)
+          return false unless node.send_type? && node.method?(:freeze)
+
+          node.receiver && mutable_literal?(node.receiver)
+        end
+
+        def recursive?
+          cop_config.fetch('Recursive', false)
         end
 
         def mutable_literal?(value)

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -673,4 +673,181 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
 
     it_behaves_like 'string literal'
   end
+
+  context 'with Recursive: false (default)' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literals' } }
+
+    it 'only freezes the outermost literal, leaving nested mutables alone' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: [], b: 'foo' }]
+                ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: [], b: 'foo' }].freeze
+      RUBY
+    end
+
+    it 'does not descend into an already-frozen outer literal' do
+      expect_no_offenses(<<~RUBY)
+        CONST = [{ a: [] }].freeze
+      RUBY
+    end
+  end
+
+  context 'with Recursive: true and nested mutable literals' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literals', 'Recursive' => true } }
+
+    it 'recursively freezes a hash nested inside an array' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: [], b: 'foo' }]
+                ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: [].freeze, b: 'foo'.freeze }.freeze].freeze
+      RUBY
+    end
+
+    it 'recursively freezes deeply nested literals' do
+      expect_offense(<<~RUBY)
+        CONST = { a: [1, [2, { b: 'x' }]] }
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = { a: [1, [2, { b: 'x'.freeze }.freeze].freeze].freeze }.freeze
+      RUBY
+    end
+
+    it 'descends into an already-frozen outer array and reports the outermost unfrozen literal' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: [] }].freeze
+                 ^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: [].freeze }.freeze].freeze
+      RUBY
+    end
+
+    it 'descends through multiple already-frozen layers' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: [] }.freeze].freeze
+                      ^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: [].freeze }.freeze].freeze
+      RUBY
+    end
+
+    it 'reports separate offenses for each outermost unfrozen literal at the same level' do
+      expect_offense(<<~RUBY)
+        CONST = [[1, 2], { a: 1 }].freeze
+                 ^^^^^^ Freeze mutable objects assigned to constants.
+                         ^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [[1, 2].freeze, { a: 1 }.freeze].freeze
+      RUBY
+    end
+
+    it 'wraps nested ranges in parentheses when freezing', :ruby27, unsupported_on: :prism do
+      expect_offense(<<~RUBY)
+        CONST = { a: 1..10 }
+                ^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = { a: (1..10).freeze }.freeze
+      RUBY
+    end
+
+    it 'does not descend into percent-literal arrays' do
+      expect_offense(<<~RUBY)
+        CONST = [%w(a b c)]
+                ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [%w(a b c).freeze].freeze
+      RUBY
+    end
+
+    it 'leaves non-literal nested expressions alone' do
+      expect_offense(<<~RUBY)
+        CONST = [foo, bar]
+                ^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [foo, bar].freeze
+      RUBY
+    end
+
+    it 'does not double-freeze nested literals that already have .freeze' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: 'foo'.freeze, b: [] }]
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: 'foo'.freeze, b: [].freeze }.freeze].freeze
+      RUBY
+    end
+
+    context 'with frozen_string_literal: true' do
+      it 'does not add .freeze to nested string literals' do
+        expect_offense(<<~RUBY)
+          # frozen_string_literal: true
+
+          CONST = [{ a: [], b: 'foo' }]
+                  ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # frozen_string_literal: true
+
+          CONST = [{ a: [].freeze, b: 'foo' }.freeze].freeze
+        RUBY
+      end
+    end
+
+    context 'when shareable_constant_value is set', :ruby30 do
+      it 'does not register an offense for nested mutable literals either' do
+        expect_no_offenses(<<~RUBY)
+          # shareable_constant_value: literal
+          CONST = [{ a: [], b: 'foo' }]
+        RUBY
+      end
+    end
+  end
+
+  context 'with Recursive: true and EnforcedStyle: strict' do
+    let(:cop_config) { { 'EnforcedStyle' => 'strict', 'Recursive' => true } }
+
+    it 'recursively freezes nested literals at the top level' do
+      expect_offense(<<~RUBY)
+        CONST = [{ a: [] }]
+                ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [{ a: [].freeze }.freeze].freeze
+      RUBY
+    end
+
+    it 'descends into an already-frozen outer literal in strict mode' do
+      expect_offense(<<~RUBY)
+        CONST = [Something.new].freeze
+                 ^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        CONST = [Something.new.freeze].freeze
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
For a constant to be truly immutable, its value needs to be deeply frozen. For example, `FOO = [{key: []}].freeze` looks like an immutable constant, but `FOO.first[:key] << 42` mutates it into `[{key: [42]}]`.

Since Ruby does not yet have a built-in `deep_freeze` (see https://bugs.ruby-lang.org/issues/21962), nested `.freeze` calls are the best we can do today. This PR teaches `Style/MutableConstant` to apply those nested `.freeze` calls for users who want stronger immutability guarantees.

## What changed

A new `Recursive` option (default: `false`) on `Style/MutableConstant`.

When `Recursive: true`:

- The cop walks into the outermost `.freeze`d literal and reports the outermost mutable nested literal(s) it finds underneath. For example, given `CONST = [{ a: [] }].freeze` the offense lands on the inner `{ a: [] }`.
- Autocorrect freezes every nested mutable literal: `[{ a: [], b: 'foo' }]` becomes `[{ a: [].freeze, b: 'foo'.freeze }.freeze].freeze`.
- `frozen_string_literal: true` and `shareable_constant_value:` are honoured for nested nodes too, so already-frozen strings and shareable constants are not re-frozen.
- `%w(...)`/`%i(...)` arrays are skipped for descent because `.freeze` cannot be appended to their contents.

When `Recursive: false` (the default), behavior is identical to the prior cop — no incompatibility for existing users.

## Why opt-in

Per @koic's feedback, recursive nested `.freeze` is impactful enough that it should be opt-in:

- Users who do not want to read/write nested `.freeze` chains by default are unaffected.
- Users who want strict deep-freeze semantics can flip the option on.
- A future `Object#deep_freeze` (https://bugs.ruby-lang.org/issues/21962) would let us revisit the recommended autocorrect.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
