### PR TITLE
Generate cleaner changelog entry filenames

### DIFF
--- a/spec/tasks/changelog_spec.rb
+++ b/spec/tasks/changelog_spec.rb
@@ -151,6 +151,19 @@ RSpec.describe Changelog do
         entry = described_class.new(type: :new, body: body, user: github_user)
         expect(entry.path).to match(%r{\Achangelog/new_add_new_lint_useless_rescue_cop_\d+.md\z})
       end
+
+      it 'does not repeat the type when the body starts with it' do
+        body = 'Fix a false positive for `Lint/FloatComparison`'
+        entry = described_class.new(type: :fix, body: body, user: github_user)
+        expect(entry.path).to include('fix_a_false_positive_for_lint_float_comparison')
+        expect(entry.path).not_to include('fix_fix')
+      end
+
+      it 'keeps the cop name even when it appears after a long description' do
+        body = 'Fix a false positive for `Layout/EmptyLinesAroundExceptionHandlingKeywords`'
+        entry = described_class.new(type: :fix, body: body, user: github_user)
+        expect(entry.path).to include('layout_empty_lines_around_exception_handling_keywords')
+      end
     end
   end
 

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -10,7 +10,7 @@ class Changelog
   HEADER = /### (.*)/.freeze
   PATH = 'CHANGELOG.md'
   REF_URL = 'https://github.com/rubocop/rubocop'
-  MAX_LENGTH = 50
+  MAX_LENGTH = 80
   CONTRIBUTOR = '[@%<user>s]: https://github.com/%<user>s'
   SIGNATURE = Regexp.new(format(Regexp.escape('[@%<user>s][]'), user: '([\w-]+)'))
   EOF = "\n"
@@ -32,8 +32,15 @@ class Changelog
     def path
       format(
         ENTRIES_PATH_TEMPLATE,
-        type: type, name: str_to_filename(body), timestamp: Time.now.strftime('%Y%m%d%H%M%S')
+        type: type, name: filename_body, timestamp: Time.now.strftime('%Y%m%d%H%M%S')
       )
+    end
+
+    # The changelog body usually starts with the same word as the entry type
+    # (e.g. a `fix` entry begins with "Fix ..."), which would produce a redundant
+    # `fix_fix_...` filename. Drop that leading duplicate.
+    def filename_body
+      str_to_filename(body).delete_prefix("#{type}_")
     end
 
     def content


### PR DESCRIPTION
Generated changelog filenames were coming out mangled - e.g. `fix_fix_a_false_positive_for_20260603100142.md`. Two causes:

- The changelog body usually starts with the same word as the entry type (a `fix` entry begins with "Fix ..."), producing a redundant `fix_fix_` prefix.
- The 50-char `MAX_LENGTH` truncated the name before the cop, which often comes last (as in "...for `Lint/FloatComparison`").

This drops the redundant leading type word and raises the limit to 80 (the longest `fix_<cop>` is 57, and 80 keeps the cop name even when a description precedes it). So `Fix a false positive for Lint/FloatComparison` now yields `fix_a_false_positive_for_lint_float_comparison_<timestamp>.md`.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/