### PR TITLE
Fix a false negative for `Lint/OrderedMagicComments`

### DIFF
--- a/changelog/fix_a_false_negative_for_ordered_magic_comments_20260604143019.md
+++ b/changelog/fix_a_false_negative_for_ordered_magic_comments_20260604143019.md
@@ -1,0 +1,1 @@
+* [#15215](https://github.com/rubocop/rubocop/pull/15215): Fix a false negative for `Lint/OrderedMagicComments` when an `encoding` magic comment is preceded by a magic comment other than `frozen_string_literal` (e.g. `shareable_constant_value`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/ordered_magic_comments.rb
+++ b/lib/rubocop/cop/lint/ordered_magic_comments.rb
@@ -38,23 +38,23 @@ module RuboCop
         def on_new_investigation
           return if processed_source.buffer.source.empty?
 
-          encoding_line, frozen_string_literal_line = magic_comment_lines
+          encoding_line, other_magic_comment_line = magic_comment_lines
 
-          return unless encoding_line && frozen_string_literal_line
-          return if encoding_line < frozen_string_literal_line
+          return unless encoding_line && other_magic_comment_line
+          return if encoding_line < other_magic_comment_line
 
           range = processed_source.buffer.line_range(encoding_line + 1)
 
           add_offense(range) do |corrector|
-            autocorrect(corrector, encoding_line, frozen_string_literal_line)
+            autocorrect(corrector, encoding_line, other_magic_comment_line)
           end
         end
 
         private
 
-        def autocorrect(corrector, encoding_line, frozen_string_literal_line)
+        def autocorrect(corrector, encoding_line, other_magic_comment_line)
           range1 = processed_source.buffer.line_range(encoding_line + 1)
-          range2 = processed_source.buffer.line_range(frozen_string_literal_line + 1)
+          range2 = processed_source.buffer.line_range(other_magic_comment_line + 1)
 
           corrector.replace(range1, range2.source)
           corrector.replace(range2, range1.source)
@@ -66,7 +66,7 @@ module RuboCop
           leading_magic_comments.each.with_index do |comment, index|
             if comment.encoding_specified?
               lines[0] = index
-            elsif comment.frozen_string_literal_specified?
+            elsif comment.valid?
               lines[1] = index
             end
 

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when an `encoding` magic comment does not precede ' \
+     'a `shareable_constant_value` magic comment' do
+    expect_offense(<<~RUBY)
+      # shareable_constant_value: literal
+      # encoding: ascii
+      ^^^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # encoding: ascii
+      # shareable_constant_value: literal
+    RUBY
+  end
+
+  it 'does not register an offense when an `encoding` magic comment precedes ' \
+     'a `shareable_constant_value` magic comment' do
+    expect_no_offenses(<<~RUBY)
+      # encoding: ascii
+      # shareable_constant_value: literal
+    RUBY
+  end
+
   it 'does not register an offense when using `encoding` magic comment is first line' do
     expect_no_offenses(<<~RUBY)
       # encoding: ascii


### PR DESCRIPTION
The cop only treated `frozen_string_literal` as an "other" magic comment, so an `encoding` comment placed after a different magic comment (e.g. `shareable_constant_value`) went unflagged - even though the message says encoding should precede *all* other magic comments. Switched to `MagicComment#valid?` so any recognized magic comment counts.