### PR TITLE
Fix a false negative for `Lint/SafeNavigationConsistency` with parentheses

### DIFF
--- a/changelog/fix_a_false_negative_for_safe_navigation_consistency_parenthesized_20260604220418.md
+++ b/changelog/fix_a_false_negative_for_safe_navigation_consistency_parenthesized_20260604220418.md
@@ -1,0 +1,1 @@
+* [#15232](https://github.com/rubocop/rubocop/pull/15232): Fix a false negative for `Lint/SafeNavigationConsistency` when a method call is wrapped in parentheses (e.g. `foo&.bar || (foo.baz)`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -39,10 +39,10 @@ module RuboCop
       #   foo.bar || foo.baz
       #
       #   # bad
-      #   foo&.bar && (foobar.baz || foo&.baz)
+      #   foo.bar && (foo&.baz)
       #
       #   # good
-      #   foo&.bar && (foobar.baz || foo.baz)
+      #   foo.bar && (foo.baz)
       #
       class SafeNavigationConsistency < Base
         include NilMethods
@@ -121,6 +121,8 @@ module RuboCop
         def operand_nodes(operand, operand_nodes)
           if operand.operator_keyword?
             collect_operands(operand, operand_nodes)
+          elsif operand.begin_type?
+            operand.children.each { |child| operand_nodes(child, operand_nodes) }
           elsif operand.call_type?
             operand_nodes << operand
           end
@@ -142,19 +144,15 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def operand_in_and?(node)
-          return true if node.parent.and_type?
+          node = node.parent while node.parent.begin_type?
 
-          parent = node.parent.parent while node.parent.begin_type?
-
-          parent&.and_type?
+          node.parent&.and_type?
         end
 
         def operand_in_or?(node)
-          return true if node.parent.or_type?
+          node = node.parent while node.parent.begin_type?
 
-          parent = node.parent.parent while node.parent.begin_type?
-
-          parent&.or_type?
+          node.parent&.or_type?
         end
 
         def nilable?(node)

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -341,4 +341,26 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
       foo&.bar && foo.baz || foo.qux
     RUBY
   end
+
+  it 'registers an offense and corrects a parenthesized operand needing safe navigation' do
+    expect_offense(<<~RUBY)
+      foo&.bar || (foo.baz)
+                      ^ Use `&.` for consistency with safe navigation.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo&.bar || (foo&.baz)
+    RUBY
+  end
+
+  it 'registers an offense and corrects a parenthesized operand with unnecessary safe navigation' do
+    expect_offense(<<~RUBY)
+      foo.bar && (foo&.baz)
+                     ^^ Use `.` instead of unnecessary `&.`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.bar && (foo.baz)
+    RUBY
+  end
 end


### PR DESCRIPTION
Operands wrapped in parentheses were silently dropped, so e.g. `foo&.bar || (foo.baz)` bypassed the consistency check. The cop now recurses into `begin` nodes so those calls participate.

This also fixes a latent hang: `operand_in_and?`/`operand_in_or?` had a `while` loop that never advanced its variable - unreachable before (begin operands were dropped) but an infinite loop once they're visible.

Also replaced a stale `@example` (a mixed `&&`/`||` case the cop never actually flagged) with one it does.