### PR TITLE
[Fix #15254] Fix an infinite loop error for `Lint/SafeNavigationWithEmpty`

### DIFF
--- a/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_with_empty.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         # @!method safe_navigation_empty_in_conditional?(node)
         def_node_matcher :safe_navigation_empty_in_conditional?, <<~PATTERN
-          (if (csend _ :empty?) ...)
+          (if (csend !csend :empty?) ...)
         PATTERN
 
         def on_if(node)

--- a/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_with_empty_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationWithEmpty, :config do
         return if foo.empty?
       RUBY
     end
+
+    it 'does not register an offense when the receiver uses safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        return if foo&.bar&.empty?
+      RUBY
+    end
   end
 
   context 'outside a conditional' do


### PR DESCRIPTION
Running autocorrection on code such as `return if foo&.bar&.empty?` with `Lint/SafeNavigationWithEmpty`, `Lint/SafeNavigationChain`, and `Style/SafeNavigation` enabled raised an "Infinite loop detected" error.

The matcher was broadened to accept any receiver, so it also matched a receiver that is itself a safe navigation chain. Expanding `foo&.bar&.empty?` into `foo&.bar && foo&.bar.empty?` is then rewritten by the other two cops back to the original form, and the three cops keep undoing each other.

Restrict the cop so it does not register an offense when the receiver of `empty?` already uses safe navigation, while still handling the cases the matcher was meant to cover (local variables, instance variables, constants, and ordinary method calls).

Since it hasn't been released yet, there's no changelog entry.

Fixes #15254.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
