### PR TITLE
[Fix #15197] Fix false positives in `Style/WhileUntilDo`

### DIFF
--- a/changelog/fix_false_positives_in_style_while_until_do.md
+++ b/changelog/fix_false_positives_in_style_while_until_do.md
@@ -1,0 +1,1 @@
+* [#15197](https://github.com/rubocop/rubocop/issues/15197): Fix false positives in `Style/WhileUntilDo` when the loop body is on the same line as the `do` keyword. ([@koic][])

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -33,6 +33,7 @@ module RuboCop
 
         def on_while(node)
           return unless node.multiline? && node.do?
+          return if same_line_body?(node)
 
           add_offense(node.loc.begin, message: format(MSG, keyword: node.keyword)) do |corrector|
             do_range = node.condition.source_range.end.join(node.loc.begin)
@@ -41,6 +42,12 @@ module RuboCop
           end
         end
         alias on_until on_while
+
+        private
+
+        def same_line_body?(node)
+          node.body && same_line?(node.loc.begin, node.body)
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -27,12 +27,49 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilDo, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects do when the body is on the next line in multiline while' do
+    expect_offense(<<~RUBY)
+      while i < 3 do
+                  ^^ Do not use `do` with multi-line `while`.
+        i += 1
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while i < 3
+        i += 1
+      end
+    RUBY
+  end
+
   it 'accepts do in single-line while' do
     expect_no_offenses('while cond do something end')
   end
 
   it 'accepts do in single-line until' do
     expect_no_offenses('until cond do something end')
+  end
+
+  it 'accepts do when the body is on the same line as `do` in multiline while' do
+    expect_no_offenses(<<~RUBY)
+      while i < 3 do i += 1
+      end
+    RUBY
+  end
+
+  it 'accepts do when the body is on the same line as `do` in multiline until' do
+    expect_no_offenses(<<~RUBY)
+      until i >= 3 do i += 1
+      end
+    RUBY
+  end
+
+  it 'accepts do when the condition is multiline and the body is on the same line as `do`' do
+    expect_no_offenses(<<~RUBY)
+      while i < 3 ||
+            j < 3 do i += 1
+      end
+    RUBY
   end
 
   it 'accepts multi-line while without do' do


### PR DESCRIPTION
Previously, the cop removed `do` from a multi-line `while`/`until` whenever `end` was on its own line, even when the loop body shared the line with the condition. In that layout the `do` keyword is required, so removing it produced a syntax error such as `while i < 3 i += 1`.

This is consistent with the cop already accepting `do` in a fully single-line loop. The cop now leaves `do` alone when the loop body is on the same line as the keyword.

Fixes #15197.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
