### PR TITLE
Fix incorrect autocorrects for `Style/FileWrite` with heredocs

### DIFF
--- a/changelog/fix_incorrect_autocorrects_for_style_file_write_20260611165136.md
+++ b/changelog/fix_incorrect_autocorrects_for_style_file_write_20260611165136.md
@@ -1,0 +1,1 @@
+* [#15275](https://github.com/rubocop/rubocop/pull/15275): Fix incorrect autocorrects for `Style/FileWrite` that deleted or duplicated heredoc bodies when a heredoc was used as the filename, in an argument expression, or in an inline block. ([@fynsta][])

--- a/lib/rubocop/cop/style/file_write.rb
+++ b/lib/rubocop/cop/style/file_write.rb
@@ -104,30 +104,33 @@ module RuboCop
 
         def replacement(mode, filename, content, write_node)
           replacement = "#{write_method(mode)}(#{filename.source}, #{content.source})"
-          heredoc = heredoc_in_write(write_node)
-          return replacement unless heredoc
+          heredocs = removed_heredocs(filename, content, write_node)
+          return replacement if heredocs.empty?
 
-          <<~REPLACEMENT.chomp
-            #{replacement}
-            #{heredoc_range(heredoc).source}
-          REPLACEMENT
+          [replacement, *heredocs.map { |heredoc| heredoc_range(heredoc).source }].join("\n")
         end
 
-        def heredoc_in_write(write_node)
-          return unless write_node.block_type? && (first_argument = write_node.body.first_argument)
-
-          find_heredoc(first_argument)
+        # Heredocs opened in the arguments keep working in the replacement, but their
+        # bodies are lost when they lie within the replaced range, so they need to be
+        # restored after the replacement.
+        def removed_heredocs(filename, content, write_node)
+          [filename, content].flat_map { |argument| find_heredocs(argument) }
+                             .select { |heredoc| removed?(heredoc, write_node) }
+                             .sort_by { |heredoc| heredoc.loc.heredoc_body.begin_pos }
         end
 
         def heredoc_range(heredoc)
           range_between(heredoc.loc.heredoc_body.begin_pos, heredoc.loc.heredoc_end.end_pos)
         end
 
-        def find_heredoc(node)
-          return node if node.respond_to?(:heredoc?) && node.heredoc?
-          return if !node.call_type? || node.receiver.nil?
+        def find_heredocs(node)
+          [node, *node.each_descendant(:any_str)].select do |child|
+            child.respond_to?(:heredoc?) && child.heredoc?
+          end
+        end
 
-          find_heredoc(node.receiver)
+        def removed?(heredoc, write_node)
+          heredoc.loc.heredoc_end.end_pos <= write_node.source_range.end_pos
         end
       end
     end

--- a/spec/rubocop/cop/style/file_write_spec.rb
+++ b/spec/rubocop/cop/style/file_write_spec.rb
@@ -136,4 +136,91 @@ RSpec.describe RuboCop::Cop::Style::FileWrite, :config do
       RUBY
     end
   end
+
+  it 'registers an offense for and corrects the `File.open` with multiline write block with heredoc as an operand' do
+    expect_offense(<<~RUBY)
+      File.open(filename, 'w') do |f|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        f.write('prefix' + <<~EOS)
+          content
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(filename, 'prefix' + <<~EOS)
+          content
+        EOS
+    RUBY
+  end
+
+  it 'registers an offense for and corrects the `File.open` with multiline write block with heredoc as a method argument' do
+    expect_offense(<<~RUBY)
+      File.open(filename, 'w') do |f|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        f.write(process(<<~EOS))
+          content
+        EOS
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(filename, process(<<~EOS))
+          content
+        EOS
+    RUBY
+  end
+
+  it 'registers an offense for and corrects the `File.open` with multiline write block with multiple heredocs' do
+    expect_offense(<<~RUBY)
+      File.open(filename, 'w') do |f|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        f.write(<<~HEAD + <<~TAIL)
+          head
+        HEAD
+          tail
+        TAIL
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(filename, <<~HEAD + <<~TAIL)
+          head
+        HEAD
+          tail
+        TAIL
+    RUBY
+  end
+
+  it 'registers an offense for and corrects the `File.open` with inline write block with heredoc' do
+    expect_offense(<<~RUBY)
+      File.open(filename, 'w') { |f| f.write(<<~EOS) }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        content
+      EOS
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(filename, <<~EOS)
+        content
+      EOS
+    RUBY
+  end
+
+  it 'registers an offense for and corrects the `File.open` with multiline write block with heredoc as a filename' do
+    expect_offense(<<~RUBY)
+      File.open(<<~PATH.strip, 'w') do |f|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `File.write`.
+        path/to/file
+      PATH
+        f.write(content)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      File.write(<<~PATH.strip, content)
+        path/to/file
+      PATH
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes a bug introduced in #15260.

The autocorrect located heredocs only by walking the receiver chain of the write argument and unconditionally appended the single body it found. A heredoc anywhere else in the arguments lost its body, which produces invalid syntax:

```console
$ cat example.rb
File.open('x', 'w') do |f|
  f.write('prefix' + <<~TEXT)
    text
  TEXT
end

$ bundle exec rubocop -A example.rb --only Style/FileWrite
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/FileWrite: Use File.write.
File.open('x', 'w') do |f| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:28: F: Lint/Syntax: unterminated string meets end of file
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
File.write('x', 'prefix' + <<~TEXT)
                           ^

1 file inspected, 2 offenses detected, 1 offense corrected

$ cat example.rb
File.write('x', 'prefix' + <<~TEXT)
```

The same happens for a heredoc inside a method call argument (`f.write(process(<<~TEXT))`), for the second of multiple heredocs (`f.write(<<~HEAD + <<~TAIL)`), and for a heredoc used as the filename (`File.open(<<~PATH.strip, 'w')`).

Conversely, for an inline block the heredoc body lies outside the replaced range, so appending it duplicated the body:

```console
$ cat example.rb
File.open('x', 'w') { |f| f.write(<<~TEXT) }
  text
TEXT

$ bundle exec rubocop -A example.rb --only Style/FileWrite
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/FileWrite: Use File.write.
File.open('x', 'w') { |f| f.write(<<~TEXT) }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
File.write('x', <<~TEXT)
  text
TEXT
  text
TEXT
```

The autocorrect now collects every heredoc in the filename and content arguments and restores exactly those whose bodies lie within the replaced source range, in source order.

Co-authored by Claude Fable 5.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
