### PR TITLE
Stop autocorrecting direct safe navigation in Lint/NumberConversion

### DIFF
--- a/changelog/fix_number_conversion_safe_navigation_autocorrect_20260606181916.md
+++ b/changelog/fix_number_conversion_safe_navigation_autocorrect_20260606181916.md
@@ -1,0 +1,1 @@
+* [#15252](https://github.com/rubocop/rubocop/issues/15252): Stop autocorrecting `Lint/NumberConversion` offenses on direct safe navigation calls. ([@RedZapdos123][])

--- a/changelog/fix_number_conversion_safe_navigation_autocorrect_20260606181916.md
+++ b/changelog/fix_number_conversion_safe_navigation_autocorrect_20260606181916.md
@@ -1,1 +1,1 @@
-* [#15252](https://github.com/rubocop/rubocop/issues/15252): Stop autocorrecting `Lint/NumberConversion` offenses on direct safe navigation calls. ([@RedZapdos123][])
+* [#15252](https://github.com/rubocop/rubocop/issues/15252): Stop autocorrecting `Lint/NumberConversion` offenses on safe navigation calls. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -117,11 +117,11 @@ module RuboCop
 
             message = format(
               MSG,
-              current: "#{receiver.source}.#{to_method}",
+              current: current_method(node, receiver, to_method),
               corrected_method: correct_method(node, receiver)
             )
             add_offense(node, message: message) do |corrector|
-              next if node.csend_type? || part_of_ignored_node?(node)
+              next if safe_navigation?(node) || part_of_ignored_node?(node)
 
               corrector.replace(node, correct_method(node, node.receiver))
 
@@ -156,9 +156,18 @@ module RuboCop
           "{ |i| #{body} }"
         end
 
+        def current_method(node, receiver, to_method)
+          operator = node.csend_type? ? '&.' : '.'
+          "#{receiver.source}#{operator}#{to_method}"
+        end
+
         def remove_parentheses(corrector, node)
           corrector.replace(node.loc.begin, ' ')
           corrector.remove(node.loc.end)
+        end
+
+        def safe_navigation?(node)
+          node.csend_type? || node.each_descendant(:csend).any?
         end
 
         def allow_receiver?(receiver)

--- a/lib/rubocop/cop/lint/number_conversion.rb
+++ b/lib/rubocop/cop/lint/number_conversion.rb
@@ -121,7 +121,7 @@ module RuboCop
               corrected_method: correct_method(node, receiver)
             )
             add_offense(node, message: message) do |corrector|
-              next if part_of_ignored_node?(node)
+              next if node.csend_type? || part_of_ignored_node?(node)
 
               corrector.replace(node, correct_method(node, node.receiver))
 

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -15,13 +15,11 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
 
     it 'when using `&.to_i`' do
       expect_offense(<<~RUBY)
-        "10"&.to_i
-        ^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `"10".to_i`, use stricter `Integer("10", 10)`.
+        foo&.to_i
+        ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `foo.to_i`, use stricter `Integer(foo, 10)`.
       RUBY
 
-      expect_correction(<<~RUBY)
-        Integer("10", 10)
-      RUBY
+      expect_no_corrections
     end
 
     it 'when using `#to_f`' do

--- a/spec/rubocop/cop/lint/number_conversion_spec.rb
+++ b/spec/rubocop/cop/lint/number_conversion_spec.rb
@@ -16,7 +16,16 @@ RSpec.describe RuboCop::Cop::Lint::NumberConversion, :config do
     it 'when using `&.to_i`' do
       expect_offense(<<~RUBY)
         foo&.to_i
-        ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `foo.to_i`, use stricter `Integer(foo, 10)`.
+        ^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `foo&.to_i`, use stricter `Integer(foo, 10)`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'when using `#to_i` on a receiver chain containing safe navigation' do
+      expect_offense(<<~RUBY)
+        foo&.bar.to_i
+        ^^^^^^^^^^^^^ Replace unsafe number conversion with number class parsing, instead of using `foo&.bar.to_i`, use stricter `Integer(foo&.bar, 10)`.
       RUBY
 
       expect_no_corrections


### PR DESCRIPTION
## Description:

Issue #15252 reported that `Lint/NumberConversion` could produce incorrect autocorrects for safe navigation calls.

When code like `foo&.to_i` was autocorrected to `Integer(foo, 10)`, the nil-safe behavior of `&.` was lost and the corrected code could raise when the receiver was `nil`.

The same problem also applied when safe navigation appeared inside the receiver chain. For example, `foo&.bar.to_i` could be autocorrected to `Integer(foo&.bar, 10)`, which can also change behavior.

This PR updates `Lint/NumberConversion` to keep reporting number conversions that involve safe navigation, but to skip autocorrection whenever safe navigation appears in the converted call chain.

It also corrects the direct safe-navigation offense message and adds regression tests for both `foo&.to_i` and `foo&.bar.to_i`.

Closes #15252.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting in WSL using `bundle exec rubocop lib/rubocop/cop/lint/number_conversion.rb spec/rubocop/cop/lint/number_conversion_spec.rb`.
- [x] I have run focused tests in WSL using `bundle exec rspec spec/rubocop/cop/lint/number_conversion_spec.rb`.
- [x] I have run the full verification suite in WSL using `bundle exec rake`.

### Before the fix: 

<img width="1265" height="311" alt="image" src="https://github.com/user-attachments/assets/018ebc69-7271-41da-a666-9a7f309d725e" />

### After the fix:

<img width="1203" height="254" alt="image" src="https://github.com/user-attachments/assets/8f2009d7-db0d-4fbf-8a35-7cb5e9d779ef" />
