### PR TITLE
Fix `Layout/IndentationWidth` for trailing-dot chains

### DIFF
--- a/changelog/fix_layout_indentation_width_trailing_dot_chain.md
+++ b/changelog/fix_layout_indentation_width_trailing_dot_chain.md
@@ -1,0 +1,1 @@
+* [#15175](https://github.com/rubocop/rubocop/pull/15175): Fix `Layout/IndentationWidth` to indent block bodies relative to the method selector for trailing-dot multi-line method chains when `EnforcedStyleAlignWith` is `relative_to_receiver`. ([@ddbrendan][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -473,8 +473,12 @@ module RuboCop
         end
 
         def block_body_indentation_base(node, end_loc)
-          if style == :relative_to_receiver && dot_on_new_line?(node)
+          return end_loc unless style == :relative_to_receiver
+
+          if dot_on_new_line?(node)
             node.send_node.loc.dot
+          elsif selector_on_new_line?(node)
+            node.send_node.loc.selector
           else
             end_loc
           end
@@ -486,6 +490,14 @@ module RuboCop
 
           receiver = send_node.receiver
           receiver && receiver.last_line < send_node.loc.dot.line
+        end
+
+        def selector_on_new_line?(node)
+          send_node = node.send_node
+          return false unless send_node.loc?(:dot) && send_node.loc?(:selector)
+
+          receiver = send_node.receiver
+          receiver && receiver.last_line < send_node.loc.selector.line
         end
       end
     end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -2278,6 +2278,35 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
                                             end
           RUBY
         end
+
+        it 'registers an offense for trailing-dot chain with body misindented relative to selector' do
+          expect_offense(<<~RUBY)
+            Foo.for_operation(arg).
+              pluck(:a, :b).
+              map do |a, b|
+              [b, a]
+              ^{} Use 2 (not 0) spaces for indentation.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Foo.for_operation(arg).
+              pluck(:a, :b).
+              map do |a, b|
+                [b, a]
+            end
+          RUBY
+        end
+
+        it 'accepts trailing-dot chain with body indented relative to selector' do
+          expect_no_offenses(<<~RUBY)
+            Foo.for_operation(arg).
+              pluck(:a, :b).
+              map do |a, b|
+                [b, a]
+              end
+          RUBY
+        end
       end
 
       it 'accepts correct indentation for block without method chain' do


### PR DESCRIPTION
## Summary

`Layout/IndentationWidth` with `EnforcedStyleAlignWith: relative_to_receiver` only handled leading-dot multi-line chains. Trailing-dot chains were accepted even when the block body was misindented relative to the method selector.

```ruby
# Previously accepted under `relative_to_receiver` despite being misindented:
Foo.for_operation(arg).
  pluck(:a, :b).
  map do |a, b|
  [b, a]      # body should be indented under `map`
end
```

This PR adds a `selector_on_new_line?` branch in `block_body_indentation_base` that mirrors the existing `dot_on_new_line?` handling, using the method selector's location as the indentation base when the dot trails the previous line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/