### PR TITLE
Make cop descriptions consistently start with a verb

### DIFF
--- a/changelog/change_make_cop_descriptions_consistently_start_with_a_20260602082454.md
+++ b/changelog/change_make_cop_descriptions_consistently_start_with_a_20260602082454.md
@@ -1,0 +1,1 @@
+* [#15198](https://github.com/rubocop/rubocop/pull/15198): Reword cop descriptions that did not start with a verb (e.g. `Lint/UnreachableCode`, `Metrics/AbcSize`, `Security/Eval`) for consistency. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -490,7 +490,7 @@ Layout/BlockEndNewline:
   VersionAdded: '0.49'
 
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/(when|in)/[else/]end.'
+  Description: 'Checks how the `when` and `in` clauses of a `case` expression are indented.'
   StyleGuide: '#indent-when-to-case'
   Enabled: true
   VersionAdded: '0.49'
@@ -541,7 +541,7 @@ Layout/ClosingParenthesisIndentation:
   IndentationWidth: ~
 
 Layout/CommentIndentation:
-  Description: 'Indentation of comments.'
+  Description: 'Checks the indentation of comments.'
   Enabled: true
   # When true, allows comments to have extra indentation if that aligns them
   # with a comment on the preceding line.
@@ -2001,7 +2001,7 @@ Lint/FloatOutOfRange:
   VersionAdded: '0.36'
 
 Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
+  Description: 'Checks for a mismatch between the format fields and the arguments to `format`/`sprintf`/`%`.'
   Enabled: true
   VersionAdded: '0.33'
 
@@ -2584,7 +2584,7 @@ Lint/UnmodifiedReduceAccumulator:
   VersionChanged: '1.5'
 
 Lint/UnreachableCode:
-  Description: 'Unreachable code.'
+  Description: 'Checks for unreachable code.'
   Enabled: true
   VersionAdded: '0.9'
 
@@ -2729,7 +2729,7 @@ Lint/UselessTimes:
   VersionChanged: '1.61'
 
 Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
+  Description: 'Checks for operators, literals, lambdas, and procs used in void context.'
   Enabled: true
   AutoCorrect: contextual
   VersionAdded: '0.9'
@@ -2739,9 +2739,7 @@ Lint/Void:
 #################### Metrics ###############################
 
 Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
+  Description: 'Checks that the ABC size of methods is not higher than the configured maximum.'
   References:
     - https://wiki.c2.com/?AbcMetric
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
@@ -2798,9 +2796,7 @@ Metrics/CollectionLiteralLength:
 
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
+  Description: 'Checks that the cyclomatic complexity of methods is not higher than the configured maximum.'
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
@@ -2840,9 +2836,7 @@ Metrics/ParameterLists:
   MaxOptionalParameters: 3
 
 Metrics/PerceivedComplexity:
-  Description: >-
-                 A complexity metric geared towards measuring complexity for a
-                 human reader.
+  Description: 'Checks that the perceived complexity of methods is not higher than the configured maximum.'
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '0.81'
@@ -2853,9 +2847,7 @@ Metrics/PerceivedComplexity:
 ################## Migration #############################
 
 Migration/DepartmentName:
-  Description: >-
-                 Check that cop names in rubocop:disable (etc) comments are
-                 given with department name.
+  Description: 'Checks that cop names in `rubocop:disable` (etc.) comments are given with a department name.'
   Enabled: true
   VersionAdded: '0.75'
 
@@ -2876,7 +2868,7 @@ Naming/AsciiIdentifiers:
   AsciiConstants: true
 
 Naming/BinaryOperatorParameterName:
-  Description: 'When defining binary operators, name the argument other.'
+  Description: 'Checks that the sole parameter of binary operator methods is named `other`.'
   StyleGuide: '#other-arg'
   Enabled: true
   VersionAdded: '0.50'
@@ -3133,7 +3125,7 @@ Naming/PredicateMethod:
     - nonzero?
 
 Naming/PredicatePrefix:
-  Description: 'Predicate method names should not be prefixed and end with a `?`.'
+  Description: 'Checks that predicate method names end with a question mark and do not start with a forbidden prefix.'
   StyleGuide: '#bool-methods-qmark'
   Enabled: true
   VersionAdded: '0.50'
@@ -3215,14 +3207,14 @@ Naming/VariableNumber:
 #################### Security ##############################
 
 Security/CompoundHash:
-  Description: 'When overwriting Object#hash to combine values, prefer delegating to Array#hash over writing a custom implementation.'
+  Description: 'Checks for `hash` implementations that combine values manually instead of delegating to `Array#hash`.'
   Enabled: pending
   Safe: false
   VersionAdded: '1.28'
   VersionChanged: '1.51'
 
 Security/Eval:
-  Description: 'The use of eval represents a serious security risk.'
+  Description: 'Checks for the use of `Kernel#eval` and `Binding#eval` with dynamic arguments.'
   Enabled: true
   VersionAdded: '0.47'
 
@@ -3258,7 +3250,7 @@ Security/MarshalLoad:
   VersionAdded: '0.47'
 
 Security/Open:
-  Description: 'The use of `Kernel#open` and `URI.open` represent a serious security risk.'
+  Description: 'Checks for the use of `Kernel#open` and `URI.open` with dynamic data.'
   Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '1.0'
@@ -3701,7 +3693,7 @@ Style/CollectionCompact:
 
 # Align with the style guide.
 Style/CollectionMethods:
-  Description: 'Preferred collection methods.'
+  Description: 'Enforces the use of consistent method names from the `Enumerable` module.'
   StyleGuide: '#map-find-select-reduce-include-size'
   Enabled: false
   VersionAdded: '0.9'
@@ -4128,7 +4120,7 @@ Style/ExplicitBlockArgument:
   VersionChanged: '1.8'
 
 Style/ExponentialNotation:
-  Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'
+  Description: 'Enforces consistency in the use of exponential (scientific) notation.'
   StyleGuide: '#exponential-notation'
   Enabled: true
   VersionAdded: '0.82'
@@ -4818,7 +4810,7 @@ Style/MultilineBlockChain:
   VersionAdded: '0.13'
 
 Style/MultilineIfModifier:
-  Description: 'Only use if/unless modifiers on single line statements.'
+  Description: 'Checks for uses of `if`/`unless` modifiers with multiline bodies.'
   StyleGuide: '#no-multiline-if-modifiers'
   Enabled: true
   VersionAdded: '0.45'
@@ -5987,12 +5979,12 @@ Style/TrailingBodyOnClass:
   VersionAdded: '0.53'
 
 Style/TrailingBodyOnMethodDefinition:
-  Description: 'Method body goes below definition.'
+  Description: 'Checks for trailing code after the method definition.'
   Enabled: true
   VersionAdded: '0.52'
 
 Style/TrailingBodyOnModule:
-  Description: 'Module body goes below module statement.'
+  Description: 'Checks for trailing code after the module definition.'
   Enabled: true
   VersionAdded: '0.53'
 


### PR DESCRIPTION
A bunch of cops had `Description`s that didn't start with a verb - noun phrases like "Unreachable code." or "Indentation of comments.", conditional openers like "When defining binary operators, ...", and the `Metrics` complexity cops that read as definitions of the metric rather than what the cop does. `Migration/DepartmentName` also used "Check" instead of "Checks". This rewords them to start with a verb, matching the convention the rest of the cops (and these cops' own YARD class docs) already follow.

Scope notes:

- Only touched descriptions that didn't start with a verb at all. Imperative-mood descriptions (`Use ...`, `Avoid ...`, `Prefer ...`) are left as-is.
- Descriptions-only change: no behavior change, so no `VersionChanged` bumps. The generated cop docs are built from the YARD comments (which were already verb-first), so they don't change either - only `config/default.yml` does.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists). N/A - no related issue.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. N/A - covered by existing `project_spec` description checks.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/).

[1]: https://chris.beams.io/posts/git-commit/