### PR TITLE
[Fix #15188] Fix false positives for `Style/YodaCondition`

### DIFF
--- a/changelog/fix_false_positives_in_style_yoda_condition.md
+++ b/changelog/fix_false_positives_in_style_yoda_condition.md
@@ -1,0 +1,1 @@
+* [#15188](https://github.com/rubocop/rubocop/issues/15188): Fix false positives in `Style/YodaCondition` when one side is an array or hash literal containing non-literal elements. ([@koic][])

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -147,7 +147,7 @@ module RuboCop
         end
 
         def constant_portion?(node)
-          node.literal? || node.const_type?
+          node.recursive_literal? || node.const_type?
         end
 
         def actual_code_range(node)

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe RuboCop::Cop::Style::YodaCondition, :config do
       expect_no_offenses('[1, 2, 3] <=> [4, 5, 6]')
     end
 
+    it 'accepts array literal containing a non-literal element on left' do
+      expect_no_offenses('[x] == [x].do_something')
+    end
+
+    it 'accepts hash literal containing a non-literal value on left' do
+      expect_no_offenses('{a: x} == foo')
+    end
+
+    it 'accepts array literal containing a splat on left', :ruby32 do
+      expect_no_offenses(<<~RUBY)
+        def foo(*)
+          [*] == [*].do_something
+        end
+      RUBY
+    end
+
     it 'accepts negation' do
       expect_no_offenses('!true')
       expect_no_offenses('not true')


### PR DESCRIPTION
This PR fixes false positives for `Style/YodaCondition` when one side is an array or hash literal containing non-literal elements, such as `[x] == [x].compact` or `{a: x} == foo`.

`[x]` is not purely constant like `42`, since its value depends on the surrounding variable. Flipping the operands provides no readability benefit in those cases.

The check now uses the recursive literal predicate so that composite literals are treated as the "constant side" only when every element is itself a literal.

Fixes #15188.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
