### PR TITLE
Fix autocorrect bugs in several Array style cops

### DIFF
--- a/changelog/fix_a_false_positive_for_array_intersect_with_single_element_with_a_splat_20260611170902.md
+++ b/changelog/fix_a_false_positive_for_array_intersect_with_single_element_with_a_splat_20260611170902.md
@@ -1,0 +1,1 @@
+* [#15267](https://github.com/rubocop/rubocop/pull/15267): Fix a false positive for `Style/ArrayIntersectWithSingleElement` with a splat argument (e.g. `array.intersect?([*foo])`), which is not a single element and was incorrectly rewritten to `array.include?(*foo)`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_array_first_last_with_compound_assignment_20260611170900.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_array_first_last_with_compound_assignment_20260611170900.md
@@ -1,0 +1,1 @@
+* [#15267](https://github.com/rubocop/rubocop/pull/15267): Fix an incorrect autocorrect for `Style/ArrayFirstLast` when `arr[0]`/`arr[-1]` is the target of a compound assignment (e.g. `arr[0] += 1`), which produced `arr.first += 1` and raised `NoMethodError`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_array_intersect_with_safe_navigation_20260611170901.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_array_intersect_with_safe_navigation_20260611170901.md
@@ -1,0 +1,1 @@
+* [#15267](https://github.com/rubocop/rubocop/pull/15267): Fix an incorrect autocorrect for `Style/ArrayIntersect` where a negated predicate on a safe-navigation chain (e.g. `a&.intersection(b)&.none?`) was rewritten to `!a&.intersect?(b)`, flipping the result when the receiver is `nil`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_concat_array_literals_with_empty_arrays_20260611170903.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_concat_array_literals_with_empty_arrays_20260611170903.md
@@ -1,0 +1,1 @@
+* [#15267](https://github.com/rubocop/rubocop/pull/15267): Fix an incorrect autocorrect for `Style/ConcatArrayLiterals` with an empty array literal argument (e.g. `arr.concat([], [b])`), which produced invalid Ruby like `arr.push(, b)`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/array_first_last.rb
+++ b/lib/rubocop/cop/style/array_first_last.rb
@@ -40,8 +40,9 @@ module RuboCop
 
           node = innermost_braces_node(node)
           return if node.parent && brace_method?(node.parent)
+          return if compound_assignment_target?(node)
 
-          preferred = (value.zero? ? 'first' : 'last')
+          preferred = preferred_name(value)
           offense_range = find_offense_range(node)
 
           add_offense(offense_range, message: format(MSG, preferred: preferred)) do |corrector|
@@ -52,6 +53,10 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def preferred_name(value)
+          value.zero? ? 'first' : 'last'
+        end
 
         def preferred_value(node, value)
           value = ".#{value}" unless node.loc.dot
@@ -73,6 +78,12 @@ module RuboCop
 
         def brace_method?(node)
           node.send_type? && (node.method?(:[]) || node.method?(:[]=))
+        end
+
+        # `arr[0] += 1` etc. would autocorrect to `arr.first += 1`, which calls the
+        # nonexistent `first=`/`last=` setter and raises `NoMethodError`.
+        def compound_assignment_target?(node)
+          node.parent&.type?(:op_asgn, :or_asgn, :and_asgn) && node.parent.children.first == node
         end
       end
     end

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -145,6 +145,10 @@ module RuboCop
 
           dot = dot_node.loc.dot.source
           bang = straight?(method_name) ? '' : '!'
+          # `a&.intersection(b)&.none?` returns `nil` when `a` is `nil`, but the negated
+          # rewrite `!a&.intersect?(b)` returns `true` there, flipping the result.
+          return if bang == '!' && dot == '&.'
+
           replacement = "#{bang}#{receiver.source}#{dot}intersect?(#{argument.source})"
 
           register_offense(node, replacement)

--- a/lib/rubocop/cop/style/array_intersect_with_single_element.rb
+++ b/lib/rubocop/cop/style/array_intersect_with_single_element.rb
@@ -29,6 +29,9 @@ module RuboCop
         def on_send(node)
           array, element = single_element(node)
           return unless array
+          # `[*foo]` is not a single element: the splat can expand to any number of
+          # elements, so `intersect?([*foo])` is not equivalent to `include?(*foo)`.
+          return if element.splat_type?
 
           add_offense(
             node.source_range.with(begin_pos: node.loc.selector.begin_pos)

--- a/lib/rubocop/cop/style/concat_array_literals.rb
+++ b/lib/rubocop/cop/style/concat_array_literals.rb
@@ -55,6 +55,10 @@ module RuboCop
               next unless prefer
 
               corrector.replace(offense, prefer)
+            elsif node.arguments.any? { |argument| argument.children.empty? }
+              # In-place bracket removal would leave dangling commas (e.g.
+              # `concat([], [b])` -> `push(, b)`), so rebuild the call instead.
+              corrector.replace(offense, preferred_method(node))
             else
               corrector.replace(node.loc.selector, 'push')
               node.arguments.each do |argument|
@@ -75,7 +79,7 @@ module RuboCop
 
         def preferred_method(node)
           new_arguments =
-            node.arguments.map do |arg|
+            node.arguments.flat_map do |arg|
               if arg.percent_literal?
                 arg.children.map { |child| child.value.inspect }
               else

--- a/spec/rubocop/cop/style/array_first_last_spec.rb
+++ b/spec/rubocop/cop/style/array_first_last_spec.rb
@@ -146,4 +146,20 @@ RSpec.describe RuboCop::Cop::Style::ArrayFirstLast, :config do
       arr&.last
     RUBY
   end
+
+  # `arr.first`/`arr.last` have no setter, so rewriting a compound-assignment
+  # target would raise `NoMethodError` at runtime.
+  it 'does not register an offense when `arr[0]` is an op-assignment target' do
+    expect_no_offenses(<<~RUBY)
+      arr[0] += 1
+      arr[-1] -= 1
+    RUBY
+  end
+
+  it 'does not register an offense when `arr[0]` is an or/and-assignment target' do
+    expect_no_offenses(<<~RUBY)
+      arr[0] ||= 1
+      arr[-1] &&= 1
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -306,6 +306,26 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
       end
     end
 
+    context 'with a safe-navigation receiver' do
+      it 'still registers an offense for a non-negated predicate' do
+        expect_offense(<<~RUBY)
+          a&.intersection(b)&.any?
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use `a&.intersect?(b)` instead of `a&.intersection(b)&.any?`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a&.intersect?(b)
+        RUBY
+      end
+
+      it 'does not register an offense for a negated predicate (the rewrite would flip the `nil` result)' do
+        expect_no_offenses(<<~RUBY)
+          a&.intersection(b)&.none?
+          a&.intersection(b)&.empty?
+        RUBY
+      end
+    end
+
     context 'with Array#any?' do
       it 'registers an offense when using `array1.any? { |e| array2.member?(e) }`' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/array_intersect_with_single_element_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_with_single_element_spec.rb
@@ -42,4 +42,12 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersectWithSingleElement, :config do
       RUBY
     end
   end
+
+  context 'with a splat element' do
+    it 'does not register an offense (a splat is not a single element)' do
+      expect_no_offenses(<<~RUBY)
+        array.intersect?([*foo])
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/style/concat_array_literals_spec.rb
+++ b/spec/rubocop/cop/style/concat_array_literals_spec.rb
@@ -140,4 +140,26 @@ RSpec.describe RuboCop::Cop::Style::ConcatArrayLiterals, :config do
       arr << item
     RUBY
   end
+
+  it 'registers an offense and corrects when an argument is an empty array literal' do
+    expect_offense(<<~RUBY)
+      arr.concat([], [b])
+          ^^^^^^^^^^^^^^^ Use `push(b)` instead of `concat([], [b])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.push(b)
+    RUBY
+  end
+
+  it 'registers an offense and corrects with an empty array literal between non-empty ones' do
+    expect_offense(<<~RUBY)
+      arr.concat([a], [], [b])
+          ^^^^^^^^^^^^^^^^^^^^ Use `push(a, b)` instead of `concat([a], [], [b])`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      arr.push(a, b)
+    RUBY
+  end
 end


### PR DESCRIPTION
While auditing the Style department I found a cluster of broken autocorrects and false positives in the Array-related cops. Bundling the fixes here since they're closely related and each is small.

- **`Style/ArrayFirstLast`**: `arr[0] += 1` was rewritten to `arr.first += 1`, which calls the nonexistent `first=` setter and raises `NoMethodError`. Compound-assignment targets are now skipped.
- **`Style/ArrayIntersect`**: `a&.intersection(b)&.none?` was rewritten to `!a&.intersect?(b)`, which returns `true` when `a` is `nil` instead of the original `nil` - a flipped result. The negated-with-safe-navigation case is no longer corrected.
- **`Style/ArrayIntersectWithSingleElement`**: `array.intersect?([*foo])` was flagged and rewritten to `array.include?(*foo)`, but a splat is not a single element and the two aren't equivalent. Splat arguments are now skipped.
- **`Style/ConcatArrayLiterals`**: `arr.concat([], [b])` autocorrected to `arr.push(, b)` (a syntax error) and the offense message showed the same invalid form. Empty array arguments are now handled, producing `arr.push(b)`.

Each fix has regression specs.