### PR TITLE
Fix a false positive for Lint/LiteralAssignmentInCondition

### DIFF
--- a/changelog/fix_false_positive_for_literal_assignment_in_condition_20260603100142.md
+++ b/changelog/fix_false_positive_for_literal_assignment_in_condition_20260603100142.md
@@ -1,0 +1,1 @@
+* [#15207](https://github.com/rubocop/rubocop/pull/15207): Fix a false positive for `Lint/LiteralAssignmentInCondition` when a literal is assigned inside a block in the condition. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_assignment_in_condition.rb
@@ -56,7 +56,17 @@ module RuboCop
         def traverse_node(node, &block)
           yield node if node.equals_asgn?
 
-          node.each_child_node { |child| traverse_node(child, &block) }
+          node.each_child_node do |child|
+            next if scope_body?(node, child)
+
+            traverse_node(child, &block)
+          end
+        end
+
+        # An assignment inside a block or method body within the condition belongs to
+        # that inner scope rather than the condition itself, so it is not inspected.
+        def scope_body?(node, child)
+          node.type?(:any_block, :any_def) && child == node.body
         end
 
         def all_literals?(node)

--- a/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_assignment_in_condition_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAssignmentInCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense for a literal assignment inside a block in the condition' do
+    expect_no_offenses(<<~RUBY)
+      if foo { |x| y = 1 }
+      end
+    RUBY
+  end
+
   it 'registers an offense when assigning literal to local variable in `while` condition' do
     expect_offense(<<~RUBY)
       while test = 42


### PR DESCRIPTION
A literal assignment inside a block in the condition, e.g.

```ruby
if foo { |x| y = 1 }
end
```

was flagged, even though `y = 1` belongs to the block body, not to the condition itself. `traverse_node` now skips block and method bodies. It still descends into the call and its arguments, so a genuine condition assignment like `if foo(x = 1) { }` is still reported.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/