### PR TITLE
Fix a false negative for `Lint/ToEnumArguments` with extra positional args

### DIFF
--- a/changelog/fix_a_false_negative_for_to_enum_arguments_extra_positional_20260605185237.md
+++ b/changelog/fix_a_false_negative_for_to_enum_arguments_extra_positional_20260605185237.md
@@ -1,0 +1,1 @@
+* [#15248](https://github.com/rubocop/rubocop/pull/15248): Fix a false negative for `Lint/ToEnumArguments` when more positional arguments are passed than the method accepts (e.g. `def m(x); to_enum(:m, x, extra); end`), which raises `ArgumentError` when the enumerator is used. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -61,7 +61,7 @@ module RuboCop
         def arguments_match?(arguments, def_node)
           index = 0
 
-          def_node.arguments.reject(&:blockarg_type?).all? do |def_arg|
+          all_present = def_node.arguments.reject(&:blockarg_type?).all? do |def_arg|
             send_arg = arguments[index]
             case def_arg.type
             when :arg, :restarg, :optarg
@@ -70,6 +70,33 @@ module RuboCop
 
             send_arg && argument_match?(send_arg, def_arg)
           end
+
+          all_present && !extra_positional_arguments?(arguments, def_node)
+        end
+
+        # The enumerator re-invokes the method with these arguments, so passing more
+        # positional arguments than the method accepts raises `ArgumentError` at runtime.
+        def extra_positional_arguments?(arguments, def_node)
+          return false if variadic_parameters?(def_node) || expandable_arguments?(arguments)
+
+          positional_arguments(arguments).size > positional_parameters(def_node).size
+        end
+
+        def variadic_parameters?(def_node)
+          def_node.arguments.any? { |arg| arg.type?(:restarg, :forward_arg) }
+        end
+
+        # A splat or argument forwarding on the call side can expand to any arity.
+        def expandable_arguments?(arguments)
+          arguments.any? { |arg| arg.type?(:splat, :forwarded_args, :forwarded_restarg) }
+        end
+
+        def positional_arguments(arguments)
+          arguments.reject { |arg| arg.type?(:hash, :kwsplat, :block_pass, :forwarded_kwrestarg) }
+        end
+
+        def positional_parameters(def_node)
+          def_node.arguments.select { |arg| arg.type?(:arg, :optarg) }
         end
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -10,6 +10,32 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'registers an offense when an extra positional argument is passed' do
+    expect_offense(<<~RUBY)
+      def m(x)
+        return to_enum(:m, x, extra) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when more positional arguments than parameters are passed' do
+    expect_offense(<<~RUBY)
+      def m(x, y = 1)
+        return to_enum(:m, x, y, z) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a splat parameter absorbs extra arguments' do
+    expect_no_offenses(<<~RUBY)
+      def m(x, *args)
+        return to_enum(:m, x, *args) unless block_given?
+      end
+    RUBY
+  end
+
   it 'registers an offense when optional arg is missing' do
     expect_offense(<<~RUBY)
       def m(x, y = 1)


### PR DESCRIPTION
The cop verified every parameter had a matching argument but ignored *extra* positional arguments, so `def m(x); to_enum(:m, x, extra); end` was accepted - even though the enumerator re-invokes `m(x, extra)` and raises `ArgumentError`. Now it flags passing more positional arguments than the method accepts, while still allowing a `restarg` / argument forwarding (or a call-side splat) to absorb extra args.