### PR TITLE
[Cop lazy loading] Implement CopLazyLoader, lazy-load Migration department

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -82,7 +82,7 @@ require_relative 'rubocop/cop/utils/format_string'
 
 require_relative 'rubocop/cop_lazy_loader'
 
-require_relative 'rubocop/cop/migration/department_name'
+require_relative 'rubocop/cop/migration'
 
 require_relative 'rubocop/cop/bundler/duplicated_gem'
 require_relative 'rubocop/cop/bundler/duplicated_group'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -80,6 +80,8 @@ require_relative 'rubocop/cop/metrics/utils/repeated_attribute_discount'
 
 require_relative 'rubocop/cop/utils/format_string'
 
+require_relative 'rubocop/cop_lazy_loader'
+
 require_relative 'rubocop/cop/migration/department_name'
 
 require_relative 'rubocop/cop/bundler/duplicated_gem'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -58,6 +58,7 @@ require_relative 'rubocop/cop/force'
 require_relative 'rubocop/cop/severity'
 require_relative 'rubocop/cop/generator'
 require_relative 'rubocop/cop/generator/configuration_injector'
+require_relative 'rubocop/cop/generator/register_cop_injector'
 require_relative 'rubocop/cop/generator/require_file_injector'
 require_relative 'rubocop/magic_comment'
 

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -136,6 +136,10 @@ module RuboCop
         RequireFileInjector.new(source_path: source_path, root_file_path: root_file_path).inject
       end
 
+      def inject_register_cop(root_dir: 'lib')
+        RegisterCopInjector.new(source_path: source_path, root_dir: root_dir, badge: badge).inject
+      end
+
       def inject_config(config_file_path: 'config/default.yml',
                         version_added: '<<next>>')
         injector =

--- a/lib/rubocop/cop/generator/register_cop_injector.rb
+++ b/lib/rubocop/cop/generator/register_cop_injector.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    class Generator
+      # A class that injects a register_cop directive into the cop's department module.
+      # It looks for other directives in the same module, and injects the directive in
+      # alphabetical order.
+      class RegisterCopInjector
+        REGISTER_COP_PATTERN = /register_cop :.+, (.+)/.freeze
+
+        MODULE_TEMPLATE = <<~RUBY
+          # frozen_string_literal: true
+
+          module RuboCop
+            module Cop
+              module %<department>s
+                extend CopLazyLoader
+
+                %<directive>s
+              end
+            end
+          end
+        RUBY
+
+        def initialize(source_path:, root_dir:, badge:, output: $stdout)
+          @source_path = Pathname(source_path)
+          @root_dir = root_dir
+          @department_module_path = Pathname("#{@source_path.dirname}.rb")
+          @badge = badge
+          @output = output
+        end
+
+        def inject # rubocop:disable Metrics/AbcSize
+          if File.exist?(department_module_path)
+            return if register_cop_directive_exists? || !target_line
+
+            File.write(department_module_path, updated_directives)
+            directive = injectable_register_cop_directive.chomp
+            output.puts "[modify] #{department_module_path} - `#{directive}` was injected."
+          else
+            File.write(department_module_path, generated_module)
+            output.puts "[create] #{department_module_path}"
+          end
+        end
+
+        private
+
+        attr_reader :source_path, :root_dir, :department_module_path, :badge, :output
+
+        def register_cop_directive_exists?
+          register_cop_entries.any? { |entry| entry.include?(injectable_register_cop_directive) }
+        end
+
+        def updated_directives
+          indentation = if (entry = register_cop_entries.grep(REGISTER_COP_PATTERN).first)
+                          entry[/\A */]
+                        else
+                          "  #{register_cop_entries[module_end_index][/\A */]}"
+                        end
+
+          register_cop_entries.insert(target_line,
+                                      "#{indentation}#{injectable_register_cop_directive}").join
+        end
+
+        def target_line
+          @target_line ||= begin
+            inject_parts = directive_fragments(injectable_register_cop_directive)
+
+            register_cop_entries.find.with_index do |entry, index|
+              current_entry_parts = directive_fragments(entry)
+              next unless current_entry_parts.any?
+
+              break index if inject_parts.last < current_entry_parts.last
+            end || last_register_cop_line || module_end_index
+          end
+        end
+
+        def last_register_cop_line
+          return unless (index = register_cop_entries.rindex do |entry|
+            entry.match?(REGISTER_COP_PATTERN)
+          end)
+
+          index + 1
+        end
+
+        def module_end_index
+          register_cop_entries.find_index { |entry| entry.strip == 'end' }
+        end
+
+        def directive_fragments(register_cop_directive)
+          directive = register_cop_directive.match(REGISTER_COP_PATTERN)
+
+          directive ? directive.captures.first.split('/') : []
+        end
+
+        def injectable_register_cop_directive
+          "register_cop :#{badge.cop_name}, '#{require_path}'\n"
+        end
+
+        def require_path
+          path = source_path.relative_path_from(root_dir)
+          path.to_s.delete_suffix('.rb')
+        end
+
+        def generated_module
+          format(MODULE_TEMPLATE, department: badge.department_name.gsub('/', '::'),
+                                  directive: injectable_register_cop_directive.chomp)
+        end
+
+        def register_cop_entries
+          @register_cop_entries ||= File.readlines(department_module_path)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/migration.rb
+++ b/lib/rubocop/cop/migration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Cops for the Migration department
+    module Migration
+      extend CopLazyLoader
+
+      register_cop :DepartmentName, 'rubocop/cop/migration/department_name'
+    end
+  end
+end

--- a/lib/rubocop/cop_lazy_loader.rb
+++ b/lib/rubocop/cop_lazy_loader.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Exposes a method to autoload a cop class and lazy-load the cop in the registry
+  module CopLazyLoader
+    def register_cop(constant_name, require_path)
+      autoload constant_name, require_path
+
+      fully_qualified_constant_name = "#{name}::#{constant_name}"
+      cop_name = RuboCop::Cop::Badge.for(fully_qualified_constant_name).to_s
+      RuboCop::Cop::Registry.global.lazy_load(cop_name, fully_qualified_constant_name)
+    end
+  end
+end

--- a/spec/rubocop/cop/generator/register_cop_injector_spec.rb
+++ b/spec/rubocop/cop/generator/register_cop_injector_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Generator::RegisterCopInjector do
+  let(:stdout) { StringIO.new }
+  let(:source_path) { 'lib/rubocop/cop/test/foo_cop.rb' }
+  let(:root_dir) { 'lib' }
+  let(:badge) { RuboCop::Cop::Badge.for('RuboCop::Cop::Test::FooCop') }
+  let(:department_module_path) { 'lib/rubocop/cop/test.rb' }
+  let(:injector) do
+    described_class.new(source_path: source_path, root_dir: root_dir, badge: badge, output: stdout)
+  end
+
+  around do |example|
+    Dir.mktmpdir('rubocop-register_cop_injector_spec-') do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p('lib/rubocop/cop')
+        example.run
+      end
+    end
+  end
+
+  context 'when a `register_cop` entry does not exist from before' do
+    before do
+      File.write(department_module_path, <<~RUBY)
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+
+              register_cop :BarCop, 'rubocop/cop/test/bar_cop'
+              register_cop :QuuxCop, 'rubocop/cop/test/quux_cop'
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'injects a `register_cop` directive in alphabetical order' do
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+
+              register_cop :BarCop, 'rubocop/cop/test/bar_cop'
+              register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+              register_cop :QuuxCop, 'rubocop/cop/test/quux_cop'
+            end
+          end
+        end
+      RUBY
+
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [modify] lib/rubocop/cop/test.rb - `register_cop :FooCop, 'rubocop/cop/test/foo_cop'` was injected.
+      MESSAGE
+    end
+  end
+
+  context 'when the new cop is last alphabetically in the department' do
+    let(:source_path) { 'lib/rubocop/cop/test/quux_cop.rb' }
+    let(:badge) { RuboCop::Cop::Badge.for('RuboCop::Cop::Test::QuuxCop') }
+
+    before do
+      File.write(department_module_path, <<~RUBY)
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+
+              register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+              register_cop :BarCop, 'rubocop/cop/test/bar_cop'
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'injects a `register_cop` directive after the last existing entry' do
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+
+              register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+              register_cop :BarCop, 'rubocop/cop/test/bar_cop'
+              register_cop :QuuxCop, 'rubocop/cop/test/quux_cop'
+            end
+          end
+        end
+      RUBY
+
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [modify] lib/rubocop/cop/test.rb - `register_cop :QuuxCop, 'rubocop/cop/test/quux_cop'` was injected.
+      MESSAGE
+    end
+  end
+
+  context 'when the department module has no `register_cop` entries yet' do
+    before do
+      File.write(department_module_path, <<~RUBY)
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'injects a `register_cop` directive before the first closing `end`' do
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+              register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+            end
+          end
+        end
+      RUBY
+
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [modify] lib/rubocop/cop/test.rb - `register_cop :FooCop, 'rubocop/cop/test/foo_cop'` was injected.
+      MESSAGE
+    end
+  end
+
+  context 'when a `register_cop` entry already exists' do
+    let(:source) { <<~RUBY }
+      # frozen_string_literal: true
+
+      module RuboCop
+        module Cop
+          module Test
+            extend CopLazyLoader
+
+            register_cop :EvenOdd, 'rubocop/cop/test/even_odd'
+            register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+            register_cop :FunName, 'rubocop/cop/test/fun_name'
+          end
+        end
+      end
+    RUBY
+
+    before { File.write(department_module_path, source) }
+
+    it 'does not write to any file' do
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq(source)
+      expect(stdout.string).to be_empty
+    end
+  end
+
+  context 'when the department module does not exist yet' do
+    it 'creates the department module with a `register_cop` directive' do
+      expect(File).not_to exist(department_module_path)
+
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test
+              extend CopLazyLoader
+
+              register_cop :FooCop, 'rubocop/cop/test/foo_cop'
+            end
+          end
+        end
+      RUBY
+
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [create] lib/rubocop/cop/test.rb
+      MESSAGE
+    end
+  end
+
+  context 'when the nested department module does not exist yet' do
+    let(:source_path) { 'lib/rubocop/cop/test/nested/foo_cop.rb' }
+    let(:badge) { RuboCop::Cop::Badge.for('RuboCop::Cop::Test::Nested::FooCop') }
+    let(:department_module_path) { 'lib/rubocop/cop/test/nested.rb' }
+
+    before do
+      FileUtils.mkdir_p('lib/rubocop/cop/test')
+    end
+
+    it 'creates the department module with a `register_cop` directive' do
+      expect(File).not_to exist(department_module_path)
+
+      generated_source = <<~RUBY
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module Test::Nested
+              extend CopLazyLoader
+
+              register_cop :FooCop, 'rubocop/cop/test/nested/foo_cop'
+            end
+          end
+        end
+      RUBY
+
+      injector.inject
+
+      expect(File.read(department_module_path)).to eq generated_source
+      expect(stdout.string).to eq(<<~MESSAGE)
+        [create] lib/rubocop/cop/test/nested.rb
+      MESSAGE
+    end
+  end
+end

--- a/spec/rubocop/cop_lazy_loader_spec.rb
+++ b/spec/rubocop/cop_lazy_loader_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::CopLazyLoader, :restore_registry do
+  subject(:test_module) do
+    Module.new do
+      extend RuboCop::CopLazyLoader
+
+      # fakes a name since anonymous modules don't have one
+      def self.name
+        'RuboCop::Cop::Test'
+      end
+    end
+  end
+
+  describe '#register_cop' do
+    it 'sets up autoload on the module' do
+      test_module.register_cop(:FooCop, 'rubocop/cop/test/foo_cop')
+
+      expect(test_module.autoload?(:FooCop)).to eq('rubocop/cop/test/foo_cop')
+    end
+
+    it 'registers the cop in the registry' do
+      test_module.register_cop(:FooCop, 'rubocop/cop/test/foo_cop')
+
+      expect(RuboCop::Cop::Registry.global.names).to include('Test/FooCop')
+    end
+  end
+end

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -15,10 +15,16 @@ task :new_cop, [:cop] do |_task, args|
   generator.write_source
   generator.write_spec
 
+  lazy_loaded_departments = [:Migration]
+
   if badge.department == :InternalAffairs
     # InternalAffairs cops are required separately, and not added to config/default.yml
     generator.inject_require(root_file_path: 'lib/rubocop/cop/internal_affairs.rb')
+  elsif lazy_loaded_departments.include?(badge.department)
+    generator.inject_register_cop
+    generator.inject_config
   else
+    # TODO: remove once all departments are lazy loaded
     generator.inject_require
     generator.inject_config
   end


### PR DESCRIPTION
Implements module to lazy-load cops for a department (`CopLazyLoader`) and migrates the Migration department to it. The PR also updates the `new_cop` Rake task to lazy-load new cops.

`CopLazyLoader` has a single method `register_cop` which autoloads cop class in the department module, and lazy-loads the cop in the registry. It's expected that each department module extends it (`extend CopLazyLoader`) and calls `register_cop` for all cops in the department.

The `Migration` department has been migrated to `CopLazyLoader` in this PR. I selected this department as the first one because it has only one cop.

The PR also updates the `new_cop` Rake task to inject `register_cop` directive into the department module, or create a module if it doesn't exist.

In the PRs after this one, I plan to migrate other departments (one department per PR) and also add documentation for lazy-loading.

Proposal: #14983.