### PR TITLE
Fix an incorrect autocorrect for Lint/LambdaWithoutLiteralBlock

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_lambda_without_literal_block_20260603101717.md
+++ b/changelog/fix_incorrect_autocorrect_for_lambda_without_literal_block_20260603101717.md
@@ -1,0 +1,1 @@
+* [#15210](https://github.com/rubocop/rubocop/pull/15210): Fix an incorrect autocorrect for `Lint/LambdaWithoutLiteralBlock` that dropped safe navigation from the block argument. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/lambda_without_literal_block.rb
+++ b/lib/rubocop/cop/lint/lambda_without_literal_block.rb
@@ -42,7 +42,7 @@ module RuboCop
           end
 
           add_offense(node) do |corrector|
-            corrector.replace(node, node.first_argument.source.delete('&'))
+            corrector.replace(node, node.first_argument.source.delete_prefix('&'))
           end
         end
       end

--- a/spec/rubocop/cop/lint/lambda_without_literal_block_spec.rb
+++ b/spec/rubocop/cop/lint/lambda_without_literal_block_spec.rb
@@ -53,4 +53,15 @@ RSpec.describe RuboCop::Cop::Lint::LambdaWithoutLiteralBlock, :config do
       lambda(&:do_something)
     RUBY
   end
+
+  it 'registers an offense and keeps safe navigation in the block argument when correcting' do
+    expect_offense(<<~RUBY)
+      lambda(&obj&.foo)
+      ^^^^^^^^^^^^^^^^^ lambda without a literal block is deprecated; use the proc without lambda instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj&.foo
+    RUBY
+  end
 end


### PR DESCRIPTION
The autocorrect removed *every* `&` from the block-argument source with `delete('&')`, so `lambda(&obj&.foo)` was rewritten to `obj.foo`, silently dropping the safe navigation. It now strips only the leading block-pass `&` with `delete_prefix`, leaving `obj&.foo` intact.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/