### PR TITLE
Clear `ExcludeLimit.tmp_dir` after `--auto-gen-config` runs

### DIFF
--- a/lib/rubocop/cli/command/auto_generate_config.rb
+++ b/lib/rubocop/cli/command/auto_generate_config.rb
@@ -31,6 +31,12 @@ module RuboCop
           result = run_all_cops(line_length_contents)
           reset_auto_gen_tmp_dir
           result
+        ensure
+          # `auto_gen_tmp_dir` points `ExcludeLimit.tmp_dir` at this command's
+          # tmp directory. Clear that process-global state on the way out so
+          # later in-process callers (e.g. other specs in the same test worker)
+          # don't read this run's leftover directory.
+          RuboCop::ExcludeLimit.tmp_dir = nil
         end
 
         private

--- a/spec/rubocop/exclude_limit_spec.rb
+++ b/spec/rubocop/exclude_limit_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::ExcludeLimit do
+  describe '.read_limits' do
+    around do |example|
+      original = described_class.tmp_dir
+      begin
+        example.run
+      ensure
+        described_class.tmp_dir = original
+      end
+    end
+
+    context 'when `tmp_dir` is not set' do
+      before { described_class.tmp_dir = nil }
+
+      it 'returns an empty hash' do
+        expect(described_class.read_limits('Metrics/MethodLength')).to eq({})
+      end
+    end
+
+    context 'when `tmp_dir` is set' do
+      around do |example|
+        Dir.mktmpdir('rubocop-exclude-limit') do |dir|
+          described_class.tmp_dir = Pathname.new(dir)
+          example.run
+        end
+      end
+
+      it 'returns an empty hash when no values were written for the cop' do
+        expect(described_class.read_limits('Metrics/MethodLength')).to eq({})
+      end
+
+      it 'ignores parameter files with no values' do
+        cop_dir = described_class.cop_dir_for('Metrics/MethodLength')
+        cop_dir.mkpath
+        cop_dir.join('Max').write('')
+
+        expect(described_class.read_limits('Metrics/MethodLength')).to eq({})
+      end
+
+      it 'returns the maximum of the written values for each parameter' do
+        cop_dir = described_class.cop_dir_for('Metrics/MethodLength')
+        cop_dir.mkpath
+        cop_dir.join('Max').write("12\n81\n47\n")
+
+        expect(described_class.read_limits('Metrics/MethodLength')).to eq('Max' => 81)
+      end
+    end
+  end
+end


### PR DESCRIPTION
While investigating the coverage fluctuation reported by @bquorning in https://github.com/simplecov-ruby/simplecov/issues/1171#issuecomment-4632677911 (observed while testing SimpleCov 1.0.0.rc1 in https://github.com/rubocop/rubocop/pull/15191), I found one branch flipped between runs: the nil-receiver arm in `lib/rubocop/cop/exclude_limit.rb`, on line 14:

```ruby
return {} unless cop_dir&.directory?
```

The cause is process-global state. `AutoGenerateConfig#run` points `ExcludeLimit.tmp_dir` at its tmp directory and never unsets it. A CLI process exits right afterwards, so normal use is unaffected, but in the spec suite any worker process that runs an example from `./spec/rubocop/formatter/disabled_config_formatter_spec.rb` keeps the global set for the rest of its life. When `./spec/rubocop/formatter/disabled_config_formatter_spec.rb` later reaches `read_limits` in the same process, it takes a different branch than it does in a clean process. Both branches return `{}`, so no test ever fails, but which branch gets covered depends on which specs share a worker and in what order. With test-queue distributing specs dynamically, that changes from run to run.

This PR makes two changes:

1. `AutoGenerateConfig#run` now clears `ExcludeLimit.tmp_dir` in an `ensure` block, mirroring the cleanup that the `with exclude limit tracking` shared context already does.
2. A new spec pins the behavior of `read_limits` with and without `tmp_dir` set, so coverage of both arms of the guard no longer depends on which other specs happen to reach it.

I put each of these changes in its own commit but let me know if you want me to squash them into one. I also didn’t add a `CHANGELOG` entry, since there are no user-facing behavior changes, but please let me know if you’d like me to do that too.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/