### PR TITLE
Fix false negatives for `Lint/RescueType` (true/false/rational/complex)

### DIFF
--- a/changelog/fix_false_negatives_for_rescue_type_20260604223227.md
+++ b/changelog/fix_false_negatives_for_rescue_type_20260604223227.md
@@ -1,0 +1,1 @@
+* [#15226](https://github.com/rubocop/rubocop/pull/15226): Fix false negatives for `Lint/RescueType` when rescuing from `true`, `false`, a rational literal (`1r`), or a complex literal (`1i`), all of which raise a `TypeError` at runtime. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         MSG = 'Rescuing from `%<invalid_exceptions>s` will raise a ' \
               '`TypeError` instead of catching the actual exception.'
-        INVALID_TYPES = %i[array dstr float hash nil int str sym].freeze
+        INVALID_TYPES = %i[array complex dstr false float hash nil int rational str sym true].freeze
 
         def on_resbody(node)
           invalid_exceptions = invalid_exceptions(node.exceptions)

--- a/spec/rubocop/cop/lint/rescue_type_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_type_spec.rb
@@ -187,4 +187,8 @@ RSpec.describe RuboCop::Cop::Lint::RescueType, :config do
   it_behaves_like 'offenses', '[]'
   it_behaves_like 'offenses', '{}'
   it_behaves_like 'offenses', ':symbol'
+  it_behaves_like 'offenses', 'true'
+  it_behaves_like 'offenses', 'false'
+  it_behaves_like 'offenses', '1r'
+  it_behaves_like 'offenses', '1i'
 end


### PR DESCRIPTION
`rescue true`, `rescue false`, `rescue 1r` (rational), and `rescue 1i` (complex) all raise `TypeError: class or module required for rescue clause` at runtime, exactly like the other invalid types the cop already catches. Added them to `INVALID_TYPES`.