### PR TITLE
Fix a false positive for `Lint/TopLevelReturnWithArgument` in blocks

### DIFF
--- a/changelog/fix_a_false_positive_for_top_level_return_with_argument_in_blocks_20260605183304.md
+++ b/changelog/fix_a_false_positive_for_top_level_return_with_argument_in_blocks_20260605183304.md
@@ -1,0 +1,1 @@
+* [#15243](https://github.com/rubocop/rubocop/pull/15243): Fix a false positive for `Lint/TopLevelReturnWithArgument` when a `return` with an argument is inside a numbered-parameter block or an `it` block. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/top_level_return_with_argument.rb
+++ b/lib/rubocop/cop/lint/top_level_return_with_argument.rb
@@ -40,7 +40,7 @@ module RuboCop
         # top-level return node's ancestors should not be of block, def, or
         # defs type.
         def top_level_return?(return_node)
-          return_node.each_ancestor(:block, :any_def).none?
+          return_node.each_ancestor(:any_block, :any_def).none?
         end
       end
     end

--- a/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
+++ b/spec/rubocop/cop/lint/top_level_return_with_argument_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe RuboCop::Cop::Lint::TopLevelReturnWithArgument, :config do
   end
 
   context 'Code segment with block level returns other than the top-level return' do
+    it 'expects no offense from a return with an argument inside a numbered-parameter block' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each { return _1 }
+      RUBY
+    end
+
+    it 'expects no offense from a return with an argument inside an `it` block', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each { return it }
+      RUBY
+    end
+
     it 'expects no offense from the return without arguments' do
       expect_no_offenses(<<~RUBY)
         foo


### PR DESCRIPTION
The top-level check walked ancestors for `:block` nodes, which excludes numbered-parameter blocks (`numblock`) and `it` blocks (`itblock`). So `return _1` inside `[1, 2].each { return _1 }` was wrongly flagged as a top-level return. Switched to `:any_block`.