### PR TITLE
Fix a false positive for `Lint/RedundantDirGlobSort` with a comparator block

### DIFF
--- a/changelog/fix_a_false_positive_for_redundant_dir_glob_sort_with_a_block_20260604143925.md
+++ b/changelog/fix_a_false_positive_for_redundant_dir_glob_sort_with_a_block_20260604143925.md
@@ -1,0 +1,1 @@
+* [#15219](https://github.com/rubocop/rubocop/pull/15219): Fix a false positive for `Lint/RedundantDirGlobSort` when `sort` is given a comparator block or a block-pass argument, which is not redundant with the default sorting. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
+++ b/lib/rubocop/cop/lint/redundant_dir_glob_sort.rb
@@ -38,10 +38,10 @@ module RuboCop
         GLOB_METHODS = %i[glob []].freeze
 
         def on_send(node)
-          return unless (receiver = node.receiver)
-          return unless receiver.receiver&.const_type? && receiver.receiver.short_name == :Dir
-          return unless GLOB_METHODS.include?(receiver.method_name)
-          return if multiple_argument?(receiver)
+          return unless dir_glob?(node.receiver)
+          # `sort` with a comparator block or block-pass changes the order, so it is
+          # not redundant with the default sorting performed by `Dir.glob`/`Dir[]`.
+          return if sort_with_comparator?(node) || multiple_argument?(node.receiver)
 
           selector = node.loc.selector
 
@@ -53,8 +53,19 @@ module RuboCop
 
         private
 
+        def dir_glob?(receiver)
+          return false unless receiver&.receiver&.const_type?
+          return false unless receiver.receiver.short_name == :Dir
+
+          GLOB_METHODS.include?(receiver.method_name)
+        end
+
         def multiple_argument?(glob_method)
           glob_method.arguments.count >= 2 || glob_method.first_argument&.splat_type?
+        end
+
+        def sort_with_comparator?(node)
+          node.parent&.any_block_type? || node.last_argument&.block_pass_type?
         end
       end
     end

--- a/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_dir_glob_sort_spec.rb
@@ -79,6 +79,41 @@ RSpec.describe RuboCop::Cop::Lint::RedundantDirGlobSort, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects a standalone `Dir.glob(...).sort`' do
+      expect_offense(<<~RUBY)
+        Dir.glob('./lib/**/*.rb').sort
+                                  ^^^^ Remove redundant `sort`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Dir.glob('./lib/**/*.rb')
+      RUBY
+    end
+
+    it 'does not register an offense for a receiverless `sort`' do
+      expect_no_offenses(<<~RUBY)
+        sort { |a, b| a <=> b }
+      RUBY
+    end
+
+    it 'does not register an offense when `sort` is given a comparator block' do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob('./lib/**/*.rb').sort { |a, b| b <=> a }.each(&method(:require))
+      RUBY
+    end
+
+    it 'does not register an offense when `sort` is given a numbered-parameter block' do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob('./lib/**/*.rb').sort { _2 <=> _1 }.each(&method(:require))
+      RUBY
+    end
+
+    it 'does not register an offense when `sort` is given a block-pass argument' do
+      expect_no_offenses(<<~RUBY)
+        Dir.glob('./lib/**/*.rb').sort(&comparator).each(&method(:require))
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.sort`' do
       expect_no_offenses(<<~RUBY)
         collection.sort


### PR DESCRIPTION
`Dir.glob(...).sort { |a, b| b <=> a }` (or `sort(&cmp)`) sorts with a custom comparator, so it isn't redundant with the default order `Dir.glob` already produces. The cop flagged it and autocorrected to `Dir.glob(...) { ... }`, leaving the comparator block dangling on `glob` and silently dropping the custom order. Now `sort` calls carrying a block or block-pass argument are skipped.