### PR TITLE
[Fix #14979] Fix false positives in `Layout/BlockAlignment`

### DIFF
--- a/changelog/fix_false_positives_for_layout_block_alignment_20260611023252.md
+++ b/changelog/fix_false_positives_for_layout_block_alignment_20260611023252.md
@@ -1,0 +1,1 @@
+* [#14979](https://github.com/rubocop/rubocop/issues/14979): Fix false positives in `Layout/BlockAlignment` when there is a line break between method arguments before the block. ([@koic][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -18,6 +18,10 @@ module RuboCop
       # `either` (which is the default) : the `end` is allowed to be in either
       # location. The autocorrect will default to `start_of_line`.
       #
+      # When the `do` or `{` appears on a continuation line of multiline
+      # method arguments, the start of the line where the method is called
+      # is used as the alignment target instead of that continuation line.
+      #
       # @example EnforcedStyleAlignWith: either (default)
       #   # bad
       #
@@ -196,21 +200,32 @@ module RuboCop
 
         def compute_do_source_line_column(node, end_loc)
           do_loc = node.loc.begin # Actually it's either do or {.
+          anchor_loc = do_line_anchor_loc(node, do_loc)
 
           # We've found that "end" is not aligned with the start node (which
           # can be a block, a variable assignment, etc). But we also allow
           # the "end" to be aligned with the start of the line where the "do"
           # is, which is a style some people use in multi-line chains of
           # blocks.
-          match = /\S.*/.match(do_loc.source_line)
+          match = /\S.*/.match(anchor_loc.source_line)
           indentation_of_do_line = match.begin(0)
-          return unless end_loc.column != indentation_of_do_line || style == :start_of_line
+          permitted_columns = permitted_do_line_columns(do_loc, indentation_of_do_line)
+          return if permitted_columns.include?(end_loc.column) && style != :start_of_line
 
           {
             source: match[0],
-            line: do_loc.line,
+            line: anchor_loc.line,
             column: indentation_of_do_line
           }
+        end
+
+        # `end` aligned with an argument continuation line that holds the `do`
+        # was accepted before the anchor moved to the method dispatch line;
+        # keep accepting it so that such code does not become an offense.
+        def permitted_do_line_columns(do_loc, indentation_of_do_line)
+          columns = [indentation_of_do_line]
+          columns << (do_loc.source_line =~ /\S/) if style == :either
+          columns
         end
 
         def loc_to_source_line_column(loc)
@@ -239,7 +254,7 @@ module RuboCop
         def compute_start_col(ancestor_node, node)
           if style == :start_of_block
             do_loc = node.loc.begin
-            return do_loc.source_line =~ /\S/
+            return do_line_anchor_loc(node, do_loc).source_line =~ /\S/
           end
           (ancestor_node || node).source_range.column
         end
@@ -252,6 +267,27 @@ module RuboCop
           range = range_between(end_pos - delta, end_pos)
 
           corrector.remove(range)
+        end
+
+        # When the `do` or `{` is on a continuation line of multiline method
+        # arguments, the indentation of that line is not a meaningful
+        # alignment target; anchor on the method dispatch position instead.
+        def do_line_anchor_loc(node, do_loc)
+          if do_line_begins_inside_argument?(node, do_loc)
+            node.send_node.selector || node.send_node.source_range
+          else
+            do_loc
+          end
+        end
+
+        def do_line_begins_inside_argument?(node, do_loc)
+          line_begin_pos = do_loc.begin_pos - do_loc.column
+          first_char_pos = line_begin_pos + (do_loc.source_line =~ /\S/)
+
+          (node.send_node.arguments + node.arguments).any? do |argument|
+            argument.source_range.begin_pos <= first_char_pos &&
+              first_char_pos < argument.source_range.end_pos
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -217,6 +217,69 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
     end
   end
 
+  context 'when there is a line break between the method arguments' do
+    it 'accepts `}` aligned with the start of the line where the method is called' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }
+      RUBY
+    end
+
+    it 'accepts `end` aligned with the start of the line where the method is called' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) do
+            process(scheme.constraint)
+          end
+      RUBY
+    end
+
+    it 'accepts `}` aligned with the start of the line where the method is called ' \
+       'when the block is chained' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+          }.to_s
+      RUBY
+    end
+
+    it 'accepts `}` aligned with the start of the line where the `{` is' do
+      expect_no_offenses(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+                    }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `}` is aligned with neither the start of the expression ' \
+       'nor the start of the line where the method is called' do
+      expect_offense(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+              }
+              ^ `}` at 5, 6 is not aligned with `out` at 1, 0 or `.brackets(lft: foo,` at 2, 2.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        out
+          .brackets(lft: foo,
+                    rgt: foo) {
+            process(scheme.constraint)
+        }
+      RUBY
+    end
+  end
+
   context 'when variables of a mass assignment spans several lines' do
     it 'accepts end aligned with the variables' do
       expect_no_offenses(<<~RUBY)
@@ -838,6 +901,55 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
+    context 'when there is a line break between the method arguments' do
+      it 'allows when `end` is aligned with the start of the line where the method is called' do
+        expect_no_offenses(<<~RUBY)
+          out
+            .brackets(lft: foo,
+                      rgt: foo) do
+              process(scheme.constraint)
+            end
+        RUBY
+      end
+
+      it 'errors when `end` is aligned with the line where the `do` is' do
+        expect_offense(<<~RUBY)
+          out
+            .brackets(lft: foo,
+                      rgt: foo) do
+              process(scheme.constraint)
+                      end
+                      ^^^ `end` at 5, 12 is not aligned with `.brackets(lft: foo,` at 2, 2.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          out
+            .brackets(lft: foo,
+                      rgt: foo) do
+              process(scheme.constraint)
+            end
+        RUBY
+      end
+
+      it 'allows when `end` is aligned with the start of the line where `super` is called' do
+        expect_no_offenses(<<~RUBY)
+          x = super(foo,
+                    bar) do
+            baz
+          end
+        RUBY
+      end
+
+      it 'allows when `}` is aligned with the start of the line where the lambda is defined' do
+        expect_no_offenses(<<~RUBY)
+          x = ->(a,
+                 b) {
+            baz
+          }
+        RUBY
+      end
+    end
+
     context 'inside a non-endless method' do
       it 'does not register an offense when `end` is aligned with the block start' do
         expect_no_offenses(<<~RUBY)
@@ -909,20 +1021,29 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         RUBY
       end
 
-      it 'registers an offense when `end` is aligned with the start of a multiline method definition' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when `end` is aligned with the start of a multiline method definition' do
+        expect_no_offenses(<<~RUBY)
           def foo = bar(123,
                         456) do
             baz
           end
-          ^^^ `end` at 4, 0 is not aligned with `456) do` at 2, 14.
+        RUBY
+      end
+
+      it 'registers an offense when `end` is not aligned with the start of a multiline method definition' do
+        expect_offense(<<~RUBY)
+          def foo = bar(123,
+                        456) do
+            baz
+              end
+              ^^^ `end` at 4, 4 is not aligned with `def foo = bar(123,` at 1, 0.
         RUBY
 
         expect_correction(<<~RUBY)
           def foo = bar(123,
                         456) do
             baz
-                        end
+          end
         RUBY
       end
 
@@ -949,20 +1070,29 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
         RUBY
       end
 
-      it 'registers an offense when `end` is aligned with the start of a multiline singleton method definition' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when `end` is aligned with the start of a multiline singleton method definition' do
+        expect_no_offenses(<<~RUBY)
           def self.foo = bar(123,
                              456) do
             baz
           end
-          ^^^ `end` at 4, 0 is not aligned with `456) do` at 2, 19.
+        RUBY
+      end
+
+      it 'registers an offense when `end` is not aligned with the start of a multiline singleton method definition' do
+        expect_offense(<<~RUBY)
+          def self.foo = bar(123,
+                             456) do
+            baz
+              end
+              ^^^ `end` at 4, 4 is not aligned with `def self.foo = bar(123,` at 1, 0.
         RUBY
 
         expect_correction(<<~RUBY)
           def self.foo = bar(123,
                              456) do
             baz
-                             end
+          end
         RUBY
       end
 


### PR DESCRIPTION
This cop allows the block `end` or `}` to be aligned with the start of the line where the `do` or `{` appears. When a method call has a line break between its arguments, the `do` or `{` sits on an argument continuation line, so the cop demanded alignment with the argument indentation, which is not a meaningful alignment target. As a result, aligning `}` with the start of the line where the method is called was reported as an offense.

The alignment target now anchors on the method dispatch line when the `do` or `{` is on an argument continuation line. With the default `EnforcedStyleAlignWith: either`, alignment with the continuation line is still accepted so that previously accepted code does not become an offense. With `start_of_block`, the required position and autocorrect move to the method dispatch line, which also changes the alignment required for blocks attached to multiline endless method definitions.

Fixes #14979

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
