### PR TITLE
Fix a false positive for Style/ConditionalAssignment with unless

### DIFF
--- a/changelog/fix_a_false_positive_for_conditional_assignment_with_unless_without_else_20260612102000.md
+++ b/changelog/fix_a_false_positive_for_conditional_assignment_with_unless_without_else_20260612102000.md
@@ -1,0 +1,1 @@
+* [#15271](https://github.com/rubocop/rubocop/pull/15271): Fix a false positive for `Style/ConditionalAssignment` with `EnforcedStyle: assign_inside_condition` when assigning an `unless` without an `else` branch (e.g. `x = unless cond; 1; end`), which was rewritten to move the assignment inside the `unless` and changed behavior when the condition was true. ([@bbatsov][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -283,7 +283,10 @@ module RuboCop
 
           _condition, *branches, else_branch = *assignment
 
-          return unless else_branch
+          # Use the node accessor rather than the raw destructured branch: for
+          # `x = unless cond; body; end` (no `else`) the parser puts `body` in the
+          # else slot, but `else_branch` correctly reports there is no `else` clause.
+          return unless assignment.else_branch
           return if allowed_single_line?([*branches, else_branch])
 
           add_offense(node, message: ASSIGN_TO_CONDITION_MSG) do |corrector|

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -633,18 +633,13 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
-    it 'corrects assignment to an unless condition' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense for assignment to an `unless` without an `else`' do
+      # `value` is `nil` when the condition is true, so moving the assignment
+      # inside the `unless` would change behavior.
+      expect_no_offenses(<<~RUBY)
         value = unless condition
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
-                      1
-                    end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        unless condition
-          value = 1
-        end
+                  1
+                end
       RUBY
     end
 


### PR DESCRIPTION
From the Style audit. With `EnforcedStyle: assign_inside_condition`, assigning an `unless` without an `else` was a false positive with a behavior-changing autocorrect:

```ruby
x = unless cond
  1
end
```

was rewritten to:

```ruby
unless cond
  x = 1
end
```

But the original assigns `nil` to `x` when `cond` is true, while the rewrite leaves `x` untouched - so the correction silently changed behavior.

The cause: for `unless ... end` the parser stores the body in the else slot, so the raw branch destructure saw a non-nil "else" and treated it as an if/else. Switching the guard to the `else_branch` node accessor (which accounts for the `unless` keyword) reports no `else` clause correctly. The `unless`/`else` case still registers an offense.

The existing spec documented the buggy correction; it's been replaced with one asserting no offense.