### PR TITLE
[Fix #15260] Fix an error for Style/FileWrite

### DIFF
--- a/changelog/fix_an_error_for_style_file_write_20260609222510.md
+++ b/changelog/fix_an_error_for_style_file_write_20260609222510.md
@@ -1,0 +1,1 @@
+* [#15260](https://github.com/rubocop/rubocop/issues/15260): Fix an error for `Style/FileWrite` when the written content is a literal or a variable. ([@augustocbx][])

--- a/lib/rubocop/cop/style/file_write.rb
+++ b/lib/rubocop/cop/style/file_write.rb
@@ -125,7 +125,7 @@ module RuboCop
 
         def find_heredoc(node)
           return node if node.respond_to?(:heredoc?) && node.heredoc?
-          return if node.send_type? && !(receiver = node.receiver)
+          return unless node.call_type? && (receiver = node.receiver)
 
           find_heredoc(receiver)
         end

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -17,6 +17,47 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when the written content is a string literal' do
+    expect_offense(<<~RUBY)
+      File.open('/tmp/test.txt', 'wb') { |f| f.write('hello') }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.binwrite`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.binwrite('/tmp/test.txt', 'hello')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when the written content is a local variable' do
+    expect_offense(<<~RUBY)
+      content = 'hello'
+      File.open(filename, 'w') { |f| f.write(content) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      content = 'hello'
+      File.write(filename, content)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when the written heredoc is chained with a safe navigation method call' do
+    expect_offense(<<~RUBY)
+      File.open(filename, 'w') do |f|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        f.write(<<~EOS&.gsub(/^/, ''))
+          content
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(filename, <<~EOS&.gsub(/^/, ''))
+          content
+        EOS
+    RUBY
+  end
+
   described_class::TRUNCATING_WRITE_MODES.each do |mode|
     it "registers an offense for and corrects `File.open(filename, '#{mode}').write(content)`" do
       write_method = mode.end_with?('b') ? :binwrite : :write


### PR DESCRIPTION
`Style/FileWrite` raised `NoMethodError: undefined method 'send_type?' for nil` when the content written inside the block was not a method call, e.g.:

```ruby
File.open('/tmp/test.txt', 'wb') { |f| f.write('hello') }
```

`find_heredoc` recursed unconditionally unless the node was a receiverless `send` node, so non-send nodes (e.g. string literals and local variables) caused recursion with `nil`. The recursion now only continues into call nodes that have a receiver.

Using `call_type?` (rather than `send_type?`) keeps traversing heredocs chained with safe navigation (e.g. `f.write(<<~EOS&.gsub(/^/, ''))`), which the previous code handled by accident and is now covered by a spec.

Fixes #15260.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/