### PR TITLE
Fix a false positive for Lint/IncompatibleIoSelectWithFiberScheduler

### DIFF
--- a/changelog/fix_false_positive_for_incompatible_io_select_20260603100417.md
+++ b/changelog/fix_false_positive_for_incompatible_io_select_20260603100417.md
@@ -1,0 +1,1 @@
+* [#15208](https://github.com/rubocop/rubocop/pull/15208): Fix a false positive for `Lint/IncompatibleIoSelectWithFiberScheduler` when the single array argument element is a splat. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
+++ b/lib/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler.rb
@@ -61,9 +61,13 @@ module RuboCop
         private
 
         def scheduler_compatible?(io1, io2)
-          return false unless io1&.array_type? && io1.values.size == 1
+          return false unless single_io_array?(io1)
 
           io2&.array_type? ? io2.values.empty? : (io2.nil? || io2.nil_type?)
+        end
+
+        def single_io_array?(node)
+          node&.array_type? && node.values.size == 1 && !node.values.first.splat_type?
         end
 
         def preferred_method(read, write, timeout)

--- a/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
+++ b/spec/rubocop/cop/lint/incompatible_io_select_with_fiber_scheduler_spec.rb
@@ -175,4 +175,10 @@ RSpec.describe RuboCop::Cop::Lint::IncompatibleIoSelectWithFiberScheduler, :conf
       collection.select { |item| item.do_something? }
     RUBY
   end
+
+  it 'does not register an offense when the single array element is a splat' do
+    expect_no_offenses(<<~RUBY)
+      IO.select([*reads])
+    RUBY
+  end
 end


### PR DESCRIPTION
`IO.select([*reads])` was flagged, and its autocorrect produced the invalid `*reads.wait_readable`. A single-element array whose element is a splat can hold any number of IOs, so it isn't the single-IO pattern the cop rewrites. The check now requires the single array element to not be a splat.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/