### PR TITLE
Fix incorrect autocorrect for `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_class_and_module_children.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_class_and_module_children.md
@@ -1,0 +1,1 @@
+* [#15174](https://github.com/rubocop/rubocop/pull/15174): Fix incorrect autocorrect for `Style/ClassAndModuleChildren` causing a syntax error when the namespace contains a method call (e.g., `class self.class::Foo; end`). ([@koic][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -181,12 +181,20 @@ module RuboCop
 
         def check_style(node, body, style)
           return if node.identifier.namespace&.cbase_type?
+          return unless const_namespace?(node.identifier.namespace)
 
           if style == :nested
             check_nested_style(node)
           else
             check_compact_style(node, body)
           end
+        end
+
+        def const_namespace?(node)
+          return true if node.nil? || node.cbase_type?
+          return false unless node.const_type?
+
+          const_namespace?(node.namespace)
         end
 
         def check_nested_style(node)

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -174,6 +174,42 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    it 'accepts a class whose namespace is a method call' do
+      expect_no_offenses(<<~RUBY)
+        class self.class::Foo
+        end
+      RUBY
+    end
+
+    it 'accepts a module whose namespace is a method call' do
+      expect_no_offenses(<<~RUBY)
+        module self.class::Foo
+        end
+      RUBY
+    end
+
+    it 'accepts a class whose namespace contains a method call at any nesting level' do
+      expect_no_offenses(<<~RUBY)
+        class self.class::Foo::Bar
+        end
+      RUBY
+    end
+
+    it 'registers an offense for not nested classes with a cbase namespace' do
+      expect_offense(<<~RUBY)
+        class ::FooClass::BarClass
+              ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module ::FooClass
+          class BarClass
+          end
+        end
+      RUBY
+    end
+
     it 'accepts :: in parent class on inheritance' do
       expect_no_offenses(<<~RUBY)
         class FooClass


### PR DESCRIPTION
This fixes a syntax error caused by `Style/ClassAndModuleChildren` when a compact-style class or module definition has a namespace that is not purely a constant chain, e.g. `class self.class::TestRailtie; end`.

Previously the cop converted such definitions to nested style, producing invalid Ruby like `module self.class\n  class TestRailtie; end\nend`. The cop now recognises non-constant namespaces (such as method calls) and skips them, leaving the original code untouched.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
