### PR TITLE
[Fix #15125] Fix a false positive for Style/ZeroLengthPredicate with File::Stat.new

### DIFF
--- a/changelog/fix_a_false_positive_for_zero_length_predicate_file_stat_20260608131955.md
+++ b/changelog/fix_a_false_positive_for_zero_length_predicate_file_stat_20260608131955.md
@@ -1,0 +1,1 @@
+* [#15125](https://github.com/rubocop/rubocop/issues/15125): Fix a false positive for `Style/ZeroLengthPredicate` when `File::Stat.new(...).size.zero?` is used. ([@augustocbx][])

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -9,8 +9,10 @@ module RuboCop
       # `receiver.length < 1` and `receiver.size == 0` that can be
       # replaced by `receiver.empty?` and `!receiver.empty?`.
       #
-      # NOTE: `File`, `Tempfile`, and `StringIO` do not have `empty?`
-      # so allow `size == 0` and `size.zero?`.
+      # NOTE: `File`, `Tempfile`, `StringIO`, and `File::Stat` do not have `empty?`
+      # so allow `size == 0` and `size.zero?`. Note that when a `File::Stat` object
+      # is stored in a variable (e.g. `stat = File.stat(path); stat.size.zero?`),
+      # the cop cannot detect the type and may still register a false positive.
       #
       # @safety
       #   This cop is unsafe because it cannot be guaranteed that the receiver
@@ -146,7 +148,8 @@ module RuboCop
         # @!method non_polymorphic_collection?(node)
         def_node_matcher :non_polymorphic_collection?, <<~PATTERN
           {(send (send (send (const {nil? cbase} :File) :stat _) ...) ...)
-           (send (send (send (const {nil? cbase} {:File :Tempfile :StringIO}) {:new :open} ...) ...) ...)}
+           (send (send (send (const {nil? cbase} {:File :Tempfile :StringIO}) {:new :open} ...) ...) ...)
+           (send (send (send (const (const {nil? cbase} :File) :Stat) :new ...) ...) ...)}
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -449,15 +449,51 @@ RSpec.describe RuboCop::Cop::Style::ZeroLengthPredicate, :config do
   end
 
   context 'when inspecting a File::Stat object' do
-    it 'does not register an offense' do
+    it 'does not register an offense for `size == 0`' do
       expect_no_offenses(<<~RUBY)
         File.stat(foo).size == 0
       RUBY
     end
 
-    it 'does not register an offense with ::File' do
+    it 'does not register an offense with ::File for `size == 0`' do
       expect_no_offenses(<<~RUBY)
         ::File.stat(foo).size == 0
+      RUBY
+    end
+
+    it 'does not register an offense for `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        File.stat(foo).size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense with ::File for `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        ::File.stat(foo).size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense for `File::Stat.new` with `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        File::Stat.new(foo).size == 0
+      RUBY
+    end
+
+    it 'does not register an offense for `::File::Stat.new` with `size == 0`' do
+      expect_no_offenses(<<~RUBY)
+        ::File::Stat.new(foo).size == 0
+      RUBY
+    end
+
+    it 'does not register an offense for `File::Stat.new` with `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        File::Stat.new(foo).size.zero?
+      RUBY
+    end
+
+    it 'does not register an offense for `::File::Stat.new` with `size.zero?`' do
+      expect_no_offenses(<<~RUBY)
+        ::File::Stat.new(foo).size.zero?
       RUBY
     end
   end


### PR DESCRIPTION
`Style/ZeroLengthPredicate` was registering a false positive for `File::Stat.new(...).size.zero?`, suggesting to replace it with `empty?`. However, `File::Stat` does not implement `empty?`, so the autocorrect would produce a `NoMethodError` at runtime.

The `non_polymorphic_collection?` matcher already excluded the `File.stat(...).size.zero?` form, but did not cover the `File::Stat.new(...)` constructor. This PR adds a third alternative to the node pattern to handle `File::Stat.new` / `::File::Stat.new`.

The cop's NOTE is also updated to mention `File::Stat` and to document the known limitation: when a `File::Stat` object is stored in a variable (e.g. `stat = File.stat(path); stat.size.zero?`), the cop cannot detect the type and may still register a false positive.

Fixes #15125.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/