### PR TITLE
Fix two false negatives for `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_negatives_for_redundant_safe_navigation_20260604214932.md
+++ b/changelog/fix_false_negatives_for_redundant_safe_navigation_20260604214932.md
@@ -1,0 +1,1 @@
+* [#15227](https://github.com/rubocop/rubocop/pull/15227): Fix false negatives for `Lint/RedundantSafeNavigation` with `&.respond_to?` on a guaranteed-instance receiver (e.g. `foo.to_s&.respond_to?(:class)`) and with `&.to_h` using a numbered-parameter or `it` block (e.g. `foo&.to_h { _1 } || {}`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -183,7 +183,7 @@ module RuboCop
         def_node_matcher :conversion_with_default?, <<~PATTERN
           {
             (or $(csend _ :to_h) (hash))
-            (or (block $(csend _ :to_h) ...) (hash))
+            (or (any_block $(csend _ :to_h) ...) (hash))
             (or $(csend _ :to_a) (array))
             (or $(csend _ :to_i) (int 0))
             (or $(csend _ :to_f) (float 0.0))
@@ -191,7 +191,6 @@ module RuboCop
           }
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
         def on_csend(node)
           range = node.loc.dot
 
@@ -204,14 +203,10 @@ module RuboCop
             end
           end
 
-          unless assume_receiver_instance_exists?(node.receiver)
-            return if !guaranteed_instance?(node.receiver) && !check?(node)
-            return if respond_to_nil_method?(node)
-          end
+          return if guarded_by_nil_receiver?(node)
 
           add_offense(range) { |corrector| corrector.replace(range, '.') }
         end
-        # rubocop:enable Metrics/AbcSize
 
         # rubocop:disable Metrics/AbcSize
         def on_or(node)
@@ -229,6 +224,18 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize
 
         private
+
+        # Returns true when the `&.` is meaningful because the receiver may actually be nil.
+        def guarded_by_nil_receiver?(node)
+          return false if assume_receiver_instance_exists?(node.receiver)
+
+          guaranteed_instance = guaranteed_instance?(node.receiver)
+          return true if !guaranteed_instance && !check?(node)
+
+          # `nil.respond_to?(<nil method>)` is `true`, so `&.` is meaningful when the receiver
+          # may be nil. A guaranteed instance can never be nil, so `&.` is still redundant there.
+          respond_to_nil_method?(node) && !guaranteed_instance
+        end
 
         def assume_receiver_instance_exists?(receiver)
           return true if receiver.const_type? && !receiver.short_name.match?(SNAKE_CASE)

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -211,6 +211,18 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when `&.respond_to?` with a `nil` method ' \
+     'follows a guaranteed-instance method' do
+    expect_offense(<<~RUBY)
+      foo.to_s&.respond_to?(:class)
+              ^^ Redundant safe navigation detected, use `.` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_s.respond_to?(:class)
+    RUBY
+  end
+
   it 'does not register an offense when `&.` is used with coercion methods' do
     expect_no_offenses(<<~RUBY)
       foo&.to_s || 'Default string'
@@ -238,6 +250,28 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
 
     expect_correction(<<~RUBY)
       foo.to_h { |k, v| [k, v] }
+    RUBY
+  end
+
+  it 'registers an offense and corrects `&.to_h` having a numbered-parameter block with default' do
+    expect_offense(<<~RUBY)
+      foo&.to_h { _1 } || {}
+         ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation with default literal detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_h { _1 }
+    RUBY
+  end
+
+  it 'registers an offense and corrects `&.to_h` having an `it`-block with default', :ruby34 do
+    expect_offense(<<~RUBY)
+      foo&.to_h { it } || {}
+         ^^^^^^^^^^^^^^^^^^^ Redundant safe navigation with default literal detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.to_h { it }
     RUBY
   end
 


### PR DESCRIPTION
Two false negatives:

- `foo.to_s&.respond_to?(:class)` wasn't flagged. The guard that protects `&.respond_to?` with a method `nil` responds to fired even when the receiver is a guaranteed instance (e.g. `to_s`), which can never be nil - so `&.` is still redundant there.
- `foo&.to_h { _1 } || {}` and `foo&.to_h { it } || {}` weren't flagged because the pattern only matched plain blocks. Now matches `any_block` (numbered-parameter and `it` blocks too).