### PR TITLE
Fix TODO autocorrect safety comments for local custom cops

### DIFF
--- a/changelog/fix_local_custom_cop_todo_autocorrect_comment_20260604000001.md
+++ b/changelog/fix_local_custom_cop_todo_autocorrect_comment_20260604000001.md
@@ -1,0 +1,1 @@
+* [#14364](https://github.com/rubocop/rubocop/issues/14364): Fix `.rubocop_todo.yml` autocorrect safety comments for local custom cops configured in the project config. ([@RedZapdos123][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -158,7 +158,7 @@ module RuboCop
         output_buffer.puts "# Offense count: #{offense_count}" if show_offense_counts?
 
         cop_class = Cop::Registry.global.find_by_cop_name(cop_name)
-        default_cfg = default_config(cop_name)
+        default_cfg = default_config(cop_name) || @config_for_pwd[cop_name]
 
         if supports_safe_autocorrect?(cop_class, default_cfg)
           output_buffer.puts '# This cop supports safe autocorrection (--autocorrect).'

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
 
   let(:expected_heading_timestamp) { "on #{Time.now} " }
   let(:config_store) { instance_double(RuboCop::ConfigStore) }
+  let(:pwd_config) { instance_double(RuboCop::Config) }
   let(:options) { { config_store: config_store } }
 
   before do
@@ -46,7 +47,8 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     RuboCop::ConfigLoader.clear_options
 
     allow(Time).to receive(:now).and_return(Time.now)
-    allow(config_store).to receive(:for_pwd).and_return(instance_double(RuboCop::Config))
+    allow(config_store).to receive(:for_pwd).and_return(pwd_config)
+    allow(pwd_config).to receive(:[]).and_return(nil)
   end
 
   context 'when any offenses are detected' do
@@ -281,6 +283,41 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
 
     it 'adds a comment about --autocorrect option' do
+      expect(output.string).to eq(expected_rubocop_todo)
+    end
+  end
+
+  context 'with local custom cop autocorrect settings', :restore_registry do
+    let(:cop_name) { 'Custom/TestCop' }
+    let(:offenses) do
+      [RuboCop::Cop::Offense.new(:convention, location, 'message', cop_name)]
+    end
+    let(:expected_rubocop_todo) do
+      [heading,
+       '# Offense count: 1',
+       '# This cop supports unsafe autocorrection (--autocorrect-all).',
+       "#{cop_name}:",
+       '  Exclude:',
+       "    - 'test_autocorrect.rb'",
+       ''].join("\n")
+    end
+
+    before do
+      stub_cop_class('Custom::TestCop') { extend RuboCop::Cop::AutoCorrector }
+
+      allow(pwd_config).to receive(:[]).with(cop_name).and_return({ 'SafeAutoCorrect' => false })
+      allow(RuboCop::ConfigLoader.default_configuration)
+        .to receive(:[])
+        .with(cop_name)
+        .and_return(nil)
+
+      formatter.started(['test_autocorrect.rb'])
+      formatter.file_started('test_autocorrect.rb', options)
+      formatter.file_finished('test_autocorrect.rb', offenses)
+      formatter.finished(['test_autocorrect.rb'])
+    end
+
+    it 'uses project config when default config is unavailable' do
       expect(output.string).to eq(expected_rubocop_todo)
     end
   end


### PR DESCRIPTION
## Description:

Issue #14364 reported that `.rubocop_todo.yml` could ignore local custom cop configuration when generating autocorrect safety comments.

When a local custom cop was not present in RuboCop's default config, `DisabledConfigFormatter` only checked the default config and incorrectly labeled the cop as supporting safe autocorrection.

This PR updates `DisabledConfigFormatter` to fall back to the project config for cops that are not present in the default config, so local custom cops preserve `SafeAutoCorrect` metadata in generated TODO comments.

It also adds a regression spec for a local custom cop configured with `SafeAutoCorrect: false` and a changelog entry for the fix.

Closes #14364.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting in WSL using `bundle exec rubocop lib/rubocop/formatter/disabled_config_formatter.rb spec/rubocop/formatter/disabled_config_formatter_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/rubocop/formatter/disabled_config_formatter_spec.rb`.
- [x] I have run the full verification suite in WSL using `bundle exec rake`.

### The validation screenshot of tests run:

<img width="1267" height="726" alt="image" src="https://github.com/user-attachments/assets/1f1c6149-8265-4b2e-b4e5-c4a920d29f92" />

### Before the fix:

<img width="566" height="212" alt="image" src="https://github.com/user-attachments/assets/8dd4053c-3cab-4b80-858e-25f810663081" />

### After the fix:

<img width="575" height="230" alt="image" src="https://github.com/user-attachments/assets/4fc64fc9-cbb1-48f7-aca0-502cb358af94" />
