### PR TITLE
Fix incorrect autocorrect for `Style/Alias` cop

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_alias_inside_visibility_modifier.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_alias_inside_visibility_modifier.md
@@ -1,0 +1,1 @@
+* [#15182](https://github.com/rubocop/rubocop/pull/15182): Fix incorrect autocorrect for `Style/Alias` causing a syntax error when the return value of `alias_method` is used, such as an argument to `public`, `private`, `protected`, or `module_function`, or the right-hand side of an assignment. ([@koic][])

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -45,6 +45,7 @@ module RuboCop
           return unless node.command?(:alias_method)
           return unless style == :prefer_alias && alias_keyword_possible?(node)
           return unless node.arguments.count == 2
+          return if alias_method_value_used?(node)
 
           msg = format(MSG_ALIAS_METHOD, current: lexical_scope_type(node))
           add_offense(node.loc.selector, message: msg) do |corrector|
@@ -78,6 +79,14 @@ module RuboCop
 
         def alias_keyword_possible?(node)
           scope_type(node) != :dynamic && node.arguments.all?(&:sym_type?)
+        end
+
+        # `alias_method` is a method call whose return value can be used
+        # (e.g., as an argument to `public`/`module_function`, or as an assignment),
+        # but `alias` is a keyword statement that cannot appear in such positions.
+        # Detect these positions so the conversion does not produce a syntax error.
+        def alias_method_value_used?(node)
+          node.argument? || node.parent&.assignment?
         end
 
         def alias_method_possible?(node)

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -125,6 +125,46 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
       RUBY
     end
 
+    it 'does not register an offense for alias_method as an argument to `public`' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          public alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method as an argument to `private`' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          private alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method as an argument to `protected`' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          protected alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method as an argument to `module_function`' do
+      expect_no_offenses(<<~RUBY)
+        module M
+          module_function alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method whose return value is assigned' do
+      expect_no_offenses(<<~RUBY)
+        class C
+          NAME = alias_method :ala, :bala
+        end
+      RUBY
+    end
+
     it 'does not register an offense for alias in a def' do
       expect_no_offenses(<<~RUBY)
         def foo


### PR DESCRIPTION
This fixes a syntax error caused by `Style/Alias` when the return value of `alias_method` is used rather than being a standalone statement.

`alias_method` is a method call and can be used as an argument to visibility modifiers like `public`, `private`, `protected`, and `module_function`, or as the right-hand side of an assignment. The `alias` keyword, however, is a statement and cannot appear in such positions.

The cop now skips the conversion when the `alias_method` call's value is used, leaving the original code untouched.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
