### PR TITLE
Fix `--start-server` to block until the server is actually running

### DIFF
--- a/changelog/fix_a_flaky_spec_for_restart_server_20260602093117.md
+++ b/changelog/fix_a_flaky_spec_for_restart_server_20260602093117.md
@@ -1,0 +1,1 @@
+* [#15196](https://github.com/rubocop/rubocop/pull/15196): Fix `--start-server` to wait until the server is running before returning, which fixes a flaky `--restart-server` spec and a race for commands run right after starting the server. ([@koic][])

--- a/lib/rubocop/server/core.rb
+++ b/lib/rubocop/server/core.rb
@@ -57,6 +57,12 @@ module RuboCop
         end
 
         Process.waitpid(pid)
+
+        # The daemon writes its pid file asynchronously after forking, so wait until
+        # the server is actually running before returning. This prevents a race where
+        # a subsequent command (e.g. `--restart-server`) observes an inconsistent
+        # state right after `--start-server` returns.
+        Server.wait_for_running_status!(true)
       end
 
       def write_port_and_token_files

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -146,6 +146,15 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           output = `ruby -I . "#{rubocop}" --start-server`
           expect(output).to match(/RuboCop server starting on \d+\.\d+\.\d+\.\d+:\d+\./)
         end
+
+        it 'reports the server as running immediately after the command returns' do
+          _stdout, stderr, status = Open3.capture3("ruby -I . \"#{rubocop}\" --start-server")
+          expect(stderr).to eq('')
+          expect(status).to be_success
+
+          server_status = `ruby -I . "#{rubocop}" --server-status`
+          expect(server_status).to match(/RuboCop server \(\d+\) is running\./)
+        end
       end
 
       describe '--stop-server' do


### PR DESCRIPTION
`--start-server` forked the daemon and returned before the daemon had written its pid file, so the command could finish while RuboCop's own `running?` predicate, which reads the pid file, was still false. Any command that gates on that predicate right after starting the server, such as `--server-status`, `--stop-server`, or `--restart-server`, could then observe an inconsistent state. For example `--restart-server` would see the server as not running, skip the stop, and then refuse to start because the daemon had meanwhile come up, leaving nothing on stdout.

Wait until the server is actually running before `--start-server` returns, so that subsequent commands, and user scripts that start the server and immediately use it, observe a consistent state.

This also removes the source of a flaky `--restart-server` spec, which was reliably hitting the race by chaining the commands with no delay.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
