### PR TITLE
[Fix #15260] Fix an error for `Style/FileWrite`

### DIFF
--- a/changelog/fix_an_error_for_style_file_write_20260610123212.md
+++ b/changelog/fix_an_error_for_style_file_write_20260610123212.md
@@ -1,0 +1,1 @@
+* [#15260](https://github.com/rubocop/rubocop/issues/15260): Fix an error for `Style/FileWrite` when a literal or variable is passed to `write` in the block form. ([@koic][])

--- a/lib/rubocop/cop/style/file_write.rb
+++ b/lib/rubocop/cop/style/file_write.rb
@@ -125,9 +125,9 @@ module RuboCop
 
         def find_heredoc(node)
           return node if node.respond_to?(:heredoc?) && node.heredoc?
-          return if node.send_type? && !(receiver = node.receiver)
+          return if !node.call_type? || node.receiver.nil?
 
-          find_heredoc(receiver)
+          find_heredoc(node.receiver)
         end
       end
     end

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when a local variable is passed to `f.write`' do
+    expect_offense(<<~RUBY)
+      content = 'hello'
+      File.open(filename, 'w') { |f| f.write(content) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      content = 'hello'
+      File.write(filename, content)
+    RUBY
+  end
+
   it 'does not register an offense when a splat argument is passed to `f.write`' do
     expect_no_offenses(<<~RUBY)
       File.open(filename, 'w') do |f|
@@ -69,6 +82,19 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
 
       expect_correction(<<~RUBY)
         File.#{write_method}(filename, content)
+      RUBY
+    end
+
+    it "registers an offense for and corrects the `File.open` with inline write block (mode '#{mode}') with string literal" do
+      write_method = mode.end_with?('b') ? :binwrite : :write
+
+      expect_offense(<<~RUBY)
+        File.open(filename, '#{mode}') { |f| f.write('hello') }
+        ^^^^^^^^^^^^^^^^^^^^^#{'^' * mode.length}^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.#{write_method}`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        File.#{write_method}(filename, 'hello')
       RUBY
     end
 


### PR DESCRIPTION
This fixes the following error for `Style/FileWrite` when a literal or variable is passed to `write` in the block form:

```console
$ cat test.rb
File.open('/tmp/test.txt', 'wb') { |f| f.write('hello') }

$ bundle exec rubocop --only Style/FileWrite test.rb
An error occurred while Style/FileWrite cop was inspecting test.rb:1:0.
undefined method 'send_type?' for nil (NoMethodError)
```

This is a regression introduced in 59a62e4 (RuboCop 1.87.0), which added a walk over the receiver chain to find a heredoc. The walk only stopped at receiverless send nodes, so any other non-heredoc content argument, such as a string literal or a local variable, recursed into `nil` and crashed. The walk now stops at any node that is not a method call with a receiver, and also follows safe navigation chains.

Fixes #15260.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
