### PR TITLE
Add optional Rubydex integration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ plugins:
 
 AllCops:
   NewCops: enable
+  # Opt into the project-wide rubydex index when the gem is available
+  # (Ruby 3.2+ on supported MRI platforms). Older Rubies, JRuby, and
+  # environments without the gem fall back to file-local analysis with
+  # a one-time warning, so this stays a no-op there.
+  UseProjectIndex: true
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,12 @@ gem 'rubocop-rake', '~> 0.7.0', require: false
 gem 'rubocop-rspec', '~> 3.9.0', require: false
 # Ruby LSP supports Ruby 3.0+.
 gem 'ruby-lsp', '~> 0.24', platform: :mri if RUBY_VERSION >= '3.0'
+# Optional project-wide static-analysis index used by `AllCops/UseProjectIndex`.
+# Not a runtime dependency of the rubocop gem itself; only listed here so that
+# the development environment can exercise the integration. The gem only publishes
+# native binaries for MRI on supported platforms, so we gate by `RUBY_ENGINE` to
+# keep JRuby and other engines unaffected.
+gem 'rubydex', require: false if RUBY_VERSION >= '3.2' && RUBY_ENGINE == 'ruby'
 gem 'simplecov', '~> 0.20'
 gem 'stackprof', platform: :mri
 gem 'test-queue'

--- a/changelog/new_optional_rubydex_integration.md
+++ b/changelog/new_optional_rubydex_integration.md
@@ -1,0 +1,1 @@
+* [#15173](https://github.com/rubocop/rubocop/pull/15173): Add optional Rubydex integration via `AllCops/UseProjectIndex` to enable cross-file detection in `Lint/ConstantReassignment` (experimental). ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -104,6 +104,12 @@ AllCops:
   # When `NewCops` is `disable`, pending cops are disabled in bulk. Can be overridden by
   # the `--disable-pending-cops` command-line option.
   NewCops: pending
+  # When `true`, RuboCop builds a project index (a project-wide map of declarations and references)
+  # once per run and makes it available to cops that opt in.
+  # The project index is implemented by the optional `rubydex` gem; when `rubydex` is not installed,
+  # a warning is shown and the flag has no effect.
+  # The default `false` preserves RuboCop's traditional file-local analysis.
+  UseProjectIndex: false
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.
   UseCache: true
@@ -1703,6 +1709,7 @@ Lint/ConstantReassignment:
   Description: 'Checks for constant reassignments.'
   Enabled: pending
   VersionAdded: '1.70'
+  VersionChanged: '<<next>>'
 
 Lint/ConstantResolution:
   Description: 'Checks that constants are fully qualified with `::`.'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -1,0 +1,59 @@
+= Project Index
+
+NOTE: The project index feature was introduced in RuboCop 1.87.
+
+WARNING: This feature is experimental and should not be considered stable. Changes to its behavior or interface may occur.
+
+RuboCop can optionally use https://github.com/Shopify/rubydex[Rubydex] to build
+a project-wide index of declarations and references. When enabled, cops that opt in can
+consult the index to detect issues that span multiple files.
+
+This integration is **opt-in and experimental**. The default behavior of RuboCop is unchanged.
+
+== Enabling
+
+1. Add `rubydex` to your `Gemfile` and `bundle install`:
++
+[source,ruby]
+----
+gem 'rubydex', require: false
+----
+
+2. Set the flag in your `.rubocop.yml`:
++
+[source,yaml]
+----
+AllCops:
+  UseProjectIndex: true
+----
+
+If `UseProjectIndex` is `true` but the `rubydex` gem is not installed, or the running Ruby
+is older than the version `rubydex` supports, RuboCop prints a warning and falls back to
+its standard file-local behavior.
+
+The integration requires Ruby 3.2 or later. On Ruby 3.1 and older, `AllCops/UseProjectIndex`
+has no effect even if set to `true`.
+
+== What it enables
+
+`Lint/ConstantReassignment` reports reassignments whose previous definition lives in another file.
+For example:
+
+[source,ruby]
+----
+# a.rb
+CROSS_FILE_CONST = :first
+
+# b.rb
+CROSS_FILE_CONST = :second
+----
+
+With `UseProjectIndex: true`, RuboCop reports a `Lint/ConstantReassignment` offense referencing the other file.
+Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
+
+== Notes
+
+- `rubydex` requires Ruby 3.2 or newer and ships native (Rust) extensions.
+- Parallel inspection is currently disabled on Windows when `UseProjectIndex` is on;
+  use serial inspection (omit `--parallel`).
+- The index is rebuilt once per `rubocop` invocation; no on-disk index is shared between runs.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -39,6 +39,7 @@ require_relative 'rubocop/warning'
 
 # rubocop:disable Style/RequireOrder
 
+require_relative 'rubocop/project_index_loader'
 require_relative 'rubocop/cop/util'
 require_relative 'rubocop/cop/offense'
 require_relative 'rubocop/cop/message_annotator'

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -41,6 +41,7 @@ module RuboCop
       include AutocorrectLogic
 
       attr_reader :config, :processed_source
+      attr_accessor :project_index
 
       # Reports of an investigation.
       # Immutable
@@ -306,7 +307,9 @@ module RuboCop
       def ready
         return self if self.class.support_multiple_source?
 
-        self.class.new(@config, @options)
+        self.class.new(@config, @options).tap do |fresh|
+          fresh.project_index = @project_index
+        end
       end
 
       ### Reserved for Cop::Cop
@@ -416,7 +419,10 @@ module RuboCop
       ### Actually private methods
 
       def reset_investigation
-        @currently_disabled_lines = @current_offenses = @processed_source = @current_corrector = nil
+        @currently_disabled_lines = nil
+        @current_offenses = nil
+        @processed_source = nil
+        @current_corrector = nil
       end
 
       # @return [Symbol, Corrector] offense status

--- a/lib/rubocop/cop/lint/constant_reassignment.rb
+++ b/lib/rubocop/cop/lint/constant_reassignment.rb
@@ -12,8 +12,13 @@ module RuboCop
       # class/module keyword definitions. It detects reassignment when a constant
       # is first defined one way and then redefined using the `NAME = value` syntax.
       #
-      # The cop cannot catch all offenses, like, for example, when a constant
-      # is reassigned in another file, or when using metaprogramming (`Module#const_set`).
+      # The cop cannot catch all offenses, like, for example, when using metaprogramming
+      # (`Module#const_set`).
+      #
+      # By default the cop also cannot detect reassignment across files.
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+      # the cop additionally consults the project-wide index and reports reassignments
+      # whose previous definition lives in another file.
       #
       # The cop only takes into account constants assigned in a "simple" way: directly
       # inside class/module definition, or within another constant. Other type of assignments
@@ -74,7 +79,10 @@ module RuboCop
       #   end
       #
       class ConstantReassignment < Base
+        include ProjectIndexHelp
+
         MSG = 'Constant `%<constant>s` is already assigned in this namespace.'
+        CROSS_FILE_MSG = 'Constant `%<constant>s` is already assigned in `%<path>s`.'
 
         RESTRICT_ON_SEND = %i[remove_const].freeze
 
@@ -101,9 +109,14 @@ module RuboCop
           return unless simple_assignment?(node)
 
           name = fully_qualified_constant_name(node)
-          return constant_definitions[name] = :casgn unless constant_definitions.key?(name)
 
-          add_offense(node, message: format(MSG, constant: constant_display_name(node)))
+          if constant_definitions.key?(name)
+            add_offense(node, message: format(MSG, constant: constant_display_name(node)))
+            return
+          end
+
+          constant_definitions[name] = :casgn
+          report_cross_file_collision(node, name, constant_display_name(node))
         end
 
         def on_send(node)
@@ -191,6 +204,25 @@ module RuboCop
 
         def constant_definitions
           @constant_definitions ||= {}
+        end
+
+        def report_cross_file_collision(node, fully_qualified_name, display_name)
+          return unless project_index
+          return unless (declaration = project_index[fully_qualified_name.delete_prefix('::')])
+          return unless (prior = prior_definition_in_other_file(declaration))
+
+          msg = format(CROSS_FILE_MSG, constant: display_name, path: prior.location.to_file_path)
+
+          add_offense(node, message: msg)
+        end
+
+        def prior_definition_in_other_file(declaration)
+          current = processed_source.file_path
+
+          declaration.definitions.find do |definition|
+            other = definition.location.to_file_path
+            !File.identical?(other, current)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/metrics/utils/iterating_block.rb
+++ b/lib/rubocop/cop/metrics/utils/iterating_block.rb
@@ -43,7 +43,7 @@ module RuboCop
             end
           end
 
-          # Returns true iff name is a known iterating type (e.g. :each, :transform_values)
+          # Returns true only when name is a known iterating type (e.g. :each, :transform_values).
           def iterating_method?(name)
             KNOWN_ITERATING_METHODS.include? name
           end

--- a/lib/rubocop/cop/mixin.rb
+++ b/lib/rubocop/cop/mixin.rb
@@ -28,6 +28,7 @@ module RuboCop
     autoload :DocumentationComment, 'rubocop/cop/mixin/documentation_comment'
     autoload :Duplication, 'rubocop/cop/mixin/duplication'
     autoload :RangeHelp, 'rubocop/cop/mixin/range_help'
+    autoload :ProjectIndexHelp, 'rubocop/cop/mixin/project_index_help'
     autoload :AnnotationComment, 'rubocop/cop/mixin/annotation_comment'
     autoload :EmptyParameter, 'rubocop/cop/mixin/empty_parameter'
     autoload :EndKeywordAlignment, 'rubocop/cop/mixin/end_keyword_alignment'

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common helpers for cops that consult the project-wide static-analysis index
+    # via `Cop::Base#project_index`.
+    #
+    # Mixed-in cops gain the `external_dependency_checksum` override that invalidates
+    # the `ResultCache` whenever the indexed project files change on disk.
+    # To run index-backed analysis, cops should simply check whether `project_index` is non-nil;
+    # the runner only exposes a non-nil index when the user opted in via `AllCops/UseProjectIndex`
+    # and the underlying gem is available.
+    module ProjectIndexHelp
+      BUILTIN_DOCUMENT_URI = 'rubydex:built-in'
+      FILE_URI_PREFIX = 'file://'
+      # Matches the spurious leading slash before a Windows drive letter that
+      # remains after stripping `file://` from a `file:///C:/...` URI.
+      WINDOWS_DRIVE_PREFIX = %r{\A/(?=[A-Za-z]:[/\\])}.freeze
+
+      def external_dependency_checksum
+        return nil unless project_index
+
+        @external_dependency_checksum ||= Digest::SHA1.hexdigest(
+          project_index_signature.join("\n")
+        )
+      end
+
+      private
+
+      def project_index_signature
+        project_index.documents.filter_map do |doc|
+          uri = doc.uri
+          next if uri == BUILTIN_DOCUMENT_URI
+
+          path = uri.delete_prefix(FILE_URI_PREFIX).sub(WINDOWS_DRIVE_PREFIX, '')
+          mtime, size = begin
+            stat = File.stat(path)
+            [stat.mtime.to_f, stat.size]
+          rescue StandardError
+            [0, 0]
+          end
+
+          "#{path}:#{mtime}:#{size}"
+        end.sort
+      end
+    end
+  end
+end

--- a/lib/rubocop/project_index_loader.rb
+++ b/lib/rubocop/project_index_loader.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Defensive loader for the optional `rubydex` gem.
+  #
+  # When `AllCops/UseProjectIndex` is enabled in the user's configuration, RuboCop builds
+  # a project-wide index using `Rubydex::Graph` and exposes it to cops that opt in.
+  # The gem is intentionally not a runtime dependency; if it is not installed,
+  # or if the running Ruby is older than what `rubydex` supports, RuboCop falls back to
+  # its standard file-local behavior.
+  module ProjectIndexLoader
+    MINIMUM_RUBY_VERSION = '3.2'
+
+    module_function
+
+    # Returns whether the `rubydex` gem can be loaded. The result is memoized
+    # for the lifetime of the process.
+    def available?
+      return @available if defined?(@available)
+
+      @available = supported_ruby? && try_require
+    end
+
+    def supported_ruby?
+      RUBY_VERSION >= MINIMUM_RUBY_VERSION
+    end
+
+    def warn_unavailable
+      return if @warned
+
+      @warned = true
+
+      if supported_ruby?
+        warn Rainbow(<<~MSG).yellow
+          `AllCops/UseProjectIndex` is enabled but the `rubydex` gem is not installed.
+          Analyses that use the project index will be skipped. Add `gem 'rubydex'` to your Gemfile.
+        MSG
+      else
+        warn Rainbow(<<~MSG).yellow
+          `AllCops/UseProjectIndex` is enabled but `rubydex` requires Ruby #{MINIMUM_RUBY_VERSION} or later (current: #{RUBY_VERSION}).
+          Analyses that use the project index will be skipped.
+        MSG
+      end
+    end
+
+    def try_require
+      require 'rubydex'
+      true
+    rescue LoadError
+      false
+    end
+
+    # Builds and resolves a `Rubydex::Graph` for the given file paths. Returns the resolved graph,
+    # or `nil` if the build fails. This is the only place in RuboCop that depends on the concrete
+    # `Rubydex::Graph` API, so callers (e.g. `Runner`) do not need to know which Rubydex classes
+    # or methods are involved.
+    def build_index(paths)
+      graph = Rubydex::Graph.new
+      graph.index_all(paths.map(&:to_s))
+      graph.resolve
+      graph
+    rescue StandardError => e
+      warn Rainbow("rubydex index build failed: #{e.message}. Continuing without it.").yellow
+    end
+  end
+end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -72,6 +72,8 @@ module RuboCop
       ResultCache.source_checksum
 
       target_files = find_target_files(paths)
+      @project_index = ProjectIndexLoader.build_index(target_files) if project_index_enabled?
+
       if @options[:list_target_files]
         list_files(target_files)
       else
@@ -100,6 +102,17 @@ module RuboCop
              end
       target_files = target_finder.find(paths, mode)
       target_files.each(&:freeze).freeze
+    end
+
+    def project_index_enabled?
+      return false unless @config_store.for_pwd.for_all_cops['UseProjectIndex']
+
+      unless ProjectIndexLoader.available?
+        ProjectIndexLoader.warn_unavailable
+        return false
+      end
+
+      true
     end
 
     def inspect_files(files) # rubocop:disable Metrics/AbcSize
@@ -171,7 +184,21 @@ module RuboCop
         return false
       end
 
+      return false if project_index_disables_parallel?
+
       puts 'Running parallel inspection' if @options[:debug]
+
+      true
+    end
+
+    def project_index_disables_parallel?
+      return false if @project_index.nil? || !Gem.win_platform?
+
+      if @options[:debug]
+        puts 'Skipping parallel inspection: the project index is enabled and parallel ' \
+             'inspection is not yet supported on Windows.'
+      end
+
       true
     end
 
@@ -406,7 +433,15 @@ module RuboCop
 
     def mobilize_team(processed_source)
       config = @config_store.for_file(processed_source.path)
-      Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+      team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+
+      if @project_index
+        team.cops.each do |cop|
+          cop.project_index = @project_index
+        end
+      end
+
+      team
     end
 
     def mobilized_cop_classes(config) # rubocop:disable Metrics/AbcSize
@@ -549,8 +584,17 @@ module RuboCop
     # level caching in ResultCache.
     def standby_team(config)
       @team_by_config ||= {}.compare_by_identity
-      @team_by_config[config] ||=
-        Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+      @team_by_config[config] ||= begin
+        team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+
+        if @project_index
+          team.cops.each do |cop|
+            cop.project_index = @project_index
+          end
+        end
+
+        team
+      end
     end
   end
 end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -8,7 +8,8 @@ module RuboCop
     MSG = '%<version>s (using %<parser_version>s, ' \
           'rubocop-ast %<rubocop_ast_version>s, ' \
           'analyzing as Ruby %<target_ruby_version>s, ' \
-          'running on %<ruby_engine>s %<ruby_version>s)%<server_mode>s [%<ruby_platform>s]'
+          'running on %<ruby_engine>s %<ruby_version>s)' \
+          '%<rubydex_indicator>s%<server_mode>s [%<ruby_platform>s]'
 
     MINIMUM_PARSABLE_PRISM_VERSION = 3.3
 
@@ -31,6 +32,7 @@ module RuboCop
                                       rubocop_ast_version: RuboCop::AST::Version::STRING,
                                       target_ruby_version: target_ruby_version,
                                       ruby_engine: RUBY_ENGINE, ruby_version: RUBY_VERSION,
+                                      rubydex_indicator: rubydex_indicator(env),
                                       server_mode: server_mode,
                                       ruby_platform: RUBY_PLATFORM)
         return verbose_version unless env
@@ -150,6 +152,22 @@ module RuboCop
     # @api private
     def self.document_version
       STRING.match('\d+\.\d+').to_s
+    end
+
+    # @api private
+    def self.rubydex_indicator(env)
+      env && rubydex_enabled?(env) && ProjectIndexLoader.available? ? ' +Rubydex' : ''
+    end
+
+    # @api private
+    def self.rubydex_enabled?(env)
+      config_for_pwd(env).for_all_cops['UseProjectIndex']
+    rescue StandardError
+      # Keep `rubocop -V` usable when the config cannot be loaded (broken YAML,
+      # missing `inherit_from` target, etc). It is the first command users run to
+      # diagnose a broken setup, so the indicator just hides rather than letting
+      # the version banner crash.
+      false
     end
 
     # @api private

--- a/spec/fixtures/cross_file_const/a.rb
+++ b/spec/fixtures/cross_file_const/a.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+CROSS_FILE_CONST = :first

--- a/spec/fixtures/cross_file_const/b.rb
+++ b/spec/fixtures/cross_file_const/b.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+CROSS_FILE_CONST = :second

--- a/spec/rubocop/cop/lint/constant_reassignment_spec.rb
+++ b/spec/rubocop/cop/lint/constant_reassignment_spec.rb
@@ -597,4 +597,74 @@ RSpec.describe RuboCop::Cop::Lint::ConstantReassignment, :config do
       M = 1
     RUBY
   end
+
+  context 'cross-file detection', :project_index do
+    let(:fixture_dir) do
+      File.expand_path('../../../fixtures/cross_file_const', __dir__)
+    end
+
+    def stage_fixture(tmpdir)
+      ['a.rb', 'b.rb'].each do |name|
+        FileUtils.cp(File.join(fixture_dir, name), File.join(tmpdir, name))
+      end
+    end
+
+    def cop_offenses(tmpdir, cache_root: nil)
+      offenses = project_index_offenses(tmpdir, cache_root: cache_root)
+
+      offenses.select { |offense| offense['cop_name'] == 'Lint/ConstantReassignment' }
+    end
+
+    def run_with_config(body)
+      Dir.mktmpdir do |tmpdir|
+        stage_fixture(tmpdir)
+        write_rubocop_config(tmpdir, body)
+        cop_offenses(tmpdir)
+      end
+    end
+
+    it 'reports a cross-file collision when UseProjectIndex is enabled' do
+      offenses = run_with_config(
+        'AllCops' => { 'UseProjectIndex' => true },
+        'Lint/ConstantReassignment' => { 'Enabled' => true }
+      )
+
+      expect(offenses).not_to be_empty
+      expect(offenses.map { |o| o['message'] }).to all(match(/already assigned in/))
+    end
+
+    it 'does not report any offense when UseProjectIndex is disabled' do
+      offenses = run_with_config(
+        'AllCops' => { 'UseProjectIndex' => false },
+        'Lint/ConstantReassignment' => { 'Enabled' => true }
+      )
+
+      expect(offenses).to be_empty
+    end
+
+    it 'invalidates the cache when an indexed file changes' do
+      Dir.mktmpdir do |tmpdir|
+        Dir.mktmpdir do |cache_dir|
+          stage_fixture(tmpdir)
+          write_rubocop_config(
+            tmpdir,
+            'AllCops' => { 'UseProjectIndex' => true },
+            'Lint/ConstantReassignment' => { 'Enabled' => true }
+          )
+
+          # First run with cache enabled: collision is reported and cached.
+          expect(cop_offenses(tmpdir, cache_root: cache_dir)).not_to be_empty
+
+          # Remove the conflicting definition from a.rb. b.rb is untouched.
+          File.write(File.join(tmpdir, 'a.rb'), "# frozen_string_literal: true\n")
+
+          # Second run with the same cache: the `external_dependency_checksum`
+          # override in `ProjectIndexHelp` hashes indexed-file mtimes, so the
+          # change to a.rb invalidates b.rb's cache entry. Without the override
+          # b.rb would hit a stale cache and still report a collision.
+          expect(cop_offenses(tmpdir, cache_root: cache_dir)).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -204,4 +204,62 @@ RSpec.describe RuboCop::Version do
       end
     end
   end
+
+  describe '.rubydex_indicator', :isolated_environment, :restore_configuration, :restore_registry do
+    subject(:indicator) { described_class.rubydex_indicator(env) }
+
+    let(:env) { instance_double(RuboCop::CLI::Environment, config_store: config_store) }
+    let(:config_store) { RuboCop::ConfigStore.new }
+
+    before { RuboCop::ConfigLoader.clear_options }
+
+    context 'when env is nil' do
+      let(:env) { nil }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when UseProjectIndex is false' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            UseProjectIndex: false
+        YAML
+      end
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when UseProjectIndex is true but the gem is unavailable' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            UseProjectIndex: true
+        YAML
+        allow(RuboCop::ProjectIndexLoader).to receive(:available?).and_return(false)
+      end
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when UseProjectIndex is true and the gem is available' do
+      before do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            UseProjectIndex: true
+        YAML
+        allow(RuboCop::ProjectIndexLoader).to receive(:available?).and_return(true)
+      end
+
+      it { is_expected.to eq(' +Rubydex') }
+    end
+
+    context 'when the config file is malformed' do
+      before do
+        create_file('.rubocop.yml', "AllCops:\n  UseProjectIndex: [\n")
+      end
+
+      it { is_expected.to be_blank }
+    end
+  end
 end

--- a/spec/support/project_index_metadata.rb
+++ b/spec/support/project_index_metadata.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Helpers for examples tagged with `:project_index`. The before hook skips the
+# example when the project-index gem cannot be loaded for the current Ruby;
+# the included module provides the tmpdir/Runner plumbing that exercises the
+# full project-index flow against a fixture project.
+module ProjectIndexSpecHelpers
+  DEFAULT_ALL_COPS = {
+    'NewCops' => 'disable',
+    # tmpdirs on macOS live under `/var/folders/...` which traverses the
+    # `/var` -> `/private/var` symlink. ResultCache otherwise warns on every
+    # save. The test isn't exercising symlink protection.
+    'AllowSymlinksInCacheRootDirectory' => true
+  }.freeze
+
+  def write_rubocop_config(tmpdir, config)
+    merged = config.dup
+    merged['AllCops'] = DEFAULT_ALL_COPS.merge(merged.fetch('AllCops', {}))
+    File.write(File.join(tmpdir, '.rubocop.yml'), YAML.dump(merged))
+  end
+
+  def project_index_offenses(tmpdir, cache_root: nil)
+    output_path = File.join(tmpdir, 'offenses.json')
+    Dir.chdir(tmpdir) do
+      config_store = RuboCop::ConfigStore.new
+      config_store.options_config = File.join(tmpdir, '.rubocop.yml')
+      options = project_index_runner_options(output_path, cache_root)
+      RuboCop::Runner.new(options, config_store).run([tmpdir])
+    end
+    JSON.load_file(output_path).fetch('files').flat_map { |f| f['offenses'] }
+  end
+
+  private
+
+  def project_index_runner_options(output_path, cache_root)
+    options = { formatters: [['json', output_path]] }
+    options[:cache] = cache_root ? 'true' : 'false'
+    options[:cache_root] = cache_root if cache_root
+    options
+  end
+end
+
+RSpec.configure do |config|
+  config.include ProjectIndexSpecHelpers, :project_index
+
+  config.before(:each, :project_index) do
+    unless RuboCop::ProjectIndexLoader.available?
+      minimum = RuboCop::ProjectIndexLoader::MINIMUM_RUBY_VERSION
+      reason = if RuboCop::ProjectIndexLoader.supported_ruby?
+                 'rubydex gem is not installed.'
+               else
+                 "rubydex requires Ruby #{minimum} or later."
+               end
+      skip reason
+    end
+  end
+end


### PR DESCRIPTION
`Lint/ConstantReassignment` previously only registered offenses for same-file reassignment within a single file. The most common real-world case (the same constant defined in two different files) was silently allowed, even though it is exactly the kind of bug Ruby's own "already initialized constant" runtime warning targets.

This commit gives the cop an optional, project-wide view. When the user opts in with `AllCops/UseProjectIndex: true` and installs the `rubydex` gem (https://github.com/Shopify/rubydex) , RuboCop reports cross-file collisions and the offense message points at the other definition's file path, so the user can find and fix the duplicate immediately.

The integration is strictly opt-in:

- Without the flag, the cop behaves exactly as before. No new runtime dependency for users who do not enable it.
- On Ruby older than 3.2 (which `rubydex` requires) or when the gem is not installed, the flag has no effect and prints a single warning per process. Existing CI matrices and Gemfiles keep working.
- Cops that benefit from the project-wide index pick it up automatically when the flag is on. There is no per-cop opt-in to repeat.

The same flag will power future index-aware cops (unused constants, unresolved references, deprecated-call detection, and similar), so enabling `UseProjectIndex` once unlocks additional checks as they land without ever growing the configuration surface.

`rubocop -V` shows `+Rubydex` in the verbose banner when the index is active, so users can confirm at a glance whether the integration is taking effect. The rubocop codebase itself enables `UseProjectIndex`, so the integration is exercised on every CI run.

This commit is the first piece of RuboCop infrastructure that builds on Rubydex. Further enhancements that take advantage of what Rubydex makes possible can be developed as separate follow-ups.

Acknowledgement: The idea of integrating Rubydex into RuboCop was proposed by @paracycle at RubyKaigi 2026. Thank you!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
