### PR TITLE
Fix a false positive for `Lint/RaiseException` in nested namespaces

### DIFF
--- a/changelog/fix_a_false_positive_for_raise_exception_nested_namespace_20260604143150.md
+++ b/changelog/fix_a_false_positive_for_raise_exception_nested_namespace_20260604143150.md
@@ -1,0 +1,1 @@
+* [#15216](https://github.com/rubocop/rubocop/pull/15216): Fix a false positive for `Lint/RaiseException` when `raise Exception` is used inside a module nested within an allowed implicit namespace (e.g. `Gem`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/raise_exception.rb
+++ b/lib/rubocop/cop/lint/raise_exception.rb
@@ -95,7 +95,7 @@ module RuboCop
           if parent.module_type?
             namespace = parent.identifier.source
 
-            return allow_implicit_namespaces.include?(namespace)
+            return true if allow_implicit_namespaces.include?(namespace)
           end
 
           implicit_namespace?(parent)

--- a/spec/rubocop/cop/lint/raise_exception_spec.rb
+++ b/spec/rubocop/cop/lint/raise_exception_spec.rb
@@ -138,6 +138,33 @@ RSpec.describe RuboCop::Cop::Lint::RaiseException, :config do
       RUBY
     end
 
+    it 'does not register an offense when Exception is raised within a nested module ' \
+       'inside an allowed namespace' do
+      expect_no_offenses(<<~RUBY)
+        module Gem
+          module Inner
+            def self.foo
+              raise Exception
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when Exception is raised within nested modules ' \
+       'none of which is allowed' do
+      expect_offense(<<~RUBY)
+        module Foo
+          module Bar
+            def self.foo
+              raise Exception
+                    ^^^^^^^^^ Use `StandardError` over `Exception`.
+            end
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when Exception with cbase specified' do
       expect_offense(<<~RUBY)
         module Gem


### PR DESCRIPTION
`implicit_namespace?` only checked the innermost enclosing module, so `raise Exception` inside a module nested within an allowed namespace (e.g. `module Gem; module Inner; raise Exception`) was flagged - even though `Exception` can resolve to the allowed namespace's exception there. Now it walks the full lexical nesting and allows the raise if any enclosing module is allowed.