### PR TITLE
[Fix #14979] Fix a false positive for `Layout/BlockAlignment` with multiline method arguments

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_block_alignment_multiline_arguments_20260610143635.md
+++ b/changelog/fix_a_false_positive_for_layout_block_alignment_multiline_arguments_20260610143635.md
@@ -1,0 +1,1 @@
+* [#14979](https://github.com/rubocop/rubocop/issues/14979): Fix a false positive for `Layout/BlockAlignment` when a block's `{` or `do` is on a continuation line of multiline method arguments. ([@augustocbx][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -201,16 +201,35 @@ module RuboCop
           # can be a block, a variable assignment, etc). But we also allow
           # the "end" to be aligned with the start of the line where the "do"
           # is, which is a style some people use in multi-line chains of
-          # blocks.
-          match = /\S.*/.match(do_loc.source_line)
+          # blocks. When the "do" is on a continuation line of multiline
+          # method arguments, the method call's line is used as the reference
+          # instead, since the continuation line's indentation reflects
+          # argument alignment rather than the start of the block.
+          reference_loc = block_begin_reference_loc(node, do_loc)
+          match = /\S.*/.match(reference_loc.source_line)
           indentation_of_do_line = match.begin(0)
           return unless end_loc.column != indentation_of_do_line || style == :start_of_line
 
           {
             source: match[0],
-            line: do_loc.line,
+            line: reference_loc.line,
             column: indentation_of_do_line
           }
+        end
+
+        def block_begin_reference_loc(node, do_loc)
+          # The `start_of_block` style explicitly aligns with the line where
+          # the "do" appears, so the continuation line is used as is.
+          return do_loc if style == :start_of_block
+
+          send_loc = node.send_node.loc
+          selector_loc = if send_loc.respond_to?(:selector)
+                           send_loc.selector
+                         elsif send_loc.respond_to?(:keyword) # `super`
+                           send_loc.keyword
+                         end
+
+          selector_loc && selector_loc.line != do_loc.line ? selector_loc : do_loc
         end
 
         def loc_to_source_line_column(loc)

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -215,6 +215,71 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         end
       RUBY
     end
+
+    # Example from issue 14979 of rubocop/rubocop on github:
+    it 'accepts `}` aligned with the method call line when the block follows multiline arguments' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+      RUBY
+    end
+
+    it 'accepts `end` aligned with the method call line when `do` follows multiline arguments' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) do
+            process(scheme.constraint)
+          end
+      RUBY
+    end
+
+    it 'accepts `}` aligned with the method call line when the block follows multiline arguments ' \
+       'and is chained' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }.to_s
+      RUBY
+    end
+
+    it 'accepts `}` aligned with the `super` keyword when the block follows multiline arguments' do
+      expect_no_offenses(<<~RUBY)
+        def call
+          super(a,
+                b) {
+            process
+          }
+        end
+      RUBY
+    end
+
+    it 'registers an offense for `}` not aligned with `super` when the block follows ' \
+       'multiline arguments' do
+      expect_offense(<<~RUBY)
+        def call
+          super(a,
+                b) {
+            process
+            }
+            ^ `}` at 5, 4 is not aligned with `super(a,` at 2, 2.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def call
+          super(a,
+                b) {
+            process
+          }
+        end
+      RUBY
+    end
   end
 
   context 'when variables of a mass assignment spans several lines' do
@@ -680,6 +745,26 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
+    it 'registers an offense for `}` aligned with the method call line when the block follows ' \
+       'multiline arguments' do
+      expect_offense(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+          ^ `}` at 5, 2 is not aligned with `out` at 1, 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+        }
+      RUBY
+    end
+
     context 'inside a non-endless method' do
       it 'does not register an offense when `end` is aligned with the block start' do
         expect_no_offenses(<<~RUBY)
@@ -835,6 +920,26 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
           .each do
             baz
           end
+      RUBY
+    end
+
+    it 'registers an offense for `}` not aligned with the block start line when the block ' \
+       'follows multiline arguments' do
+      expect_offense(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+          ^ `}` at 5, 2 is not aligned with `rgt: foo) {` at 3, 12.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+                    }
       RUBY
     end
 


### PR DESCRIPTION
Fix a false positive for `Layout/BlockAlignment` when a block's `{` or `do` is on a continuation line of multiline method arguments.

Fixes #14979

This picks up #15077 (by @55728), which was closed as stale without review; the author invited a new PR. I confirmed the reproduction on that thread.

## Root Cause

`compute_do_source_line_column` uses `do_loc.source_line` to determine the indentation of the line where the `{`/`do` appears. When the method arguments span multiple lines, that line is an argument continuation line whose indentation reflects argument alignment rather than the start of the block:

```ruby
out
  .brackets(lft: foo,
            rgt: foo) {           # cop saw this line -> first non-space at column 12 (`rgt:`)
    process(scheme.constraint)
  }                               # column 2 matches neither 0 (`out`) nor 12 -> false positive
```

## Solution

When the `{`/`do` is on a different line than the method call, use the call's line as the alignment reference instead:

- send/csend -> `loc.selector` (e.g. `.brackets`), `super` -> `loc.keyword`
- If the `{`/`do` is on the same line as the selector (or there is no selector location, e.g. `foo.()`), behavior is unchanged
- The `start_of_block` style keeps using the literal `{`/`do` line, as that is its documented behavior

## Tests

Seven new examples covering all three `EnforcedStyleAlignWith` styles: brace and `do...end` blocks after multiline arguments, a chained block, `super` with multiline arguments (accepted and offense cases), and offense/autocorrect cases for `start_of_line` and `start_of_block`. The four examples encoding the new behavior fail without the fix.

- `bundle exec rspec spec/rubocop/cop/layout/block_alignment_spec.rb` — 85 examples, 0 failures
- `PARSER_ENGINE=parser_prism bundle exec rspec spec/rubocop/cop/layout/block_alignment_spec.rb` — 85 examples, 0 failures
- `bundle exec rake` — passes (one pre-existing, environment-dependent failure in `spec/rubocop/config_spec.rb` that also fails on master in my environment; unrelated to this change)

## Risks

For the default `either` style, a closer aligned with the argument *continuation* line (e.g. column 12 above) is no longer accepted — the method call's line replaces it as the second allowed alignment. This is the intended semantics of the fix, but code relying on the old alignment would newly flag.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
