### PR TITLE
Fix a false positive for `Lint/UselessRuby2Keywords` across scope boundaries

### DIFF
--- a/changelog/fix_a_false_positive_for_useless_ruby2_keywords_outer_scope_20260605183825.md
+++ b/changelog/fix_a_false_positive_for_useless_ruby2_keywords_outer_scope_20260605183825.md
@@ -1,0 +1,1 @@
+* [#15245](https://github.com/rubocop/rubocop/pull/15245): Fix a false positive for `Lint/UselessRuby2Keywords` when `ruby2_keywords` in a nested class or module refers to a method of the same name defined in an outer scope. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -107,11 +107,15 @@ module RuboCop
         end
 
         def find_method_definition(node, method_name)
-          node.each_ancestor.lazy.map do |ancestor|
-            ancestor.each_child_node(:def, :any_block).find do |child|
+          node.each_ancestor do |ancestor|
+            found = ancestor.each_child_node(:def, :any_block).find do |child|
               method_definition(child, method_name)
             end
-          end.find(&:itself)
+            return found if found
+            # A method defined in an outer lexical scope does not define this scope's method,
+            # so stop searching once a class/module boundary is crossed without a match.
+            return nil if ancestor.type?(:class, :module, :sclass)
+          end
         end
 
         # `ruby2_keywords` is only allowed if there's a `restarg` and no keyword arguments

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -132,6 +132,19 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when the `def` is in an outer scope' do
+      expect_no_offenses(<<~RUBY)
+        class Outer
+          def foo(**kwargs)
+          end
+
+          class Inner
+            ruby2_keywords :foo
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with a dynamically defined method' do


### PR DESCRIPTION
`find_method_definition` walked every ancestor, so `ruby2_keywords :foo` in a nested class bound to a `def foo(**kwargs)` in an *outer* class and got flagged - even though `ruby2_keywords` resolves against the current lexical scope (the nested class has no such method). Now the ancestor walk stops at a class/module/singleton-class boundary.