### PR TITLE
Clarify the `Lint/RequireRangeParentheses` offense message

### DIFF
--- a/changelog/change_clarify_require_range_parentheses_message_20260604221907.md
+++ b/changelog/change_clarify_require_range_parentheses_message_20260604221907.md
@@ -1,0 +1,1 @@
+* [#15234](https://github.com/rubocop/rubocop/pull/15234): Reword the `Lint/RequireRangeParentheses` offense message, which incorrectly called the flagged (finite) range "endless". ([@bbatsov][])

--- a/lib/rubocop/cop/lint/require_range_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_range_parentheses.rb
@@ -38,7 +38,8 @@ module RuboCop
       #   42)
       #
       class RequireRangeParentheses < Base
-        MSG = 'Wrap the endless range literal `%<range>s` to avoid precedence ambiguity.'
+        MSG = 'Wrap the range literal `%<range>s` in parentheses ' \
+              'to avoid confusion with an endless range.'
 
         def on_irange(node)
           return if node.parent&.begin_type?

--- a/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_range_parentheses_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Lint::RequireRangeParentheses, :config do
   it 'registers an offense when the end of the range (`..`) is line break' do
     expect_offense(<<~RUBY)
       42..
-      ^^^^ Wrap the endless range literal `42..` to avoid precedence ambiguity.
+      ^^^^ Wrap the range literal `42..` in parentheses to avoid confusion with an endless range.
       do_something
     RUBY
   end
@@ -12,8 +12,18 @@ RSpec.describe RuboCop::Cop::Lint::RequireRangeParentheses, :config do
   it 'registers an offense when the end of the range (`...`) is line break' do
     expect_offense(<<~RUBY)
       42...
-      ^^^^^ Wrap the endless range literal `42...` to avoid precedence ambiguity.
+      ^^^^^ Wrap the range literal `42...` in parentheses to avoid confusion with an endless range.
       do_something
+    RUBY
+  end
+
+  it 'registers an offense for a multiline range in a `when` clause' do
+    expect_offense(<<~RUBY)
+      case condition
+      when 42..
+           ^^^^ Wrap the range literal `42..` in parentheses to avoid confusion with an endless range.
+        do_something
+      end
     RUBY
   end
 


### PR DESCRIPTION
The cop fires on a multiline but *finite* range (e.g. `1..` / `42` on the next line, which Ruby parses as `(1..42)`), yet the message called it an "endless range literal" - factually wrong, and liable to make a developer dismiss it as a false positive. Reworded to "Wrap the range literal `42..` in parentheses to avoid confusion with an endless range." Also added the missing `case`/`when` spec that the cop's own NOTE highlights.