### PR TITLE
Fix incorrect autocorrect for `Style/HashConversion` cop

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_hash_conversion_anonymous_splat.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_hash_conversion_anonymous_splat.md
@@ -1,0 +1,1 @@
+* [#15186](https://github.com/rubocop/rubocop/pull/15186): Fix incorrect autocorrect for `Style/HashConversion` causing a syntax error when `Hash[...]` is passed an anonymous splat (`*`). ([@koic][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -73,7 +73,7 @@ module RuboCop
           first_argument = node.first_argument
           if first_argument.hash_type?
             register_offense_for_hash(node, first_argument)
-          elsif first_argument.splat_type?
+          elsif first_argument.type?(:splat, :forwarded_restarg)
             add_offense(node, message: MSG_SPLAT) unless allowed_splat_argument?
           elsif use_zip_method_without_argument?(first_argument)
             register_offense_for_zip_method(node, first_argument)

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -227,6 +227,14 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
         Hash[*ary]
       RUBY
     end
+
+    it 'does not register an offense for an anonymous splat (`*`)', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*)
+          Hash[*]
+        end
+      RUBY
+    end
   end
 
   context 'AllowSplatArgument: false' do
@@ -236,6 +244,17 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
       expect_offense(<<~RUBY)
         Hash[*ary]
         ^^^^^^^^^^ Prefer `array_of_pairs.to_h` to `Hash[*array]`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'reports uncorrectable offense for an anonymous splat (`*`)', :ruby32 do
+      expect_offense(<<~RUBY)
+        def foo(*)
+          Hash[*]
+          ^^^^^^^ Prefer `array_of_pairs.to_h` to `Hash[*array]`.
+        end
       RUBY
 
       expect_no_corrections


### PR DESCRIPTION
This fixes a syntax error caused by `Style/HashConversion` when the single argument to `Hash[...]` is an anonymous splat (`*`). The cop previously only skipped autocorrection for the named splat (`Hash[*ary]`), so once `Style/ArgumentsForwarding` rewrote `def foo(*args); Hash[*args]; end` to `def foo(*); Hash[*]; end`, this cop tried to convert `Hash[*]` to `(*).to_h`, producing invalid Ruby like `*.to_h`.

The cop now also treats `forwarded_restarg` (anonymous splat) the same as `splat`, leaving `Hash[*]` untouched.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
