### PR TITLE
Fix various typos and grammar mistakes in documentation

### DIFF
--- a/changelog/fix_typos_and_grammar_in_docs.md
+++ b/changelog/fix_typos_and_grammar_in_docs.md
@@ -1,0 +1,1 @@
+* [#15184](https://github.com/rubocop/rubocop/pull/15184): Fix various typos and grammar mistakes in documentation and cop descriptions. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/automated_code_review.adoc
+++ b/docs/modules/ROOT/pages/automated_code_review.adoc
@@ -1,6 +1,6 @@
 = Automated Code Review
 
-The section describes SaaS solutions that provide automated code reviews for Ruby based on RuboCop.
+This section describes SaaS solutions that provide automated code reviews for Ruby based on RuboCop.
 
 NOTE: The services are listed in alphabetical order.
 
@@ -19,7 +19,7 @@ https://www.codefactor.io[CodeFactor] reports various code metrics like duplicat
 
 == Codety
 
-https://www.codety.io[Codety] detects code issues for 30+ programming languages and IaC frameworks, Codety Scanner is open source and it embeds 6,000+ code analysis rules(including RuboCop rules).
+https://www.codety.io[Codety] detects code issues for 30+ programming languages and IaC frameworks. Codety Scanner is open source and it embeds 6,000+ code analysis rules (including RuboCop rules).
 
 == Pronto
 

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -13,7 +13,7 @@ NOTE: RuboCop might be working with other Ruby implementations as well, but it's
 
 == Support Matrix
 
-RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of a MRI version.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
+RuboCop generally aims to follow MRI's own support policy - meaning RuboCop would support all officially supported MRI releases.footnote:[Typically the last 3 releases.] To give people extra time for a smooth transition, we've customarily provided support for about one year after EOL of an MRI version.footnote:[At the core team's discretion this policy might be waived aside for MRI releases causing significant maintenance overhead.]
 
 The following table is the runtime support matrix.
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -277,7 +277,7 @@ AllCops:
 
 Ruby continues to move into the direction of having all string literals frozen by default.
 Ruby 3.4, for example, will show a warning if a non-frozen string literal from a file without
-the frozen string literal magic comment gets modified. By starting ruby with the environment
+the frozen string literal magic comment gets modified. By starting Ruby with the environment
 variable `RUBYOPT` set to `--enable=frozen-string-literal` you can opt into that behaviour today.
 For RuboCop to provide accurate analysis you must also configure the `StringLiteralsFrozenByDefault`
 option.

--- a/docs/modules/ROOT/pages/configuration/cop_settings.adoc
+++ b/docs/modules/ROOT/pages/configuration/cop_settings.adoc
@@ -17,7 +17,7 @@ Layout/LineLength:
 
 Most cops are enabled by default. Cops, introduced or significantly updated
 between major versions, are in a special pending status (read more in
-xref:versioning.adoc["Versioning"]). Some cops, configured the above `Enabled: false`
+xref:versioning.adoc["Versioning"]). Some cops, configured with `Enabled: false`
 in https://github.com/rubocop/rubocop/blob/master/config/default.yml[config/default.yml],
 are disabled by default.
 

--- a/docs/modules/ROOT/pages/cops_gemspec.adoc
+++ b/docs/modules/ROOT/pages/cops_gemspec.adoc
@@ -405,12 +405,12 @@ gem "bar"
 | 1.40
 |===
 
-An attribute assignment method calls should be listed only once
+An attribute assignment method call should be listed only once
 in a gemspec.
 
 Assigning to an attribute with the same name using `spec.foo =` or
 `spec.attribute#[]=` will be an unintended usage. On the other hand,
-duplication of methods such # as `spec.requirements`,
+duplication of methods such as `spec.requirements`,
 `spec.add_runtime_dependency`, and others are permitted because it is
 the intended use of appending values.
 
@@ -588,7 +588,7 @@ spec.add_dependency 'rspec'
 Requires a gemspec to have `rubygems_mfa_required` metadata set.
 
 This setting tells RubyGems that MFA (Multi-Factor Authentication) is
-required for accounts to be able perform privileged operations, such as
+required for accounts to be able to perform privileged operations, such as
 (see RubyGems' documentation for the full list of privileged
 operations):
 
@@ -764,10 +764,10 @@ end
 |===
 
 Checks that `RUBY_VERSION` and `Ruby::VERSION` constants are not used in gemspec.
-Using `RUBY_VERSION` and `Ruby::VERSION` are dangerous because value of the
+Using `RUBY_VERSION` and `Ruby::VERSION` is dangerous because the value of the
 constant is determined by `rake release`.
-It's possible to have dependency based on ruby version used
-to execute `rake release` and not user's ruby version.
+It's possible to have a dependency based on the Ruby version used
+to execute `rake release` and not the user's Ruby version.
 
 [#examples-gemspecrubyversionglobalsusage]
 === Examples

--- a/docs/modules/ROOT/pages/cops_layout.adoc
+++ b/docs/modules/ROOT/pages/cops_layout.adoc
@@ -317,7 +317,7 @@ keyword is. If it's set to `begin`, the `end` shall be aligned with the
 `Layout/EndAlignment` cop aligns with keywords (e.g. `if`, `while`, `case`)
 by default. On the other hand, `||= begin` that this cop targets tends to
 align with the start of the line, it defaults to `EnforcedStyleAlignWith: start_of_line`.
-These style can be configured by each cop.
+These styles can be configured by each cop.
 
 [#examples-layoutbeginendalignment]
 === Examples
@@ -729,7 +729,7 @@ You can configure the following order:
      - private_methods
 ----
 
-Instead of putting all literals in the expected order, is also
+Instead of putting all literals in the expected order, it is also
 possible to group categories of macros. Visibility levels are handled
 automatically.
 
@@ -2634,10 +2634,10 @@ start of the line where the matching keyword appears.
 
 This `Layout/EndAlignment` cop aligns with keywords (e.g. `if`, `while`, `case`)
 by default. On the other hand, `Layout/BeginEndAlignment` cop aligns with
-`EnforcedStyleAlignWith: start_of_line` by default due to `||= begin` tends
+`EnforcedStyleAlignWith: start_of_line` by default because `||= begin` tends
 to align with the start of the line. `Layout/DefEndAlignment` cop also aligns with
 `EnforcedStyleAlignWith: start_of_line` by default.
-These style can be configured by each cop.
+These styles can be configured by each cop.
 
 [#examples-layoutendalignment]
 === Examples
@@ -7257,7 +7257,7 @@ foo.map{ |a|
 |===
 
 Checks for space between the name of a receiver and a left
-brackets.
+bracket.
 
 [#examples-layoutspacebeforebrackets]
 === Examples

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -56,7 +56,7 @@ Checks for ambiguous block association with method
 when param passed without parentheses.
 
 This cop can customize allowed methods with `AllowedMethods`.
-By default, there are no methods to allowed.
+By default, there are no allowed methods.
 
 [#examples-lintambiguousblockassociation]
 === Examples
@@ -792,7 +792,7 @@ end
 | -
 |===
 
-Checks for overwriting an exception with an exception result by use ``rescue =>``.
+Checks for overwriting an exception with an exception result by using ``rescue =>``.
 
 You intended to write as `rescue StandardError`.
 However, you have written `rescue => StandardError`.
@@ -826,7 +826,7 @@ end
 | Yes
 | No
 | 1.70
-| -
+| <<next>>
 |===
 
 Checks for constant reassignments.
@@ -838,8 +838,13 @@ The cop tracks constants defined via `NAME = value` syntax as well as
 class/module keyword definitions. It detects reassignment when a constant
 is first defined one way and then redefined using the `NAME = value` syntax.
 
-The cop cannot catch all offenses, like, for example, when a constant
-is reassigned in another file, or when using metaprogramming (`Module#const_set`).
+The cop cannot catch all offenses, like, for example, when using metaprogramming
+(`Module#const_set`).
+
+By default the cop also cannot detect reassignment across files.
+When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+the cop additionally consults the project-wide index and reports reassignments
+whose previous definition lives in another file.
 
 The cop only takes into account constants assigned in a "simple" way: directly
 inside class/module definition, or within another constant. Other type of assignments
@@ -927,12 +932,12 @@ the code that uses the gem. Enable this cop without using `Only`/`Ignore`
 
 Large projects will over time end up with one or two constant names that
 are problematic because of a conflict with a library or just internally
-using the same name a namespace and a class. To avoid too many unnecessary
-offenses, Enable this cop with `Only: [The, Constant, Names, Causing, Issues]`
+using the same name for a namespace and a class. To avoid too many unnecessary
+offenses, enable this cop with `Only: [The, Constant, Names, Causing, Issues]`
 
-NOTE: `Style/RedundantConstantBase` cop is disabled if this cop is enabled to prevent
-conflicting rules. Because it respects user configurations that want to enable
-this cop which is disabled by default.
+NOTE: `Style/RedundantConstantBase` cop is disabled if this cop is enabled,
+to prevent conflicting rules. This is because it respects user configurations
+that want to enable this cop which is disabled by default.
 
 [#examples-lintconstantresolution]
 === Examples
@@ -1271,7 +1276,7 @@ alternative value as `Alternative`. And you can set the deprecated version as
       Alternative: 'alternative_value'
       DeprecatedVersion: 'deprecated_version'
 
-By default, `NIL`, `TRUE`, `FALSE`, `Net::HTTPServerException, `Random::DEFAULT`,
+By default, `NIL`, `TRUE`, `FALSE`, `Net::HTTPServerException`, `Random::DEFAULT`,
 `Struct::Group`, and `Struct::Passwd` are configured.
 
 [#examples-lintdeprecatedconstants]
@@ -2934,7 +2939,7 @@ and will be removed when Ruby 2.5 becomes EOL.
 `ERB.new` with non-keyword arguments is deprecated since ERB 2.2.0.
 Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.
 This cop identifies places where `ERB.new(str, trim_mode, eoutvar)` can
-be replaced by `ERB.new(str, :trim_mode: trim_mode, eoutvar: eoutvar)`.
+be replaced by `ERB.new(str, trim_mode: trim_mode, eoutvar: eoutvar)`.
 
 [#examples-linterbnewarguments]
 === Examples
@@ -3861,7 +3866,7 @@ end
 
 Checks that there is an `# rubocop:enable ...` statement
 after a `# rubocop:disable ...` statement. This will prevent leaving
-cop disables on wide ranges of code, that latter contributors to
+cop disables on wide ranges of code, that later contributors to
 a file wouldn't be aware of.
 
 You can set `MaximumRangeSize` to define the maximum number of
@@ -4134,8 +4139,8 @@ named captures.
 |===
 
 In math and Python, we can use `x < y < z` style comparison to compare
-multiple value. However, we can't use the comparison in Ruby. However,
-the comparison is not syntax error. This cop checks the bad usage of
+multiple values. However, we can't use the comparison in Ruby. However,
+the comparison is not a syntax error. This cop checks the bad usage of
 comparison operators.
 
 [#examples-lintmultiplecomparison]
@@ -4506,7 +4511,7 @@ that are hard to debug. To ensure this doesn't happen,
 always sort the list.
 
 `Dir.glob` and `Dir[]` sort globbed results by default in Ruby 3.0.
-So all bad cases are acceptable when Ruby 3.0 or higher are used.
+So all bad cases are acceptable when Ruby 3.0 or higher is used.
 
 NOTE: This cop will be deprecated and removed when supporting only Ruby 3.0 and higher.
 
@@ -4622,9 +4627,9 @@ end
 | 1.1
 |===
 
-Warns the usage of unsafe number conversions. Unsafe
-number conversion can cause unexpected error if auto type conversion
-fails. Cop prefer parsing with number class instead.
+Warns against the usage of unsafe number conversions. Unsafe
+number conversion can cause an unexpected error if auto type conversion
+fails. The cop prefers parsing with a number class instead.
 
 Conversion with `Integer`, `Float`, etc. will raise an `ArgumentError`
 if given input that is not numeric (eg. an empty string), whereas
@@ -4633,10 +4638,10 @@ As such, this cop is disabled by default because it's not necessarily
 always correct to raise if a value is not numeric.
 
 NOTE: Some values cannot be converted properly using one of the `Kernel`
-method (for instance, `Time` and `DateTime` values are allowed by this
+methods (for instance, `Time` and `DateTime` values are allowed by this
 cop by default). Similarly, Rails' duration methods do not work well
 with `Integer()` and can be allowed with `AllowedMethods`. By default,
-there are no methods to allowed.
+there are no allowed methods.
 
 [#safety-lintnumberconversion]
 === Safety
@@ -4761,7 +4766,7 @@ Assigning to a numbered parameter (from `_1` to `_9`) causes an error in Ruby 3.
   ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]
   -e:1: _1 is reserved for numbered parameter
 
-NOTE: The parametered parameters are from `_1` to `_9`. This cop checks `_0`, and over `_10`
+NOTE: The numbered parameters are from `_1` to `_9`. This cop checks `_0`, and over `_10`
 as well to prevent confusion.
 
 [#examples-lintnumberedparameterassignment]
@@ -5249,8 +5254,8 @@ x += 1
 Detects instances of rubocop:enable comments that can be
 removed.
 
-When comment enables all cops at once `rubocop:enable all`
-that cop checks whether any cop was actually enabled.
+When a comment enables all cops at once `rubocop:enable all`
+the cop checks whether any cop was actually enabled.
 
 [#examples-lintredundantcopenabledirective]
 === Examples
@@ -5799,14 +5804,14 @@ Specifically, these cases are detected for each conversion method:
   or with `String.new` or `String()`.
 * `to_sym` when called on a symbol literal or interpolated symbol.
 * `to_i` when called on an integer literal or with `Integer()`.
-* `to_f` when called on a float literal of with `Float()`.
+* `to_f` when called on a float literal or with `Float()`.
 * `to_r` when called on a rational literal or with `Rational()`.
-* `to_c` when called on a complex literal of with `Complex()`.
+* `to_c` when called on a complex literal or with `Complex()`.
 * `to_a` when called on an array literal, or with `Array.new`, `Array()` or `Array[]`.
 * `to_h` when called on a hash literal, or with `Hash.new`, `Hash()` or `Hash[]`.
 * `to_set` when called on `Set.new` or `Set[]`.
 
-In all cases, chaining one same `to_*` conversion methods listed above is redundant.
+In all cases, chaining one of the same `to_*` conversion methods listed above is redundant.
 
 The cop can also register an offense for chaining conversion methods on methods that are
 expected to return a specific type regardless of receiver (eg. `foo.inspect.to_s` and
@@ -6129,7 +6134,7 @@ end
 | -
 |===
 
-Checks for uses a file requiring itself with `require_relative`.
+Checks for a file requiring itself with `require_relative`.
 
 [#examples-lintrequirerelativeselfpath]
 === Examples
@@ -6712,7 +6717,7 @@ end
 | -
 |===
 
-Checks for a rescued exception that get shadowed by a
+Checks for a rescued exception that gets shadowed by a
 less specific exception being rescued before a more specific
 exception is rescued.
 
@@ -7553,7 +7558,7 @@ end
 | -
 |===
 
-Checks for Regexpes (both literals and via `Regexp.new` / `Regexp.compile`)
+Checks for Regexps (both literals and via `Regexp.new` / `Regexp.compile`)
 that contain unescaped `]` characters.
 
 It emulates the following Ruby warning:
@@ -7767,8 +7772,8 @@ end
 |===
 
 Checks for unreachable code.
-The check are based on the presence of flow of control
-statement in non-final position in `begin` (implicit) blocks.
+The check is based on the presence of flow-of-control
+statements in non-final position in `begin` (implicit) blocks.
 
 [#examples-lintunreachablecode]
 === Examples
@@ -9037,7 +9042,7 @@ end
 Looks for `ruby2_keywords` calls for methods that do not need it.
 
 `ruby2_keywords` should only be called on methods that accept an argument splat
-(`\*args`) but do not explicit keyword arguments (`k:` or `k: true`) or
+(`\*args`) but do not have explicit keyword arguments (`k:` or `k: true`) or
 a keyword splat (`**kwargs`).
 
 [#examples-lintuselessruby2keywords]

--- a/docs/modules/ROOT/pages/cops_metrics.adoc
+++ b/docs/modules/ROOT/pages/cops_metrics.adoc
@@ -115,7 +115,7 @@ NOTE: This cop does not apply for `Struct` definitions.
 
 NOTE: The `ExcludedMethods` configuration is deprecated and only kept
 for backwards compatibility. Please use `AllowedMethods` and `AllowedPatterns`
-instead. By default, there are no methods to allowed.
+instead. By default, there are no allowed methods.
 
 [#examples-metricsblocklength]
 === Examples
@@ -492,7 +492,7 @@ Each construct will be counted as one line regardless of its actual size.
 NOTE: The `ExcludedMethods` and `IgnoredMethods` configuration is
 deprecated and only kept for backwards compatibility.
 Please use `AllowedMethods` and `AllowedPatterns` instead.
-By default, there are no methods to allowed.
+By default, there are no allowed methods.
 
 [#examples-metricsmethodlength]
 === Examples

--- a/docs/modules/ROOT/pages/cops_naming.adoc
+++ b/docs/modules/ROOT/pages/cops_naming.adoc
@@ -167,7 +167,7 @@ FOÖ = "foo"
 |===
 
 Makes sure that certain binary operator methods have their
-sole  parameter named `other`.
+sole parameter named `other`.
 
 [#examples-namingbinaryoperatorparametername]
 === Examples
@@ -1252,7 +1252,7 @@ end
 Checks that predicate methods end with `?` and non-predicate methods do not.
 
 The names of predicate methods (methods that return a boolean value) should end
-in a question mark. Methods that don't return a boolean, shouldn't
+in a question mark. Methods that don't return a boolean shouldn't
 end in a question mark.
 
 The cop assesses a predicate method as one that returns boolean values. Likewise,
@@ -1268,7 +1268,7 @@ mode, methods with a question mark will register an offense if any known non-boo
 return values are detected.
 
 The cop also has `AllowedMethods` configuration in order to prevent the cop from
-registering an offense from a method name that does not confirm to the naming
+registering an offense from a method name that does not conform to the naming
 guidelines. By default, `call` is allowed. The cop also has `AllowedPatterns`
 configuration to allow method names by regular expression.
 
@@ -1486,7 +1486,7 @@ methods which begin with a forbidden prefix are not allowed, even if
 they end with a `?`. These methods should be changed to remove the
 prefix.
 
-When `UseSorbetSigs` set to true (optional), the cop will only report
+When `UseSorbetSigs` is set to true (optional), the cop will only report
 offenses if the method has a Sorbet `sig` with a return type of
 `T::Boolean`. Dynamic methods are not supported with this configuration.
 
@@ -1661,7 +1661,7 @@ def_node_matcher(:even?) { |value| }
 | 0.68
 |===
 
-Makes sure that rescued exceptions variables are named as
+Makes sure that rescued exception variables are named as
 expected.
 
 The `PreferredName` config option takes a `String`. It represents

--- a/docs/modules/ROOT/pages/cops_security.adoc
+++ b/docs/modules/ROOT/pages/cops_security.adoc
@@ -110,7 +110,7 @@ If argument starts with a pipe character (`'|'`) and the receiver is the `IO` cl
 a subprocess is created in the same way as `Kernel#open`, and its output is returned.
 `Kernel#open` may allow unintentional command injection, which is the reason these
 `IO` methods are a security risk.
-Consider to use `File.read` to disable the behavior of subprocess invocation.
+Consider using `File.read` to disable the behavior of subprocess invocation.
 
 [#safety-securityiomethods]
 === Safety

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -323,7 +323,7 @@ other prevents confusion about their different semantics
 is resolved at runtime).
 It also flags uses of `alias :symbol` rather than `alias bareword`.
 
-However, it will always enforce `method_alias` when used `alias`
+However, it will always enforce `alias_method` when `alias` is used
 in an instance method definition and in a singleton method definition.
 If used in a block, always enforce `alias_method`
 unless it is an `instance_eval` block.
@@ -1814,8 +1814,8 @@ Starting with Ruby 1.9 character literals are
 essentially one-character strings, so this syntax
 is mostly redundant at this point.
 
-? character literal can be used to express meta and control character.
-That's a good use case of ? literal so it doesn't count it as an offense.
+A `?` character literal can be used to express meta and control characters.
+That's a good use case of a `?` literal so it doesn't count as an offense.
 
 [#examples-stylecharacterliteral]
 === Examples
@@ -3774,7 +3774,7 @@ Dir.empty?('path/to/dir')
 |===
 
 Detects comments to enable/disable RuboCop.
-This is useful if want to make sure that every RuboCop error gets fixed
+This is useful if you want to make sure that every RuboCop error gets fixed
 and not quickly disabled with a comment.
 
 Specific cops can be allowed with the `AllowedCops` configuration. Note that
@@ -6288,9 +6288,10 @@ manner for all cases, so only two scenarios are considered -
 if the first argument is a string literal and if the second
 argument is an array literal.
 
-Autocorrection will be applied when using argument is a literal or known built-in conversion
-methods such as `to_d`, `to_f`, `to_h`, `to_i`, `to_r`, `to_s`, and `to_sym` on variables,
-provided that their return value is not an array. For example, when using `to_s`,
+Autocorrection will be applied when the argument is a literal or uses a known
+built-in conversion method such as `to_d`, `to_f`, `to_h`, `to_i`, `to_r`, `to_s`,
+and `to_sym` on variables, provided that their return value is not an array.
+For example, when using `to_s`,
 `'%s' % [1, 2, 3].to_s` can be autocorrected without any incompatibility:
 
 [source,ruby]
@@ -9203,7 +9204,7 @@ both magic comment directives and values.
 Required capitalization can be set with the `DirectiveCapitalization` and
 `ValueCapitalization` configuration keys.
 
-NOTE: If one of these configuration is set to nil, any capitalization is allowed.
+NOTE: If one of these configurations is set to nil, any capitalization is allowed.
 
 [#examples-stylemagiccommentformat]
 === Examples
@@ -10268,7 +10269,7 @@ return foo.minmax
 Enforces the use of `max` or `min` instead of comparison for greater or less.
 
 NOTE: It can be used if you want to present limit or threshold in Ruby 2.7+.
-That it is slow though. So autocorrection will apply generic `max` or `min`:
+It is slow though. So autocorrection will apply generic `max` or `min`:
 
 [source,ruby]
 ----
@@ -14136,8 +14137,8 @@ A.foo
 | -
 |===
 
-Checks for the instantiation of array using redundant `Array` constructor.
-Autocorrect replaces to array literal which is the simplest and fastest.
+Checks for the instantiation of an array using a redundant `Array` constructor.
+Autocorrect replaces it with an array literal which is the simplest and fastest.
 
 [#examples-styleredundantarrayconstructor]
 === Examples
@@ -14512,16 +14513,16 @@ x != y
 | -
 |===
 
-Avoid redundant `::` prefix on constant.
+Avoid redundant `::` prefix on a constant.
 
-How Ruby searches constant is a bit complicated, and it can often be difficult to
+How Ruby searches constants is a bit complicated, and it can often be difficult to
 understand from the code whether the `::` is intended or not. Where `Module.nesting`
 is empty, there is no need to prepend `::`, so it would be nice to consistently
 avoid such meaningless `::` prefix to avoid confusion.
 
-NOTE: This cop is disabled if `Lint/ConstantResolution` cop is enabled to prevent
-conflicting rules. Because it respects user configurations that want to enable
-`Lint/ConstantResolution` cop which is disabled by default.
+NOTE: This cop is disabled if `Lint/ConstantResolution` cop is enabled,
+to prevent conflicting rules. This is because it respects user configurations
+that want to enable `Lint/ConstantResolution` cop which is disabled by default.
 
 [#examples-styleredundantconstantbase]
 === Examples
@@ -15548,8 +15549,8 @@ r = /[ab]/
 | -
 |===
 
-Checks for the instantiation of regexp using redundant `Regexp.new` or `Regexp.compile`.
-Autocorrect replaces to regexp literal which is the simplest and fastest.
+Checks for the instantiation of a regexp using a redundant `Regexp.new` or `Regexp.compile`.
+Autocorrect replaces it with a regexp literal which is the simplest and fastest.
 
 [#examples-styleredundantregexpconstructor]
 === Examples
@@ -16087,8 +16088,8 @@ Struct.new(:foo)
 
 Enforces using `//` or `%r` around regular expressions.
 
-NOTE: The following `%r` cases using a regexp starts with a blank or `=`
-as a method argument allowed to prevent syntax errors.
+NOTE: The following `%r` cases using a regexp that starts with a blank or `=`
+as a method argument are allowed to prevent syntax errors.
 
 [source,ruby]
 ----
@@ -16314,17 +16315,17 @@ require 'a'
 | 0.34
 |===
 
-Checks for uses of `rescue` in its modifier form is added for following
+Checks for uses of `rescue` in its modifier form. It is added for the following
 reasons:
 
 * The syntax of modifier form `rescue` can be misleading because it
   might lead us to believe that `rescue` handles the given exception
-  but it actually rescue all exceptions to return the given rescue
+  but it actually rescues all exceptions to return the given rescue
   block. In this case, value returned by handle_error or
   SomeException.
 
 * Modifier form `rescue` would rescue all the exceptions. It would
-  silently skip all exception or errors and handle the error.
+  silently skip all exceptions or errors and handle the error.
   Example: If `NoMethodError` is raised, modifier form rescue would
   handle the exception.
 
@@ -17100,7 +17101,7 @@ array.grep_v(regexp)
 | 0.29
 |===
 
-Enforces the use the shorthand for self-assignment.
+Enforces the use of the shorthand for self-assignment.
 
 [#examples-styleselfassignment]
 === Examples
@@ -19231,11 +19232,11 @@ foo = (bar = baz) ? a : b
 | -
 |===
 
-Newcomers to ruby applications may write top-level methods,
+Newcomers to Ruby applications may write top-level methods,
 when ideally they should be organized in appropriate classes or modules.
 This cop looks for definitions of top-level methods and warns about them.
 
-However for ruby scripts it is perfectly fine to use top-level methods.
+However, for Ruby scripts it is perfectly fine to use top-level methods.
 Hence this cop is disabled by default.
 
 [#examples-styletoplevelmethoddefinition]
@@ -20354,11 +20355,11 @@ This cop supports two styles:
 
 `forbid_mixed_logical_operators` style forbids the use of more than one type
 of logical operators. This makes the `unless` condition easier to read
-because either all conditions need to be met or any condition need to be met
+because either all conditions need to be met or any condition needs to be met
 in order for the expression to be truthy or falsey.
 
-`forbid_logical_operators` style forbids any use of logical operator.
-This makes it even more easy to read the `unless` condition as
+`forbid_logical_operators` style forbids any use of logical operators.
+This makes it even easier to read the `unless` condition as
 there is only one condition in the expression.
 
 [#examples-styleunlesslogicaloperators]

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -148,7 +148,7 @@ NodePattern.new('send').match(node) # => true
 
 It matches because the root is a `send` type. Now let's match it deeply using
 parentheses to define details for sub-nodes. If you don't care about what an internal
-node is, you can use `+...+` to skip it and just consider " a node".
+node is, you can use `+...+` to skip it and just consider "a node".
 
 [source,ruby]
 ----
@@ -455,7 +455,7 @@ end
 
 You can specify any gem requirement using https://guides.rubygems.org/patterns/#declaring-dependencies[the same syntax as your `Gemfile`].
 
-You can also handle multiple versions of a gem with `target_gem_version`. It behaves similar to `target_ruby_version`, allowing you to inspect a gem version at runtime:
+You can also handle multiple versions of a gem with `target_gem_version`. It behaves similarly to `target_ruby_version`, allowing you to inspect a gem version at runtime:
 
 [source,ruby]
 ----

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -47,7 +47,7 @@ $ rubocop --out result.txt
 # Both progress and offense count formats to $stdout.
 # The offense count formatter outputs only the final summary,
 # so you'll mostly see the outputs from the progress formatter,
-# and at the end the offense count summary will be outputted.
+# and at the end the offense count summary will be output.
 $ rubocop --format progress --format offenses
 
 # Progress format to $stdout and JSON format to the file rubocop.json.

--- a/docs/modules/ROOT/pages/plugins.adoc
+++ b/docs/modules/ROOT/pages/plugins.adoc
@@ -83,7 +83,7 @@ AllCops:
   SuggestExtensions: false
 ----
 
-Suggest default extensions if `SuggestExtensions: true`.
+Default extensions are suggested when `SuggestExtensions: true`.
 
 You can also opt-out of suggestions for a particular plugin as so (unspecified
 plugins will continue to be notified, as appropriate):

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -91,7 +91,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Choose a formatter, see xref:formatters.adoc[Formatters].
 
 | `-F/--fail-fast`
-| Inspect files in order of modification time and stops after first file with offenses.
+| Inspect files in order of modification time and stop after the first file with offenses.
 
 | `--fail-level`
 | Minimum xref:configuration/cop_settings.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like any autocorrectable offense to trigger failure, regardless of severity.
@@ -124,7 +124,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | List all files RuboCop will inspect.
 
 | `--[no-]auto-gen-only-exclude`
-| Generate only `Exclude` parameters and not `Max` when running `--auto-gen-config`, except if the number of files with offenses is bigger than `exclude-limit`. Default is false
+| Generate only `Exclude` parameters and not `Max` when running `--auto-gen-config`, except if the number of files with offenses is bigger than `exclude-limit`. Default is false.
 
 | `--[no-]auto-gen-timestamp`
 | Include the date and time when `--auto-gen-config` was run in the config file it generates. Default is true.

--- a/docs/modules/ROOT/pages/usage/lsp.adoc
+++ b/docs/modules/ROOT/pages/usage/lsp.adoc
@@ -12,7 +12,7 @@ Therefore, if you want real-time feedback from RuboCop in your editor or IDE,
 opting to use this language server instead of the server mode will not only provide a fast and efficient solution,
 but also offer a straightforward setup for integration.
 
-== Examples of LSP Client
+== Examples of LSP Clients
 
 Here are examples of LSP client configurations.
 
@@ -148,7 +148,7 @@ language-servers = [
 ]
 ----
 
-Before Helix 23.10 or earlier:
+Helix 23.10 or earlier:
 
 [source,toml]
 ----
@@ -181,9 +181,9 @@ Add the following to its settings (accessible via `Preferences → Package Setti
 
 == Autocorrection
 
-The language server supports `textDocument/formatting` method and is autocorrectable. The autocorrection is safe by default (`rubocop -a`).
+The language server supports the `textDocument/formatting` method and is autocorrectable. The autocorrection is safe by default (`rubocop -a`).
 
-LSP client can switch to unsafe autocorrection (`rubocop -A`) by passing the following `safeAutocorrect` parameter in the `initialize` request.
+An LSP client can switch to unsafe autocorrection (`rubocop -A`) by passing the following `safeAutocorrect` parameter in the `initialize` request.
 
 [source,json]
 ----
@@ -211,7 +211,7 @@ NOTE: The `rubocop.formatAutocorrectsAll` execute command was introduced in Rubo
 
 == Lint Mode
 
-LSP client can run lint cops by passing the following `lintMode` parameter in the `initialize` request
+An LSP client can run lint cops by passing the following `lintMode` parameter in the `initialize` request
 if you only want to enable the feature as a linter like `ruby -w`:
 
 [source,json]
@@ -236,7 +236,7 @@ NOTE: The `lintMode` parameter was introduced in RuboCop 1.55.
 
 == Layout Mode
 
-LSP client can run layout cops by passing the following `layoutMode` parameter in the `initialize` request
+An LSP client can run layout cops by passing the following `layoutMode` parameter in the `initialize` request
 if you only want to enable the feature as a formatter:
 
 [source,json]

--- a/docs/modules/ROOT/pages/usage/source_code_directives.adoc
+++ b/docs/modules/ROOT/pages/usage/source_code_directives.adoc
@@ -77,7 +77,7 @@ The syntax of directives can be checked using the cop `Lint/CopDirectiveSyntax`.
 == Temporarily Enabling Cops in Source Code
 
 In a similar way to disabling cops within source code, you can also temporarily enable specific
-cops if you want to enforce specific rules for part of the totality of a file.
+cops if you want to enforce specific rules for part of a file.
 
 Let's use the cop `Style/AsciiComments`, which is by default `Enabled: false`. Say you want a
 specific file to have ASCII-only comments to be compatible with some post-processing tool:

--- a/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
+++ b/docs/modules/ROOT/pages/v1_upgrade_notes.adoc
@@ -5,7 +5,7 @@
 
 Your custom cops should continue to work in v1.
 
-Nevertheless it is suggested that you tweak them to use the v1 API by following these steps:
+Nevertheless, it is suggested that you tweak them to use the v1 API by following these steps:
 
 1) Your class should inherit from `RuboCop::Cop::Base` instead of `RuboCop::Cop::Cop`.
 
@@ -39,7 +39,7 @@ end
 
 Your class must `extend AutoCorrector`.
 
-The `corrector` is now yielded from `add_offense`. Move the code of your method `autocorrect` in that block and do not wrap your correction in a lambda. `Corrector` are more powerful and can now be `merge`d.
+The `corrector` is now yielded from `add_offense`. Move the code of your method `autocorrect` into that block and do not wrap your correction in a lambda. `Corrector`s are more powerful and can now be `merge`d.
 
 ==== Example:
 
@@ -109,7 +109,7 @@ If your cop uses `investigate`, `investigate_post_walk`, `join_force?`, or inter
 
 === Upgrading specs
 
-It is highly recommended you use `expect_offense` / `expect_correction` / `expect_no_offense` in your specs, e.g.:
+It is highly recommended you use `expect_offense` / `expect_correction` / `expect_no_offenses` in your specs, e.g.:
 
 [source,ruby]
 ----

--- a/docs/modules/ROOT/partials/cops_layout_footer.adoc
+++ b/docs/modules/ROOT/partials/cops_layout_footer.adoc
@@ -12,8 +12,8 @@ is available on the following Layout cops:
 * MultilineMethodArgumentLineBreaks
 * MultilineMethodParameterLineBreaks
 
-Those cops ignore their respective expressions if all or the elements of
-the expression are on the same line. If `AllowMultilineFinalElement` is
+Those cops ignore their respective expressions if all of the elements
+of the expression are on the same line. If `AllowMultilineFinalElement` is
 set to `true`, the cop will also ignore multiline expressions if the last
 element starts on the same line, but ends on a different one.
 

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -3,12 +3,12 @@
 module RuboCop
   module Cop
     module Gemspec
-      # An attribute assignment method calls should be listed only once
+      # An attribute assignment method call should be listed only once
       # in a gemspec.
       #
       # Assigning to an attribute with the same name using `spec.foo =` or
       # `spec.attribute#[]=` will be an unintended usage. On the other hand,
-      # duplication of methods such # as `spec.requirements`,
+      # duplication of methods such as `spec.requirements`,
       # `spec.add_runtime_dependency`, and others are permitted because it is
       # the intended use of appending values.
       #

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Requires a gemspec to have `rubygems_mfa_required` metadata set.
       #
       # This setting tells RubyGems that MFA (Multi-Factor Authentication) is
-      # required for accounts to be able perform privileged operations, such as
+      # required for accounts to be able to perform privileged operations, such as
       # (see RubyGems' documentation for the full list of privileged
       # operations):
       #

--- a/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
+++ b/lib/rubocop/cop/gemspec/ruby_version_globals_usage.rb
@@ -4,10 +4,10 @@ module RuboCop
   module Cop
     module Gemspec
       # Checks that `RUBY_VERSION` and `Ruby::VERSION` constants are not used in gemspec.
-      # Using `RUBY_VERSION` and `Ruby::VERSION` are dangerous because value of the
+      # Using `RUBY_VERSION` and `Ruby::VERSION` is dangerous because the value of the
       # constant is determined by `rake release`.
-      # It's possible to have dependency based on ruby version used
-      # to execute `rake release` and not user's ruby version.
+      # It's possible to have a dependency based on the Ruby version used
+      # to execute `rake release` and not the user's Ruby version.
       #
       # @example
       #

--- a/lib/rubocop/cop/layout/begin_end_alignment.rb
+++ b/lib/rubocop/cop/layout/begin_end_alignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       # `Layout/EndAlignment` cop aligns with keywords (e.g. `if`, `while`, `case`)
       # by default. On the other hand, `||= begin` that this cop targets tends to
       # align with the start of the line, it defaults to `EnforcedStyleAlignWith: start_of_line`.
-      # These style can be configured by each cop.
+      # These styles can be configured by each cop.
       #
       # @example EnforcedStyleAlignWith: start_of_line (default)
       #   # bad

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -49,7 +49,7 @@ module RuboCop
       #      - private_methods
       # ----
       #
-      # Instead of putting all literals in the expected order, is also
+      # Instead of putting all literals in the expected order, it is also
       # possible to group categories of macros. Visibility levels are handled
       # automatically.
       #

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -19,10 +19,10 @@ module RuboCop
       #
       # This `Layout/EndAlignment` cop aligns with keywords (e.g. `if`, `while`, `case`)
       # by default. On the other hand, `Layout/BeginEndAlignment` cop aligns with
-      # `EnforcedStyleAlignWith: start_of_line` by default due to `||= begin` tends
+      # `EnforcedStyleAlignWith: start_of_line` by default because `||= begin` tends
       # to align with the start of the line. `Layout/DefEndAlignment` cop also aligns with
       # `EnforcedStyleAlignWith: start_of_line` by default.
-      # These style can be configured by each cop.
+      # These styles can be configured by each cop.
       #
       # @example EnforcedStyleAlignWith: keyword (default)
       #   # bad

--- a/lib/rubocop/cop/layout/space_before_brackets.rb
+++ b/lib/rubocop/cop/layout/space_before_brackets.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Layout
       # Checks for space between the name of a receiver and a left
-      # brackets.
+      # bracket.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -7,7 +7,7 @@ module RuboCop
       # when param passed without parentheses.
       #
       # This cop can customize allowed methods with `AllowedMethods`.
-      # By default, there are no methods to allowed.
+      # By default, there are no allowed methods.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
+++ b/lib/rubocop/cop/lint/constant_overwritten_in_rescue.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for overwriting an exception with an exception result by use ``rescue =>``.
+      # Checks for overwriting an exception with an exception result by using ``rescue =>``.
       #
       # You intended to write as `rescue StandardError`.
       # However, you have written `rescue => StandardError`.

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -13,12 +13,12 @@ module RuboCop
       #
       # Large projects will over time end up with one or two constant names that
       # are problematic because of a conflict with a library or just internally
-      # using the same name a namespace and a class. To avoid too many unnecessary
-      # offenses, Enable this cop with `Only: [The, Constant, Names, Causing, Issues]`
+      # using the same name for a namespace and a class. To avoid too many unnecessary
+      # offenses, enable this cop with `Only: [The, Constant, Names, Causing, Issues]`
       #
-      # NOTE: `Style/RedundantConstantBase` cop is disabled if this cop is enabled to prevent
-      # conflicting rules. Because it respects user configurations that want to enable
-      # this cop which is disabled by default.
+      # NOTE: `Style/RedundantConstantBase` cop is disabled if this cop is enabled,
+      # to prevent conflicting rules. This is because it respects user configurations
+      # that want to enable this cop which is disabled by default.
       #
       # @example
       #   # By default checks every constant

--- a/lib/rubocop/cop/lint/deprecated_constants.rb
+++ b/lib/rubocop/cop/lint/deprecated_constants.rb
@@ -14,7 +14,7 @@ module RuboCop
       #       Alternative: 'alternative_value'
       #       DeprecatedVersion: 'deprecated_version'
       #
-      # By default, `NIL`, `TRUE`, `FALSE`, `Net::HTTPServerException, `Random::DEFAULT`,
+      # By default, `NIL`, `TRUE`, `FALSE`, `Net::HTTPServerException`, `Random::DEFAULT`,
       # `Struct::Group`, and `Struct::Passwd` are configured.
       #
       # @example

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -23,7 +23,7 @@ module RuboCop
       # `ERB.new` with non-keyword arguments is deprecated since ERB 2.2.0.
       # Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.
       # This cop identifies places where `ERB.new(str, trim_mode, eoutvar)` can
-      # be replaced by `ERB.new(str, :trim_mode: trim_mode, eoutvar: eoutvar)`.
+      # be replaced by `ERB.new(str, trim_mode: trim_mode, eoutvar: eoutvar)`.
       #
       # @example
       #   # Target codes supports Ruby 2.6 and higher only

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -6,7 +6,7 @@ module RuboCop
     module Lint
       # Checks that there is an `# rubocop:enable ...` statement
       # after a `# rubocop:disable ...` statement. This will prevent leaving
-      # cop disables on wide ranges of code, that latter contributors to
+      # cop disables on wide ranges of code, that later contributors to
       # a file wouldn't be aware of.
       #
       # You can set `MaximumRangeSize` to define the maximum number of

--- a/lib/rubocop/cop/lint/multiple_comparison.rb
+++ b/lib/rubocop/cop/lint/multiple_comparison.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     module Lint
       # In math and Python, we can use `x < y < z` style comparison to compare
-      # multiple value. However, we can't use the comparison in Ruby. However,
-      # the comparison is not syntax error. This cop checks the bad usage of
+      # multiple values. However, we can't use the comparison in Ruby. However,
+      # the comparison is not a syntax error. This cop checks the bad usage of
       # comparison operators.
       #
       # @example

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -12,7 +12,7 @@ module RuboCop
       # always sort the list.
       #
       # `Dir.glob` and `Dir[]` sort globbed results by default in Ruby 3.0.
-      # So all bad cases are acceptable when Ruby 3.0 or higher are used.
+      # So all bad cases are acceptable when Ruby 3.0 or higher is used.
       #
       # NOTE: This cop will be deprecated and removed when supporting only Ruby 3.0 and higher.
       #

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -3,9 +3,9 @@
 module RuboCop
   module Cop
     module Lint
-      # Warns the usage of unsafe number conversions. Unsafe
-      # number conversion can cause unexpected error if auto type conversion
-      # fails. Cop prefer parsing with number class instead.
+      # Warns against the usage of unsafe number conversions. Unsafe
+      # number conversion can cause an unexpected error if auto type conversion
+      # fails. The cop prefers parsing with a number class instead.
       #
       # Conversion with `Integer`, `Float`, etc. will raise an `ArgumentError`
       # if given input that is not numeric (eg. an empty string), whereas
@@ -14,10 +14,10 @@ module RuboCop
       # always correct to raise if a value is not numeric.
       #
       # NOTE: Some values cannot be converted properly using one of the `Kernel`
-      # method (for instance, `Time` and `DateTime` values are allowed by this
+      # methods (for instance, `Time` and `DateTime` values are allowed by this
       # cop by default). Similarly, Rails' duration methods do not work well
       # with `Integer()` and can be allowed with `AllowedMethods`. By default,
-      # there are no methods to allowed.
+      # there are no allowed methods.
       #
       # @safety
       #   Autocorrection is unsafe because it is not guaranteed that the

--- a/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
+++ b/lib/rubocop/cop/lint/numbered_parameter_assignment.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]
       #   -e:1: _1 is reserved for numbered parameter
       #
-      # NOTE: The parametered parameters are from `_1` to `_9`. This cop checks `_0`, and over `_10`
+      # NOTE: The numbered parameters are from `_1` to `_9`. This cop checks `_0`, and over `_10`
       # as well to prevent confusion.
       #
       # @example

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -6,8 +6,8 @@ module RuboCop
       # Detects instances of rubocop:enable comments that can be
       # removed.
       #
-      # When comment enables all cops at once `rubocop:enable all`
-      # that cop checks whether any cop was actually enabled.
+      # When a comment enables all cops at once `rubocop:enable all`
+      # the cop checks whether any cop was actually enabled.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -17,14 +17,14 @@ module RuboCop
       #   or with `String.new` or `String()`.
       # * `to_sym` when called on a symbol literal or interpolated symbol.
       # * `to_i` when called on an integer literal or with `Integer()`.
-      # * `to_f` when called on a float literal of with `Float()`.
+      # * `to_f` when called on a float literal or with `Float()`.
       # * `to_r` when called on a rational literal or with `Rational()`.
-      # * `to_c` when called on a complex literal of with `Complex()`.
+      # * `to_c` when called on a complex literal or with `Complex()`.
       # * `to_a` when called on an array literal, or with `Array.new`, `Array()` or `Array[]`.
       # * `to_h` when called on a hash literal, or with `Hash.new`, `Hash()` or `Hash[]`.
       # * `to_set` when called on `Set.new` or `Set[]`.
       #
-      # In all cases, chaining one same `to_*` conversion methods listed above is redundant.
+      # In all cases, chaining one of the same `to_*` conversion methods listed above is redundant.
       #
       # The cop can also register an offense for chaining conversion methods on methods that are
       # expected to return a specific type regardless of receiver (eg. `foo.inspect.to_s` and

--- a/lib/rubocop/cop/lint/require_relative_self_path.rb
+++ b/lib/rubocop/cop/lint/require_relative_self_path.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for uses a file requiring itself with `require_relative`.
+      # Checks for a file requiring itself with `require_relative`.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for a rescued exception that get shadowed by a
+      # Checks for a rescued exception that gets shadowed by a
       # less specific exception being rescued before a more specific
       # exception is rescued.
       #

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for Regexpes (both literals and via `Regexp.new` / `Regexp.compile`)
+      # Checks for Regexps (both literals and via `Regexp.new` / `Regexp.compile`)
       # that contain unescaped `]` characters.
       #
       # It emulates the following Ruby warning:

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     module Lint
       # Checks for unreachable code.
-      # The check are based on the presence of flow of control
-      # statement in non-final position in `begin` (implicit) blocks.
+      # The check is based on the presence of flow-of-control
+      # statements in non-final position in `begin` (implicit) blocks.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Looks for `ruby2_keywords` calls for methods that do not need it.
       #
       # `ruby2_keywords` should only be called on methods that accept an argument splat
-      # (`\*args`) but do not explicit keyword arguments (`k:` or `k: true`) or
+      # (`\*args`) but do not have explicit keyword arguments (`k:` or `k: true`) or
       # a keyword splat (`**kwargs`).
       #
       # @example

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -17,7 +17,7 @@ module RuboCop
       #
       # NOTE: The `ExcludedMethods` configuration is deprecated and only kept
       # for backwards compatibility. Please use `AllowedMethods` and `AllowedPatterns`
-      # instead. By default, there are no methods to allowed.
+      # instead. By default, there are no allowed methods.
       #
       # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -15,7 +15,7 @@ module RuboCop
       # NOTE: The `ExcludedMethods` and `IgnoredMethods` configuration is
       # deprecated and only kept for backwards compatibility.
       # Please use `AllowedMethods` and `AllowedPatterns` instead.
-      # By default, there are no methods to allowed.
+      # By default, there are no allowed methods.
       #
       # @example CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
       #

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Naming
       # Makes sure that certain binary operator methods have their
-      # sole  parameter named `other`.
+      # sole parameter named `other`.
       #
       # @example
       #

--- a/lib/rubocop/cop/naming/predicate_method.rb
+++ b/lib/rubocop/cop/naming/predicate_method.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks that predicate methods end with `?` and non-predicate methods do not.
       #
       # The names of predicate methods (methods that return a boolean value) should end
-      # in a question mark. Methods that don't return a boolean, shouldn't
+      # in a question mark. Methods that don't return a boolean shouldn't
       # end in a question mark.
       #
       # The cop assesses a predicate method as one that returns boolean values. Likewise,
@@ -22,7 +22,7 @@ module RuboCop
       # return values are detected.
       #
       # The cop also has `AllowedMethods` configuration in order to prevent the cop from
-      # registering an offense from a method name that does not confirm to the naming
+      # registering an offense from a method name that does not conform to the naming
       # guidelines. By default, `call` is allowed. The cop also has `AllowedPatterns`
       # configuration to allow method names by regular expression.
       #

--- a/lib/rubocop/cop/naming/predicate_prefix.rb
+++ b/lib/rubocop/cop/naming/predicate_prefix.rb
@@ -17,7 +17,7 @@ module RuboCop
       # they end with a `?`. These methods should be changed to remove the
       # prefix.
       #
-      # When `UseSorbetSigs` set to true (optional), the cop will only report
+      # When `UseSorbetSigs` is set to true (optional), the cop will only report
       # offenses if the method has a Sorbet `sig` with a return type of
       # `T::Boolean`. Dynamic methods are not supported with this configuration.
       #

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # Makes sure that rescued exceptions variables are named as
+      # Makes sure that rescued exception variables are named as
       # expected.
       #
       # The `PreferredName` config option takes a `String`. It represents

--- a/lib/rubocop/cop/security/io_methods.rb
+++ b/lib/rubocop/cop/security/io_methods.rb
@@ -10,7 +10,7 @@ module RuboCop
       # a subprocess is created in the same way as `Kernel#open`, and its output is returned.
       # `Kernel#open` may allow unintentional command injection, which is the reason these
       # `IO` methods are a security risk.
-      # Consider to use `File.read` to disable the behavior of subprocess invocation.
+      # Consider using `File.read` to disable the behavior of subprocess invocation.
       #
       # @safety
       #   This cop is unsafe because false positive will occur if the variable passed as

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -10,7 +10,7 @@ module RuboCop
       # is resolved at runtime).
       # It also flags uses of `alias :symbol` rather than `alias bareword`.
       #
-      # However, it will always enforce `method_alias` when used `alias`
+      # However, it will always enforce `alias_method` when `alias` is used
       # in an instance method definition and in a singleton method definition.
       # If used in a block, always enforce `alias_method`
       # unless it is an `instance_eval` block.

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -8,8 +8,8 @@ module RuboCop
       # essentially one-character strings, so this syntax
       # is mostly redundant at this point.
       #
-      # ? character literal can be used to express meta and control character.
-      # That's a good use case of ? literal so it doesn't count it as an offense.
+      # A `?` character literal can be used to express meta and control characters.
+      # That's a good use case of a `?` literal so it doesn't count as an offense.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module Style
       # Detects comments to enable/disable RuboCop.
-      # This is useful if want to make sure that every RuboCop error gets fixed
+      # This is useful if you want to make sure that every RuboCop error gets fixed
       # and not quickly disabled with a comment.
       #
       # Specific cops can be allowed with the `AllowedCops` configuration. Note that

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -11,9 +11,10 @@ module RuboCop
       # if the first argument is a string literal and if the second
       # argument is an array literal.
       #
-      # Autocorrection will be applied when using argument is a literal or known built-in conversion
-      # methods such as `to_d`, `to_f`, `to_h`, `to_i`, `to_r`, `to_s`, and `to_sym` on variables,
-      # provided that their return value is not an array. For example, when using `to_s`,
+      # Autocorrection will be applied when the argument is a literal or uses a known
+      # built-in conversion method such as `to_d`, `to_f`, `to_h`, `to_i`, `to_r`, `to_s`,
+      # and `to_sym` on variables, provided that their return value is not an array.
+      # For example, when using `to_s`,
       # `'%s' % [1, 2, 3].to_s` can be autocorrected without any incompatibility:
       #
       # [source,ruby]

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -10,7 +10,7 @@ module RuboCop
       # Required capitalization can be set with the `DirectiveCapitalization` and
       # `ValueCapitalization` configuration keys.
       #
-      # NOTE: If one of these configuration is set to nil, any capitalization is allowed.
+      # NOTE: If one of these configurations is set to nil, any capitalization is allowed.
       #
       # @example EnforcedStyle: snake_case (default)
       #   # The `snake_case` style will enforce that the frozen string literal

--- a/lib/rubocop/cop/style/min_max_comparison.rb
+++ b/lib/rubocop/cop/style/min_max_comparison.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Enforces the use of `max` or `min` instead of comparison for greater or less.
       #
       # NOTE: It can be used if you want to present limit or threshold in Ruby 2.7+.
-      # That it is slow though. So autocorrection will apply generic `max` or `min`:
+      # It is slow though. So autocorrection will apply generic `max` or `min`:
       #
       # [source,ruby]
       # ----

--- a/lib/rubocop/cop/style/redundant_array_constructor.rb
+++ b/lib/rubocop/cop/style/redundant_array_constructor.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for the instantiation of array using redundant `Array` constructor.
-      # Autocorrect replaces to array literal which is the simplest and fastest.
+      # Checks for the instantiation of an array using a redundant `Array` constructor.
+      # Autocorrect replaces it with an array literal which is the simplest and fastest.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/redundant_constant_base.rb
+++ b/lib/rubocop/cop/style/redundant_constant_base.rb
@@ -3,16 +3,16 @@
 module RuboCop
   module Cop
     module Style
-      # Avoid redundant `::` prefix on constant.
+      # Avoid redundant `::` prefix on a constant.
       #
-      # How Ruby searches constant is a bit complicated, and it can often be difficult to
+      # How Ruby searches constants is a bit complicated, and it can often be difficult to
       # understand from the code whether the `::` is intended or not. Where `Module.nesting`
       # is empty, there is no need to prepend `::`, so it would be nice to consistently
       # avoid such meaningless `::` prefix to avoid confusion.
       #
-      # NOTE: This cop is disabled if `Lint/ConstantResolution` cop is enabled to prevent
-      # conflicting rules. Because it respects user configurations that want to enable
-      # `Lint/ConstantResolution` cop which is disabled by default.
+      # NOTE: This cop is disabled if `Lint/ConstantResolution` cop is enabled,
+      # to prevent conflicting rules. This is because it respects user configurations
+      # that want to enable `Lint/ConstantResolution` cop which is disabled by default.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/redundant_regexp_constructor.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_constructor.rb
@@ -3,8 +3,8 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for the instantiation of regexp using redundant `Regexp.new` or `Regexp.compile`.
-      # Autocorrect replaces to regexp literal which is the simplest and fastest.
+      # Checks for the instantiation of a regexp using a redundant `Regexp.new` or `Regexp.compile`.
+      # Autocorrect replaces it with a regexp literal which is the simplest and fastest.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Style
       # Enforces using `//` or `%r` around regular expressions.
       #
-      # NOTE: The following `%r` cases using a regexp starts with a blank or `=`
-      # as a method argument allowed to prevent syntax errors.
+      # NOTE: The following `%r` cases using a regexp that starts with a blank or `=`
+      # as a method argument are allowed to prevent syntax errors.
       #
       # [source,ruby]
       # ----

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -3,17 +3,17 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for uses of `rescue` in its modifier form is added for following
+      # Checks for uses of `rescue` in its modifier form. It is added for the following
       # reasons:
       #
       # * The syntax of modifier form `rescue` can be misleading because it
       #   might lead us to believe that `rescue` handles the given exception
-      #   but it actually rescue all exceptions to return the given rescue
+      #   but it actually rescues all exceptions to return the given rescue
       #   block. In this case, value returned by handle_error or
       #   SomeException.
       #
       # * Modifier form `rescue` would rescue all the exceptions. It would
-      #   silently skip all exception or errors and handle the error.
+      #   silently skip all exceptions or errors and handle the error.
       #   Example: If `NoMethodError` is raised, modifier form rescue would
       #   handle the exception.
       #

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Enforces the use the shorthand for self-assignment.
+      # Enforces the use of the shorthand for self-assignment.
       #
       # @example
       #

--- a/lib/rubocop/cop/style/top_level_method_definition.rb
+++ b/lib/rubocop/cop/style/top_level_method_definition.rb
@@ -3,11 +3,11 @@
 module RuboCop
   module Cop
     module Style
-      # Newcomers to ruby applications may write top-level methods,
+      # Newcomers to Ruby applications may write top-level methods,
       # when ideally they should be organized in appropriate classes or modules.
       # This cop looks for definitions of top-level methods and warns about them.
       #
-      # However for ruby scripts it is perfectly fine to use top-level methods.
+      # However, for Ruby scripts it is perfectly fine to use top-level methods.
       # Hence this cop is disabled by default.
       #
       # @example

--- a/lib/rubocop/cop/style/unless_logical_operators.rb
+++ b/lib/rubocop/cop/style/unless_logical_operators.rb
@@ -14,11 +14,11 @@ module RuboCop
       #
       # `forbid_mixed_logical_operators` style forbids the use of more than one type
       # of logical operators. This makes the `unless` condition easier to read
-      # because either all conditions need to be met or any condition need to be met
+      # because either all conditions need to be met or any condition needs to be met
       # in order for the expression to be truthy or falsey.
       #
-      # `forbid_logical_operators` style forbids any use of logical operator.
-      # This makes it even more easy to read the `unless` condition as
+      # `forbid_logical_operators` style forbids any use of logical operators.
+      # This makes it even easier to read the `unless` condition as
       # there is only one condition in the expression.
       #
       # @example EnforcedStyle: forbid_mixed_logical_operators (default)


### PR DESCRIPTION
Goes through every `.adoc` doc page (hand-written and auto-generated) and fixes a batch of typos, missing/duplicate words, subject-verb agreement issues, and other clear grammar mistakes. For the auto-generated `cops_*.adoc` files, the fixes are applied to the YARD comments in the cop source files.

Notable fixes:

- `method_alias` -> `alias_method` in `Style/Alias` description
- `Regexpes` -> `Regexps` in `Lint/UnescapedBracketInRegexp`
- `parametered parameters` -> `numbered parameters` in `Lint/NumberedParameterAssignment`
- A number of subject/verb agreement errors (`The check are` -> `The check is`, etc.)
- Several `there are no methods to allowed` -> `there are no allowed methods`
- Missing articles, wrong prepositions (`of with` -> `or with`, `to allowed` -> `allowed`, etc.)
- Capitalization fixes (`ruby` -> `Ruby` where it refers to the language)
- Various rephrasings of sentences that were ungrammatical or hard to parse

The full `bundle exec rake update_cops_documentation internal_investigation` passes.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. (Docs syntax check + self-lint pass; full spec run not needed for doc-only changes.)
* [x] Added an entry to the changelog folder.