### PR TITLE
Fix false negatives for `Lint/SelfAssignment` with `||=`/`&&=`

### DIFF
--- a/changelog/fix_false_negatives_for_self_assignment_or_and_asgn_20260604220805.md
+++ b/changelog/fix_false_negatives_for_self_assignment_or_and_asgn_20260604220805.md
@@ -1,0 +1,1 @@
+* [#15233](https://github.com/rubocop/rubocop/pull/15233): Fix false negatives for `Lint/SelfAssignment` with `||=` and `&&=` on constants, attributes, and hash keys (e.g. `Foo ||= Foo`, `foo.bar ||= foo.bar`, `hash['foo'] ||= hash['foo']`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/self_assignment.rb
+++ b/lib/rubocop/cop/lint/self_assignment.rb
@@ -90,11 +90,34 @@ module RuboCop
         def on_or_asgn(node)
           return if allow_rbs_inline_annotation? && rbs_inline_annotation?(node.lhs)
 
-          add_offense(node) if rhs_matches_lhs?(node.rhs, node.lhs)
+          add_offense(node) if or_and_asgn_self_assignment?(node.lhs, node.rhs)
         end
         alias on_and_asgn on_or_asgn
 
         private
+
+        def or_and_asgn_self_assignment?(lhs, rhs)
+          case lhs.type
+          when :casgn
+            rhs.const_type? && lhs.namespace == rhs.namespace && lhs.short_name == rhs.short_name
+          when :send, :csend
+            reader_self_assignment?(lhs, rhs)
+          else
+            rhs_matches_lhs?(rhs, lhs)
+          end
+        end
+
+        # Compares two reader calls (attribute `foo.bar` or key `hash['foo']`).
+        def reader_self_assignment?(lhs, rhs)
+          return false unless rhs.type == lhs.type
+          return false unless lhs.method?(rhs.method_name)
+          return false unless lhs.receiver == rhs.receiver
+          return false unless lhs.arguments == rhs.arguments
+
+          # `hash[foo] ||= hash[foo]` is intentionally allowed because a method-call key may
+          # return different results on each call.
+          lhs.arguments.none?(&:call_type?)
+        end
 
         def multiple_self_assignment?(node)
           lhs = node.lhs

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -130,6 +130,59 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense when using shorthand-or constant self-assignment' do
+    expect_offense(<<~RUBY)
+      Foo ||= Foo
+      ^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-and constant self-assignment' do
+    expect_offense(<<~RUBY)
+      Foo &&= Foo
+      ^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-or attribute self-assignment' do
+    expect_offense(<<~RUBY)
+      foo.bar ||= foo.bar
+      ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-and attribute self-assignment' do
+    expect_offense(<<~RUBY)
+      foo.bar &&= foo.bar
+      ^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-or key self-assignment with a literal key' do
+    expect_offense(<<~RUBY)
+      hash['foo'] ||= hash['foo']
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'does not register an offense for shorthand-or attribute assignment with different attributes' do
+    expect_no_offenses(<<~RUBY)
+      foo.bar ||= foo.baz
+    RUBY
+  end
+
+  it 'does not register an offense for shorthand-or key assignment with different keys' do
+    expect_no_offenses(<<~RUBY)
+      hash['foo'] ||= hash['bar']
+    RUBY
+  end
+
+  it 'does not register an offense for shorthand-or key assignment with a method-call key' do
+    expect_no_offenses(<<~RUBY)
+      hash[foo] ||= hash[foo]
+    RUBY
+  end
+
   it 'registers an offense when using attribute self-assignment' do
     expect_offense(<<~RUBY)
       foo.bar = foo.bar


### PR DESCRIPTION
The `||=`/`&&=` path only recognized local/instance/class/global variable self-assignment, so the constant, attribute, and hash-key forms (`Foo ||= Foo`, `foo.bar ||= foo.bar`, `hash['foo'] ||= hash['foo']`) went unflagged - even though the plain `=` versions are caught. Now handled, keeping the existing exclusions (`Foo ||= ::Foo`, different keys/receivers, and `hash[foo] ||= hash[foo]` where a method-call key may return different results).