### PR TITLE
[Fix #15168] Fix false positives in `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/changelog/fix_false_positives_in_lint_parentheses_as_grouped_expression.md
+++ b/changelog/fix_false_positives_in_lint_parentheses_as_grouped_expression.md
@@ -1,0 +1,1 @@
+* [#15168](https://github.com/rubocop/rubocop/issues/15168): Fix false positives in `Lint/ParenthesesAsGroupedExpression` when the first argument is a call-like expression with its own parentheses, such as `yield(...)`. ([@koic][])

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -63,7 +63,7 @@ module RuboCop
         end
 
         def spaces_before_left_parenthesis(node)
-          return 0 if node.parenthesized?
+          return 0 if node.parenthesized? || !node.first_argument.source.start_with?('(')
 
           node.first_argument.source_range.begin_pos - node.loc.selector.end_pos
         end

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
     expect_no_offenses('a b(c)')
   end
 
+  it 'accepts method with `yield` as arg to method without parens' do
+    expect_no_offenses('a yield(c)')
+  end
+
+  it 'accepts method with `super` as arg to method without parens' do
+    expect_no_offenses('a super(c)')
+  end
+
+  it 'accepts method with `defined?` as arg to method without parens' do
+    expect_no_offenses('a defined?(c)')
+  end
+
   it 'accepts an operator call with argument in parentheses' do
     expect_no_offenses(<<~RUBY)
       a % (b + c)


### PR DESCRIPTION
Fixes #15168.

This PR fixes false positives in `Lint/ParenthesesAsGroupedExpression` when the first argument is a call-like expression with its own parentheses, such as `yield(...)`, `super(...)`, or `defined?(...)`.

The previous regex-based space detection required `(` to appear immediately after the whitespace following the method name. The position-based replacement dropped that constraint, so the cop incorrectly flagged code like the following and the autocorrect collapsed `write` and `yield` into a single `writeyield` token:

```ruby
write yield(content)
```

Restore the original constraint by skipping the offense unless the first argument source starts with `(`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
