### PR TITLE
Fix a false negative for `Lint/ToEnumArguments` with extra keyword args

### DIFF
--- a/changelog/fix_a_false_negative_for_to_enum_arguments_extra_keyword_args_20260607061500.md
+++ b/changelog/fix_a_false_negative_for_to_enum_arguments_extra_keyword_args_20260607061500.md
@@ -1,1 +1,1 @@
-* [#15257](https://github.com/rubocop/rubocop/issues/15257): Fix a false negative for `Lint/ToEnumArguments` when extra keyword arguments are passed (e.g. `def m(x:); to_enum(:m, x: x, y: 1); end`), which raises `ArgumentError` when the enumerator is used. ([@RedZapdos123][])
+* [#15257](https://github.com/rubocop/rubocop/issues/15257): Fix a false negative for `Lint/ToEnumArguments` when explicit extra keyword arguments are passed (e.g. `def m(x:); to_enum(:m, x: x, y: 1); end`), which raises `ArgumentError` when the enumerator is used. ([@RedZapdos123][])

--- a/changelog/fix_a_false_negative_for_to_enum_arguments_extra_keyword_args_20260607061500.md
+++ b/changelog/fix_a_false_negative_for_to_enum_arguments_extra_keyword_args_20260607061500.md
@@ -1,0 +1,1 @@
+* [#15257](https://github.com/rubocop/rubocop/issues/15257): Fix a false negative for `Lint/ToEnumArguments` when extra keyword arguments are passed (e.g. `def m(x:); to_enum(:m, x: x, y: 1); end`), which raises `ArgumentError` when the enumerator is used. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -71,7 +71,9 @@ module RuboCop
             send_arg && argument_match?(send_arg, def_arg)
           end
 
-          all_present && !extra_positional_arguments?(arguments, def_node)
+          all_present &&
+            !extra_positional_arguments?(arguments, def_node) &&
+            !extra_keyword_arguments?(arguments, def_node)
         end
 
         # The enumerator re-invokes the method with these arguments, so passing more
@@ -97,6 +99,40 @@ module RuboCop
 
         def positional_parameters(def_node)
           def_node.arguments.select { |arg| arg.type?(:arg, :optarg) }
+        end
+
+        # The enumerator re-invokes the method with these arguments, so passing
+        # unexpected keyword arguments raises `ArgumentError` at runtime.
+        def extra_keyword_arguments?(arguments, def_node)
+          return false if variadic_keyword_parameters?(def_node)
+          return false if expandable_keyword_arguments?(arguments)
+
+          (passed_keyword_arguments(arguments) - keyword_parameters(def_node)).any?
+        end
+
+        def variadic_keyword_parameters?(def_node)
+          def_node.arguments.any? { |arg| arg.type?(:kwrestarg, :forward_arg) }
+        end
+
+        # A call-side keyword splat or argument forwarding can expand to any set of keywords.
+        def expandable_keyword_arguments?(arguments)
+          arguments.any? do |arg|
+            arg.forwarded_args_type? || arg.each_child_node(:kwsplat, :forwarded_kwrestarg).any?
+          end
+        end
+
+        def passed_keyword_arguments(arguments)
+          arguments.filter_map do |arg|
+            next unless arg.hash_type?
+
+            arg.pairs.filter_map { |pair| pair.key.value if pair.key.sym_type? }
+          end.flatten
+        end
+
+        def keyword_parameters(def_node)
+          def_node.arguments.filter_map do |arg|
+            arg.children[0] if arg.type?(:kwarg, :kwoptarg)
+          end
         end
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'registers an offense when an extra keyword argument is passed' do
+    expect_offense(<<~RUBY)
+      def m(x:)
+        return to_enum(:m, x: x, y: 1) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
   it 'registers an offense when splat keyword arg is missing' do
     expect_offense(<<~RUBY)
       def m(x, y = 1, *args, required:, optional: true, **kwargs)
@@ -180,6 +189,14 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
         end
       RUBY
     end
+  end
+
+  it 'does not register an offense when a keyword splat may supply extra keywords' do
+    expect_no_offenses(<<~RUBY)
+      def m(x:)
+        return to_enum(:m, x: x, **kwargs) unless block_given?
+      end
+    RUBY
   end
 
   context 'arguments forwarding', :ruby30 do

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'registers an offense when keyword rest arguments are not forwarded' do
+    expect_offense(<<~RUBY)
+      def m(x:, **kwargs)
+        return to_enum(:m, x: x, y: 1) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
   it 'registers an offense when arguments are swapped' do
     expect_offense(<<~RUBY)
       def m(x, y = 1)
@@ -195,6 +204,14 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     expect_no_offenses(<<~RUBY)
       def m(x:)
         return to_enum(:m, x: x, **kwargs) unless block_given?
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when keyword rest arguments are forwarded' do
+    expect_no_offenses(<<~RUBY)
+      def m(x:, **kwargs)
+        return to_enum(:m, x: x, y: 1, **kwargs) unless block_given?
       end
     RUBY
   end


### PR DESCRIPTION
## Description:

Issue #15257 reported that `Lint/ToEnumArguments` could miss extra keyword arguments.

The cop verified that required and optional keyword parameters had matching arguments, but it did not reject additional explicit keyword pairs. As a result, code such as `def m(x:); to_enum(:m, x: x, y: 1); end` was accepted even though the enumerator re-invokes the method with an unexpected keyword argument and raises `ArgumentError` at runtime.

This PR updates `Lint/ToEnumArguments` to flag unexpected explicit keyword arguments, while still allowing cases where the call site uses keyword forwarding or a keyword splat that can expand dynamically.

It also adds regression tests for the extra-keyword case, keyword-splat handling, and keyword-rest forwarding behavior.

Closes #15257.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/lint/to_enum_arguments.rb spec/rubocop/cop/lint/to_enum_arguments_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/lint/to_enum_arguments_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake`.

### Before the fix: 

<img width="512" height="139" alt="image" src="https://github.com/user-attachments/assets/f18d7966-a991-452f-b945-097f313818a4" />

### After the fix:

<img width="587" height="245" alt="image" src="https://github.com/user-attachments/assets/0345d1ef-615e-4623-96f8-e8665fc0c474" />