### PR TITLE
Fix a bad autocorrect for `Lint/RegexpAsCondition` with a negated regexp

### DIFF
--- a/changelog/fix_a_bad_autocorrect_for_regexp_as_condition_with_a_negated_regexp_20260604212451.md
+++ b/changelog/fix_a_bad_autocorrect_for_regexp_as_condition_with_a_negated_regexp_20260604212451.md
@@ -1,0 +1,1 @@
+* [#15221](https://github.com/rubocop/rubocop/pull/15221): Fix a bad autocorrect for `Lint/RegexpAsCondition` when the regexp literal is negated (e.g. `if !/foo/`), which inverted the condition. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/regexp_as_condition.rb
+++ b/lib/rubocop/cop/lint/regexp_as_condition.rb
@@ -26,7 +26,15 @@ module RuboCop
           return if node.ancestors.none?(&:conditional?)
           return if part_of_ignored_node?(node)
 
-          add_offense(node) { |corrector| corrector.replace(node, "#{node.source} =~ $_") }
+          add_offense(node) do |corrector|
+            # `!` binds tighter than `=~`, so `!/foo/ =~ $_` would parse as
+            # `(!/foo/) =~ $_`. Wrap the match in parentheses to preserve the meaning.
+            if node.parent&.send_type? && node.parent.method?(:!)
+              corrector.replace(node.parent, "!(#{node.source} =~ $_)")
+            else
+              corrector.replace(node, "#{node.source} =~ $_")
+            end
+          end
 
           ignore_node(node)
         end

--- a/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Lint::RegexpAsCondition, :config do
     RUBY
 
     expect_correction(<<~RUBY)
-      if !/foo/ =~ $_
+      if !(/foo/ =~ $_)
       end
     RUBY
   end


### PR DESCRIPTION
`if !/foo/` was corrected to `if !/foo/ =~ $_`. Because `!` binds tighter than `=~`, that parses as `(!/foo/) =~ $_` - calling `=~` on a boolean, which silently inverts the branch (it never runs). Now it wraps the match: `!(/foo/ =~ $_)`. The spec previously asserted the broken output, so that's corrected too.