### PR TITLE
Fix a false negative for Lint/InterpolationCheck

### DIFF
--- a/changelog/fix_false_negative_for_interpolation_check_20260603101436.md
+++ b/changelog/fix_false_negative_for_interpolation_check_20260603101436.md
@@ -1,0 +1,1 @@
+* [#15209](https://github.com/rubocop/rubocop/pull/15209): Fix a false negative for `Lint/InterpolationCheck` when interpolation appears in a multiline single-quoted string. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -24,8 +24,25 @@ module RuboCop
         MSG = 'Interpolation in single quoted string detected. ' \
               'Use double quoted strings if you need interpolation.'
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def on_str(node)
+          check(node)
+        end
+
+        # A multiline single-quoted string is parsed as a `dstr` of `str` segments, so it
+        # is not covered by `on_str`. Inspect single-quoted `dstr`s here; double-quoted
+        # interpolation is also a `dstr`, hence the delimiter check.
+        def on_dstr(node)
+          # A heredoc is also a `dstr`, but its `loc` is a `Parser::Source::Map::Heredoc`
+          # with no `begin`, so bail before touching it.
+          return if heredoc?(node)
+
+          check(node) if node.loc.begin&.source == "'"
+        end
+
+        private
+
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def check(node)
           return if node.parent&.regexp_type?
           return unless /(?<!\\)#\{.*\}/.match?(node.source)
           return if heredoc?(node)
@@ -35,8 +52,6 @@ module RuboCop
           add_offense(node) { |corrector| autocorrect(corrector, node) }
         end
         # rubocop:enable Metrics/CyclomaticComplexity
-
-        private
 
         def autocorrect(corrector, node)
           starting_token, ending_token = if node.source.include?('"')

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -109,4 +109,25 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck, :config do
       'a "b" } #{c}'
     RUBY
   end
+
+  it 'registers an offense and corrects interpolation in a multiline single quoted string' do
+    expect_offense(<<~'RUBY')
+      foo = 'something with #{interpolation}
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Interpolation in single quoted string detected. Use double quoted strings if you need interpolation.
+      spanning lines'
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      foo = "something with #{interpolation}
+      spanning lines"
+    RUBY
+  end
+
+  it 'does not register an offense (or crash) for interpolation in a heredoc' do
+    expect_no_offenses(<<~'RUBY')
+      foo = <<~TEXT
+        something with #{interpolation}
+      TEXT
+    RUBY
+  end
 end


### PR DESCRIPTION
A multiline single-quoted string is parsed as a `dstr` of `str` segments, so a string like

```ruby
'foo
bar #{interpolation}'
```

was never inspected: the cop only handled `on_str`, and the segment `str` nodes don't have their own `loc.begin`. Added an `on_dstr` handler that inspects single-quoted `dstr`s. Genuine double-quoted interpolation is also a `dstr`, so the delimiter is checked to avoid flagging it.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/