### PR TITLE
[Fix #15125] Fix a false positive for `Style/ZeroLengthPredicate`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_zerolengthpredicate.md
+++ b/changelog/fix_a_false_positive_for_style_zerolengthpredicate.md
@@ -1,0 +1,1 @@
+* [#15125](https://github.com/rubocop/rubocop/issues/15125): Fix a false positive for `Style/ZeroLengthPredicate` when the receiver is a local variable assigned from `File.stat`, `File.new`, `Tempfile.new`/`open`, or `StringIO.new`/`open`. ([@TsunakawaShunya][])

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -58,6 +58,7 @@ module RuboCop
         def check_zero_length_predicate(node)
           return unless zero_length_predicate?(node.parent)
           return if non_polymorphic_collection?(node.parent)
+          return if non_polymorphic_collection_via_lvar?(node.receiver)
 
           offense = node.loc.selector.join(node.parent.source_range.end)
           message = format(ZERO_MSG, current: offense.source)
@@ -74,6 +75,7 @@ module RuboCop
           lhs, opr, rhs = zero_length_comparison
 
           return if non_polymorphic_collection?(node.parent)
+          return if non_polymorphic_collection_via_lvar?(node.receiver)
 
           add_offense(
             node.parent, message: format(ZERO_MSG, current: "#{lhs} #{opr} #{rhs}")
@@ -89,6 +91,7 @@ module RuboCop
           lhs, opr, rhs = nonzero_length_comparison
 
           return if non_polymorphic_collection?(node.parent)
+          return if non_polymorphic_collection_via_lvar?(node.receiver)
 
           add_offense(
             node.parent, message: format(NONZERO_MSG, current: "#{lhs} #{opr} #{rhs}")
@@ -148,6 +151,37 @@ module RuboCop
           {(send (send (send (const {nil? cbase} :File) :stat _) ...) ...)
            (send (send (send (const {nil? cbase} {:File :Tempfile :StringIO}) {:new :open} ...) ...) ...)}
         PATTERN
+
+        # Matches a constructor expression for a non-polymorphic collection
+        # (an object that implements `#size` but not `#empty?`).
+        # @!method non_polymorphic_constructor?(node)
+        def_node_matcher :non_polymorphic_constructor?, <<~PATTERN
+          {(send (const {nil? cbase} :File) :stat _)
+           (send (const {nil? cbase} {:File :Tempfile :StringIO}) {:new :open} ...)}
+        PATTERN
+
+        def non_polymorphic_collection_via_lvar?(receiver)
+          return false unless receiver&.lvar_type?
+
+          scope = enclosing_lvar_scope(receiver)
+          return false unless scope
+
+          name = receiver.children.first
+          scope.each_descendant(:lvasgn).any? do |asgn|
+            non_polymorphic_lvasgn?(asgn, name, receiver)
+          end
+        end
+
+        def non_polymorphic_lvasgn?(asgn, name, receiver)
+          asgn.children.first == name &&
+            asgn.source_range.end_pos <= receiver.source_range.begin_pos &&
+            non_polymorphic_constructor?(asgn.children[1])
+        end
+
+        def enclosing_lvar_scope(node)
+          node.each_ancestor(:any_def, :block, :class, :module).first ||
+            node.each_ancestor.to_a.last
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -567,4 +567,99 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
       RUBY
     end
   end
+
+  context 'when the receiver is a local variable assigned from a non-polymorphic source' do
+    it 'does not register an offense for `lvar.size.zero?` assigned from `File.stat`' do
+      expect_no_offenses(<<~RUBY)
+        stat = File.stat('foo')
+        stat.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense for `lvar.size == 0` assigned from `File.stat`' do
+      expect_no_offenses(<<~RUBY)
+        stat = File.stat('foo')
+        stat.size == 0
+      RUBY
+    end
+
+    it 'does not register an offense for `0 == lvar.size` assigned from `File.stat`' do
+      expect_no_offenses(<<~RUBY)
+        stat = File.stat('foo')
+        0 == stat.size
+      RUBY
+    end
+
+    it 'does not register an offense for `lvar.size != 0` assigned from `File.stat`' do
+      expect_no_offenses(<<~RUBY)
+        stat = File.stat('foo')
+        stat.size != 0
+      RUBY
+    end
+
+    it 'does not register an offense when assigned from `File.new`' do
+      expect_no_offenses(<<~RUBY)
+        f = File.new('foo')
+        f.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense when assigned from `Tempfile.new`' do
+      expect_no_offenses(<<~RUBY)
+        t = Tempfile.new('foo')
+        t.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense when assigned from `Tempfile.open`' do
+      expect_no_offenses(<<~RUBY)
+        t = Tempfile.open('foo')
+        t.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense when assigned from `StringIO.new`' do
+      expect_no_offenses(<<~RUBY)
+        io = StringIO.new('foo')
+        io.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense with top-level `::File.stat`' do
+      expect_no_offenses(<<~RUBY)
+        stat = ::File.stat('foo')
+        stat.size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense when the assignment is inside a method' do
+      expect_no_offenses(<<~RUBY)
+        def empty_file?(path)
+          stat = File.stat(path)
+          stat.size.zero?
+        end
+      RUBY
+    end
+
+    it 'still registers an offense for an array lvar' do
+      expect_offense(<<~RUBY)
+        arr = [1, 2, 3]
+        arr.size.zero?
+            ^^^^^^^^^^ Use `empty?` instead of `size.zero?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        arr = [1, 2, 3]
+        arr.empty?
+      RUBY
+    end
+
+    it 'still registers an offense when the only preceding assignment is non-polymorphic-incompatible' do
+      expect_offense(<<~RUBY)
+        stat = [1, 2, 3]
+        stat.size.zero?
+             ^^^^^^^^^^ Use `empty?` instead of `size.zero?`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Closes #15125.

## Summary

`Style/ZeroLengthPredicate` already excludes direct chains like `File.stat(path).size.zero?` from offenses, because `File::Stat` and friends (`File`, `Tempfile`, `StringIO`) implement `#size` but not `#empty?`. However, when the same object is bound to a local variable first, the exclusion was bypassed:

```ruby
stat = File.stat('.')
stat.size.zero?  # <- previously reported `Use empty? instead of size.zero?.`
```

Applying the autocorrect produced `stat.empty?`, which raises `NoMethodError` at runtime.

This PR extends the existing exclusion to cover local variables assigned (in the same scope, before the use site) from `File.stat`, `File.new`, `Tempfile.new`/`open`, or `StringIO.new`/`open`.

## Approach and why

Two options were considered:

- **A. Skip the offense for `lvar.size.zero?` when the lvar was assigned from a non-polymorphic constructor (this PR).**
- **B. Detect `File::Stat`-like receivers and autocorrect to `!size?` instead of `empty?`** (as suggested in the issue).

I went with **A** because:

- It is strictly a false-positive fix that converts current broken autocorrects into no-offenses. The behavior change is one-directional and conservative.
- B would convert today's no-offense forms (e.g. `File.stat(foo).size == 0`) into offenses with a new autocorrect target (`!size?`), which is a larger semantic change that probably needs maintainer input before shipping.
- A is the minimum fix that prevents the runtime `NoMethodError` reported in the issue.

If maintainers prefer the `!size?` direction, I'm happy to follow up with a separate PR.

### What is covered

- `stat = File.stat(path); stat.size.zero?`
- `f = File.new(path); f.size == 0`
- Same-scope `Tempfile.new`/`open`, `StringIO.new`/`open` via lvar.

### What is intentionally not covered

(static analysis limits; left for a future PR if needed)

- `File::Stat` instances passed in as method arguments.
- Instance variables / method return values.
- Multi-hop assignments like `a = File.stat(...); b = a; b.size.zero?`.
- Reassignment within scope (`stat = File.stat; ...; stat = [1,2,3]; stat.size.zero?` stays excluded — false-negative on purpose to avoid generating broken autocorrects).

## Implementation notes

- Added a node matcher `non_polymorphic_constructor?` for the bare constructor expression (the existing `non_polymorphic_collection?` only matches a `size`/`length`/`zero?`/`==`-wrapped chain).
- Added a helper `non_polymorphic_collection_via_lvar?` that, for a `lvar` receiver, scans the enclosing scope for a preceding `lvasgn` with a matching name whose RHS is a non-polymorphic constructor.
- Wired one early `return` into each of `check_zero_length_predicate`, `check_zero_length_comparison`, and `check_nonzero_length_comparison`.

The scan is gated by `receiver&.lvar_type?`, so the additional cost is paid only when the receiver is actually a local variable.

## Before submitting the PR make sure the following are checked:

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote good commit messages.
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
- [x] Added an entry (file) to the changelog folder named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.