### PR TITLE
Add `--enable-all-cops` and `--disable-all-cops` command line options

### DIFF
--- a/changelog/new_add_enable_all_cops_and_disable_all_cops_options_20260429194020.md
+++ b/changelog/new_add_enable_all_cops_and_disable_all_cops_options_20260429194020.md
@@ -1,0 +1,1 @@
+* [#15167](https://github.com/rubocop/rubocop/pull/15167): Add `--enable-all-cops` and `--disable-all-cops` command line options that override `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files. ([@koic][])

--- a/docs/modules/ROOT/pages/configuration/cop_settings.adoc
+++ b/docs/modules/ROOT/pages/configuration/cop_settings.adoc
@@ -47,6 +47,12 @@ All cops in the `Style` department are then enabled. In this case, only the cops
 in the `Style` department that are enabled by default will be enabled.
 The cops in the `Style` department that are disabled by default will remain disabled.
 
+The same effects can be obtained from the command line using `--disable-all-cops`
+and `--enable-all-cops`. These options take precedence over the configuration
+files, which is useful when you want to inspect the source with a different cop
+set without modifying `.rubocop.yml`. Note that `--disable-all-cops` does not
+disable `Lint/Syntax`, which is always enabled.
+
 If a department is disabled, cops in that department can still be individually
 enabled, and that setting overrides the setting for its department in the same
 configuration file and in any inherited file.

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -48,6 +48,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `-d/--debug`
 | Displays some extra debug output.
 
+| `--disable-all-cops`
+| Run with all cops disabled by default, except `Lint/Syntax`. Overrides `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files.
+
 | `--disable-pending-cops`
 | Run without pending cops.
 
@@ -68,6 +71,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 
 | `--display-only-safe-correctable`
 | Only output safe correctable offense messages.
+
+| `--enable-all-cops`
+| Run with all cops enabled, including those disabled by default. Overrides `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files.
 
 | `--enable-pending-cops`
 | Run with pending cops.

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -190,6 +190,8 @@ module RuboCop
       ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
       ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
+      ConfigLoader.enabled_by_default = @options[:enable_all_cops]
+      ConfigLoader.disabled_by_default = @options[:disable_all_cops]
     end
 
     def set_options_to_pending_cops_reporter

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -24,7 +24,7 @@ module RuboCop
       include FileFinder
 
       attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops,
-                    :ignore_unrecognized_cops
+                    :enabled_by_default, :disabled_by_default, :ignore_unrecognized_cops
       attr_writer :default_configuration, :cache_root
       attr_reader :loaded_plugins, :loaded_features
 
@@ -41,6 +41,8 @@ module RuboCop
         @loaded_features = Set.new
         @disable_pending_cops = nil
         @enable_pending_cops = nil
+        @enabled_by_default = nil
+        @disabled_by_default = nil
         @ignore_parent_exclusion = nil
         @ignore_unrecognized_cops = nil
         @cache_root = nil
@@ -121,7 +123,7 @@ module RuboCop
       end
 
       def configuration_from_file(config_file, check: true)
-        return default_configuration if config_file == DEFAULT_FILE
+        return apply_default_overrides(default_configuration) if config_file == DEFAULT_FILE
 
         config = load_file(config_file, check: check)
         config.validate_after_resolution if check
@@ -188,6 +190,19 @@ module RuboCop
       # Merges the given configuration with the default one.
       def merge_with_default(config, config_file, unset_nil: true)
         resolver.merge_with_default(config, config_file, unset_nil: unset_nil)
+      end
+
+      # Applies CLI overrides for `AllCops/EnabledByDefault` and
+      # `AllCops/DisabledByDefault` to the given configuration. Used when the
+      # configuration would otherwise be returned without going through
+      # `merge_with_default` (e.g. there is no user-supplied `.rubocop.yml`).
+      def apply_default_overrides(config)
+        return config if @enabled_by_default.nil? && @disabled_by_default.nil?
+
+        hash = config.transform_values do |params|
+          params.is_a?(Hash) ? params.merge('Enabled' => !@disabled_by_default) : params
+        end
+        Config.new(hash, config.loaded_path)
       end
 
       # @api private

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -92,11 +92,11 @@ module RuboCop
     # only cops from user configuration are enabled. If
     # AllCops:EnabledByDefault is true, it changes the Enabled params so that
     # only cops explicitly disabled in user configuration are disabled.
+    # When the `--disable-all-cops` or `--enable-all-cops` CLI option is given,
+    # it takes precedence over the configuration values.
     def merge_with_default(config, config_file, unset_nil:)
       default_configuration = ConfigLoader.default_configuration
-
-      disabled_by_default = config.for_all_cops['DisabledByDefault']
-      enabled_by_default = config.for_all_cops['EnabledByDefault']
+      disabled_by_default, enabled_by_default = resolve_default_overrides(config)
 
       if disabled_by_default || enabled_by_default
         default_configuration = transform(default_configuration) do |params|
@@ -168,6 +168,14 @@ module RuboCop
     end
 
     private
+
+    def resolve_default_overrides(config)
+      if ConfigLoader.disabled_by_default || ConfigLoader.enabled_by_default
+        [ConfigLoader.disabled_by_default, ConfigLoader.enabled_by_default]
+      else
+        [config.for_all_cops['DisabledByDefault'], config.for_all_cops['EnabledByDefault']]
+      end
+    end
 
     def disabled?(hash, department)
       hash[department].is_a?(Hash) && hash[department]['Enabled'] == false

--- a/lib/rubocop/config_store.rb
+++ b/lib/rubocop/config_store.rb
@@ -36,7 +36,7 @@ module RuboCop
     end
 
     def force_default_config!
-      @options_config = ConfigLoader.default_configuration
+      @options_config = ConfigLoader.apply_default_overrides(ConfigLoader.default_configuration)
     end
 
     def unvalidated

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -91,6 +91,8 @@ module RuboCop
         option(opts, '-F', '--fail-fast')
         option(opts, '--disable-pending-cops')
         option(opts, '--enable-pending-cops')
+        option(opts, '--disable-all-cops')
+        option(opts, '--enable-all-cops')
         option(opts, '--ignore-disable-comments')
         option(opts, '--force-exclusion')
         option(opts, '--only-recognized-file-types')
@@ -396,6 +398,7 @@ module RuboCop
       validate_display_only_failed_and_display_only_correctable
       validate_display_only_correctable_and_autocorrect
       validate_lsp_and_editor_mode
+      validate_enable_all_cops_and_disable_all_cops
       disable_parallel_when_invalid_option_combo
 
       return if incompatible_options.size <= 1
@@ -447,6 +450,13 @@ module RuboCop
       return if !@options.key?(:lsp) || !@options.key?(:editor_mode)
 
       raise OptionArgumentError, 'Do not specify `--editor-mode` as it is redundant in `--lsp`.'
+    end
+
+    def validate_enable_all_cops_and_disable_all_cops
+      return if !@options.key?(:enable_all_cops) || !@options.key?(:disable_all_cops)
+
+      raise OptionArgumentError,
+            '--enable-all-cops cannot be used together with --disable-all-cops.'
     end
 
     def validate_autocorrect
@@ -621,8 +631,16 @@ module RuboCop
       display_cop_names:                ['Display cop names in offense messages.',
                                          'Default is true.'],
       disable_pending_cops:             'Run without pending cops.',
+      disable_all_cops:                 ['Run with all cops disabled by default,',
+                                         'except `Lint/Syntax`. Overrides',
+                                         '`AllCops/EnabledByDefault` and',
+                                         '`AllCops/DisabledByDefault` in config files.'],
       display_style_guide:              'Display style guide URLs in offense messages.',
       enable_pending_cops:              'Run with pending cops.',
+      enable_all_cops:                  ['Run with all cops enabled, including those',
+                                         'disabled by default. Overrides',
+                                         '`AllCops/EnabledByDefault` and',
+                                         '`AllCops/DisabledByDefault` in config files.'],
       extra_details:                    'Display extra details in offense messages.',
       lint:                             'Run only lint cops.',
       safe:                             'Run only safe cops.',

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -2183,6 +2183,77 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     end
   end
 
+  describe '--enable-all-cops' do
+    before do
+      create_file('example.rb', "# frozen_string_literal: true\n\n[1, 2].collect { |x| x }\n")
+    end
+
+    it 'enables cops that are disabled by default' do
+      expect(cli.run(['--format', 'simple', '--only', 'Style/CollectionMethods',
+                      '--enable-all-cops', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/CollectionMethods')
+    end
+
+    it 'overrides AllCops/DisabledByDefault from the configuration file' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          DisabledByDefault: true
+      YAML
+
+      expect(cli.run(['--format', 'simple', '--only', 'Style/CollectionMethods',
+                      '--enable-all-cops', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/CollectionMethods')
+    end
+
+    it 'works in combination with --force-default-config' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          DisabledByDefault: true
+      YAML
+
+      expect(cli.run(['--format', 'simple', '--only', 'Style/CollectionMethods',
+                      '--enable-all-cops', '--force-default-config', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/CollectionMethods')
+    end
+  end
+
+  describe '--disable-all-cops' do
+    before { create_file('example.rb', "x = 'foo'\n") }
+
+    it 'disables cops that are enabled by default' do
+      expect(cli.run(['--format', 'simple', '--disable-all-cops', 'example.rb'])).to eq(0)
+      expect($stdout.string).to include('no offenses detected')
+    end
+
+    it 'still reports `Lint/Syntax` errors' do
+      create_file('example.rb', '1 /// 2')
+
+      expect(cli.run(['--format', 'simple', '--disable-all-cops', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Lint/Syntax')
+    end
+
+    it 'overrides AllCops/EnabledByDefault from the configuration file' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          EnabledByDefault: true
+      YAML
+
+      expect(cli.run(['--format', 'simple', '--disable-all-cops', 'example.rb'])).to eq(0)
+      expect($stdout.string).to include('no offenses detected')
+    end
+  end
+
+  describe '--enable-all-cops with --disable-all-cops' do
+    before { create_file('example.rb', 'x = 1') }
+
+    it 'reports an error' do
+      expect(cli.run(['--enable-all-cops', '--disable-all-cops', 'example.rb'])).to eq(2)
+      expect($stderr.string).to include(
+        '--enable-all-cops cannot be used together with --disable-all-cops.'
+      )
+    end
+  end
+
   describe '--force-exclusion' do
     context 'when explicitly excluded' do
       let(:target_file) { 'example.rb' }

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1716,6 +1716,48 @@ RSpec.describe RuboCop::ConfigLoader do
           expect(cop_enabled?(cop_class)).to be false
         end
       end
+
+      context 'when ConfigLoader.enabled_by_default is set' do
+        let(:config) { '' }
+
+        before { described_class.enabled_by_default = true }
+
+        it 'enables cops that are disabled by default' do
+          cop_class = RuboCop::Cop::Style::CollectionMethods
+          expect(cop_enabled?(cop_class)).to be true
+        end
+
+        it 'overrides AllCops/DisabledByDefault from the config file' do
+          create_file(file_path, <<~YAML)
+            AllCops:
+              DisabledByDefault: true
+          YAML
+
+          cop_class = RuboCop::Cop::Style::CollectionMethods
+          expect(cop_enabled?(cop_class)).to be true
+        end
+      end
+
+      context 'when ConfigLoader.disabled_by_default is set' do
+        let(:config) { '' }
+
+        before { described_class.disabled_by_default = true }
+
+        it 'disables cops that are enabled by default' do
+          cop_class = RuboCop::Cop::Layout::TrailingWhitespace
+          expect(cop_enabled?(cop_class)).to be false
+        end
+
+        it 'overrides AllCops/EnabledByDefault from the config file' do
+          create_file(file_path, <<~YAML)
+            AllCops:
+              EnabledByDefault: true
+          YAML
+
+          cop_class = RuboCop::Cop::Style::CollectionMethods
+          expect(cop_enabled?(cop_class)).to be false
+        end
+      end
     end
 
     context 'when a new cop is introduced' do

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                containing offenses.
                   --disable-pending-cops       Run without pending cops.
                   --enable-pending-cops        Run with pending cops.
+                  --disable-all-cops           Run with all cops disabled by default,
+                                               except `Lint/Syntax`. Overrides
+                                               `AllCops/EnabledByDefault` and
+                                               `AllCops/DisabledByDefault` in config files.
+                  --enable-all-cops            Run with all cops enabled, including those
+                                               disabled by default. Overrides
+                                               `AllCops/EnabledByDefault` and
+                                               `AllCops/DisabledByDefault` in config files.
                   --ignore-disable-comments    Report offenses even if they have been manually disabled
                                                with a `rubocop:disable` or `rubocop:todo` directive.
                   --force-exclusion            Any files excluded by `Exclude` in configuration
@@ -286,6 +294,13 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         msg = 'Do not specify `--editor-mode` as it is redundant in `--lsp`.'
         expect do
           options.parse %w[--lsp --editor-mode]
+        end.to raise_error(RuboCop::OptionArgumentError, msg)
+      end
+
+      it 'rejects using `--enable-all-cops` with `--disable-all-cops`' do
+        msg = '--enable-all-cops cannot be used together with --disable-all-cops.'
+        expect do
+          options.parse %w[--enable-all-cops --disable-all-cops]
         end.to raise_error(RuboCop::OptionArgumentError, msg)
       end
 


### PR DESCRIPTION
These options enable or disable all cops by default, overriding `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files.

For example, this option provides a convenient way to check whether a given cop already exists, without temporarily editing `.rubocop.yml`.

```console
$ echo '{ "type" => type}' | bundle exec rubocop --stdin example.rb --enable-all-cops
```

The `--disable-all-cops` option is provided for symmetry with `--enable-all-cops`. Note that `--disable-all-cops` does not disable `Lint/Syntax`, which is always enabled.

```console
$ echo '{ "type" => type}' | bundle exec rubocop --stdin example.rb --disable-all-cops
```

The primary use case assumes using coding agents and humans to verify behavior, including the behavior of cops that are disabled by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
