### PR TITLE
Fix two `Lint/ScriptPermission` bugs (config autocorrect, virtual-source crash)

### DIFF
--- a/changelog/fix_lint_script_permission_autocorrect_config_and_virtual_source_crash_20260604212802.md
+++ b/changelog/fix_lint_script_permission_autocorrect_config_and_virtual_source_crash_20260604212802.md
@@ -1,0 +1,1 @@
+* [#15222](https://github.com/rubocop/rubocop/pull/15222): Fix `Lint/ScriptPermission` to honor a cop-level `AutoCorrect: false` setting and to not crash on sources without a file on disk (e.g. unsaved editor buffers). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/script_permission.rb
+++ b/lib/rubocop/cop/lint/script_permission.rb
@@ -46,7 +46,7 @@ module RuboCop
           message = format_message_from(processed_source)
 
           add_offense(comment, message: message) do
-            autocorrect if autocorrect_requested?
+            autocorrect if autocorrect?
           end
         end
 
@@ -57,6 +57,10 @@ module RuboCop
         end
 
         def executable?(processed_source)
+          # Virtual sources (LSP buffers, programmatic `ProcessedSource`) have no file on
+          # disk to stat or `chmod`, so treat them as executable to skip the offense.
+          return true unless File.exist?(processed_source.file_path)
+
           # Returns true if stat is executable or if the operating system
           # doesn't distinguish executable files from nonexecutable files.
           # See at: https://github.com/ruby/ruby/blob/ruby_2_4/file.c#L5362

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
           expect(file.stat).not_to be_executable
         end
       end
+
+      context 'if `AutoCorrect: false` is configured for the cop' do
+        let(:cop_config) { { 'AutoCorrect' => false } }
+
+        it 'leaves the file intact' do
+          expect_offense(<<~RUBY, file)
+            #!/usr/bin/ruby
+            ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
+          RUBY
+
+          expect_no_corrections
+          expect(file.stat).not_to be_executable
+        end
+      end
     end
   end
 
@@ -87,6 +101,15 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
 
     it 'skips investigation' do
       expect_no_offenses(source)
+    end
+  end
+
+  context 'with a source that has no file on disk' do
+    it 'does not crash (e.g. an unsaved editor buffer or programmatic source)' do
+      expect_no_offenses(<<~RUBY)
+        #!/usr/bin/ruby
+        puts 'hello, world'
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Two bugs:

- It used `autocorrect_requested?`, which checks only the `--autocorrect` CLI flag, so a cop-level `AutoCorrect: false` was ignored and the `chmod` ran anyway. Now uses `autocorrect?`.
- It called `File.stat` on the file path unconditionally, crashing with `Errno::ENOENT` on sources with no file on disk (LSP buffers, programmatic `ProcessedSource`, path `(string)`). Now guards `File.exist?` first.