### PR TITLE
docs: fix grammar in cops index intro

### DIFF
--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -88,7 +88,7 @@ Cop-related errors are silenced by default but can be surfaced using the
 
 == Available cops
 
-In the following section you find all available cops:
+In the following section you'll find all available cops:
 
 // START_COP_LIST
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## What

Fixes a missing auxiliary verb in the intro to the available cops list in
`docs/modules/ROOT/pages/cops.adoc`: "In the following section you find all
available cops" → "In the following section you'll find all available cops".

## Why

The original sentence is missing a modal/auxiliary verb (`will`/`'ll` or
`can`), which makes it grammatically awkward. This is a one-word fix that
matches the tone of nearby prose in the same file (and the style used in
the recent docs grammar pass in 519206df1).

## AI disclosure

Per project norms (AGENTS.md guidance) — this PR is AI-generated and
unattended, written by a Cursor Anthropic Claude Opus 4.7 agent under
@adv0r as a personal token-burn initiative before my Cursor billing
cycle ends. Opened as **draft** for review. Single-file, single-fix
scope. Happy to iterate or close if not useful.

(I read AGENTS.md / CLAUDE.md before opening. I did **not** run the full
\`bundle exec rake\` because the local Ruby is 2.6 and the project requires
\`>= 2.7.0\`, so installing the full gem set is not trivially available in
this environment. I did run the standalone \`codespell\` check that the
\`codespell\` rake task wraps — \`git ls-files --empty-directory | xargs
codespell\` — and it passes cleanly. The change is a single-word
grammatical edit in a non-generated \`.adoc\` file, so it should not affect
specs, self-lint, or the documentation syntax check.)

Made with [Cursor](https://cursor.com)
