### PR TITLE
Fix false negatives for `Lint/SharedMutableDefault` with `capacity:`

### DIFF
--- a/changelog/fix_false_negatives_for_shared_mutable_default_with_capacity_20260605184901.md
+++ b/changelog/fix_false_negatives_for_shared_mutable_default_with_capacity_20260605184901.md
@@ -1,0 +1,1 @@
+* [#15247](https://github.com/rubocop/rubocop/pull/15247): Fix false negatives for `Lint/SharedMutableDefault` when a mutable default is combined with a `capacity:` keyword argument and given as an array or `Array.new`/`Hash.new` (e.g. `Hash.new([], capacity: 42)`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/shared_mutable_default.rb
+++ b/lib/rubocop/cop/lint/shared_mutable_default.rb
@@ -56,7 +56,9 @@ module RuboCop
               {array hash (send (const {nil? cbase} {:Array :Hash}) :new)}
               !#capacity_keyword_argument?
             ])
-            (send (const {nil? cbase} :Hash) :new hash #capacity_keyword_argument?)
+            (send (const {nil? cbase} :Hash) :new
+              {array hash (send (const {nil? cbase} {:Array :Hash}) :new)}
+              #capacity_keyword_argument?)
           }
         PATTERN
 

--- a/spec/rubocop/cop/lint/shared_mutable_default_spec.rb
+++ b/spec/rubocop/cop/lint/shared_mutable_default_spec.rb
@@ -44,6 +44,23 @@ RSpec.describe RuboCop::Cop::Lint::SharedMutableDefault, :config do
         Hash.new(capacity: 42)
       RUBY
     end
+
+    it 'registers an offense for a mutable default alongside `capacity`' do
+      expect_offense(<<~RUBY)
+        Hash.new([], capacity: 42)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
+        Hash.new(Array.new, capacity: 42)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
+        Hash.new(Hash.new, capacity: 42)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not create a Hash with a mutable default value [...]
+      RUBY
+    end
+
+    it 'does not register an offense for an immutable default alongside `capacity`' do
+      expect_no_offenses(<<~RUBY)
+        Hash.new(0, capacity: 42)
+      RUBY
+    end
   end
 
   context 'when Hash is initialized with an array' do


### PR DESCRIPTION
The `capacity:` keyword-argument branch of the matcher only recognized a `hash` default, so `Hash.new([], capacity: 42)`, `Hash.new(Array.new, capacity: 42)`, and `Hash.new(Hash.new, capacity: 42)` went unflagged - even though they create a shared mutable default. Now it matches the same mutable forms as the no-keyword branch.