### PR TITLE
Fix incorrect autocorrects for Lint/LiteralInInterpolation

### DIFF
--- a/changelog/fix_literal_in_interpolation_autocorrects_20260606164242.md
+++ b/changelog/fix_literal_in_interpolation_autocorrects_20260606164242.md
@@ -1,0 +1,1 @@
+* [#15250](https://github.com/rubocop/rubocop/issues/15250): Fix incorrect autocorrects for `Lint/LiteralInInterpolation` with embedded quotes and escaped interpolation text. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -119,11 +119,13 @@ module RuboCop
         end
 
         def autocorrected_value_for_string(node)
-          if node.source.start_with?("'", '%q')
-            node.children.last.inspect[1..-2]
-          else
-            node.children.last
-          end
+          return node.source.delete_prefix('"').delete_suffix('"') unless node.value.valid_encoding?
+
+          escape_string_content(node.children.last)
+        end
+
+        def escape_string_content(string)
+          string.gsub(/[\\"]|#(?=[@{$])/, '\\\\\&')
         end
 
         def autocorrected_value_for_symbol(node)

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -341,6 +341,28 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
     RUBY
   end
 
+  it 'handles double quotes in double quotes when autocorrecting' do
+    expect_offense(<<~'RUBY')
+      "this is #{"\""} silly"
+                 ^^^^ Literal interpolation detected.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "this is \" silly"
+    RUBY
+  end
+
+  it 'handles escaped interpolation text in double quotes when autocorrecting' do
+    expect_offense(<<~'RUBY')
+      "this is #{"\#{1}"} silly"
+                 ^^^^^^^ Literal interpolation detected.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "this is \#{1} silly"
+    RUBY
+  end
+
   it 'handles backslash in single quotes when autocorrecting' do
     expect_offense(<<~'RUBY')
       x = "ABC".gsub(/(A)(B)(C)/, "D#{'\2'}F")


### PR DESCRIPTION
## Description:

Issue #15250 reported that `Lint/LiteralInInterpolation` could produce incorrect autocorrects for interpolated string literals.

When the interpolated string literal contained embedded double quotes or escaped interpolation text, the cop inserted the literal value into the surrounding interpolated string without escaping characters that are special in the outer string context. This could produce invalid Ruby syntax or change runtime behavior.

This PR updates `Lint/LiteralInInterpolation` to escape string content before replacing the interpolation, while preserving the existing invalid-encoding handling.

It also adds regression tests for embedded double quotes and escaped interpolation text.

Closes #15250.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting in WSL using `bundle exec rubocop lib/rubocop/cop/lint/literal_in_interpolation.rb spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run the full verification suite in WSL using `bundle exec rake`.

### Before the fix:

<img width="1028" height="548" alt="image" src="https://github.com/user-attachments/assets/fa625607-e589-410c-9844-1101f968d56c" />

### After the fix:

<img width="920" height="353" alt="image" src="https://github.com/user-attachments/assets/74f39a7f-9aaa-4d9c-846a-f4c6d4d577c0" />