### PR TITLE
Fix an incorrect autocorrect for Style/BlockDelimiters with rescue/ensure

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_block_delimiters_with_rescue_or_ensure_20260612120000.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_block_delimiters_with_rescue_or_ensure_20260612120000.md
@@ -1,0 +1,1 @@
+* [#15273](https://github.com/rubocop/rubocop/pull/15273): Fix an incorrect autocorrect for `Style/BlockDelimiters` that converted a single-line `do...end` block containing a block-level `rescue` or `ensure` to `{...}`, producing invalid Ruby. ([@bbatsov][])

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -389,9 +389,23 @@ module RuboCop
 
         def require_do_end?(node)
           return false if node.braces? || node.multiline?
-          return false unless (resbody = node.each_descendant(:resbody).first)
 
-          resbody.children.first&.array_type?
+          body = node.body
+          return false unless body
+          # `ensure` and a block-level `rescue` are illegal inside `{ }`; only a
+          # bare modifier rescue (`expr rescue expr`) can be written with braces.
+          return true if body.ensure_type?
+          return false unless body.rescue_type?
+
+          !modifier_rescue?(body)
+        end
+
+        def modifier_rescue?(rescue_node)
+          return false if rescue_node.body.nil? || rescue_node.else_branch
+          return false unless rescue_node.resbody_branches.one?
+
+          resbody = rescue_node.resbody_branches.first
+          resbody.exceptions.empty? && resbody.exception_variable.nil?
         end
 
         def braces_required_method?(method_name)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -580,6 +580,36 @@ RSpec.describe RuboCop::Cop::Style::BlockDelimiters, :config do
       RUBY
     end
 
+    it 'does not flag a single-line do-end block containing a block-level `rescue`' do
+      # `{ rescue ... }` is a syntax error, so the block must stay `do...end`.
+      expect_no_offenses(<<~RUBY)
+        foo do rescue => e; bar end
+      RUBY
+    end
+
+    it 'does not flag a single-line do-end block containing a bare `rescue`' do
+      expect_no_offenses(<<~RUBY)
+        foo do rescue; bar end
+      RUBY
+    end
+
+    it 'does not flag a single-line do-end block containing `ensure`' do
+      expect_no_offenses(<<~RUBY)
+        foo do bar ensure baz end
+      RUBY
+    end
+
+    it 'still converts a single-line do-end block with a modifier rescue' do
+      expect_offense(<<~RUBY)
+        foo do bar rescue baz end
+            ^^ Prefer `{...}` over `do...end` for single-line blocks.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { bar rescue baz }
+      RUBY
+    end
+
     it 'does not autocorrect do-end if {} would change the meaning' do
       expect_offense(<<~RUBY)
         s.subspec 'Subspec' do |sp| end


### PR DESCRIPTION
From the Style audit. A single-line `do...end` block containing a block-level `rescue` or `ensure` was autocorrected to `{...}`, which is a syntax error:

```ruby
foo do rescue => e; bar end   # -> foo { rescue => e; bar }   (SyntaxError)
foo do bar ensure baz end     # -> foo { bar ensure baz }     (SyntaxError)
```

Braces don't permit `rescue`/`ensure` clauses; only a bare modifier rescue (`expr rescue expr`) is valid inside `{...}`. `require_do_end?` previously only kept the block as `do...end` when the rescue caught multiple exception classes (`rescue A, B`), missing bare rescue, `rescue => e`, single-class rescue, and `ensure` entirely. It now keeps any block-level `rescue`/`ensure` as `do...end` while still converting the modifier-rescue form.

Multi-line blocks are unaffected (they already wrap the body in `begin...end`).