### PR TITLE
Tidy up cosmetic inconsistencies in config/default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -372,7 +372,7 @@ Gemspec/RubyVersionGlobalsUsage:
   Include:
     - '**/*.gemspec'
 
-#################### Layout ###########################
+#################### Layout ################################
 
 Layout/AccessModifierIndentation:
   Description: Checks indentation of private/protected visibility modifiers.
@@ -2844,14 +2844,14 @@ Metrics/PerceivedComplexity:
   AllowedPatterns: []
   Max: 8
 
-################## Migration #############################
+#################### Migration #############################
 
 Migration/DepartmentName:
   Description: 'Checks that cop names in `rubocop:disable` (etc.) comments are given with a department name.'
   Enabled: true
   VersionAdded: '0.75'
 
-#################### Naming ##############################
+#################### Naming ################################
 
 Naming/AccessorMethodName:
   Description: Checks the naming of accessor methods for get_/set_.
@@ -3038,7 +3038,10 @@ Naming/InclusiveLanguage:
         - block
     slave:
       WholeWord: true
-      Suggestions: ['replica', 'secondary', 'follower']
+      Suggestions:
+        - replica
+        - secondary
+        - follower
 
 Naming/MemoizedInstanceVariableName:
   Description: >-
@@ -3266,7 +3269,7 @@ Security/YAMLLoad:
   VersionAdded: '0.47'
   SafeAutoCorrect: false
 
-#################### Style ###############################
+#################### Style #################################
 
 Style/AccessModifierDeclarations:
   Description: 'Checks style of how access modifiers are used.'


### PR DESCRIPTION
A couple of small cosmetic cleanups in `config/default.yml`:

- The department section banners had inconsistent widths, and `Migration` used 18 leading `#` characters where everything else uses 20. Normalized them all to a uniform 60-character width with 20 leading `#`.
- `Naming/InclusiveLanguage` wrote the `slave` term's `Suggestions` as an inline array while every other term uses a block list. Switched it to the block-list style for consistency.

Formatting only - the parsed configuration is identical and the generated docs don't change.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists). N/A - no related issue.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. N/A - covered by existing `project_spec` config checks.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the changelog folder. N/A - cosmetic-only change with no user-visible effect.

[1]: https://chris.beams.io/posts/git-commit/