### PR TITLE
Fix false positives and a crash in several Style cops

### DIFF
--- a/changelog/fix_a_crash_for_constant_visibility_with_a_numeric_argument_20260612110003.md
+++ b/changelog/fix_a_crash_for_constant_visibility_with_a_numeric_argument_20260612110003.md
@@ -1,0 +1,1 @@
+* [#15272](https://github.com/rubocop/rubocop/pull/15272): Fix a crash for `Style/ConstantVisibility` when a visibility declaration has a numeric literal argument (e.g. `private_constant 42`). ([@bbatsov][])

--- a/changelog/fix_a_false_positive_for_colon_method_call_with_java_interop_20260612110001.md
+++ b/changelog/fix_a_false_positive_for_colon_method_call_with_java_interop_20260612110001.md
@@ -1,0 +1,1 @@
+* [#15272](https://github.com/rubocop/rubocop/pull/15272): Fix a false positive for `Style/ColonMethodCall` with chained JRuby interop calls (e.g. `Java::com::something_method`). ([@bbatsov][])

--- a/changelog/fix_alias_numbered_and_it_block_handling_20260612110002.md
+++ b/changelog/fix_alias_numbered_and_it_block_handling_20260612110002.md
@@ -1,0 +1,1 @@
+* [#15272](https://github.com/rubocop/rubocop/pull/15272): Fix `Style/Alias` not detecting block scope for numbered-parameter and `it` blocks, which caused a false positive for `alias_method` and a false negative for `alias` inside such blocks. ([@bbatsov][])

--- a/changelog/fix_false_positives_for_date_time_20260612110000.md
+++ b/changelog/fix_false_positives_for_date_time_20260612110000.md
@@ -1,0 +1,1 @@
+* [#15272](https://github.com/rubocop/rubocop/pull/15272): Fix false positives for `Style/DateTime`: a bare `to_datetime` call on implicit self is no longer flagged, and historic-date calls using safe navigation (e.g. `DateTime&.iso8601(str, Date::ENGLAND)`) are now exempted. ([@bbatsov][])

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -113,7 +113,7 @@ module RuboCop
               return :lexical
             when :def, :defs
               return :dynamic
-            when :block
+            when :block, :numblock, :itblock
               return :instance_eval if parent.method?(:instance_eval)
 
               return :dynamic

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -24,10 +24,9 @@ module RuboCop
 
         MSG = 'Do not use `::` for method calls.'
 
-        # @!method java_type_node?(node)
-        def_node_matcher :java_type_node?, <<~PATTERN
-          (send
-            (const nil? :Java) _)
+        # @!method java_root?(node)
+        def_node_matcher :java_root?, <<~PATTERN
+          (const nil? :Java)
         PATTERN
 
         def self.autocorrect_incompatible_with
@@ -37,10 +36,18 @@ module RuboCop
         def on_send(node)
           return unless node.receiver && node.double_colon?
           return if node.camel_case_method?
-          # ignore Java interop code like Java::int
-          return if java_type_node?(node)
+          # ignore Java interop code like `Java::int` or `Java::com::method`
+          return if java_interop?(node)
 
           add_offense(node.loc.dot) { |corrector| corrector.replace(node.loc.dot, '.') }
+        end
+
+        private
+
+        def java_interop?(node)
+          receiver = node.receiver
+          receiver = receiver.receiver while receiver.respond_to?(:receiver) && receiver.receiver
+          java_root?(receiver)
         end
       end
     end

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -89,7 +89,10 @@ module RuboCop
 
             arguments = arguments.first.children.first.to_a if arguments.first&.splat_type?
             constant_values = arguments.map do |argument|
-              argument.value.to_sym if argument.respond_to?(:value)
+              # `respond_to?(:value)` is too broad: `int`/`float` nodes respond to it
+              # but their value is a `Numeric`, which has no `to_sym` (e.g.
+              # `private_constant 42`). Only symbol/string arguments are real names.
+              argument.value.to_sym if argument.type?(:sym, :str)
             end
 
             constant_values.include?(node.name)

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -59,12 +59,12 @@ module RuboCop
 
         # @!method historic_date?(node)
         def_node_matcher :historic_date?, <<~PATTERN
-          (send _ _ _ (const (const {nil? (cbase)} :Date) _))
+          (call _ _ _ (const (const {nil? (cbase)} :Date) _))
         PATTERN
 
         # @!method to_datetime?(node)
         def_node_matcher :to_datetime?, <<~PATTERN
-          (call _ :to_datetime)
+          (call !nil? :to_datetime)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -218,6 +218,40 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
       RUBY
     end
 
+    it 'registers an offense for alias in a numbered block', :ruby27 do
+      expect_offense(<<~RUBY)
+        included do
+          do_something(_1)
+          alias :ala :bala
+          ^^^^^ Use `alias_method` instead of `alias`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        included do
+          do_something(_1)
+          alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'registers an offense for alias in an `it` block', :ruby34 do
+      expect_offense(<<~RUBY)
+        included do
+          do_something(it)
+          alias :ala :bala
+          ^^^^^ Use `alias_method` instead of `alias`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        included do
+          do_something(it)
+          alias_method :ala, :bala
+        end
+      RUBY
+    end
+
     it 'does not register an offense for alias_method with explicit receiver' do
       expect_no_offenses(<<~RUBY)
         class C
@@ -237,6 +271,24 @@ RSpec.describe RuboCop::Cop::Style::Alias, :config do
     it 'does not register an offense for alias_method in a block' do
       expect_no_offenses(<<~RUBY)
         dsl_method do
+          alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method in a numbered block', :ruby27 do
+      expect_no_offenses(<<~RUBY)
+        dsl_method do
+          do_something(_1)
+          alias_method :ala, :bala
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for alias_method in an `it` block', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        dsl_method do
+          do_something(it)
           alias_method :ala, :bala
         end
       RUBY

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -68,4 +68,8 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall, :config do
   it 'does not register an offense for Java package namespaces' do
     expect_no_offenses('Java::com')
   end
+
+  it 'does not register an offense for a chained Java interop method call' do
+    expect_no_offenses('Java::com::something_method')
+  end
 end

--- a/spec/rubocop/cop/style/constant_visibility_spec.rb
+++ b/spec/rubocop/cop/style/constant_visibility_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
           end
         RUBY
       end
+
+      it 'does not crash when the visibility declaration has a numeric literal argument' do
+        expect_offense(<<~RUBY)
+          class Foo
+            BAR = 42
+            ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+            private_constant 42
+          end
+        RUBY
+      end
     end
 
     context 'with a multi-statement body' do

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
     expect_no_offenses("::DateTime.iso8601('2016-06-29', ::Date::ITALY)")
   end
 
+  it 'does not register an offense when using DateTime with safe navigation for historic date' do
+    expect_no_offenses("DateTime&.iso8601('1751-04-23', Date::ENGLAND)")
+  end
+
   it 'does not register an offense when using DateTime in another namespace' do
     expect_no_offenses('Icalendar::Values::DateTime.new(start_at)')
   end
@@ -81,6 +85,14 @@ RSpec.describe RuboCop::Cop::Style::DateTime, :config do
       expect_offense(<<~RUBY)
         thing&.to_datetime
         ^^^^^^^^^^^^^^^^^^ Do not use `#to_datetime`.
+      RUBY
+    end
+
+    it 'does not register an offense for a bare `to_datetime` call on implicit self' do
+      expect_no_offenses(<<~RUBY)
+        def to_time
+          to_datetime
+        end
       RUBY
     end
   end


### PR DESCRIPTION
A batch of false-positive/crash fixes from the Style audit, grouped together since each is small.

- **`Style/DateTime`**: a bare `to_datetime` (implicit-self call, e.g. a class defining its own `to_datetime`) was flagged as a coercion. Also, historic-date calls using safe navigation (`DateTime&.iso8601('1751-04-23', Date::ENGLAND)`) weren't exempted because the guard matched only `send`, not `csend`.
- **`Style/ColonMethodCall`**: chained JRuby interop like `Java::com::something_method` was flagged and would be "corrected" to `Java::com.something_method`, changing semantics. The Java-root check now walks the whole receiver chain.
- **`Style/Alias`**: scope detection didn't handle numbered-parameter (`_1`) or `it` blocks, so `alias_method` inside one was wrongly flagged and `alias` inside one was wrongly accepted.
- **`Style/ConstantVisibility`**: `private_constant 42` crashed with `NoMethodError` (`Integer#to_sym`); only symbol/string arguments are treated as names now.

Each fix has regression specs.