### PR TITLE
Fix incorrect autocorrect for redundant cop directive cops with prefix names

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_redundant_cop_directive_prefix_names_20260604143539.md
+++ b/changelog/fix_incorrect_autocorrect_for_redundant_cop_directive_prefix_names_20260604143539.md
@@ -1,0 +1,1 @@
+* [#15217](https://github.com/rubocop/rubocop/pull/15217): Fix an incorrect autocorrect for `Lint/RedundantCopDisableDirective` and `Lint/RedundantCopEnableDirective` when a cop name in the directive is a prefix of another cop name in the same directive (e.g. `Lint/AmbiguousOperator` and `Lint/AmbiguousOperatorPrecedence`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -283,7 +283,10 @@ module RuboCop
         end
 
         def matching_range(haystack, needle)
-          offset = haystack.source.index(needle)
+          # Match the cop name as a whole token so a shorter name is not found inside a
+          # longer one that shares its prefix (e.g. `Lint/AmbiguousOperator` in
+          # `Lint/AmbiguousOperatorPrecedence`).
+          offset = haystack.source.index(/#{Regexp.escape(needle)}(?!\w)/)
           return unless offset
 
           offset += haystack.begin_pos

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -74,7 +74,10 @@ module RuboCop
         end
 
         def cop_name_indention(comment, name)
-          comment.text.index(name)
+          # Match the cop name as a whole token so a shorter name is not found inside a
+          # longer one that shares its prefix (e.g. `Layout/EmptyLines` in
+          # `Layout/EmptyLinesAfterModuleInclusion`).
+          comment.text.index(/#{Regexp.escape(name)}(?!\w)/)
         end
 
         def range_with_comma(comment, name)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -210,6 +210,29 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
             end
           end
 
+          context 'multiple cops, where a redundant one shares a prefix with a non-redundant one' do
+            let(:offenses) do
+              [
+                RuboCop::Cop::Offense.new(:convention,
+                                          FakeLocation.new(line: 7, column: 0),
+                                          'Ambiguous operator precedence.',
+                                          'Lint/AmbiguousOperatorPrecedence')
+              ]
+            end
+
+            it 'locates and removes the right cop name' do
+              expect_offense(<<~RUBY.gsub("<\n", '')) # Wrap lines & avoid issue with JRuby
+                # rubocop:disable Lint/AmbiguousOperatorPrecedence, Lint/AmbiguousOperator
+                                                                    ^^^^^^^^^^^^^^^^^^^^^^ <
+                Unnecessary disabling of `Lint/AmbiguousOperator`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                # rubocop:disable Lint/AmbiguousOperatorPrecedence
+              RUBY
+            end
+          end
+
           context 'multiple cops, with abbreviated names' do
             include_context 'mock console output'
 

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -175,6 +175,21 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
         # rubocop:enable Layout/LineLength
       RUBY
     end
+
+    it 'locates the right cop when a redundant one shares a prefix with a necessary one' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/EmptyLinesAroundClassBody
+        foo
+        # rubocop:enable Layout/EmptyLinesAroundClassBody, Layout/EmptyLines
+                                                           ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/EmptyLines.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/EmptyLinesAroundClassBody
+        foo
+        # rubocop:enable Layout/EmptyLinesAroundClassBody
+      RUBY
+    end
   end
 
   context 'when middle cop is unnecessarily enabled' do


### PR DESCRIPTION
Both `Lint/RedundantCopDisableDirective` and `Lint/RedundantCopEnableDirective` located a cop name in the directive comment with `String#index`. When a shorter cop name is a prefix of a longer sibling listed earlier (e.g. `Lint/AmbiguousOperator` inside `Lint/AmbiguousOperatorPrecedence`), `index` matched the longer name - putting the offense underline and the autocorrect at the wrong position and corrupting the comment. Now the name is matched as a whole token.