### PR TITLE
Fix incorrect autocorrects for `Lint/UselessTimes`

### DIFF
--- a/changelog/fix_incorrect_autocorrects_for_useless_times_20260605182729.md
+++ b/changelog/fix_incorrect_autocorrects_for_useless_times_20260605182729.md
@@ -1,0 +1,1 @@
+* [#15241](https://github.com/rubocop/rubocop/pull/15241): Fix incorrect autocorrects for `Lint/UselessTimes` when the `times` block uses `next`/`break` (which became a syntax error) or takes multiple block arguments (which became undefined references). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -82,6 +82,11 @@ module RuboCop
         end
 
         def autocorrect_block(corrector, node)
+          # A block with multiple arguments can't be reduced to its body (the extra arguments
+          # would become undefined references), and `next`/`break`/`redo` bound to the block
+          # become orphaned (a syntax error) once the block is removed.
+          return if node.arguments.size > 1 || orphans_loop_control_keyword?(node)
+
           block_arg = block_arg(node)
           return if block_reassigns_arg?(node, block_arg)
 
@@ -89,6 +94,13 @@ module RuboCop
           source.gsub!(/\b#{block_arg}\b/, '0') if block_arg
 
           corrector.replace(node, fix_indentation(source, node.loc.column...node.body.loc.column))
+        end
+
+        def orphans_loop_control_keyword?(node)
+          node.body&.each_node(:next, :break, :redo)&.any? do |control|
+            inner = control.each_ancestor.take_while { |ancestor| !ancestor.equal?(node) }
+            inner.none? { |ancestor| ancestor.type?(:any_block, :while, :until, :for) }
+          end
         end
 
         def fix_indentation(source, range)

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -302,5 +302,45 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
         expect_no_corrections
       end
     end
+
+    context 'when the block cannot be safely reduced to its body' do
+      it 'does not correct a block whose body uses `next`' do
+        expect_offense(<<~RUBY)
+          1.times { next 42 }
+          ^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not correct a block whose body uses `break`' do
+        expect_offense(<<~RUBY)
+          1.times { break }
+          ^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not correct a block with multiple arguments' do
+        expect_offense(<<~RUBY)
+          1.times { |i, j| do_something(i, j) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'still corrects a block whose `next` is nested in an inner block' do
+        expect_offense(<<~RUBY)
+          1.times { [1, 2].each { next } }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2].each { next }
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Reducing a `1.times { ... }` block to its body broke two cases:

- `next`/`break`/`redo` bound to the block became orphaned loop-control keywords - a `SyntaxError` (`1.times { next 42 }` → bare `next 42`).
- a block with multiple arguments left them as undefined references - a `NameError` (`1.times { |i, j| ... }`).

Both are now left uncorrected (still flagged). A `next`/`break` nested in an inner block is still safely corrected.