### PR TITLE
Fix a false negative for `Lint/SendWithMixinArgument` with implicit/self receiver

### DIFF
--- a/changelog/fix_a_false_negative_for_send_with_mixin_argument_receivers_20260604215859.md
+++ b/changelog/fix_a_false_negative_for_send_with_mixin_argument_receivers_20260604215859.md
@@ -1,0 +1,1 @@
+* [#15231](https://github.com/rubocop/rubocop/pull/15231): Fix a false negative for `Lint/SendWithMixinArgument` when `send`/`public_send`/`__send__` is called with no explicit receiver or with a `self` receiver (e.g. `send(:include, Bar)`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/send_with_mixin_argument.rb
+++ b/lib/rubocop/cop/lint/send_with_mixin_argument.rb
@@ -45,7 +45,7 @@ module RuboCop
         # @!method send_with_mixin_argument?(node)
         def_node_matcher :send_with_mixin_argument?, <<~PATTERN
           (send
-            (const _ _) {:#{SEND_METHODS.join(' :')}}
+            {nil? self (const _ _)} {:#{SEND_METHODS.join(' :')}}
             ({sym str} $#mixin_method?)
               $(const _ _)+)
         PATTERN

--- a/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
+++ b/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
@@ -12,6 +12,36 @@ RSpec.describe RuboCop::Cop::Lint::SendWithMixinArgument, :config do
     RUBY
   end
 
+  it 'registers an offense when using `send` with `include` and no explicit receiver' do
+    expect_offense(<<~RUBY)
+      class Foo
+        send(:include, Bar)
+        ^^^^^^^^^^^^^^^^^^^ Use `include Bar` instead of `send(:include, Bar)`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        include Bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `send` with `include` and a `self` receiver' do
+    expect_offense(<<~RUBY)
+      class Foo
+        self.send(:include, Bar)
+             ^^^^^^^^^^^^^^^^^^^ Use `include Bar` instead of `send(:include, Bar)`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        self.include Bar
+      end
+    RUBY
+  end
+
   it 'registers an offense when using `send` with `prepend`' do
     expect_offense(<<~RUBY)
       Foo.send(:prepend, Bar)


### PR DESCRIPTION
The matcher only recognized a constant receiver (`Foo.send(:include, Bar)`), so the no-receiver form (`send(:include, Bar)`) and the `self` form (`self.send(:include, Bar)`) - the historically canonical way to mix in what used to be a private method - went unflagged. Now matches a `nil` or `self` receiver, correcting to `include Bar` and `self.include Bar`.