### PR TITLE
Make `Lint/RedundantWithObject` autocorrect unsafe

### DIFF
--- a/changelog/change_make_redundant_with_object_autocorrect_unsafe_20260604212943.md
+++ b/changelog/change_make_redundant_with_object_autocorrect_unsafe_20260604212943.md
@@ -1,0 +1,1 @@
+* [#15223](https://github.com/rubocop/rubocop/pull/15223): Make `Lint/RedundantWithObject` autocorrect unsafe, since `each_with_object` returns the memo object while the corrected `each` returns the receiver. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2351,7 +2351,9 @@ Lint/RedundantWithIndex:
 Lint/RedundantWithObject:
   Description: 'Checks for redundant `with_object`.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.51'
+  VersionChanged: '<<next>>'
 
 Lint/RefinementImportMethods:
   Description: 'Use `Refinement#import_methods` when using `include` or `prepend` in `refine` block.'

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -5,6 +5,11 @@ module RuboCop
     module Lint
       # Checks for redundant `with_object`.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because the return value changes:
+      #   `each_with_object` returns the memo object, while the corrected `each` returns
+      #   the receiver. This matters when the result of the expression is used.
+      #
       # @example
       #   # bad
       #   ary.each_with_object([]) do |v|


### PR DESCRIPTION
`each_with_object` returns the memo object, but the corrected `each` returns the receiver - so the autocorrect silently changes the value whenever the expression's result is used. Marked `SafeAutoCorrect: false` with a `@safety` note; detection is unchanged, only the rewrite now requires `-A`.