### PR TITLE
Cache `FilePatterns#match?` results per path

### DIFF
--- a/changelog/change_cache_file_patterns_match_results_20260516122008.md
+++ b/changelog/change_cache_file_patterns_match_results_20260516122008.md
@@ -1,0 +1,1 @@
+* [#15171](https://github.com/rubocop/rubocop/pull/15171): Cache `FilePatterns#match?` results per path so cops sharing the same `Include`/`Exclude` configuration do not each repeat `File.fnmatch?` work on every file. ([@Darhazer][])

--- a/lib/rubocop/file_patterns.rb
+++ b/lib/rubocop/file_patterns.rb
@@ -21,11 +21,19 @@ module RuboCop
     def initialize(patterns)
       @strings = Set.new
       @patterns = []
+      @match_cache = {}
       partition_patterns(patterns)
     end
 
     def match?(path)
-      @strings.include?(path) || @patterns.any? { |pattern| PathUtil.match_path?(pattern, path) }
+      # `FilePatterns.from` memoizes one instance per pattern array (by identity),
+      # so this cache is shared across every cop using the same Include/Exclude
+      # list. Patterns are immutable within a run, so caching by path is safe.
+      cached = @match_cache[path]
+      return cached unless cached.nil?
+
+      @match_cache[path] =
+        @strings.include?(path) || @patterns.any? { |pattern| PathUtil.match_path?(pattern, path) }
     end
 
     private

--- a/spec/rubocop/file_patterns_spec.rb
+++ b/spec/rubocop/file_patterns_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# `be_match` here calls `FilePatterns#match?(path)`, which is unrelated to the
+# RSpec-builtin `match` matcher (regex/pattern), so the predicate matcher is
+# not redundant in this file.
+# rubocop:disable RSpec/RedundantPredicateMatcher
+RSpec.describe RuboCop::FilePatterns do
+  describe '#match?' do
+    let(:patterns) { ['lib/**/*.rb', 'README.md'] }
+    let(:file_patterns) { described_class.new(patterns) }
+
+    it 'matches exact-string patterns via the Set fast path' do
+      expect(file_patterns).to be_match('README.md')
+    end
+
+    it 'matches glob patterns via fnmatch' do
+      expect(file_patterns).to be_match('lib/foo/bar.rb')
+    end
+
+    it 'returns false when no pattern matches' do
+      expect(file_patterns).not_to be_match('spec/foo_spec.rb')
+    end
+
+    it 'memoizes positive results per path' do
+      expect(RuboCop::PathUtil).to receive(:match_path?).once.and_call_original
+      2.times { file_patterns.match?('lib/foo.rb') }
+    end
+
+    it 'memoizes negative results per path' do
+      expect(RuboCop::PathUtil).to receive(:match_path?).once.and_call_original
+      2.times { file_patterns.match?('other/foo.rb') }
+    end
+
+    it 'caches independently per path' do
+      expect(RuboCop::PathUtil).to receive(:match_path?).twice.and_call_original
+      file_patterns.match?('lib/a.rb')
+      file_patterns.match?('lib/b.rb')
+    end
+  end
+
+  describe '.from' do
+    it 'returns the same instance for the same patterns array (by identity)' do
+      patterns = ['lib/**/*.rb']
+      expect(described_class.from(patterns)).to equal(described_class.from(patterns))
+    end
+
+    it 'returns different instances for different patterns arrays' do
+      lib = described_class.from(['lib/**/*.rb'])
+      spec = described_class.from(['spec/**/*.rb'])
+      expect(lib).not_to equal(spec)
+    end
+
+    it 'returns different instances when one patterns array is a subset of the other' do
+      subset = described_class.from(['lib/**/*.rb'])
+      superset = described_class.from(['lib/**/*.rb', 'spec/**/*.rb'])
+      expect(subset).not_to equal(superset)
+    end
+  end
+end
+# rubocop:enable RSpec/RedundantPredicateMatcher


### PR DESCRIPTION
## Summary

For projects with many cops sharing the same `Include`/`Exclude` configuration, `Cop::Base#relevant_file?` was repeating the same `File.fnmatch?` work for every cop on every file. `FilePatterns.from` already memoises one `FilePatterns` instance per pattern array (by identity), so memoising the per-path match result on that instance deduplicates the work across all cops sharing the pattern set.

## Background
I've run --profile against a large Rails codebase that has almost all cops enabled + multiple plugins (~1 700 files, ~600 cops between core + plugins, cold cache, --no-server) with stackprof, wall-clock mode.

 | Frame | Self | Total |
  | --- | ---: | ---: |
  | `Commissioner#trigger_responding_cops → Kernel#public_send` | 2.9 % | **47.3 %** |
  | `Team#roundup_relevant_cops` | 0.3 % | **13.8 %** |
  | `Cop::Base#excluded_file?` | 0.4 % | 9.9 % |
  | `Cop::Base#relevant_file?` | 0.4 % | 9.5 % |
  | `Cop::Base#file_name_matches_any?` | 0.3 % | 6.0 % |
  | `FilePatterns#match?` | 0.2 % | 5.2 % |
  | `PathUtil.match_path?` | 0.4 % | 4.9 % |
  | `File.fnmatch?` | **4.5 %** | 4.5 % |

Than gave the results to Claude / Opus 4.7 to analyse

```
The headline trigger_responding_cops → public_send 47 % is inclusive — almost all of it is real cop work, not dispatch overhead, so attacking the dispatcher itself yields little.

  The biggest fixable cost was one frame up: Team#roundup_relevant_cops runs once per file and, for every cop, walks excluded_file? → relevant_file? → file_name_matches_any? → 
  FilePatterns#match? → File.fnmatch?. With ~600 cops × ~1 700 files that's ~1 M fnmatch calls. File.fnmatch? alone burns 4.5 % of wall time.

  Two caches already sit around this work:
  - Config#clusivity_config_for_badge? short-circuits cops with no Include/Exclude config.
  - FilePatterns.from(patterns) memoises the wrapper per pattern array (by object identity), so many cops with the same Include/Exclude share one FilePatterns instance.
  
  What was missing: the actual (pattern-set, path) → bool result. Cops with no per-cop file rules use AllCops's patterns, which means a single FilePatterns instance is consulted hundreds of times per file with the same path.
```

Note that we have `Exclude:` under `AllCops:` which might be the reason why `fnmatch?` is being run for every cop.


## Result

 Re-profiled on the same codebase:

  | Frame | Baseline | Patched | Δ |
  | --- | ---: | ---: | ---: |
  | `File.fnmatch?` (self) | 4.5 % | **2.3 %** | −2.2 pp |
  | `FilePatterns#match?` (total) | 5.2 % | 2.2 % | −3.0 pp |
  | `PathUtil.match_path?` (total) | 4.9 % | ~1.6 % | −3.3 pp |
  | `Cop::Base#excluded_file?` (total) | 9.9 % | ~7 % | −3 pp |
  | `Team#roundup_relevant_cops` (total) | 13.8 % | **11.1 %** | −2.7 pp |

  
  PathUtil.match_path? is invoked ~1 240 times vs ~3 730 before — about ⅔ of the work deduplicated. The residual calls are the genuinely-unique (pattern-set, path) combinations.

  Overall: ~3 pp of total wall time on this run. GC time ticked up slightly (5.3 % → 7.8 %) from the cache hash entries; the wall-time win dominates.


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
