### PR TITLE
Fix an incorrect autocorrect for `Lint/NumericOperationWithConstantResult`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_numeric_operation_with_constant_result_safe_navigation_20260604142757.md
+++ b/changelog/fix_incorrect_autocorrect_for_numeric_operation_with_constant_result_safe_navigation_20260604142757.md
@@ -1,0 +1,1 @@
+* [#15214](https://github.com/rubocop/rubocop/pull/15214): Fix an incorrect autocorrect for `Lint/NumericOperationWithConstantResult` when using safe navigation, as the result is `nil` when the receiver is `nil`. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
+++ b/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
@@ -58,6 +58,9 @@ module RuboCop
                          '(op-asgn (lvasgn $_lhs) $_operation ({int lvar} $_rhs))'
 
         def on_send(node)
+          # Safe navigation short-circuits to `nil` when the receiver is `nil`, so the
+          # result is not constant and replacing it with `0`/`1` would change behavior.
+          return if node.csend_type?
           return unless (lhs, operation, rhs = operation_with_constant_result?(node))
           return unless (result = constant_result?(lhs, operation, rhs))
 

--- a/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
+++ b/spec/rubocop/cop/lint/numeric_operation_with_constant_result_spec.rb
@@ -102,25 +102,12 @@ RSpec.describe RuboCop::Cop::Lint::NumericOperationWithConstantResult, :config d
     RUBY
   end
 
-  it 'registers an offense when a variable is multiplied by 0 using safe navigation' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using safe navigation, ' \
+     'as the result is `nil` when the receiver is `nil`' do
+    expect_no_offenses(<<~RUBY)
       x&.*(0)
-      ^^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      0
-    RUBY
-  end
-
-  it 'registers an offense when a variable is divided by using safe navigation' do
-    expect_offense(<<~RUBY)
+      x&.**(0)
       x&./(x)
-      ^^^^^^^ Numeric operation with a constant result detected.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      1
     RUBY
   end
 end


### PR DESCRIPTION
The cop aliased `on_csend` to `on_send`, so it flagged and corrected safe-navigation calls like `x&.*(0)`. But `&.` short-circuits to `nil` when the receiver is `nil`, so the result isn't constant - rewriting it to `0`/`1` silently changes behavior. This skips safe navigation in `on_send`.