### PR TITLE
[Fix #7201] Add style guide URL to JSON offenses

### DIFF
--- a/changelog/new_add_style_guide_url_to_json_formatter.md
+++ b/changelog/new_add_style_guide_url_to_json_formatter.md
@@ -1,0 +1,1 @@
+* [#7201](https://github.com/rubocop/rubocop/issues/7201): Add `style_guide_url` to JSON formatter offenses when available. ([@Will-thom][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -243,6 +243,7 @@ The JSON structure is like the following example:
           "severity": "convention",
           "message": "Line is too long. [81/80]",
           "cop_name": "Layout/LineLength",
+          "style_guide_url": "https://rubystyle.guide#max-line-length",
           "corrected": true,
           "correctable": true,
           "location": {
@@ -280,6 +281,9 @@ The JSON structure is like the following example:
   }
 }
 ----
+
+The `style_guide_url` key is present for an offense only when the cop provides
+a style guide URL.
 
 == JUnit Style Formatter
 

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -22,7 +22,7 @@ module RuboCop
 
     def serialize_offense(offense)
       status = :uncorrected if %i[corrected corrected_with_todo].include?(offense.status)
-      {
+      serialized = {
         # Calling #to_s here ensures that the serialization works when using
         # other json serializers such as Oj. Some of these gems do not call
         # #to_s implicitly.
@@ -35,6 +35,8 @@ module RuboCop
         cop_name: offense.cop_name,
         status:   status || offense.status
       }
+      serialized[:style_guide_url] = offense.style_guide_url if offense.style_guide_url
+      serialized
     end
 
     def message(offense)
@@ -47,7 +49,8 @@ module RuboCop
     def deserialize_offenses(offenses)
       offenses.map! do |o|
         location = location_from_source_buffer(o)
-        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym)
+        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym,
+                         style_guide_url: o['style_guide_url'])
       end
     end
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -189,10 +189,11 @@ module RuboCop
       # No correction can be applied to global offenses
       def add_global_offense(message = nil, severity: nil)
         severity = find_severity(nil, severity)
-        message = find_message(nil, message)
+        message, style_guide_url = find_message_and_style_guide_url(nil, message)
         range = Offense::NO_LOCATION
         status = enabled_line?(range.line) ? :unsupported : :disabled
-        current_offenses << Offense.new(severity, range, message, name, status)
+        current_offenses << Offense.new(severity, range, message, name, status,
+                                        style_guide_url: style_guide_url)
       end
 
       # Adds an offense on the specified range (or node with an expression)
@@ -206,7 +207,7 @@ module RuboCop
         range_to_pass = callback_argument(range)
 
         severity = find_severity(range_to_pass, severity)
-        message = find_message(range_to_pass, message)
+        message, style_guide_url = find_message_and_style_guide_url(range_to_pass, message)
 
         status, corrector = enabled_line?(range.line) ? correct(range, &block) : :disabled
 
@@ -214,7 +215,8 @@ module RuboCop
         # template file, we convert it to location info in the original file.
         range = range_for_original(range)
 
-        current_offenses << Offense.new(severity, range, message, name, status, corrector)
+        current_offenses << Offense.new(severity, range, message, name, status, corrector,
+                                        style_guide_url: style_guide_url)
       end
 
       # This method should be overridden when a cop's behavior depends
@@ -484,14 +486,9 @@ module RuboCop
         end
       end
 
-      def find_message(range, message)
-        annotate(message || message(range))
-      end
-
-      def annotate(message)
-        RuboCop::Cop::MessageAnnotator.new(
-          config, cop_name, cop_config, @options
-        ).annotate(message)
+      def find_message_and_style_guide_url(range, custom_message)
+        annotator = RuboCop::Cop::MessageAnnotator.new(config, cop_name, cop_config, @options)
+        [annotator.annotate(custom_message || message(range)), annotator.style_guide_url]
       end
 
       def file_name_matches_any?(file, parameter, default_result)

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -192,8 +192,9 @@ module RuboCop
         message, style_guide_url = find_message_and_style_guide_url(nil, message)
         range = Offense::NO_LOCATION
         status = enabled_line?(range.line) ? :unsupported : :disabled
-        current_offenses << Offense.new(severity, range, message, name, status,
-                                        style_guide_url: style_guide_url)
+        current_offenses << Offense.new(
+          severity, range, message, name, status, style_guide_url: style_guide_url
+        )
       end
 
       # Adds an offense on the specified range (or node with an expression)
@@ -215,8 +216,9 @@ module RuboCop
         # template file, we convert it to location info in the original file.
         range = range_for_original(range)
 
-        current_offenses << Offense.new(severity, range, message, name, status, corrector,
-                                        style_guide_url: style_guide_url)
+        current_offenses << Offense.new(
+          severity, range, message, name, status, corrector, style_guide_url: style_guide_url
+        )
       end
 
       # This method should be overridden when a cop's behavior depends

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -69,8 +69,6 @@ module RuboCop
         [style_guide_url, *reference_urls].compact
       end
 
-      private
-
       def style_guide_url
         url = cop_config['StyleGuide']
         return nil if url.nil? || url.empty?
@@ -84,6 +82,8 @@ module RuboCop
           end
         end
       end
+
+      private
 
       # Returns the base style guide URL from AllCops or the specific department
       #

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -54,6 +54,14 @@ module RuboCop
 
       # @api public
       #
+      # @!attribute [r] style_guide_url
+      #
+      # @return [String, nil]
+      #   the URL to the style guide for this offense, or `nil` when not available
+      attr_reader :style_guide_url
+
+      # @api public
+      #
       # @!attribute [r] corrector
       #
       # @return [Corrector | nil]
@@ -88,22 +96,23 @@ module RuboCop
 
       # @api private
       def initialize(severity, location, message, cop_name, # rubocop:disable Metrics/ParameterLists
-                     status = :uncorrected, corrector = nil)
+                     status = :uncorrected, corrector = nil, style_guide_url: nil)
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
         @message = message.freeze
         @cop_name = cop_name.freeze
         @status = status
         @corrector = corrector
+        @style_guide_url = style_guide_url
         freeze
       end
 
       def marshal_dump
-        [@severity, @location, @message, @cop_name, @status]
+        [@severity, @location, @message, @cop_name, @status, @style_guide_url]
       end
 
       def marshal_load(array)
-        @severity, @location, @message, @cop_name, @status = array
+        @severity, @location, @message, @cop_name, @status, @style_guide_url = array
       end
 
       # @api public

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -47,7 +47,7 @@ module RuboCop
       end
 
       def hash_for_offense(offense)
-        {
+        hash = {
           severity:    offense.severity.name,
           message:     offense.message,
           cop_name:    offense.cop_name,
@@ -55,6 +55,8 @@ module RuboCop
           correctable: offense.correctable?,
           location:    hash_for_location(offense)
         }
+        hash[:style_guide_url] = offense.style_guide_url if offense.style_guide_url
+        hash
       end
 
       # TODO: Consider better solution for Offense#real_column.

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -243,4 +243,23 @@ RSpec.describe RuboCop::Cop::MessageAnnotator do
                             https://example.com/some_style_guide])
     end
   end
+
+  describe '#style_guide_url' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'StyleGuideBaseURL' => 'http://example.org/styleguide' })
+    end
+
+    it 'returns nil without StyleGuide URL' do
+      expect(annotator.style_guide_url).to be_nil
+    end
+
+    it 'returns only the style guide URL when references are also specified' do
+      config['Cop/Cop'] = {
+        'StyleGuide' => '#target_based_url',
+        'References' => ['https://example.com/reference']
+      }
+
+      expect(annotator.style_guide_url).to eq('http://example.org/styleguide#target_based_url')
+    end
+  end
 end

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe RuboCop::Cop::Offense do
     expect(o1 == o2).to be(true)
   end
 
+  it 'preserves style guide URL when marshaled' do
+    offense = described_class.new(
+      :convention,
+      location,
+      'message',
+      'CopName',
+      :corrected,
+      nil,
+      style_guide_url: 'https://rubystyle.guide#instance-vars'
+    )
+
+    loaded_offense = Marshal.load(Marshal.dump(offense))
+
+    expect(loaded_offense.style_guide_url).to eq('https://rubystyle.guide#instance-vars')
+  end
+
   it 'is frozen' do
     expect(offense).to be_frozen
   end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -140,6 +140,23 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
       }
       expect(hash[:location]).to eq(location_hash)
     end
+
+    context 'when offense has a style guide URL' do
+      let(:offense) do
+        RuboCop::Cop::Offense.new(
+          :convention,
+          location,
+          'This is message',
+          'CopName',
+          :corrected,
+          style_guide_url: 'https://rubystyle.guide#instance-vars'
+        )
+      end
+
+      it 'sets Offense#style_guide_url value for :style_guide_url key' do
+        expect(hash[:style_guide_url]).to eq('https://rubystyle.guide#instance-vars')
+      end
+    end
   end
 
   describe '#hash_for_location' do

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         end
       end
 
+      context 'an offense with a style guide URL' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :uncorrected,
+            style_guide_url: 'https://rubystyle.guide#underscore-unused-vars'
+          )
+        end
+
+        it 'serializes the style guide URL' do
+          cache.save([offense])
+          expect(cache.load[0].style_guide_url)
+            .to eq('https://rubystyle.guide#underscore-unused-vars')
+        end
+      end
+
       context 'an offense with status unsupported' do
         let(:offense) do
           RuboCop::Cop::Offense.new(


### PR DESCRIPTION
Summary: Adds style_guide_url to JSON formatter offense hashes when a cop has a style guide URL, stores it on Offense, and preserves it in result cache serialization. Tests: bundle exec rspec spec/rubocop/cop/message_annotator_spec.rb spec/rubocop/formatter/json_formatter_spec.rb spec/rubocop/result_cache_spec.rb; bundle exec rubocop on the touched Ruby/spec files; manual JSON formatter check with --display-style-guide --format json --only Style/For. bundle exec rake was attempted locally in Docker, but timed out after 10 minutes.