### PR TITLE
Fix a bad autocorrect for `Lint/RedundantSplatExpansion` with empty literals

### DIFF
--- a/changelog/fix_a_bad_autocorrect_for_redundant_splat_expansion_with_empty_literals_20260604212259.md
+++ b/changelog/fix_a_bad_autocorrect_for_redundant_splat_expansion_with_empty_literals_20260604212259.md
@@ -1,0 +1,1 @@
+* [#15220](https://github.com/rubocop/rubocop/pull/15220): Fix a bad autocorrect for `Lint/RedundantSplatExpansion` when splatting an empty literal (e.g. `when *[]` or `rescue *[]`), which expanded to invalid or semantically different code. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -122,6 +122,10 @@ module RuboCop
 
               grandparent = node.parent.parent
               return if grandparent && !ASSIGNMENT_TYPES.include?(grandparent.type)
+            # An empty array/percent literal (`*[]`, `*%w()`, ...) expands to nothing, so
+            # removing the splat would produce invalid or semantically different code.
+            elsif expanded_item.array_type? && expanded_item.children.empty?
+              return
             end
 
             yield

--- a/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_splat_expansion_spec.rb
@@ -296,6 +296,48 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSplatExpansion, :config do
     RUBY
   end
 
+  context 'expanding an empty literal' do
+    it 'does not register an offense for an empty array in a `when` condition' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when *[]
+          bar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for an empty percent literal in a `when` condition' do
+      expect_no_offenses(<<~RUBY)
+        case foo
+        when *%w()
+          bar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for an empty array in a `rescue`' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          foo
+        rescue *[]
+          bar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for an empty array as a method argument' do
+      expect_no_offenses(<<~RUBY)
+        do_something(*[])
+      RUBY
+    end
+
+    it 'does not register an offense for an empty array inside an array literal' do
+      expect_no_offenses(<<~RUBY)
+        [*[]]
+      RUBY
+    end
+  end
+
   context 'splat expansion inside of an array' do
     it 'registers an offense and corrects the expansion of an array literal' \
        'inside of an array literal' do


### PR DESCRIPTION
Splatting an empty literal (`*[]`, `*%w()`, `*%i()`, ...) expands to nothing, so removing the splat produces broken code: `when *[]` becomes a syntax error and `rescue *[]` becomes a bare `rescue` that catches `StandardError` (the opposite of catching nothing). The cop now leaves empty-literal splats alone.