### PR TITLE
[Fix #15185] Make `Layout/EmptyLineAfterGuardClause` accept new SimpleCov directives

### DIFF
--- a/changelog/new_make_layout_empty_line_after_guard_clause_accept_simplecov_directives.md
+++ b/changelog/new_make_layout_empty_line_after_guard_clause_accept_simplecov_directives.md
@@ -1,0 +1,1 @@
+* [#15185](https://github.com/rubocop/rubocop/issues/15185): Make `Layout/EmptyLineAfterGuardClause` accept the new `# simplecov:disable` and `# simplecov:enable` directive comments. ([@koic][])

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -5,8 +5,10 @@ module RuboCop
     module Layout
       # Enforces empty line after guard clause.
       #
-      # This cop allows `# :nocov:` directive after guard clause because
-      # SimpleCov excludes code from the coverage report by wrapping it in `# :nocov:`:
+      # This cop allows a SimpleCov directive comment after guard clause because
+      # SimpleCov excludes code from the coverage report by wrapping it in such directives.
+      # Both the legacy `# :nocov:` comment and the newer `# simplecov:disable` /
+      # `# simplecov:enable` comments are recognized:
       #
       # [source,ruby]
       # ----
@@ -14,6 +16,13 @@ module RuboCop
       #   # :nocov:
       #   return if condition
       #   # :nocov:
+      #   bar
+      # end
+      #
+      # def foo
+      #   # simplecov:disable
+      #   return if condition
+      #   # simplecov:enable
       #   bar
       # end
       # ----
@@ -58,7 +67,7 @@ module RuboCop
 
         MSG = 'Add empty line after guard clause.'
         END_OF_HEREDOC_LINE = 1
-        SIMPLE_DIRECTIVE_COMMENT_PATTERN = /\A# *:nocov:\z/.freeze
+        SIMPLECOV_COMMENT_PATTERN = /\A#\s*(?::nocov:|simplecov\s*:\s*(?:disable|enable)\b)/.freeze
 
         # @!method guard_clause_branch?(node)
         def_node_matcher :guard_clause_branch?, <<~PATTERN
@@ -213,10 +222,10 @@ module RuboCop
           parent.begin_type? && same_line?(node, node.right_sibling)
         end
 
-        # SimpleCov excludes code from the coverage report by wrapping it in `# :nocov:`:
+        # SimpleCov excludes code from the coverage report by wrapping it in directive comments:
         # https://github.com/simplecov-ruby/simplecov#ignoringskipping-code
         def simplecov_directive_comment?(comment)
-          SIMPLE_DIRECTIVE_COMMENT_PATTERN.match?(comment.text)
+          SIMPLECOV_COMMENT_PATTERN.match?(comment.text)
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_guard_clause_spec.rb
@@ -340,6 +340,88 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterGuardClause, :config do
     RUBY
   end
 
+  it 'accepts using guard clause is after `:nocov:` comment with a trailing reason' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # :nocov: legacy adapter
+        return if condition
+        # :nocov: legacy adapter
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause wrapped in `# simplecov:disable` / `# simplecov:enable` comments' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # simplecov:disable
+        return if condition
+        # simplecov:enable
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause after `# simplecov:enable` with categories and a reason' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # simplecov:disable line, branch legacy adapter
+        return if condition
+        # simplecov:enable line, branch legacy adapter
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause after `# simplecov:enable` without a space after `#`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        #simplecov:disable
+        return if condition
+        #simplecov:enable
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts a guard clause after `# simplecov : enable` with spaces around the colon' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        # simplecov : disable
+        return if condition
+        # simplecov : enable
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense when no empty line follows the closing `# simplecov:enable` comment' do
+    expect_offense(<<~RUBY)
+      def foo
+        # simplecov:disable
+        return if condition
+        ^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        # simplecov:enable
+        bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        # simplecov:disable
+        return if condition
+        # simplecov:enable
+
+        bar
+      end
+    RUBY
+  end
+
   it 'accepts a guard clause inside oneliner block' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
SimpleCov deprecates the `# :nocov:` toggle comment in favor of the new `# simplecov:disable` / `# simplecov:enable` directive comments.

This makes `Layout/EmptyLineAfterGuardClause` recognize the new directives in addition to `# :nocov:`, so wrapping a guard clause in them no longer registers a false offense. `# :nocov:` is only deprecated and still works, so both forms are supported.

Fixes #15185.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
