### PR TITLE
Fix invalid autocorrects in class-comparison style cops

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_case_equality_with_an_operator_argument_20260611174000.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_case_equality_with_an_operator_argument_20260611174000.md
@@ -1,0 +1,1 @@
+* [#15268](https://github.com/rubocop/rubocop/pull/15268): Fix an incorrect autocorrect for `Style/CaseEquality` when the argument is an operator or unary expression (e.g. `Array === a + b`), which produced mis-parsed code like `a + b.is_a?(Array)`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison_with_a_qualified_name_20260611174002.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison_with_a_qualified_name_20260611174002.md
@@ -1,0 +1,1 @@
+* [#15268](https://github.com/rubocop/rubocop/pull/15268): Fix an incorrect autocorrect for `Style/ClassEqualityComparison` inside a namespace when the class name string is already fully qualified (e.g. `bar.class.name == '::Bar'`), which produced `instance_of?(::::Bar)` and was a syntax error. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison_with_a_string_20260611174001.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_class_equality_comparison_with_a_string_20260611174001.md
@@ -1,0 +1,1 @@
+* [#15268](https://github.com/rubocop/rubocop/pull/15268): Fix an incorrect autocorrect for `Style/ClassEqualityComparison` when comparing `Class` itself to a string literal (e.g. `var.class == 'Date'`), which produced `var.instance_of?('Date')` and raised `TypeError`; such comparisons are no longer autocorrected. ([@bbatsov][])

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -96,13 +96,25 @@ module RuboCop
         end
 
         def const_replacement(lhs, rhs)
-          "#{rhs.source}.is_a?(#{lhs.source})"
+          "#{parenthesize_if_needed(rhs)}.is_a?(#{lhs.source})"
         end
 
         def send_replacement(lhs, rhs)
           return unless self_class?(lhs)
 
-          "#{rhs.source}.is_a?(#{lhs.source})"
+          "#{parenthesize_if_needed(rhs)}.is_a?(#{lhs.source})"
+        end
+
+        # `Array === a + b` must become `(a + b).is_a?(Array)`, not
+        # `a + b.is_a?(Array)` (which parses as `a + (b.is_a?(Array))`).
+        def parenthesize_if_needed(node)
+          requires_parentheses?(node) ? "(#{node.source})" : node.source
+        end
+
+        def requires_parentheses?(node)
+          return true if node.type?(:and, :or, :if, :range) || node.assignment?
+
+          node.send_type? && (node.operator_method? || node.unary_operation?)
         end
       end
     end

--- a/lib/rubocop/cop/style/class_equality_comparison.rb
+++ b/lib/rubocop/cop/style/class_equality_comparison.rb
@@ -90,23 +90,31 @@ module RuboCop
         private
 
         def class_name(class_node, node)
-          if class_name_method?(node.children.first.method_name)
-            if (receiver = class_node.receiver) && class_name_method?(class_node.method_name)
-              return receiver.source
-            end
+          unless class_name_method?(node.children.first.method_name)
+            # `var.class == 'Foo'` compares a `Class` to a `String` (always false) and
+            # has no valid `instance_of?` rewrite, so don't suggest one.
+            return if class_node.str_type?
 
-            if class_node.str_type?
-              value = trim_string_quotes(class_node)
-              value.prepend('::') if require_cbase?(class_node)
-              return value
-            elsif unable_to_determine_type?(class_node)
-              # When a variable or return value of a method is used, it returns nil
-              # because the type is not known and cannot be suggested.
-              return
-            end
+            return class_node.source
           end
 
+          if (receiver = class_node.receiver) && class_name_method?(class_node.method_name)
+            return receiver.source
+          end
+
+          return string_class_name(class_node) if class_node.str_type?
+          # When a variable or return value of a method is used, the type is not known
+          # and cannot be suggested.
+          return if unable_to_determine_type?(class_node)
+
           class_node.source
+        end
+
+        def string_class_name(class_node)
+          value = trim_string_quotes(class_node)
+          # Avoid `::::Foo` when the name is already fully qualified.
+          value.prepend('::') if require_cbase?(class_node) && !value.start_with?('::')
+          value
         end
 
         def class_name_method?(method_name)

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -56,6 +56,28 @@ RSpec.describe RuboCop::Cop::Style::CaseEquality, :config do
       RUBY
     end
 
+    it 'wraps an operator-expression argument in parentheses when correcting' do
+      expect_offense(<<~RUBY)
+        Array === a + b
+              ^^^ Avoid the use of the case equality operator `===`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a + b).is_a?(Array)
+      RUBY
+    end
+
+    it 'wraps a negated argument in parentheses when correcting' do
+      expect_offense(<<~RUBY)
+        Array === !foo
+              ^^^ Avoid the use of the case equality operator `===`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (!foo).is_a?(Array)
+      RUBY
+    end
+
     it_behaves_like 'offenses'
   end
 

--- a/spec/rubocop/cop/style/class_equality_comparison_spec.rb
+++ b/spec/rubocop/cop/style/class_equality_comparison_spec.rb
@@ -241,6 +241,36 @@ RSpec.describe RuboCop::Cop::Style::ClassEqualityComparison, :config do
         end
       RUBY
     end
+
+    it 'does not prepend a second `::` when the class name is already fully qualified' do
+      expect_offense(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.class.name == '::Bar'
+                ^^^^^^^^^^^^^^^^^^^^^ Use `instance_of?(::Bar)` instead of comparing classes.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Foo
+          def bar?(value)
+            bar.instance_of?(::Bar)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when comparing `Class` itself against a string literal' do
+    it 'registers an offense but does not correct (no valid `instance_of?` rewrite)' do
+      expect_offense(<<~RUBY)
+        var.class == 'Date'
+            ^^^^^^^^^^^^^^^ Use `instance_of?` instead of comparing classes.
+      RUBY
+
+      expect_no_corrections
+    end
   end
 
   context 'with instance variable comparison in module' do


### PR DESCRIPTION
Three more autocorrect bugs from the Style audit, all in the class/equality comparison cops. Each rewrite produced invalid or mis-parsed Ruby.

- **`Style/CaseEquality`**: `Array === a + b` was corrected to `a + b.is_a?(Array)`, which Ruby parses as `a + (b.is_a?(Array))`. Operator and unary arguments are now wrapped: `(a + b).is_a?(Array)`, `(!foo).is_a?(Array)`.
- **`Style/ClassEqualityComparison`**: `var.class == 'Date'` compares a `Class` to a `String` (always false) and was rewritten to `var.instance_of?('Date')`, which raises `TypeError` at runtime. It's no longer autocorrected.
- **`Style/ClassEqualityComparison`**: inside a namespace, `bar.class.name == '::Bar'` became `instance_of?(::::Bar)` (a syntax error) because the cbase `::` was prepended unconditionally. Already-qualified names are now left alone.

Each fix has regression specs.