### PR TITLE
Fix false positives for return in nested scopes

### DIFF
--- a/changelog/fix_false_positives_for_return_in_nested_scopes_20260603093220.md
+++ b/changelog/fix_false_positives_for_return_in_nested_scopes_20260603093220.md
@@ -1,0 +1,1 @@
+* [#15204](https://github.com/rubocop/rubocop/pull/15204): Fix false positives in `Lint/EnsureReturn` and `Lint/NoReturnInBeginEndBlocks` for `return` inside a nested method definition or lambda. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -43,7 +43,25 @@ module RuboCop
         MSG = 'Do not return from an `ensure` block.'
 
         def on_ensure(node)
-          node.branch&.each_node(:return) { |return_node| add_offense(return_node) }
+          node.branch&.each_node(:return) do |return_node|
+            next if return_from_inner_scope?(return_node, node)
+
+            add_offense(return_node)
+          end
+        end
+
+        private
+
+        # A `return` inside a nested method definition or lambda within the
+        # `ensure` returns from that inner scope, not from the method whose
+        # `ensure` this is, so it is not an offense. A `return` inside a plain
+        # block (or `proc`) does propagate out, so it remains an offense.
+        def return_from_inner_scope?(return_node, ensure_node)
+          return_node.each_ancestor do |ancestor|
+            break if ancestor == ensure_node
+            return true if ancestor.any_def_type? || (ancestor.any_block_type? && ancestor.lambda?)
+          end
+          false
         end
       end
     end

--- a/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
+++ b/lib/rubocop/cop/lint/no_return_in_begin_end_blocks.rb
@@ -41,6 +41,8 @@ module RuboCop
         def on_lvasgn(node)
           node.each_node(:kwbegin) do |kwbegin_node|
             kwbegin_node.each_node(:return) do |return_node|
+              next if return_from_inner_scope?(return_node, kwbegin_node)
+
               add_offense(return_node)
             end
           end
@@ -51,6 +53,20 @@ module RuboCop
         alias on_casgn on_lvasgn
         alias on_or_asgn on_lvasgn
         alias on_op_asgn on_lvasgn
+
+        private
+
+        # A `return` inside a nested method definition or lambda within the
+        # `begin..end` returns from that inner scope rather than the assignment
+        # context, so it is not an offense. A `return` inside a plain block (or
+        # `proc`) does propagate out, so it remains an offense.
+        def return_from_inner_scope?(return_node, kwbegin_node)
+          return_node.each_ancestor do |ancestor|
+            break if ancestor == kwbegin_node
+            return true if ancestor.any_def_type? || (ancestor.any_block_type? && ancestor.lambda?)
+          end
+          false
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -61,4 +61,38 @@ RSpec.describe RuboCop::Cop::Lint::EnsureReturn, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for `return` inside a lambda in `ensure`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        do_something
+      ensure
+        handler = -> { return 42 }
+        handler.call
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `return` inside a method definition in `ensure`' do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        do_something
+      ensure
+        def bar
+          return 1
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `return` inside a block in `ensure`' do
+    expect_offense(<<~RUBY)
+      def foo
+        do_something
+      ensure
+        [1, 2].each { return }
+                      ^^^^^^ Do not return from an `ensure` block.
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/lint/no_return_in_begin_end_blocks_spec.rb
+++ b/spec/rubocop/cop/lint/no_return_in_begin_end_blocks_spec.rb
@@ -121,4 +121,23 @@ RSpec.describe RuboCop::Cop::Lint::NoReturnInBeginEndBlocks, :config do
     it_behaves_like 'rejects return inside a block', operator
     it_behaves_like 'accepts a block with no return', operator
   end
+
+  it 'does not register an offense for `return` inside a method definition in `begin..end`' do
+    expect_no_offenses(<<~RUBY)
+      x = begin
+        def foo
+          return 1
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `return` inside a lambda in `begin..end`' do
+    expect_no_offenses(<<~RUBY)
+      x = begin
+        handler = -> { return 1 }
+        handler.call
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Both `Lint/EnsureReturn` and `Lint/NoReturnInBeginEndBlocks` walked the whole subtree with `each_node(:return)`, so they flagged a `return` that lives inside a nested method definition or lambda - where the `return` belongs to that inner scope and never escapes the method (or assignment) being checked.

```ruby
def foo
  do_something
ensure
  handler = -> { return 42 } # was flagged, but this returns from the lambda
  handler.call
end
```

The fix skips a `return` whose nearest enclosing scope (walking up to the `ensure`/`begin..end`) is a `def`/`defs` or a lambda. A `return` in a plain block or a `proc` does propagate out of the method, so those stay offenses.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/