### PR TITLE
Fix incorrect autocorrect for `Style/FileWrite` cop

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_file_write.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_file_write.md
@@ -1,0 +1,1 @@
+* [#15180](https://github.com/rubocop/rubocop/pull/15180): Fix incorrect autocorrect for `Style/FileWrite` causing a syntax error when the written heredoc is chained with another method call. ([@koic][])

--- a/lib/rubocop/cop/style/file_write.rb
+++ b/lib/rubocop/cop/style/file_write.rb
@@ -104,28 +104,30 @@ module RuboCop
 
         def replacement(mode, filename, content, write_node)
           replacement = "#{write_method(mode)}(#{filename.source}, #{content.source})"
+          heredoc = heredoc_in_write(write_node)
+          return replacement unless heredoc
 
-          if heredoc?(write_node)
-            first_argument = write_node.body.first_argument
-
-            <<~REPLACEMENT.chomp
-              #{replacement}
-              #{heredoc_range(first_argument).source}
-            REPLACEMENT
-          else
-            replacement
-          end
+          <<~REPLACEMENT.chomp
+            #{replacement}
+            #{heredoc_range(heredoc).source}
+          REPLACEMENT
         end
 
-        def heredoc?(write_node)
-          write_node.block_type? && (first_argument = write_node.body.first_argument) &&
-            first_argument.respond_to?(:heredoc?) && first_argument.heredoc?
+        def heredoc_in_write(write_node)
+          return unless write_node.block_type? && (first_argument = write_node.body.first_argument)
+
+          find_heredoc(first_argument)
         end
 
-        def heredoc_range(first_argument)
-          range_between(
-            first_argument.loc.heredoc_body.begin_pos, first_argument.loc.heredoc_end.end_pos
-          )
+        def heredoc_range(heredoc)
+          range_between(heredoc.loc.heredoc_body.begin_pos, heredoc.loc.heredoc_end.end_pos)
+        end
+
+        def find_heredoc(node)
+          return node if node.respond_to?(:heredoc?) && node.heredoc?
+          return if node.send_type? && !(receiver = node.receiver)
+
+          find_heredoc(receiver)
         end
       end
     end

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -90,5 +90,24 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
           EOS
       RUBY
     end
+
+    it "registers an offense for and corrects the `File.open` with multiline write block (mode '#{mode}') with heredoc chained method call" do
+      write_method = mode.end_with?('b') ? :binwrite : :write
+
+      expect_offense(<<~RUBY)
+        File.open(filename, '#{mode}') do |f|
+        ^^^^^^^^^^^^^^^^^^^^^#{'^' * mode.length}^^^^^^^^^ Use `File.#{write_method}`.
+          f.write(<<~EOS.gsub(/^/, ''))
+            content
+          EOS
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        File.#{write_method}(filename, <<~EOS.gsub(/^/, ''))
+            content
+          EOS
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This fixes a syntax error caused by `Style/FileWrite` when the written heredoc is chained with another method call such as `<<~EOS.gsub(...)`.

Previously the cop's `heredoc?` predicate only matched when the first argument to `f.write` was directly a heredoc node. When the heredoc was wrapped in a method chain, the corrector replaced the entire block without re-emitting the heredoc body and end marker, producing invalid Ruby like `File.write("...", <<~EOS.gsub(...))` with no terminator.

The cop now walks the receiver chain to find the heredoc and re-emits its body and end marker after the rewritten call.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
