### PR TITLE
Order metadata fields consistently in config/default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -543,11 +543,11 @@ Layout/ClosingParenthesisIndentation:
 Layout/CommentIndentation:
   Description: 'Checks the indentation of comments.'
   Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '1.86'
   # When true, allows comments to have extra indentation if that aligns them
   # with a comment on the preceding line.
   AllowForAlignment: false
-  VersionAdded: '0.49'
-  VersionChanged: '1.86'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
   IndentationWidth: ~
@@ -912,9 +912,9 @@ Layout/HashAlignment:
     Align the elements of a hash literal if they span more than
     one line.
   Enabled: true
-  AllowMultipleStyles: true
   VersionAdded: '0.49'
   VersionChanged: '1.16'
+  AllowMultipleStyles: true
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -989,8 +989,8 @@ Layout/HeredocArgumentClosingParenthesis:
   Description: >-
                  Checks for the placement of the closing parenthesis in a
                  method call that passes a HEREDOC string as an argument.
-  Enabled: false
   StyleGuide: '#heredoc-argument-closing-parentheses'
+  Enabled: false
   VersionAdded: '0.68'
 
 Layout/HeredocIndentation:
@@ -1426,6 +1426,7 @@ Layout/SpaceBeforeBlockBraces:
                  before it.
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.52'
   EnforcedStyle: space
   SupportedStyles:
     - space
@@ -1434,7 +1435,6 @@ Layout/SpaceBeforeBlockBraces:
   SupportedStylesForEmptyBraces:
     - space
     - no_space
-  VersionChanged: '0.52'
 
 Layout/SpaceBeforeBrackets:
   Description: 'Checks for receiver with a space before the opening brackets.'
@@ -1927,9 +1927,9 @@ Lint/EmptyConditionalBody:
   Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
   Enabled: true
   AutoCorrect: contextual
-  AllowComments: true
   VersionAdded: '0.89'
   VersionChanged: '1.73'
+  AllowComments: true
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
@@ -1965,9 +1965,9 @@ Lint/EmptyInterpolation:
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
   Enabled: true
-  AllowComments: true
   VersionAdded: '0.45'
   VersionChanged: '0.83'
+  AllowComments: true
 
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'
@@ -2021,14 +2021,14 @@ Lint/HeredocMethodCallPosition:
   Description: >-
                  Checks for the ordering of a method call where
                  the receiver of the call is a HEREDOC.
-  Enabled: false
   StyleGuide: '#heredoc-method-calls'
+  Enabled: false
   VersionAdded: '0.68'
 
 Lint/IdentityComparison:
   Description: 'Prefer `equal?` over `==` when comparing `object_id`.'
-  Enabled: true
   StyleGuide: '#identity-comparison'
+  Enabled: true
   VersionAdded: '0.91'
 
 Lint/ImplicitStringConcatenation:
@@ -2128,9 +2128,9 @@ Lint/MissingSuper:
                   Checks for the presence of constructors and lifecycle callbacks
                   without calls to `super`.
   Enabled: true
-  AllowedParentClasses: []
   VersionAdded: '0.89'
   VersionChanged: '1.4'
+  AllowedParentClasses: []
 
 Lint/MixedCaseRange:
   Description: 'Checks for mixed-case character ranges since they include likely unintended characters.'
@@ -2488,10 +2488,10 @@ Lint/SuppressedException:
   Description: "Don't suppress exceptions."
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
-  AllowComments: true
-  AllowNil: true
   VersionAdded: '0.9'
   VersionChanged: '1.12'
+  AllowComments: true
+  AllowNil: true
 
 Lint/SuppressedExceptionInNumberConversion:
   Description: 'Checks for cases where exceptions unrelated to the numeric constructors may be unintentionally swallowed.'
@@ -3328,6 +3328,8 @@ Style/ArgumentsForwarding:
   Description: 'Use arguments forwarding.'
   StyleGuide: '#arguments-forwarding'
   Enabled: pending
+  VersionAdded: '1.1'
+  VersionChanged: '1.58'
   AllowOnlyRestArgument: true
   UseAnonymousForwarding: true
   RedundantRestArgumentNames:
@@ -3341,8 +3343,6 @@ Style/ArgumentsForwarding:
     - blk
     - block
     - proc
-  VersionAdded: '1.1'
-  VersionChanged: '1.58'
 
 Style/ArrayCoercion:
   Description: >-
@@ -3795,11 +3795,11 @@ Style/CommentedKeyword:
 
 Style/ComparableBetween:
   Description: 'Enforces the use of `Comparable#between?` instead of logical comparison.'
+  StyleGuide: '#ranges-or-between'
   Enabled: pending
   Safe: false
   VersionAdded: '1.74'
   VersionChanged: '1.75'
-  StyleGuide: '#ranges-or-between'
 
 Style/ComparableClamp:
   Description: 'Enforces the use of `Comparable#clamp` instead of comparison by minimum and maximum.'
@@ -4223,6 +4223,8 @@ Style/FormatString:
 Style/FormatStringToken:
   Description: 'Use a consistent style for format string tokens.'
   Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '1.74'
   EnforcedStyle: annotated
   SupportedStyles:
     # Prefer tokens which contain a sprintf like type annotation like
@@ -4241,8 +4243,6 @@ Style/FormatStringToken:
   #     only register offenses for strings given to `printf`, `sprintf`,
   #     format` and `%` methods. Other strings are not considered.
   Mode: aggressive
-  VersionAdded: '0.49'
-  VersionChanged: '1.74'
   AllowedMethods: []
   AllowedPatterns: []
 
@@ -4436,9 +4436,9 @@ Style/IdenticalConditionalBranches:
 Style/IfInsideElse:
   Description: 'Finds if nodes inside else, which can be converted to elsif.'
   Enabled: true
-  AllowIfModifier: false
   VersionAdded: '0.36'
   VersionChanged: '1.3'
+  AllowIfModifier: false
 
 Style/IfUnlessModifier:
   Description: >-
@@ -4569,14 +4569,14 @@ Style/ItAssignment:
 Style/ItBlockParameter:
   Description: 'Checks for blocks with one argument where `it` block parameter can be used.'
   Enabled: pending
+  VersionAdded: '1.75'
+  VersionChanged: '1.76'
   EnforcedStyle: allow_single_line
   SupportedStyles:
     - allow_single_line
     - only_numbered_parameters
     - always
     - disallow
-  VersionAdded: '1.75'
-  VersionChanged: '1.76'
 
 Style/KeywordArgumentsMerging:
   Description: >-
@@ -4701,10 +4701,10 @@ Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: '#method-invocation-parens'
   Enabled: true
-  AllowedMethods: []
-  AllowedPatterns: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
+  AllowedMethods: []
+  AllowedPatterns: []
 
 Style/MethodCalledOnDoEndBlock:
   Description: 'Avoid chaining a method call on a do...end block.'
@@ -5129,9 +5129,9 @@ Style/OneLineConditional:
                  single-line if/then/else/end constructs.
   StyleGuide: '#ternary-operator'
   Enabled: true
-  AlwaysCorrectToMultiline: false
   VersionAdded: '0.9'
   VersionChanged: '0.90'
+  AlwaysCorrectToMultiline: false
 
 Style/OpenStructUse:
   Description: >-
@@ -5224,6 +5224,7 @@ Style/PercentLiteralDelimiters:
   StyleGuide: '#percent-literal-braces'
   Enabled: true
   VersionAdded: '0.19'
+  VersionChanged: '0.48'
   # Specify the default preferred delimiter for all types with the 'default' key
   # Override individual delimiters (even with default specified) by specifying
   # an individual key
@@ -5234,7 +5235,6 @@ Style/PercentLiteralDelimiters:
     '%r': '{}'
     '%w': '[]'
     '%W': '[]'
-  VersionChanged: '0.48'
 
 Style/PercentQLiterals:
   Description: 'Checks if uses of %Q/%q match the configured preference.'
@@ -5461,9 +5461,9 @@ Style/RedundantInitialize:
   Enabled: pending
   AutoCorrect: contextual
   Safe: false
-  AllowComments: true
   VersionAdded: '1.27'
   VersionChanged: '1.61'
+  AllowComments: true
 
 Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'
@@ -5627,10 +5627,10 @@ Style/ReturnNilInPredicateMethodDefinition:
   StyleGuide: '#bool-methods-qmark'
   Enabled: pending
   SafeAutoCorrect: false
-  AllowedMethods: []
-  AllowedPatterns: []
   VersionAdded: '1.53'
   VersionChanged: '1.67'
+  AllowedMethods: []
+  AllowedPatterns: []
 
 Style/ReverseFind:
   Description: 'Use `array.rfind` instead of `array.reverse.find`.'
@@ -6057,10 +6057,10 @@ Style/TrailingUnderscoreVariable:
   Description: >-
                  Checks for the usage of unneeded trailing underscores at the
                  end of parallel variable assignment.
-  AllowNamedUnderscoreVariables: true
   Enabled: true
   VersionAdded: '0.31'
   VersionChanged: '0.35'
+  AllowNamedUnderscoreVariables: true
 
 # `TrivialAccessors` requires exact name matches and doesn't allow
 # predicated methods by default.
@@ -6193,6 +6193,9 @@ Style/YodaCondition:
   References:
     - 'https://en.wikipedia.org/wiki/Yoda_conditions'
   Enabled: true
+  Safe: false
+  VersionAdded: '0.49'
+  VersionChanged: '0.75'
   EnforcedStyle: forbid_for_all_comparison_operators
   SupportedStyles:
     # check all comparison operators
@@ -6203,9 +6206,6 @@ Style/YodaCondition:
     - require_for_all_comparison_operators
     # enforce yoda only for equality operators: `!=` and `==`
     - require_for_equality_operators_only
-  Safe: false
-  VersionAdded: '0.49'
-  VersionChanged: '0.75'
 
 Style/YodaExpression:
   Description: 'Forbid the use of yoda expressions.'


### PR DESCRIPTION
Small consistency cleanup in `config/default.yml`. Two field-ordering quirks: four cops had `StyleGuide` listed after `Enabled` instead of before it, and 18 cops had `VersionChanged` sitting after their configuration options (or separated from `VersionAdded`). This puts `StyleGuide` before `Enabled` and keeps `VersionAdded`/`VersionChanged` together right after `Enabled`, ahead of the options, matching what the rest of the file already does.

It's a pure reordering - no values change, the sorted set of lines is identical before and after, and the generated cop docs are unaffected (they don't depend on field order).

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists). N/A - no related issue.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. N/A - covered by existing `project_spec` config checks.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the changelog folder. N/A - internal-only change with no user-visible effect.

[1]: https://chris.beams.io/posts/git-commit/