### PR TITLE
Fix a false negative for `Lint/RequireRelativeSelfPath` with absolute paths

### DIFF
--- a/changelog/fix_a_false_negative_for_require_relative_self_path_absolute_20260604215615.md
+++ b/changelog/fix_a_false_negative_for_require_relative_self_path_absolute_20260604215615.md
@@ -1,0 +1,1 @@
+* [#15230](https://github.com/rubocop/rubocop/pull/15230): Fix a false negative for `Lint/RequireRelativeSelfPath` when requiring the current file by name with its extension (e.g. `require_relative 'foo.rb'`) and the file path is absolute. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/require_relative_self_path.rb
+++ b/lib/rubocop/cop/lint/require_relative_self_path.rb
@@ -40,11 +40,11 @@ module RuboCop
         def same_file?(file_path, required_feature)
           return false unless File.extname(file_path) == '.rb'
 
-          file_path == required_feature || remove_ext(file_path) == required_feature
-        end
-
-        def remove_ext(file_path)
-          File.basename(file_path, File.extname(file_path))
+          # `require_relative` is resolved relative to the current file's directory, so a
+          # bare `foo`/`foo.rb` (no path separator) requires the current file itself. Compare
+          # against the basename so this works whether `file_path` is relative or absolute.
+          basename = File.basename(file_path, '.rb')
+          required_feature == basename || required_feature == "#{basename}.rb"
         end
       end
     end

--- a/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
+++ b/spec/rubocop/cop/lint/require_relative_self_path_spec.rb
@@ -60,4 +60,33 @@ RSpec.describe RuboCop::Cop::Lint::RequireRelativeSelfPath, :config do
       require_relative 'Rakefile'
     RUBY
   end
+
+  context 'when the file path is absolute' do
+    it 'registers an offense for the with-extension form' do
+      expect_offense(<<~RUBY, '/path/to/foo.rb')
+        require_relative 'foo.rb'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the `require_relative` that requires itself.
+        require_relative 'bar'
+      RUBY
+
+      expect_correction(<<~RUBY)
+        require_relative 'bar'
+      RUBY
+    end
+
+    it 'registers an offense for the without-extension form' do
+      expect_offense(<<~RUBY, '/path/to/foo.rb')
+        require_relative 'foo'
+        ^^^^^^^^^^^^^^^^^^^^^^ Remove the `require_relative` that requires itself.
+      RUBY
+
+      expect_correction('')
+    end
+
+    it 'does not register an offense for a different file with the same basename in another directory' do
+      expect_no_offenses(<<~RUBY, '/path/to/foo.rb')
+        require_relative 'sub/foo'
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The with-extension form (`require_relative 'foo.rb'`) was only flagged when the processed file path was the bare string `foo.rb`. In real runs the path is absolute (`/project/lib/foo.rb`), so the comparison never matched and the self-require went undetected. Now it compares against the basename, which works regardless of whether the path is relative or absolute - and still ignores requires with a path component (`sub/foo`).