### PR TITLE
Fix a false positive for `Lint/UselessSetterCall` with nested destructuring

### DIFF
--- a/changelog/fix_a_false_positive_for_useless_setter_call_nested_destructuring_20260605184147.md
+++ b/changelog/fix_a_false_positive_for_useless_setter_call_nested_destructuring_20260605184147.md
@@ -1,0 +1,1 @@
+* [#15246](https://github.com/rubocop/rubocop/pull/15246): Fix a false positive for `Lint/UselessSetterCall` when a multiple assignment uses nested destructuring (e.g. `(a, b), c = arg, other_arg`), which misaligned variables with the right-hand side values. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -107,7 +107,10 @@ module RuboCop
           end
 
           def process_multiple_assignment(masgn_node)
-            masgn_node.assignments.each_with_index do |lhs_node, index|
+            # Iterate the top-level destructuring slots so each maps to the right-hand side
+            # element at the same position. Using the flattened `assignments` would misalign
+            # the index when a slot is itself a nested destructuring (e.g. `(a, b), c = x, y`).
+            masgn_node.lhs.children.each_with_index do |lhs_node, index|
               next unless ASSIGNMENT_TYPES.include?(lhs_node.type)
 
               if masgn_node.rhs.array_type? && (rhs_node = masgn_node.rhs.children[index])

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -138,6 +138,17 @@ RSpec.describe RuboCop::Cop::Lint::UselessSetterCall, :config do
     end
   end
 
+  context 'when a variable from a multiple assignment with nested destructuring holds an argument' do
+    it 'accepts the setter call' do
+      expect_no_offenses(<<~RUBY)
+        def test(arg, other_arg)
+          (a, b), c = arg, other_arg
+          c.attr = 5
+        end
+      RUBY
+    end
+  end
+
   context 'when a lvar contains an object passed as argument at the end of the method' do
     it 'accepts the setter call on the lvar' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
The multiple-assignment tracker iterated the *flattened* `assignments`, so a nested destructuring slot misaligned the positional index used to map each variable to its RHS value. For `(a, b), c = arg, other_arg`, `c` mapped past the end of the RHS and was treated as a local object - so `c.attr = 5` was wrongly flagged, even though `c` holds a method argument. Now it iterates the top-level destructuring slots, keeping indices aligned.