### PR TITLE
Add autocorrect and accurate message to `Lint/RefinementImportMethods`

### DIFF
--- a/changelog/change_lint_refinement_import_methods_autocorrect_and_message_20260604222202.md
+++ b/changelog/change_lint_refinement_import_methods_autocorrect_and_message_20260604222202.md
@@ -1,0 +1,1 @@
+* [#15235](https://github.com/rubocop/rubocop/pull/15235): Add autocorrection to `Lint/RefinementImportMethods` (replacing `include`/`prepend` with `import_methods`) and report that the functionality was removed (not just deprecated) on Ruby 3.2+. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2358,6 +2358,7 @@ Lint/RefinementImportMethods:
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '1.27'
+  VersionChanged: '<<next>>'
 
 Lint/RegexpAsCondition:
   Description: >-

--- a/lib/rubocop/cop/lint/refinement_import_methods.rb
+++ b/lib/rubocop/cop/lint/refinement_import_methods.rb
@@ -32,9 +32,12 @@ module RuboCop
       #   end
       #
       class RefinementImportMethods < Base
+        extend AutoCorrector
         extend TargetRubyVersion
 
         MSG = 'Use `import_methods` instead of `%<current>s` because it is deprecated in Ruby 3.1.'
+        MSG_REMOVED = 'Use `import_methods` instead of `%<current>s` ' \
+                      'because it was removed in Ruby 3.2.'
         RESTRICT_ON_SEND = %i[include prepend].freeze
 
         minimum_target_ruby_version 3.1
@@ -44,7 +47,11 @@ module RuboCop
           return unless (parent = node.parent)
           return unless parent.block_type? && parent.method?(:refine)
 
-          add_offense(node.loc.selector, message: format(MSG, current: node.method_name))
+          template = target_ruby_version >= 3.2 ? MSG_REMOVED : MSG
+          message = format(template, current: node.method_name)
+          add_offense(node.loc.selector, message: message) do |corrector|
+            corrector.replace(node.loc.selector, 'import_methods')
+          end
         end
       end
     end

--- a/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
+++ b/spec/rubocop/cop/lint/refinement_import_methods_spec.rb
@@ -1,25 +1,41 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::RefinementImportMethods, :config do
-  context 'Ruby >= 3.1', :ruby31 do
-    it 'registers an offense when using `include` in `refine` block' do
+  # The "deprecated in Ruby 3.1" wording only applies when the target is exactly 3.1.
+  # Prism floors the target Ruby to a higher version, so these run on Parser only.
+  context 'Ruby 3.1', :ruby31, unsupported_on: :prism do
+    it 'registers an offense and corrects when using `include` in `refine` block' do
       expect_offense(<<~RUBY)
         refine Foo do
           include Bar
           ^^^^^^^ Use `import_methods` instead of `include` because it is deprecated in Ruby 3.1.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        refine Foo do
+          import_methods Bar
+        end
+      RUBY
     end
 
-    it 'registers an offense when using `prepend` in `refine` block' do
+    it 'registers an offense and corrects when using `prepend` in `refine` block' do
       expect_offense(<<~RUBY)
         refine Foo do
           prepend Bar
           ^^^^^^^ Use `import_methods` instead of `prepend` because it is deprecated in Ruby 3.1.
         end
       RUBY
-    end
 
+      expect_correction(<<~RUBY)
+        refine Foo do
+          import_methods Bar
+        end
+      RUBY
+    end
+  end
+
+  context 'Ruby >= 3.1', :ruby31 do
     it 'does not register an offense when using `import_methods` in `refine` block' do
       expect_no_offenses(<<~RUBY)
         refine Foo do
@@ -39,6 +55,38 @@ RSpec.describe RuboCop::Cop::Lint::RefinementImportMethods, :config do
     it 'does not register an offense when using `include` on the top level' do
       expect_no_offenses(<<~RUBY)
         include Foo
+      RUBY
+    end
+  end
+
+  context 'Ruby >= 3.2', :ruby32 do
+    it 'reports that `include` was removed and corrects' do
+      expect_offense(<<~RUBY)
+        refine Foo do
+          include Bar
+          ^^^^^^^ Use `import_methods` instead of `include` because it was removed in Ruby 3.2.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        refine Foo do
+          import_methods Bar
+        end
+      RUBY
+    end
+
+    it 'reports that `prepend` was removed and corrects' do
+      expect_offense(<<~RUBY)
+        refine Foo do
+          prepend Bar
+          ^^^^^^^ Use `import_methods` instead of `prepend` because it was removed in Ruby 3.2.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        refine Foo do
+          import_methods Bar
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Two related fixes:

- The cop has an `@safety` section and `SafeAutoCorrect: false` but never wired up a corrector. Implemented the (mechanical) autocorrection that rewrites `include`/`prepend` to `import_methods`, making the existing safety annotation truthful.
- The message always said the methods were "deprecated in Ruby 3.1", but they were *removed* in Ruby 3.2 (raising `NoMethodError`). It now reports the stronger "removed in Ruby 3.2" wording when the target Ruby is 3.2+.