### PR TITLE
Fix a false negative for `Lint/RedundantWithIndex` with no block argument

### DIFF
--- a/changelog/fix_a_false_negative_for_redundant_with_index_zero_param_blocks_20260604215124.md
+++ b/changelog/fix_a_false_negative_for_redundant_with_index_zero_param_blocks_20260604215124.md
@@ -1,0 +1,1 @@
+* [#15228](https://github.com/rubocop/rubocop/pull/15228): Fix a false negative for `Lint/RedundantWithIndex` when the block takes no arguments (e.g. `ary.each_with_index { do_something }`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -62,7 +62,7 @@ module RuboCop
           {
             (block
               $(call _ {:each_with_index :with_index} ...)
-              (args (arg _)) ...)
+              {(args (arg _)) (args)} ...)
             (numblock
               $(call _ {:each_with_index :with_index} ...) 1 ...)
             (itblock

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithIndex, :config do
     RUBY
   end
 
+  it 'registers an offense for `ary.each_with_index { do_something }` (no block argument)' do
+    expect_offense(<<~RUBY)
+      ary.each_with_index { do_something }
+          ^^^^^^^^^^^^^^^ Use `each` instead of `each_with_index`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { do_something }
+    RUBY
+  end
+
+  it 'registers an offense for `ary.each.with_index { do_something }` (no block argument)' do
+    expect_offense(<<~RUBY)
+      ary.each.with_index { do_something }
+               ^^^^^^^^^^ Remove redundant `with_index`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ary.each { do_something }
+    RUBY
+  end
+
   it 'registers an offense for `ary&.each_with_index { |v| v }` and corrects to `ary&.each`' do
     expect_offense(<<~RUBY)
       ary&.each_with_index { |v| v }


### PR DESCRIPTION
The cop flagged `each_with_index`/`with_index` blocks that take a single unused argument, but not blocks that take no arguments at all (`ary.each_with_index { do_something }`) - where the index is equally unused and `each` behaves identically. Now matches zero-argument blocks too.