### PR TITLE
Fix a false positive for Lint/FloatComparison

### DIFF
--- a/changelog/fix_false_positive_for_float_comparison_20260603095900.md
+++ b/changelog/fix_false_positive_for_float_comparison_20260603095900.md
@@ -1,0 +1,1 @@
+* [#15206](https://github.com/rubocop/rubocop/pull/15206): Fix a false positive for `Lint/FloatComparison` when comparing against a parenthesized zero or `nil`. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/float_comparison.rb
+++ b/lib/rubocop/cop/lint/float_comparison.rb
@@ -104,6 +104,7 @@ module RuboCop
 
         def literal_safe?(node)
           return false unless node
+          return literal_safe?(node.children.first) if node.begin_type?
 
           (node.numeric_type? && node.value.zero?) || node.nil_type?
         end

--- a/spec/rubocop/cop/lint/float_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/float_comparison_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe RuboCop::Cop::Lint::FloatComparison, :config do
     RUBY
   end
 
+  it 'does not register an offense when comparing against a parenthesized zero or nil' do
+    expect_no_offenses(<<~RUBY)
+      x == (0.0)
+      x == ((0))
+      Float('not_a_float', exception: false) == (nil)
+    RUBY
+  end
+
   it 'does not register an offense when comparing with multiple arguments' do
     expect_no_offenses(<<~RUBY)
       x.==(0.1, 0.2)


### PR DESCRIPTION
`x == 0.0` is exempt (comparing against zero is safe), but `x == (0.0)` was still flagged. `literal_safe?` didn't unwrap parenthesized (`begin`) nodes the way the sibling `float?` helper already does, so the documented zero/`nil` exemptions were defeated by a pair of parentheses. `literal_safe?` now recurses through `begin` nodes.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/