### PR TITLE
Fix InternalAffairs cop bug and test-quality issues found by audit

### DIFF
--- a/changelog/fix_fix_20260602201702.md
+++ b/changelog/fix_fix_20260602201702.md
@@ -1,0 +1,1 @@
+* [#15202](https://github.com/rubocop/rubocop/pull/15202): Fix `InternalAffairs/RedundantLetRuboCopConfigNew` crash when `let(:config)` has no enclosing `describe`. ([@bbatsov][])

--- a/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new.rb
@@ -46,8 +46,7 @@ module RuboCop
 
         def on_block(node)
           return unless let_rubocop_config_new?(node)
-
-          describe = find_describe_method_node(node)
+          return unless (describe = find_describe_method_node(node))
 
           unless (exist_config = describe.last_argument.source == ':config')
             additional_message = ' and specify `:config` in `describe`'
@@ -65,7 +64,10 @@ module RuboCop
         private
 
         def find_describe_method_node(block_node)
-          block_node.ancestors.find { |node| node.block_type? && node.method?(:describe) }.send_node
+          describe = block_node.ancestors.find do |ancestor|
+            ancestor.block_type? && ancestor.method?(:describe)
+          end
+          describe&.send_node
         end
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -395,4 +395,31 @@ RSpec.describe 'RuboCop Project', type: :feature do
       expect(warnings).to eq []
     end
   end
+
+  describe 'cop specs' do
+    # The offense/correction expectation helpers have a singular/plural asymmetry
+    # (`expect_offense` but `expect_no_offenses`, `expect_correction` but
+    # `expect_no_corrections`) that makes them easy to misspell. A misspelled helper
+    # inside an `expect_offense` heredoc fixture silently does nothing, so the test
+    # passes for the wrong reason. Guard against the known-invalid spellings.
+    it 'do not use misspelled offense/correction expectation helpers' do
+      invalid = %w[
+        expect_no_offense expect_offenses expect_corrections expect_no_correction add_no_offenses
+      ]
+      pattern = /\b(?:#{invalid.join('|')})\b/
+
+      offenders = Dir['spec/rubocop/cop/**/*_spec.rb'].sort.filter_map do |path|
+        lines = File.readlines(path, encoding: Encoding::UTF_8)
+        hits = lines.each_index.select { |index| lines[index].match?(pattern) }
+        next if hits.empty?
+
+        "#{path}:\n  #{hits.map { |index| "#{index + 1}: #{lines[index].strip}" }.join("\n  ")}"
+      end
+
+      expect(offenders).to(be_empty, <<~MSG)
+        Misspelled offense/correction expectation helper(s) found:
+        #{offenders.join("\n")}
+      MSG
+    end
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/cop_description_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
           end
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'registers an offense if the description like `This cop is ...`' do
@@ -65,6 +67,8 @@ RSpec.describe RuboCop::Cop::InternalAffairs::CopDescription, :config do
           end
         end
       RUBY
+
+      expect_no_corrections
     end
   end
 

--- a/spec/rubocop/cop/internal_affairs/example_description_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/example_description_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
     it 'does not register an offense when given a proper description' do
       expect_no_offenses(<<~RUBY)
         it 'does not flag' do
-          expect_no_offense('code')
+          expect_no_offenses('code')
         end
       RUBY
     end
@@ -241,7 +241,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::ExampleDescription, :config do
     it 'does not crash when given a proper description that is split with +' do
       expect_no_offenses(<<~RUBY)
         it "does " + 'not register an offense' do
-          expect_no_offense('code')
+          expect_no_offenses('code')
         end
       RUBY
     end

--- a/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/location_exists_spec.rb
@@ -291,4 +291,20 @@ RSpec.describe RuboCop::Cop::InternalAffairs::LocationExists, :config do
       RUBY
     end
   end
+
+  context 'when the code does not need `loc?`/`loc_is?`' do
+    it 'does not register an offense for already-corrected code' do
+      expect_no_offenses(<<~RUBY)
+        node.loc?(:begin)
+        node.loc_is?(:begin, '(')
+      RUBY
+    end
+
+    it 'does not register an offense when the `respond_to?` receiver is not `loc`' do
+      expect_no_offenses(<<~RUBY)
+        node.respond_to?(:foo)
+        foo.respond_to?(:bar)
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_let_rubocop_config_new_spec.rb
@@ -85,4 +85,12 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantLetRuboCopConfigNew, :con
       end
     RUBY
   end
+
+  it 'does not register an offense (or crash) when `let(:config)` has no enclosing `describe`' do
+    expect_no_offenses(<<~RUBY)
+      shared_context 'with config' do
+        let(:config) { RuboCop::Config.new }
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument, :config 
     context 'when there are others keyword arguments' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY, 'example_cop.rb')
-          add_no_offenses(node,
+          add_offense(node,
                       location: :selector,
                       message: message(node),
                       severity: :fatal)

--- a/spec/rubocop/cop/internal_affairs/style_detected_api_use_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/style_detected_api_use_spec.rb
@@ -65,4 +65,26 @@ RSpec.describe RuboCop::Cop::InternalAffairs::StyleDetectedApiUse, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when style_detected is used in a conditional expression' do
+    expect_offense(<<~RUBY)
+      def on_send(node)
+        return add_offense(node) if style_detected(:foo)
+                                    ^^^^^^^^^^^^^^^^^^^^ `*_style_detected` method called in conditional.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when style_detected suppresses the positive/negative pairing check' do
+    expect_no_offenses(<<~RUBY)
+      def on_send(node)
+        if offense?
+          add_offense(node)
+        else
+          correct_style_detected
+          style_detected(:foo)
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/internal_affairs/useless_restrict_on_send_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_restrict_on_send_spec.rb
@@ -74,14 +74,11 @@ RSpec.describe RuboCop::Cop::InternalAffairs::UselessRestrictOnSend, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `after_send` with alias_method' do
+  it 'does not register an offense when using `RESTRICT_ON_SEND` and defines `after_send` with string-form alias_method' do
     expect_no_offenses(<<~RUBY)
       class FooCop
         RESTRICT_ON_SEND = %i[bad_method].freeze
-        def after_send(node)
-          # ...
-        end
-        self.alias_method "after_send", "any"
+        alias_method "after_send", "any"
       end
     RUBY
   end


### PR DESCRIPTION
I've started poking at making our cops and their specs more uniform, and along the way I stumbled on a few things that are worth fixing on their own.

The actual bug: `InternalAffairs/RedundantLetRuboCopConfigNew` blows up with a `NoMethodError` when a `let(:config) { RuboCop::Config.new }` isn't wrapped in a `describe`, because it calls `send_node` on the `nil` that `find` returns.

The rest is test hygiene. A handful of specs weren't actually exercising the cop at all: the fixture called something the cop never matches (`expect_no_offense` instead of `expect_no_offenses`, `add_no_offenses` instead of `add_offense`, or a stray `def` quietly doing the work an `alias_method` was supposed to be testing), so they stayed green without testing anything. I fixed those and added a few `expect_no_offenses`/`expect_no_corrections` cases for branches that had no coverage at all.

Three of those were the same silly mistake, a misspelled `expect_*` helper that does nothing inside a heredoc fixture, so I added a `project_spec` check that scans cop specs for the usual misspellings to keep us honest. A normal cop can't catch these since they live inside the fixture strings, so a plain text scan it is.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/