### PR TITLE
Backfill missing spec coverage for several Lint cops

### DIFF
--- a/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_regexp_quantifiers_spec.rb
@@ -92,6 +92,35 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRegexpQuantifiers, :config do
     end
   end
 
+  context 'with other mixed greedy quantifier combinations' do
+    [['+', '*'], ['*', '+'], ['*', '?'], ['?', '+'], ['?', '*']].each do |inner, outer|
+      it "registers an offense and corrects `(?:a#{inner})#{outer}`" do
+        expect_offense(<<~RUBY)
+          foo = /(?:a#{inner})#{outer}/
+                     ^^^ Replace redundant quantifiers `#{inner}` and `#{outer}` with a single `*`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo = /(?:a*)/
+        RUBY
+      end
+    end
+  end
+
+  context 'with multiple adjacent redundant groups' do
+    it 'registers an offense for each group' do
+      expect_offense(<<~RUBY)
+        foo = /(?:a+)+(?:b+)+/
+                          ^^^ Replace redundant quantifiers `+` and `+` with a single `+`.
+                   ^^^ Replace redundant quantifiers `+` and `+` with a single `+`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = /(?:a+)(?:b+)/
+      RUBY
+    end
+  end
+
   context 'with nested interval quantifiers that can be normalized' do
     it 'registers an offense and corrects' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_require_statement_spec.rb
@@ -186,6 +186,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
       RUBY
     end
 
+    context 'target ruby version <= 3.1', :ruby31, unsupported_on: :prism do
+      it 'does not register an offense when requiring `set`' do
+        expect_no_offenses(<<~RUBY)
+          require 'set'
+        RUBY
+      end
+    end
+
     context 'target ruby version >= 3.2', :ruby32 do
       it 'registers an offense and corrects when using requiring `set`' do
         expect_offense(<<~RUBY)
@@ -196,6 +204,14 @@ RSpec.describe RuboCop::Cop::Lint::RedundantRequireStatement, :config do
 
         expect_correction(<<~RUBY)
           require 'uri'
+        RUBY
+      end
+    end
+
+    context 'target ruby version <= 3.3', :ruby33 do
+      it 'does not register an offense when requiring `pathname`' do
+        expect_no_offenses(<<~RUBY)
+          require 'pathname'
         RUBY
       end
     end

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -223,6 +223,25 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
     RUBY
   end
 
+  context 'with the other default nil-safe methods in `AllowedMethods`' do
+    let(:cop_config) do
+      { 'AllowedMethods' => %w[instance_of? kind_of? is_a? eql? equal?] }
+    end
+
+    %w[instance_of? kind_of? is_a? eql? equal?].each do |method|
+      it "registers an offense and corrects `&.#{method}` in a condition" do
+        expect_offense(<<~RUBY, method: method)
+          do_something if foo&.%{method}(bar)
+                             ^^ Redundant safe navigation detected, use `.` instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          do_something if foo.#{method}(bar)
+        RUBY
+      end
+    end
+  end
+
   it 'does not register an offense when `&.` is used with coercion methods' do
     expect_no_offenses(<<~RUBY)
       foo&.to_s || 'Default string'

--- a/spec/rubocop/cop/lint/redundant_with_object_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_object_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe RuboCop::Cop::Lint::RedundantWithObject, :config do
   end
 
   context 'Ruby 2.7', :ruby27 do
+    it 'does not register an offense when the second numbered parameter is used' do
+      expect_no_offenses(<<~RUBY)
+        ary.each_with_object([]) { _1 << _2 }
+      RUBY
+    end
+
     it 'registers an offense and corrects when using `ary.each_with_object { _1 }`' do
       expect_offense(<<~RUBY)
         ary.each_with_object([]) { _1 }

--- a/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/regexp_as_condition_spec.rb
@@ -27,6 +27,47 @@ RSpec.describe RuboCop::Cop::Lint::RegexpAsCondition, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects for a regexp literal in a `while` condition' do
+    expect_offense(<<~RUBY)
+      while /foo/
+            ^^^^^ Do not use regexp literal as a condition. The regexp literal matches `$_` implicitly.
+        bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      while /foo/ =~ $_
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for a regexp literal in an `until` condition' do
+    expect_offense(<<~RUBY)
+      until /foo/
+            ^^^^^ Do not use regexp literal as a condition. The regexp literal matches `$_` implicitly.
+        bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      until /foo/ =~ $_
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects for a regexp literal in a ternary condition' do
+    expect_offense(<<~RUBY)
+      /foo/ ? a : b
+      ^^^^^ Do not use regexp literal as a condition. The regexp literal matches `$_` implicitly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      /foo/ =~ $_ ? a : b
+    RUBY
+  end
+
   it 'does not register an offense for a regexp literal outside conditions' do
     expect_no_offenses(<<~RUBY)
       /foo/

--- a/spec/rubocop/cop/lint/return_in_void_context_spec.rb
+++ b/spec/rubocop/cop/lint/return_in_void_context_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Lint::ReturnInVoidContext, :config do
       RUBY
     end
 
+    it 'registers an offense when returning `nil`' do
+      expect_offense(<<~RUBY)
+        class A
+          def initialize
+            return nil
+            ^^^^^^ Do not return a value in `initialize`.
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense when the value is returned in a block' do
       expect_offense(<<~RUBY)
         class A

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -560,5 +560,24 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
         x&.select { foo(it) }&.bar
       RUBY
     end
+
+    context 'with a method added to `AllowedMethods`' do
+      let(:cop_config) { { 'AllowedMethods' => %w[foo] } }
+
+      it 'does not register an offense for the allowed method' do
+        expect_no_offenses('x&.bar.foo')
+      end
+
+      it 'still registers an offense for a method that is not allowed' do
+        expect_offense(<<~RUBY)
+          x&.bar.baz
+                ^^^^ Do not chain ordinary method call after safe navigation operator.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x&.bar&.baz
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/lint/self_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/self_assignment_spec.rb
@@ -183,6 +183,27 @@ RSpec.describe RuboCop::Cop::Lint::SelfAssignment, :config do
     RUBY
   end
 
+  it 'registers an offense when using shorthand-or instance var self-assignment' do
+    expect_offense(<<~RUBY)
+      @foo ||= @foo
+      ^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-or class var self-assignment' do
+    expect_offense(<<~RUBY)
+      @@foo ||= @@foo
+      ^^^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
+  it 'registers an offense when using shorthand-and global var self-assignment' do
+    expect_offense(<<~RUBY)
+      $foo &&= $foo
+      ^^^^^^^^^^^^^ Self-assignment detected.
+    RUBY
+  end
+
   it 'registers an offense when using attribute self-assignment' do
     expect_offense(<<~RUBY)
       foo.bar = foo.bar

--- a/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
+++ b/spec/rubocop/cop/lint/send_with_mixin_argument_spec.rb
@@ -110,6 +110,28 @@ RSpec.describe RuboCop::Cop::Lint::SendWithMixinArgument, :config do
     RUBY
   end
 
+  it 'registers an offense when using `public_send` with `prepend`' do
+    expect_offense(<<~RUBY)
+      Foo.public_send(:prepend, Bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `prepend Bar` instead of `public_send(:prepend, Bar)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Foo.prepend Bar
+    RUBY
+  end
+
+  it 'registers an offense when using `__send__` with `extend`' do
+    expect_offense(<<~RUBY)
+      Foo.__send__(:extend, Bar)
+          ^^^^^^^^^^^^^^^^^^^^^^ Use `extend Bar` instead of `__send__(:extend, Bar)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Foo.extend Bar
+    RUBY
+  end
+
   it 'registers an offense when using `__send__` method' do
     expect_offense(<<~RUBY)
       Foo.__send__(:include, Bar)

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -4,6 +4,38 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
   let(:cop_config) { { 'IgnoreImplicitReferences' => false } }
 
   describe 'method argument shadowing' do
+    context 'when a non-positional argument is shadowed' do
+      it 'registers an offense for an optional argument' do
+        expect_offense(<<~RUBY)
+          def do_something(foo = 1)
+            foo = 2
+            ^^^^^^^ Argument `foo` was shadowed by a local variable before it was used.
+            puts foo
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a keyword argument' do
+        expect_offense(<<~RUBY)
+          def do_something(foo:)
+            foo = 2
+            ^^^^^^^ Argument `foo` was shadowed by a local variable before it was used.
+            puts foo
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a rest argument' do
+        expect_offense(<<~RUBY)
+          def do_something(*foo)
+            foo = 2
+            ^^^^^^^ Argument `foo` was shadowed by a local variable before it was used.
+            puts foo
+          end
+        RUBY
+      end
+    end
+
     context 'when a single argument is shadowed' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedException, :config do
       RUBY
     end
 
+    it 'registers an offense when `rescue Exception` precedes a bare `rescue` clause' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue Exception
+        ^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
+          handle_exception
+        rescue
+          handle_standard_error
+        end
+      RUBY
+    end
+
     it 'accepts rescuing a single exception that is assigned to a variable' do
       expect_no_offenses(<<~RUBY)
         begin


### PR DESCRIPTION
Pure test coverage (no behavior changes) for gaps surfaced during the Lint department audit. Each test documents existing, correct behavior so future regressions get caught:

- `RegexpAsCondition` - `while`/`until`/ternary conditions
- `ReturnInVoidContext` - `return nil`
- `SendWithMixinArgument` - `prepend`/`extend` via `public_send`/`__send__`
- `SelfAssignment` - ivar/cvar/gvar `||=`/`&&=`
- `ShadowedArgument` - optional/keyword/rest arguments
- `ShadowedException` - `rescue Exception` preceding a bare `rescue`
- `RedundantRegexpQuantifiers` - mixed greedy combinations and multiple adjacent groups
- `RedundantRequireStatement` - negative boundary tests for `set` (< 3.2) and `pathname` (< 4.0)
- `RedundantWithObject` - two-numbered-parameter block
- `RedundantSafeNavigation` / `SafeNavigationChain` - `AllowedMethods` handling

No changelog entry (spec-only).