### PR TITLE
Fix incorrect autocorrect for `Style/StructInheritance` cop

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_style_struct_inheritance.md
+++ b/changelog/fix_incorrect_autocorrect_for_style_struct_inheritance.md
@@ -1,0 +1,1 @@
+* [#15192](https://github.com/rubocop/rubocop/pull/15192): Fix incorrect autocorrect for `Style/StructInheritance` causing a syntax error when the inherited `Struct.new` is called without parentheses. ([@koic][])

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -61,6 +61,8 @@ module RuboCop
             corrector.remove(range_with_surrounding_space(parent.loc.end, newlines: false))
           elsif (class_node = parent.parent).body.nil?
             corrector.remove(range_for_empty_class_body(class_node, parent))
+          elsif unparenthesized_struct_new?(parent)
+            wrap_unparenthesized_call_with_do(corrector, parent)
           else
             corrector.insert_after(parent, ' do')
           end
@@ -72,6 +74,17 @@ module RuboCop
           else
             range_by_whole_lines(class_node.loc.end, include_final_newline: true)
           end
+        end
+
+        def unparenthesized_struct_new?(parent)
+          parent.send_type? && parent.arguments.any? && !parent.parenthesized?
+        end
+
+        def wrap_unparenthesized_call_with_do(corrector, parent)
+          args_source = parent.arguments.map(&:source).join(', ')
+          range = parent.loc.selector.end.join(parent.source_range.end)
+
+          corrector.replace(range, "(#{args_source}) do")
         end
       end
     end

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance, :config do
     RUBY
   end
 
+  it 'registers an offense and adds parentheses when extending instance of Struct without parentheses' do
+    expect_offense(<<~RUBY)
+      class Person < Struct.new :first_name, :last_name
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`. Use a block to customize the struct.
+        def foo; end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Person = Struct.new(:first_name, :last_name) do
+        def foo; end
+      end
+    RUBY
+  end
+
   it 'registers an offense when extending instance of ::Struct' do
     expect_offense(<<~RUBY)
       class Person < ::Struct.new(:first_name, :last_name)


### PR DESCRIPTION
This fixes a syntax error caused by `Style/StructInheritance` when the inherited `Struct.new` is called without parentheses. Previously the cop inserted ` do` at the end of the parent send's source range. When `Style/MethodCallWithArgsParentheses` ran in the same iteration, it inserted a closing paren at the same position, producing invalid `Struct.new(:a, :b do)` with `do` inside the argument list.

The cop now wraps the unparenthesized argument list in parentheses and appends ` do` as a single combined edit, eliminating the position conflict.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
