### PR TITLE
Fix an infinite loop for `Layout/RedundantLineBreak` cop

### DIFF
--- a/changelog/fix_infinite_loop_for_layout_redundant_line_break.md
+++ b/changelog/fix_infinite_loop_for_layout_redundant_line_break.md
@@ -1,0 +1,1 @@
+* [#15170](https://github.com/rubocop/rubocop/pull/15170): Fix an infinite loop for `Layout/RedundantLineBreak` when a single-line block is chained with a safe navigation method call. ([@koic][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -114,7 +114,9 @@ module RuboCop
 
         def other_cop_takes_precedence?(node)
           single_line_block_chain_enabled? && any_descendant?(node, :any_block) do |block_node|
-            block_node.parent.send_type? && block_node.parent.loc.dot && block_node.single_line?
+            next unless (parent = block_node.parent)
+
+            parent.call_type? && parent.loc.dot && block_node.single_line?
           end
         end
 

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'accepts a safe navigation method call chained onto a single line block' do
+        expect_no_offenses(<<~RUBY)
+          e.select { |i| i.cond? }
+           &.join
+          a = e.select { |i| i.cond? }
+               &.join
+          e.select { |i| i.cond? }
+           &.join + []
+        RUBY
+      end
+
       it 'accepts a method call chained onto a single line numbered block', :ruby27 do
         expect_no_offenses(<<~RUBY)
           e.select { _1.cond? }


### PR DESCRIPTION
This fixes an infinite loop between `Layout/RedundantLineBreak`, `Layout/SingleLineBlockChain`, and `Layout/MultilineMethodCallIndentation` when a single-line block is chained with a safe navigation method call, e.g. `routes.detect { |r| r.match?(x) }&.mailbox_class`.

Previously `Layout/RedundantLineBreak#other_cop_takes_precedence?` only handled regular `send` chains, so when `Layout/SingleLineBlockChain` inserted a line break before the safe-navigation call, the line break was treated as redundant and removed, recreating the offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
