### PR TITLE
Fix a false positive for `Lint/SuppressedExceptionInNumberConversion`

### DIFF
--- a/changelog/fix_a_false_positive_for_suppressed_exception_in_number_conversion_20260605182042.md
+++ b/changelog/fix_a_false_positive_for_suppressed_exception_in_number_conversion_20260605182042.md
@@ -1,0 +1,1 @@
+* [#15239](https://github.com/rubocop/rubocop/pull/15239): Fix a false positive for `Lint/SuppressedExceptionInNumberConversion` when the numeric constructor already passes `exception: false` (e.g. `Integer(arg, exception: false) rescue nil`), which also produced an autocorrect with a duplicate `exception: false` keyword. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/suppressed_exception_in_number_conversion.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception_in_number_conversion.rb
@@ -88,6 +88,10 @@ module RuboCop
             return unless (method = numeric_constructor_rescue_nil(node))
           end
 
+          # `Integer(arg, exception: false)` already suppresses the conversion error, so there
+          # is nothing unintentionally swallowed; adding another `exception: false` is wrong.
+          return if exception_keyword_argument?(method)
+
           arguments = method.arguments.map(&:source) << 'exception: false'
           prefer = "#{method.method_name}(#{arguments.join(', ')})"
           prefer = "#{method.receiver.source}#{method.loc.dot.source}#{prefer}" if method.receiver
@@ -99,6 +103,14 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize
 
         private
+
+        def exception_keyword_argument?(method)
+          method.arguments.any? do |argument|
+            argument.hash_type? && argument.pairs.any? do |pair|
+              pair.key.sym_type? && pair.key.value == :exception
+            end
+          end
+        end
 
         def expected_exception_classes_only?(exception_classes)
           return true unless (arguments = exception_classes.first)

--- a/spec/rubocop/cop/lint/suppressed_exception_in_number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/suppressed_exception_in_number_conversion_spec.rb
@@ -234,6 +234,18 @@ RSpec.describe RuboCop::Cop::Lint::SuppressedExceptionInNumberConversion, :confi
     RUBY
   end
 
+  it 'does not register an offense when using `Integer(arg, exception: false) rescue nil`' do
+    expect_no_offenses(<<~RUBY)
+      Integer(arg, exception: false) rescue nil
+    RUBY
+  end
+
+  it 'does not register an offense when using `BigDecimal(arg, exception: false) rescue nil`' do
+    expect_no_offenses(<<~RUBY)
+      BigDecimal(arg, exception: false) rescue nil
+    RUBY
+  end
+
   it 'does not register an offense when using `Integer(arg) rescue 42`' do
     expect_no_offenses(<<~RUBY)
       Integer(arg) rescue 42


### PR DESCRIPTION
`Integer(arg, exception: false) rescue nil` was flagged and autocorrected to `Integer(arg, exception: false, exception: false)` - a duplicate keyword. When the numeric constructor already passes `exception: false` the error is suppressed intentionally, so there's nothing to flag. Now those calls are skipped (also covers `BigDecimal`/`Complex`/`Rational`).