### PR TITLE
Fix autocorrect bugs in loop and control-flow style cops

### DIFF
--- a/changelog/fix_a_crash_and_an_incorrect_autocorrect_for_combinable_loops_with_for_loops_20260612100001.md
+++ b/changelog/fix_a_crash_and_an_incorrect_autocorrect_for_combinable_loops_with_for_loops_20260612100001.md
@@ -1,0 +1,1 @@
+* [#15270](https://github.com/rubocop/rubocop/pull/15270): Fix a crash for `Style/CombinableLoops` when a `for` loop has an empty body, and stop autocorrecting consecutive `for` loops whose iteration variables differ (which produced code referencing an undefined variable). ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_and_or_with_jump_keywords_20260612100000.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_and_or_with_jump_keywords_20260612100000.md
@@ -1,0 +1,1 @@
+* [#15270](https://github.com/rubocop/rubocop/pull/15270): Fix an incorrect autocorrect for `Style/AndOr` when an operand is `next`, `break`, or `yield` with an argument (e.g. `foo and next 1`), which produced invalid Ruby like `foo && next 1`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_comparable_clamp_with_an_operator_receiver_20260612100002.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_comparable_clamp_with_an_operator_receiver_20260612100002.md
@@ -1,0 +1,1 @@
+* [#15270](https://github.com/rubocop/rubocop/pull/15270): Fix an incorrect autocorrect for `Style/ComparableClamp` when the clamped value is an operator expression (e.g. `a + b`), which produced mis-parsed code like `a + b.clamp(low, high)`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -71,7 +71,7 @@ module RuboCop
             node.each_child_node do |expr|
               if expr.send_type?
                 correct_send(expr, corrector)
-              elsif expr.return_type? || expr.assignment?
+              elsif expr.type?(:return, :next, :break, :yield) || expr.assignment?
                 correct_other(expr, corrector)
               end
             end

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -85,8 +85,13 @@ module RuboCop
         def on_for(node)
           return unless node.parent&.begin_type?
           return unless same_collection_looping_for?(node, node.left_sibling)
+          return unless node.body && node.left_sibling.body
 
           add_offense(node) do |corrector|
+            # Combining loops with different iteration variables would leave the second
+            # body referencing an undefined variable, so only autocorrect when they match.
+            next unless node.variable == node.left_sibling.variable
+
             combine_with_left_sibling(corrector, node)
           end
         end

--- a/lib/rubocop/cop/style/comparable_clamp.rb
+++ b/lib/rubocop/cop/style/comparable_clamp.rb
@@ -90,7 +90,7 @@ module RuboCop
             max = if_body.source
           end
 
-          prefer = "#{else_body_source}.clamp(#{min}, #{max})"
+          prefer = "#{parenthesize_if_needed(else_body)}.clamp(#{min}, #{max})"
 
           add_offense(node, message: format(MSG, prefer: prefer)) do |corrector|
             autocorrect(corrector, node, prefer)
@@ -118,6 +118,17 @@ module RuboCop
           lhs, op, rhs = *if_condition
 
           (lhs.source == else_body && op == :<) || (rhs.source == else_body && op == :>)
+        end
+
+        # `a + b` must become `(a + b).clamp(low, high)`, not `a + b.clamp(low, high)`
+        # (which parses as `a + (b.clamp(low, high))`).
+        def parenthesize_if_needed(node)
+          if node.type?(:and, :or, :if, :range) || node.assignment? ||
+             (node.send_type? && (node.operator_method? || node.unary_operation?))
+            "(#{node.source})"
+          else
+            node.source
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -359,6 +359,43 @@ RSpec.describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'with `next`/`break` with arguments on the right' do
+      it 'autocorrects and adds parentheses' do
+        expect_offense(<<~RUBY)
+          items.each do |item|
+            foo and next 1
+                ^^^ Use `&&` instead of `and`.
+            bar and break 2
+                ^^^ Use `&&` instead of `and`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.each do |item|
+            foo && (next 1)
+            bar && (break 2)
+          end
+        RUBY
+      end
+    end
+
+    context 'with `yield` with arguments on the right' do
+      it 'autocorrects and adds parentheses' do
+        expect_offense(<<~RUBY)
+          def m
+            foo and yield 1
+                ^^^ Use `&&` instead of `and`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def m
+            foo && (yield 1)
+          end
+        RUBY
+      end
+    end
+
     context 'with !obj.method arg on right' do
       it 'autocorrects "and" with && and adds parens' do
         expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/combinable_loops_spec.rb
+++ b/spec/rubocop/cop/style/combinable_loops_spec.rb
@@ -253,5 +253,25 @@ RSpec.describe RuboCop::Cop::Style::CombinableLoops, :config do
         items.each {}
       RUBY
     end
+
+    it 'does not register an offense (or crash) when one of the `for` loops has an empty body' do
+      expect_no_offenses(<<~RUBY)
+        for item in items
+          do_something(item)
+        end
+        for item in items
+        end
+      RUBY
+    end
+
+    it 'registers an offense but does not correct when the iteration variables differ' do
+      expect_offense(<<~RUBY)
+        for item in items do do_something(item) end
+        for other in items do do_something_else(other) end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Combine this loop with the previous loop.
+      RUBY
+
+      expect_no_corrections
+    end
   end
 end

--- a/spec/rubocop/cop/style/comparable_clamp_spec.rb
+++ b/spec/rubocop/cop/style/comparable_clamp_spec.rb
@@ -244,6 +244,23 @@ RSpec.describe RuboCop::Cop::Style::ComparableClamp, :config do
 
       expect_no_corrections
     end
+
+    it 'wraps an operator-expression receiver in parentheses when correcting' do
+      expect_offense(<<~RUBY)
+        if a + b < low
+        ^^^^^^^^^^^^^^ Use `(a + b).clamp(low, high)` instead of `if/elsif/else`.
+          low
+        elsif high < a + b
+          high
+        else
+          a + b
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a + b).clamp(low, high)
+      RUBY
+    end
   end
 
   context 'target ruby version <= 2.3', :ruby23, unsupported_on: :prism do


### PR DESCRIPTION
Four more autocorrect/crash fixes from the Style audit, grouped by their loop/control-flow theme.

- **`Style/AndOr`**: `foo and next 1` was rewritten to `foo && next 1`, a syntax error (same for `break`/`yield` with arguments). These operands are now parenthesized: `foo && (next 1)`.
- **`Style/CombinableLoops`**: `on_for` crashed with `NoMethodError` when a `for` loop had an empty body. It now has the same `node.body` guard `on_block` already uses.
- **`Style/CombinableLoops`**: `on_for` autocorrected consecutive `for` loops with different iteration variables (`for item ...` / `for x ...`), leaving the merged body referencing an undefined variable. `on_for` now mirrors `on_block`'s variable-equality guard and only flags without correcting.
- **`Style/ComparableClamp`**: an operator-expression value like `a + b` was rewritten to `a + b.clamp(low, high)`, which parses as `a + (b.clamp(...))`. The receiver is now wrapped: `(a + b).clamp(low, high)`.

Each fix has regression specs.