### PR TITLE
Fix a false negative for `Lint/SafeNavigationChain` with parentheses

### DIFF
--- a/changelog/fix_a_false_negative_for_safe_navigation_chain_parenthesized_20260604215359.md
+++ b/changelog/fix_a_false_negative_for_safe_navigation_chain_parenthesized_20260604215359.md
@@ -1,0 +1,1 @@
+* [#15229](https://github.com/rubocop/rubocop/pull/15229): Fix a false negative for `Lint/SafeNavigationChain` when an ordinary method is chained after a parenthesized safe navigation call (e.g. `(x&.foo).bar`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -34,6 +34,7 @@ module RuboCop
           {
             (send $(csend ...) $_ ...)
             (send $(any_block (csend ...) ...) $_ ...)
+            (send $(begin (csend ...)) $_ ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for ordinary method call after a parenthesized safe navigation call' do
+      expect_offense(<<~RUBY)
+        (x&.foo).bar
+                ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (x&.foo)&.bar
+      RUBY
+    end
+
     it 'registers an offense for ordinary method chain exists after safe navigation method call' do
       expect_offense(<<~RUBY)
         something


### PR DESCRIPTION
`(x&.foo).bar` raises `NoMethodError` when `x` is nil, exactly like `x&.foo.bar`, but the cop missed it because the parentheses wrap the safe navigation in a `begin` node. Now it matches a single-statement parenthesized safe-navigation receiver and corrects to `(x&.foo)&.bar`.