### PR TITLE
Fix a false positive for `Lint/ShadowingOuterLocalVariable` with `case`/`in`

### DIFF
--- a/changelog/fix_a_false_positive_for_shadowing_outer_local_variable_with_case_in_20260604213427.md
+++ b/changelog/fix_a_false_positive_for_shadowing_outer_local_variable_with_case_in_20260604213427.md
@@ -1,0 +1,1 @@
+* [#15224](https://github.com/rubocop/rubocop/pull/15224): Fix a false positive for `Lint/ShadowingOuterLocalVariable` when a block argument has the same name as a pattern variable from a different `in` branch of the same `case`. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -75,6 +75,8 @@ module RuboCop
         end
 
         def same_conditions_node_different_branch?(variable, outer_local_variable)
+          return true if different_case_in_branch?(variable, outer_local_variable)
+
           variable_node = variable_node(variable)
           return false unless node_or_its_ascendant_conditional?(variable_node)
 
@@ -86,6 +88,18 @@ module RuboCop
 
           outer_local_variable_node.if_type? &&
             variable_node == outer_local_variable_node.else_branch
+        end
+
+        # `case ... in` binds variables in the pattern itself, so a block argument in one
+        # `in` branch does not shadow a pattern variable from a different `in` branch of the
+        # same `case` (the branches are mutually exclusive).
+        def different_case_in_branch?(variable, outer_local_variable)
+          inner_branch = variable.scope.node.each_ancestor(:in_pattern).first
+          outer_branch = outer_local_variable.declaration_node.each_ancestor(:in_pattern).first
+
+          return false unless inner_branch && outer_branch
+
+          inner_branch != outer_branch && inner_branch.parent == outer_branch.parent
         end
 
         def variable_node(variable)

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -297,6 +297,35 @@ RSpec.describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable, :config do
     end
   end
 
+  context 'when a block argument has same name as a pattern variable' \
+          'from a different branch of the same `case`/`in`', :ruby27 do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        case condition
+        in String => foo
+          foo
+        in Integer
+          bar.each do |foo|
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a block argument has same name as a pattern variable' \
+          'from the same branch of a `case`/`in`', :ruby27 do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        case condition
+        in String => foo
+          bar.each do |foo|
+                       ^^^ Shadowing outer local variable - `foo`.
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when a block argument has different name with outer scope variables' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
A block argument in one `in` branch was flagged as shadowing a pattern variable bound in a *different* `in` branch of the same `case` - but those branches are mutually exclusive, so it's not shadowing (the equivalent `case`/`when` case is already exempt). Now sibling-branch pattern variables are exempt, while genuine shadowing within the same branch still flags.