### PR TITLE
Clarify documentation for several Lint cops

### DIFF
--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Lint
       # Checks for `rand(1)` calls.
-      # Such calls always return `0`.
+      # Such calls always return `0`, and so do `rand(-1)`, `rand(1.0)`, and `rand(-1.0)`.
       #
       # @example
       #

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -18,6 +18,7 @@ module RuboCop
       # * `to_sym` when called on a symbol literal or interpolated symbol.
       # * `to_i` when called on an integer literal or with `Integer()`.
       # * `to_f` when called on a float literal or with `Float()`.
+      # * `to_d` when called with `BigDecimal()`.
       # * `to_r` when called on a rational literal or with `Rational()`.
       # * `to_c` when called on a complex literal or with `Complex()`.
       # * `to_a` when called on an array literal, or with `Array.new`, `Array()` or `Array[]`.
@@ -62,6 +63,12 @@ module RuboCop
       #   # good - chaining to a type constructor with exceptions suppressed
       #   # in this case, `Integer()` could return `nil`
       #   Integer(var, exception: false).to_i
+      #
+      #   # bad
+      #   BigDecimal(var).to_d
+      #
+      #   # good
+      #   BigDecimal(var)
       #
       #   # bad - chaining the same conversion
       #   foo.to_s.to_s

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -3,10 +3,13 @@
 module RuboCop
   module Cop
     module Lint
-      # Checks for expressions where there is a call to a predicate
-      # method with at least one argument, where no parentheses are used around
-      # the parameter list, and a boolean operator, && or ||, is used in the
-      # last argument.
+      # Checks for method calls with at least one argument where no parentheses
+      # are used around the parameter list, and the call could be misread as an
+      # operand of a boolean operator (`&&` or `||`). Two forms are flagged:
+      #
+      # * a predicate method whose last argument is a `&&`/`||` expression, and
+      # * any method whose first argument is a ternary expression with a
+      #   `&&`/`||` condition.
       #
       # The idea behind warning for these constructs is that the user might
       # be under the impression that the return value from the method call is
@@ -23,6 +26,12 @@ module RuboCop
       #   if day.is?(:tuesday) && month == :jan
       #     # ...
       #   end
+      #
+      #   # bad
+      #   foo a && b ? c : d
+      #
+      #   # good
+      #   foo(a && b ? c : d)
       class RequireParentheses < Base
         include RangeHelp
 

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe RuboCop::Cop::Lint::RequireParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for a non-predicate method with a ternary whose condition uses `&&`' do
+    expect_offense(<<~RUBY)
+      foo a && b ? c : d
+      ^^^^^^^^^^ Use parentheses in the method call to avoid confusion about precedence.
+    RUBY
+  end
+
   context 'when using safe navigation operator' do
     it 'registers an offense for missing parentheses around expression with && operator' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
A few documentation accuracy fixes surfaced while auditing the Lint department (no behavior changes):

- `Lint/RandOne` only said it checks `rand(1)`, though it also flags `rand(-1)`, `rand(1.0)`, and `rand(-1.0)`.
- `Lint/RequireParentheses` described only the predicate-method form, but its ternary check fires for any method (e.g. `foo a && b ? c : d`). Documented both forms with an example, and added the missing spec for that path.
- `Lint/RedundantTypeConversion` was missing `to_d` from its bulleted list and examples even though it detects it.