### PR TITLE
[Fix #15131] Prefer bitwise predicate for zero bit checks

### DIFF
--- a/changelog/fix_style_bitwise_predicate_zero_comparison.md
+++ b/changelog/fix_style_bitwise_predicate_zero_comparison.md
@@ -1,0 +1,1 @@
+* [#15131](https://github.com/rubocop/rubocop/issues/15131): Avoid suggesting `Style/NumericPredicate` before `Style/BitwisePredicate` for bit flag zero comparisons. ([@puneetdixit200][])

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -66,16 +66,26 @@ module RuboCop
 
         # @!method bit_operation?(node)
         def_node_matcher :bit_operation?, <<~PATTERN
-          (begin
-            (send _ :& _))
+          {
+            (begin
+              (send _ :& _))
+            (send _ :& _)
+          }
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
-        def on_send(node)
-          return unless node.receiver&.begin_type?
-          return unless (preferred_method = preferred_method(node))
+        # @!method bit_operation(node)
+        def_node_matcher :bit_operation, <<~PATTERN
+          {
+            (begin
+              $(send _ :& _))
+            $(send _ :& _)
+          }
+        PATTERN
 
-          bit_operation = node.receiver.children.first
+        def on_send(node)
+          return unless (preferred_method = preferred_method(node))
+          return unless (bit_operation = bit_operation(node.receiver))
+
           lhs, _operator, rhs = *bit_operation
 
           preferred = if preferred_method == 'allbits?' && lhs.source == node.first_argument.source
@@ -88,7 +98,6 @@ module RuboCop
             corrector.replace(node, preferred)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -90,6 +90,7 @@ module RuboCop
         def on_send(node)
           numeric, replacement = check(node)
           return unless numeric
+          return if bitwise_zero_comparison?(node, numeric)
 
           return if allowed_method_name?(node.method_name) ||
                     node.each_ancestor(:send, :block).any? do |ancestor|
@@ -106,6 +107,18 @@ module RuboCop
 
         def allowed_method_name?(name)
           allowed_method?(name) || matches_allowed_pattern?(name)
+        end
+
+        def bitwise_zero_comparison?(node, numeric)
+          style == :predicate &&
+            target_ruby_version >= 2.5 &&
+            node.method?(:==) &&
+            zero_integer?(node.first_argument) &&
+            bit_operation?(numeric)
+        end
+
+        def zero_integer?(node)
+          node&.int_type? && node.value.zero?
         end
 
         def check(node)
@@ -178,6 +191,15 @@ module RuboCop
         # @!method inverted_comparison(node)
         def_node_matcher :inverted_comparison, <<~PATTERN
           (send (int 0) ${:== :> :<} [$(...) !gvar_type?])
+        PATTERN
+
+        # @!method bit_operation?(node)
+        def_node_matcher :bit_operation?, <<~PATTERN
+          {
+            (begin
+              (send _ :& _))
+            (send _ :& _)
+          }
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/bitwise_predicate_spec.rb
+++ b/spec/rubocop/cop/style/bitwise_predicate_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe RuboCop::Cop::Style::BitwisePredicate, :config do
         RUBY
       end
 
+      it 'registers an offense when using unparenthesized `&` in conjunction with `> 0`' do
+        expect_offense(<<~RUBY)
+          variable & flags > 0
+          ^^^^^^^^^^^^^^^^^^^^ Replace with `variable.anybits?(flags)` for comparison with bit flags.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          variable.anybits?(flags)
+        RUBY
+      end
+
       it 'registers an offense when using `&` in conjunction with `>= 1` for comparisons' do
         expect_offense(<<~RUBY)
           (variable & flags) >= 1
@@ -142,6 +153,17 @@ RSpec.describe RuboCop::Cop::Style::BitwisePredicate, :config do
 
         expect_correction(<<~RUBY)
           variable.nobits?(flags)
+        RUBY
+      end
+
+      it 'registers an offense when using unparenthesized `&` in conjunction with `== 0`' do
+        expect_offense(<<~RUBY)
+          stat.mode & 0o077 == 0o000
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace with `stat.mode.nobits?(0o077)` for comparison with bit flags.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          stat.mode.nobits?(0o077)
         RUBY
       end
 

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         expect_no_offenses('0 == $CHILD_STATUS')
       end
 
+      it 'does not register an offense for bit flag zero comparisons handled by Style/BitwisePredicate', :ruby25 do
+        expect_no_offenses('stat.mode & 0o077 == 0o000')
+        expect_no_offenses('(stat.mode & 0o077) == 0')
+      end
+
       context 'when comparing against a method argument variable' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
This updates `Style/BitwisePredicate` so unparenthesized bitwise zero comparisons, such as `stat.mode & 0o077 == 0o000`, are reported directly as `nobits?` checks. It also makes `Style/NumericPredicate` skip that same shape so it no longer suggests the intermediate `.zero?` autocorrection first.

I kept the `allbits?` handling unchanged because the unparenthesized `& ... == ...` form can also be an array intersection comparison.

Tests run:

* `bundle exec rspec spec/rubocop/cop/style/bitwise_predicate_spec.rb spec/rubocop/cop/style/numeric_predicate_spec.rb --format progress`
* `bundle exec rubocop --force-exclusion lib/rubocop/cop/style/bitwise_predicate.rb lib/rubocop/cop/style/numeric_predicate.rb spec/rubocop/cop/style/bitwise_predicate_spec.rb spec/rubocop/cop/style/numeric_predicate_spec.rb`
* `bundle exec rake`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [x] Commit message starts with `[Fix #issue-number]` because the related issue exists.
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry to the changelog folder.