### PR TITLE
Fix an incorrect autocorrect for Lint/ErbNewArguments

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_erb_new_arguments_20260603095656.md
+++ b/changelog/fix_incorrect_autocorrect_for_erb_new_arguments_20260603095656.md
@@ -1,0 +1,1 @@
+* [#15205](https://github.com/rubocop/rubocop/pull/15205): Fix an incorrect autocorrect for `Lint/ErbNewArguments` when a keyword argument follows the `safe_level` argument. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/erb_new_arguments.rb
+++ b/lib/rubocop/cop/lint/erb_new_arguments.rb
@@ -148,7 +148,9 @@ module RuboCop
           arguments = node.arguments
           overridden_kwargs = kwargs.dup
 
-          overridden_kwargs[0] = "trim_mode: #{arguments[2].source}" if arguments[2]
+          if arguments[2] && !arguments[2].hash_type?
+            overridden_kwargs[0] = "trim_mode: #{arguments[2].source}"
+          end
 
           if arguments[3] && !arguments[3].hash_type?
             overridden_kwargs[1] = "eoutvar: #{arguments[3].source}"

--- a/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/erb_new_arguments_spec.rb
@@ -100,6 +100,17 @@ RSpec.describe RuboCop::Cop::Lint::ErbNewArguments, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when using `ERB.new` with a non-keyword 2nd argument and a keyword 3rd argument' do
+      expect_offense(<<~RUBY)
+        ERB.new(str, nil, trim_mode: '-')
+                     ^^^ Passing safe_level with the 2nd argument of `ERB.new` is deprecated. Do not use it, and specify other arguments as keyword arguments.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ERB.new(str, trim_mode: '-')
+      RUBY
+    end
+
     context 'when using `ActionView::Template::Handlers::ERB.new`' do
       it 'does not register an offense when using `ERB.new` without arguments' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
When the `safe_level` (2nd) argument was followed directly by a keyword hash, e.g. `ERB.new(str, nil, trim_mode: '-')`, the autocorrect mistook the keyword hash for a positional `trim_mode` value and produced invalid Ruby:

```ruby
ERB.new(str, trim_mode: trim_mode: '-')
```

The positional `trim_mode` override now carries the same `!hash_type?` guard the sibling `eoutvar` branch already had, so it correctly becomes `ERB.new(str, trim_mode: '-')`.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/