### PR TITLE
Fix a bad autocorrect for `Lint/SymbolConversion` with embedded quotes

### DIFF
--- a/changelog/fix_a_bad_autocorrect_for_symbol_conversion_dstr_embedded_quote_20260605183111.md
+++ b/changelog/fix_a_bad_autocorrect_for_symbol_conversion_dstr_embedded_quote_20260605183111.md
@@ -1,0 +1,1 @@
+* [#15242](https://github.com/rubocop/rubocop/pull/15242): Fix a bad autocorrect for `Lint/SymbolConversion` when the receiver is an interpolated string containing an embedded double quote (e.g. `"foo#{bar}\"qux".to_sym`), which produced a syntax error. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/symbol_conversion.rb
+++ b/lib/rubocop/cop/lint/symbol_conversion.rb
@@ -77,11 +77,28 @@ module RuboCop
 
         def on_send(node)
           return unless node.receiver
+          return unless (correction = symbol_conversion_correction(node.receiver))
 
-          if node.receiver.type?(:str, :sym)
-            register_offense(node, correction: node.receiver.value.to_sym.inspect)
-          elsif node.receiver.dstr_type?
-            register_offense(node, correction: ":\"#{node.receiver.value.to_sym}\"")
+          register_offense(node, correction: correction)
+        end
+
+        def symbol_conversion_correction(receiver)
+          if receiver.type?(:str, :sym)
+            receiver.value.to_sym.inspect
+          elsif receiver.dstr_type? && !receiver.heredoc?
+            dstr_correction(receiver)
+          end
+        end
+
+        # Reuse the already-escaped inner source for a plain `"..."` string so embedded
+        # quotes stay escaped. Percent literals (`%{}`, `%Q{}`, ...) and adjacent string
+        # concatenation have multi-character or no delimiters, so slicing the source would
+        # corrupt them; fall back to the node's value there.
+        def dstr_correction(receiver)
+          if receiver.loc.begin&.source == '"'
+            ":\"#{receiver.source[1..-2]}\""
+          else
+            ":\"#{receiver.value.to_sym}\""
           end
         end
 

--- a/spec/rubocop/cop/lint/symbol_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/symbol_conversion_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
   it_behaves_like 'offense', '"foo_bar".to_sym', ':foo_bar'
   it_behaves_like 'offense', '"foo-bar".to_sym', ':"foo-bar"'
   it_behaves_like 'offense', '"foo-#{bar}".to_sym', ':"foo-#{bar}"'
+  # Interpolated string with an embedded (escaped) double quote.
+  it_behaves_like 'offense', '"foo#{bar}\"qux".to_sym', ':"foo#{bar}\"qux"'
+  # Percent-literal strings have multi-character delimiters, so the source can't just be
+  # sliced; the inner value must be used instead.
+  it_behaves_like 'offense', '%{foo#{bar}}.to_sym', ':"foo#{bar}"'
+  it_behaves_like 'offense', '%Q{foo#{bar}}.to_sym', ':"foo#{bar}"'
+  it_behaves_like 'offense', '%(foo#{bar}).to_sym', ':"foo#{bar}"'
+  it_behaves_like 'offense', '%<foo#{bar}>.to_sym', ':"foo#{bar}"'
+  # Adjacent string concatenation parses as a `dstr` with no `begin` delimiter.
+  it_behaves_like 'offense', '"x" "y#{z}".to_sym', ':"xy#{z}"'
 
   # Unnecessary `intern`
   it_behaves_like 'offense', ':foo.intern', ':foo'
@@ -35,6 +45,14 @@ RSpec.describe RuboCop::Cop::Lint::SymbolConversion, :config do
   it 'does not register an offense for a normal symbol' do
     expect_no_offenses(<<~RUBY)
       :foo
+    RUBY
+  end
+
+  it 'does not register an offense for `to_sym` on an interpolated heredoc' do
+    expect_no_offenses(<<~'RUBY')
+      <<~TEXT.to_sym
+        foo#{bar}
+      TEXT
     RUBY
   end
 


### PR DESCRIPTION
For an interpolated-string receiver, the correction was built from the unescaped string value, so an embedded double quote (`"foo#{bar}\"qux".to_sym`) produced `:"foo#{bar}"qux"` - an unbalanced, invalid symbol. Now the correction reuses the already-escaped inner source, and heredoc receivers (whose source isn't a simple quoted string) are skipped.