### PR TITLE
Fix a false negative for `Lint/UnescapedBracketInRegexp`

### DIFF
--- a/changelog/fix_a_false_negative_for_unescaped_bracket_in_regexp_20260605185535.md
+++ b/changelog/fix_a_false_negative_for_unescaped_bracket_in_regexp_20260605185535.md
@@ -1,0 +1,1 @@
+* [#15249](https://github.com/rubocop/rubocop/pull/15249): Fix a false negative for `Lint/UnescapedBracketInRegexp` when an unescaped `]` is preceded by an escaped backslash (e.g. `/abc\\]123/`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -68,7 +68,9 @@ module RuboCop
 
           expr.text.scan(/(?<!\\)\]/) do
             pos = Regexp.last_match.begin(0)
-            next if pos.zero? # if the unescaped bracket is the first character, Ruby does not warn
+            # If the unescaped bracket is the first character of the regexp, Ruby does not warn.
+            # `pos` is relative to the sub-expression, so add its start offset (`expr.ts`).
+            next if (expr.ts + pos).zero?
 
             location = range_at_index(node, expr.ts, pos)
 

--- a/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
       end
     end
 
+    context 'unescaped bracket preceded by an escaped backslash' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~'RUBY')
+          /abc\\]123/
+                ^ Regular expression has `]` without escape.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /abc\\\]123/
+        RUBY
+      end
+    end
+
     context 'unescaped bracket in regexp with regexp options' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
The "first character" exemption (Ruby doesn't warn about a leading `]`) checked the bracket's position *within the current sub-expression* rather than its absolute position in the regexp. When a preceding escaped backslash split the parse into sub-expressions, a bare `]` at offset 0 of a later sub-expression was wrongly skipped - e.g. `/abc\\]123/` (escaped backslash then bare bracket) went unflagged even though Ruby warns. Now compares the absolute position.