### PR TITLE
Fix an incorrect autocorrect for `Lint/UselessAssignment` with `&&=`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_useless_assignment_with_and_asgn_20260605182325.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_useless_assignment_with_and_asgn_20260605182325.md
@@ -1,0 +1,1 @@
+* [#15240](https://github.com/rubocop/rubocop/pull/15240): Fix an incorrect autocorrect for `Lint/UselessAssignment` that rewrote a first-seen `foo &&= 1` to `foo && 1`, raising `NameError` at runtime. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -67,16 +67,21 @@ module RuboCop
           range = offense_range(assignment)
 
           add_offense(range, message: message) do |corrector|
-            # In cases like `x = 1, y = 2`, where removing a variable would cause a syntax error,
-            # and where changing `x ||= 1` to `x = 1` would cause `NameError`,
-            # the autocorrect will be skipped, even if the variable is unused.
-            next if sequential_assignment?(assignment_node) ||
-                    assignment_node.parent&.or_asgn_type?
+            next if uncorrectable_assignment?(assignment_node)
 
             autocorrect(corrector, assignment)
           end
 
           ignore_node(assignment_node) if chained_assignment?(assignment_node)
+        end
+
+        # Autocorrect is skipped when removing a variable would cause a syntax error
+        # (`x = 1, y = 2`), or where rewriting `x ||= 1`/`x &&= 1` to `x = 1` would raise
+        # `NameError` because the variable is not declared before the operator assignment.
+        def uncorrectable_assignment?(assignment_node)
+          sequential_assignment?(assignment_node) ||
+            assignment_node.parent&.or_asgn_type? ||
+            assignment_node.parent&.and_asgn_type?
         end
 
         def ignored_assignment?(variable, assignment_node, assignment)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -353,6 +353,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
     end
   end
 
+  context 'when a variable is first assigned with `&&=`' do
+    it 'registers an offense but does not autocorrect (it would raise `NameError`)' do
+      expect_offense(<<~RUBY)
+        def foo
+          bar &&= 1
+          ^^^ Useless assignment to variable - `bar`. Use `&&` instead of `&&=`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
   context 'when a variable is assigned multiple times but unreferenced' do
     it 'registers offenses for each assignment' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
When `foo &&= 1` is the first appearance of `foo`, autocorrect rewrote it to `foo && 1` - which raises `NameError`, since `&&=` on an undeclared local declares it (result nil) but `&&` references it before assignment. The cop already skipped the same `||=` case; this extends the guard to `&&=`.