### PR TITLE
Fix a false negative for Lint/NonLocalExitFromIterator

### DIFF
--- a/changelog/fix_false_negative_for_non_local_exit_from_iterator_20260603101859.md
+++ b/changelog/fix_false_negative_for_non_local_exit_from_iterator_20260603101859.md
@@ -1,0 +1,1 @@
+* [#15211](https://github.com/rubocop/rubocop/pull/15211): Fix a false negative for `Lint/NonLocalExitFromIterator` when the iterator receiver uses safe navigation. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -74,7 +74,7 @@ module RuboCop
         end
 
         # @!method chained_send?(node)
-        def_node_matcher :chained_send?, '(send !nil? ...)'
+        def_node_matcher :chained_send?, '(call !nil? ...)'
 
         # @!method define_method?(node)
         def_node_matcher :define_method?, <<~PATTERN

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe RuboCop::Cop::Lint::NonLocalExitFromIterator, :config do
         RUBY
       end
 
+      it 'registers an offense when the receiver uses safe navigation' do
+        expect_offense(<<~RUBY)
+          items&.each do |item|
+            return if item.stock == 0
+            ^^^^^^ Non-local exit from iterator, [...]
+            item.update!(foobar: true)
+          end
+        RUBY
+      end
+
       it 'registers an offense for numblocks' do
         expect_offense(<<~RUBY)
           items.each do


### PR DESCRIPTION
A `return` in an iterator block whose receiver used safe navigation, e.g. `items&.each { |item| return if ... }`, was not flagged, because the `chained_send?` matcher only matched `send` nodes, not `csend`. It now uses the `call` node pattern, which matches both.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

[1]: https://chris.beams.io/posts/git-commit/