### PR TITLE
Fix a crash and a false negative in `Lint/TrailingCommaInAttributeDeclaration`

### DIFF
--- a/changelog/fix_lint_trailing_comma_in_attribute_declaration_crash_and_defs_20260605183545.md
+++ b/changelog/fix_lint_trailing_comma_in_attribute_declaration_crash_and_defs_20260605183545.md
@@ -1,0 +1,1 @@
+* [#15244](https://github.com/rubocop/rubocop/pull/15244): Fix `Lint/TrailingCommaInAttributeDeclaration` to detect a trailing comma before a singleton method definition (e.g. `def self.bar`) and to not crash when a `def` is the sole argument (e.g. `attr_reader def bar; end`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
+++ b/lib/rubocop/cop/lint/trailing_comma_in_attribute_declaration.rb
@@ -35,7 +35,10 @@ module RuboCop
         RESTRICT_ON_SEND = %i[attr_reader attr_writer attr_accessor attr].freeze
 
         def on_send(node)
-          return unless node.attribute_accessor? && node.last_argument.def_type?
+          return unless node.attribute_accessor? && node.last_argument.any_def_type?
+          # A lone `def` argument (e.g. `attr_reader def foo; end`) has no preceding
+          # attribute, so there is no trailing comma to flag.
+          return unless node.arguments.size > 1
 
           trailing_comma = trailing_comma_range(node)
 

--- a/spec/rubocop/cop/lint/trailing_comma_in_attribute_declaration_spec.rb
+++ b/spec/rubocop/cop/lint/trailing_comma_in_attribute_declaration_spec.rb
@@ -24,6 +24,44 @@ RSpec.describe RuboCop::Cop::Lint::TrailingCommaInAttributeDeclaration, :config 
     RUBY
   end
 
+  it 'registers an offense when a trailing comma precedes a singleton method definition' do
+    expect_offense(<<~RUBY)
+      class Foo
+        attr_reader :bar,
+                        ^ Avoid leaving a trailing comma in attribute declarations.
+
+        def self.baz; end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        attr_reader :bar
+
+        def self.baz; end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `attr_accessor` with a trailing comma' do
+    expect_offense(<<~RUBY)
+      class Foo
+        attr_accessor :bar,
+                          ^ Avoid leaving a trailing comma in attribute declarations.
+
+        def baz; end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo
+        attr_accessor :bar
+
+        def baz; end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when not using trailing comma' do
     expect_no_offenses(<<~RUBY)
       class Foo
@@ -32,6 +70,14 @@ RSpec.describe RuboCop::Cop::Lint::TrailingCommaInAttributeDeclaration, :config 
         def baz
           puts "Qux"
         end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense (or crash) when a `def` is the sole argument' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        attr_reader def bar; end
       end
     RUBY
   end


### PR DESCRIPTION
Two issues:

- The cop only matched a trailing instance-method `def`, missing `def self.bar` (a `defs` node) - so `attr_reader :foo,` before a singleton method went undetected. Now matches `any_def`.
- `attr_reader def bar; end` (a lone `def` argument) passed the guards and then dereferenced `arguments[-2]` (nil), raising inside the cop. Now requires more than one argument.