### PR TITLE
Tidy up and modernize a batch of Lint cops

### DIFF
--- a/lib/rubocop/cop/lint/ambiguous_assignment.rb
+++ b/lib/rubocop/cop/lint/ambiguous_assignment.rb
@@ -28,7 +28,7 @@ module RuboCop
         MISTAKES = { '=-' => '-=', '=+' => '+=', '=*' => '*=', '=!' => '!=' }.freeze
 
         def on_asgn(node)
-          return unless (rhs = rhs(node))
+          return unless (rhs = node.expression)
 
           range = range_between(node.loc.operator.end_pos - 1, rhs.source_range.begin_pos + 1)
           source = range.source
@@ -38,16 +38,6 @@ module RuboCop
         end
 
         SIMPLE_ASSIGNMENT_TYPES.each { |asgn_type| alias_method :"on_#{asgn_type}", :on_asgn }
-
-        private
-
-        def rhs(node)
-          if node.casgn_type?
-            node.children[2]
-          else
-            node.children[1]
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator_precedence.rb
@@ -44,13 +44,6 @@ module RuboCop
         RESTRICT_ON_SEND = PRECEDENCE.flatten.freeze
         MSG = 'Wrap expressions with varying precedence with parentheses to avoid ambiguity.'
 
-        def on_new_investigation
-          # Cache the precedence of each node being investigated
-          # so that we only need to calculate it once
-          @node_precedences = {}
-          super
-        end
-
         def on_and(node)
           return unless (parent = node.parent)
 
@@ -77,9 +70,7 @@ module RuboCop
         private
 
         def precedence(node)
-          @node_precedences.fetch(node) do
-            PRECEDENCE.index { |operators| operators.include?(operator_name(node)) }
-          end
+          PRECEDENCE.index { |operators| operators.include?(operator_name(node)) }
         end
 
         def operator?(node)

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -80,7 +80,6 @@ module RuboCop
           check_assignment_chain(arg_name, arg_value)
         end
 
-        # rubocop:disable Metrics/AbcSize
         def check_assignment_chain(arg_name, node)
           return unless node.lvasgn_type?
 
@@ -88,7 +87,7 @@ module RuboCop
           current_node = node
 
           while current_node.lvasgn_type?
-            seen_variables << current_node.children.first if current_node.lvasgn_type?
+            seen_variables << current_node.children.first
             current_node = current_node.children.last
           end
 
@@ -99,7 +98,6 @@ module RuboCop
 
           add_offense(current_node, message: format(MSG, arg_name: arg_name))
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -73,7 +73,6 @@ module RuboCop
       #   require 'my_debugger/start'
       class Debugger < Base
         MSG = 'Remove debugger entry point `%<source>s`.'
-        BLOCK_TYPES = %i[block numblock itblock kwbegin].freeze
 
         def on_send(node)
           return if assumed_usage_context?(node)

--- a/lib/rubocop/cop/lint/deprecated_constants.rb
+++ b/lib/rubocop/cop/lint/deprecated_constants.rb
@@ -49,7 +49,7 @@ module RuboCop
           #        Maybe further investigation of RuboCop AST will lead to an essential solution.
           return unless node.loc
 
-          constant = node.absolute? ? constant_name(node, node.short_name) : node.source
+          constant = node.source.delete_prefix('::')
           return unless (deprecated_constant = deprecated_constants[constant])
 
           alternative = deprecated_constant['Alternative']
@@ -62,12 +62,6 @@ module RuboCop
         end
 
         private
-
-        def constant_name(node, nested_constant_name)
-          return nested_constant_name.to_s unless node.namespace.const_type?
-
-          constant_name(node.namespace, "#{node.namespace.short_name}::#{nested_constant_name}")
-        end
 
         def message(good, bad, deprecated_version)
           deprecated_message = ", deprecated since Ruby #{deprecated_version}" if deprecated_version

--- a/lib/rubocop/cop/lint/empty_block.rb
+++ b/lib/rubocop/cop/lint/empty_block.rb
@@ -77,7 +77,7 @@ module RuboCop
           return false unless processed_source.contains_comment?(node.source_range)
 
           line_comment = processed_source.comment_at_line(node.source_range.line)
-          !line_comment || !comment_disables_cop?(line_comment.source)
+          !line_comment || !comment_disables_cop?(line_comment)
         end
 
         def allow_empty_lambdas?
@@ -85,8 +85,8 @@ module RuboCop
         end
 
         def comment_disables_cop?(comment)
-          regexp_pattern = "# rubocop : (disable|todo) ([^,],)* (all|#{cop_name})"
-          Regexp.new(regexp_pattern.gsub(' ', '\s*')).match?(comment)
+          directive = DirectiveComment.new(comment)
+          directive.disabled? && directive.cop_names.include?(cop_name)
         end
       end
     end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousBlockAssociation, :config do
   it_behaves_like 'accepts', 'scope :active, Proc.new { where(status: "active") }'
   it_behaves_like('accepts', 'assert_equal posts.find { |p| p.title == "Foo" }, results.first')
   it_behaves_like('accepts', 'assert_equal(posts.find { |p| p.title == "Foo" }, results.first)')
+  # `[]` method call (the block can only associate with the `[]` argument)
+  it_behaves_like('accepts', 'foo[bar { |x| x }]')
+  # assignment method (the block can only associate with the right-hand side)
+  it_behaves_like('accepts', 'obj.attr = bar { |x| x }')
   it_behaves_like('accepts', 'assert_equal(results.first, posts.find { |p| p.title == "Foo" })')
   it_behaves_like('accepts', 'allow(cop).to receive(:on_int) { raise RuntimeError }')
   it_behaves_like('accepts', 'allow(cop).to(receive(:on_int) { raise RuntimeError })')


### PR DESCRIPTION
Continuing the cop/spec uniformity pass, this time over the first chunk of the Lint department (alphabetically, `ambiguous_assignment` through `empty_ensure`). Nothing user-facing here, just internal cleanup that fell out of the review.

Dead code:
- `Lint/Debugger`: an unused `BLOCK_TYPES` constant.
- `Lint/CircularArgumentReference`: an `if current_node.lvasgn_type?` guard sitting inside a `while current_node.lvasgn_type?` loop (always true), which also let me drop a now-unnecessary `Metrics/AbcSize` disable.
- `Lint/AmbiguousOperatorPrecedence`: a precedence "cache" that never cached anything - `Hash#fetch` with a block returns the block's value without storing it, so the hash and its `on_new_investigation` reset were pure overhead.

Modernizations (all behavior-preserving, covered by existing specs):
- `Lint/AmbiguousAssignment`: `node.expression` instead of a private `rhs` helper that branched on `casgn_type?` and indexed children by hand.
- `Lint/DeprecatedConstants`: `node.source.delete_prefix('::')` instead of a recursive `constant_name`.
- `Lint/EmptyBlock`: parse the inline directive with `DirectiveComment` instead of a bespoke regex that didn't handle multi-cop directives.

Plus a couple of `accepts` cases for `Lint/AmbiguousBlockAssociation`, whose `[]` and assignment allow-branches had no coverage (the existing `Hash[...]` case isn't ambiguous, so it never hit the `[]` branch).

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/