### PR TITLE
Fix a false negative for `Lint/SafeNavigationWithEmpty`

### DIFF
--- a/changelog/fix_a_false_negative_for_safe_navigation_with_empty_20260604214319.md
+++ b/changelog/fix_a_false_negative_for_safe_navigation_with_empty_20260604214319.md
@@ -1,0 +1,1 @@
+* [#15225](https://github.com/rubocop/rubocop/pull/15225): Fix a false negative for `Lint/SafeNavigationWithEmpty` when the receiver of `&.empty?` is a local variable, instance variable, constant, or other non-method-call expression. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         # @!method safe_navigation_empty_in_conditional?(node)
         def_node_matcher :safe_navigation_empty_in_conditional?, <<~PATTERN
-          (if (csend (send ...) :empty?) ...)
+          (if (csend _ :empty?) ...)
         PATTERN
 
         def on_if(node)

--- a/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
@@ -13,6 +13,41 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationWithEmpty, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when the receiver is a local variable' do
+      expect_offense(<<~RUBY)
+        foo = build_collection
+        return if foo&.empty?
+                  ^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = build_collection
+        return if foo && foo.empty?
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the receiver is an instance variable' do
+      expect_offense(<<~RUBY)
+        return if @foo&.empty?
+                  ^^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if @foo && @foo.empty?
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the receiver is a constant' do
+      expect_offense(<<~RUBY)
+        return if FOO&.empty?
+                  ^^^^^^^^^^^ Avoid calling `empty?` with the safe navigation operator in conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        return if FOO && FOO.empty?
+      RUBY
+    end
+
     it 'does not register an offense on `.empty?`' do
       expect_no_offenses(<<~RUBY)
         return if foo.empty?


### PR DESCRIPTION
The matcher required the `&.empty?` receiver to be a method call (`send`), so `foo&.empty?` where `foo` is a local variable, instance variable, constant, etc. was silently accepted - which is the cop's core case. Now it matches any receiver.