### PR TITLE
Fix autocorrects that mangle comments in two Style cops

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_class_methods_definitions_with_a_comment_20260612130001.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_class_methods_definitions_with_a_comment_20260612130001.md
@@ -1,0 +1,1 @@
+* [#15274](https://github.com/rubocop/rubocop/pull/15274): Fix an incorrect autocorrect for `Style/ClassMethodsDefinitions` that corrupted a preceding comment containing `def <name>` and left the method undefined as a class method. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_dig_chain_with_a_trailing_comment_20260612130000.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_dig_chain_with_a_trailing_comment_20260612130000.md
@@ -1,0 +1,1 @@
+* [#15274](https://github.com/rubocop/rubocop/pull/15274): Fix an incorrect autocorrect for `Style/DigChain` that duplicated a trailing comment and dropped indentation when the chain was inside a method or block. ([@bbatsov][])

--- a/lib/rubocop/cop/style/class_methods_definitions.rb
+++ b/lib/rubocop/cop/style/class_methods_definitions.rb
@@ -140,13 +140,19 @@ module RuboCop
 
         def extract_def_from_sclass(def_node, sclass_node)
           range = source_range_with_comment(def_node)
-          source = range.source.sub!(
-            "def #{def_node.method_name}",
-            "def self.#{def_node.method_name}"
-          )
-
+          source = prefix_def_with_self(range, def_node)
           source = source.gsub(/^ {#{indentation_diff(def_node, sclass_node)}}/, '')
           [range, source.chomp]
+        end
+
+        # Splice in `self.` at the actual `def` keyword rather than substituting the
+        # first textual `def <name>`, which may appear inside a preceding comment.
+        def prefix_def_with_self(range, def_node)
+          keyword_offset = def_node.loc.keyword.begin_pos - range.begin_pos
+          name_end_offset = def_node.loc.name.end_pos - range.begin_pos
+          source = range.source.dup
+          source[keyword_offset...name_end_offset] = "def self.#{def_node.method_name}"
+          source
         end
 
         def indentation_diff(node1, node2)

--- a/lib/rubocop/cop/style/dig_chain.rb
+++ b/lib/rubocop/cop/style/dig_chain.rb
@@ -79,6 +79,11 @@ module RuboCop
             corrector.replace(range, replacement)
 
             comments_in_range(node).reverse_each do |comment|
+              # Only relocate comments that the replacement destroys. A trailing
+              # comment after the chain survives in place, so moving it would
+              # duplicate it (and splitting the line drops the indentation).
+              next if comment.source_range.begin_pos >= range.end_pos
+
               corrector.insert_before(node, "#{comment.source}\n")
             end
           end

--- a/spec/rubocop/cop/style/class_methods_definitions_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_definitions_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe RuboCop::Cop::Style::ClassMethodsDefinitions, :config do
       RUBY
     end
 
+    it 'does not corrupt a preceding comment that mentions `def <name>`' do
+      expect_offense(<<~RUBY)
+        class A
+          class << self
+          ^^^^^^^^^^^^^ Do not define public methods within class << self.
+            # See def two for usage
+            def two
+              :two
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          # See def two for usage
+          def self.two
+            :two
+          end
+        end
+      RUBY
+    end
+
     it 'registers an offense and corrects when defining class methods with `class << self` and ' \
        'there is no blank line between method definition and attribute accessor' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/style/dig_chain_spec.rb
+++ b/spec/rubocop/cop/style/dig_chain_spec.rb
@@ -168,6 +168,21 @@ RSpec.describe RuboCop::Cop::Style::DigChain, :config do
       RUBY
     end
 
+    it 'keeps a trailing comment in place and preserves indentation inside a method' do
+      expect_offense(<<~RUBY)
+        def m
+          foo.dig(:a).dig(:b) # c
+              ^^^^^^^^^^^^^^^ Use `dig(:a, :b)` instead of chaining.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def m
+          foo.dig(:a, :b) # c
+        end
+      RUBY
+    end
+
     context '`...` argument forwarding' do
       it 'registers an offense and corrects with forwarded args' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Two comment-corrupting autocorrect bugs from the Style audit.

- **`Style/DigChain`**: collapsing a chain that lives inside a method/block duplicated the trailing comment and dropped the expression's indentation:

  ```ruby
  def m
    foo.dig(:a).dig(:b) # c
  end
  ```

  became

  ```ruby
  def m
    # c
  foo.dig(:a, :b) # c
  end
  ```

  The cop relocated every comment on the chain's lines, but the trailing comment survives the replacement, so moving it duplicated it (and `insert_before` split the line). Only comments inside the replaced range are relocated now.

- **`Style/ClassMethodsDefinitions`**: converting `class << self` to `def self.` did `source.sub!("def two", "def self.two")` over a range that included the preceding comment, so a comment like `# See def two for usage` was rewritten and the actual `def two` was left untouched. The `self.` is now spliced at the real `def` keyword offset.

Both have regression specs.