### PR TITLE
Fix an error for `Style/RedundantFormat` with heredocs

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_format_with_heredocs_20260612105500.md
+++ b/changelog/fix_an_error_for_style_redundant_format_with_heredocs_20260612105500.md
@@ -1,0 +1,1 @@
+* [#15276](https://github.com/rubocop/rubocop/pull/15276): Fix an error for `Style/RedundantFormat` when the format string is a heredoc with format arguments. ([@fynsta][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -108,6 +108,7 @@ module RuboCop
 
         def detect_unnecessary_fields(node)
           return unless node.first_argument&.str_type?
+          return if node.first_argument.heredoc?
 
           string = node.first_argument.value
           arguments = node.arguments[1..]

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -481,6 +481,39 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           RUBY
         end
       end
+
+      context 'with heredocs' do
+        it 'registers an offense when the only argument is a heredoc' do
+          expect_offense(<<~RUBY, method: method)
+            %{method}(<<~MESSAGE)
+            ^{method}^^^^^^^^^^^^ Use `<<~MESSAGE` directly instead of `%{method}`.
+              foo
+            MESSAGE
+          RUBY
+
+          expect_correction(<<~RUBY)
+            <<~MESSAGE
+              foo
+            MESSAGE
+          RUBY
+        end
+
+        it 'does not register an offense when a heredoc has annotated fields' do
+          expect_no_offenses(<<~RUBY)
+            #{method}(<<~MESSAGE, greeting: 'Hello')
+              %<greeting>s, world!
+            MESSAGE
+          RUBY
+        end
+
+        it 'does not register an offense when a heredoc has unannotated fields' do
+          expect_no_offenses(<<~RUBY)
+            #{method}(<<~MESSAGE, 1)
+              %d
+            MESSAGE
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the following error for `Style/RedundantFormat` when the format string is a heredoc and format arguments are given:

```console
$ cat example.rb
puts format(<<~MESSAGE, greeting: 'Hello')
  %<greeting>s, world!
MESSAGE

$ bundle exec rubocop --only Style/RedundantFormat example.rb
An error occurred while Style/RedundantFormat cop was inspecting example.rb:1:5.
undefined method 'begin' for an instance of Parser::Source::Map::Heredoc (NoMethodError)
```

The all-fields-literal replacement builds a quoted string from the format string's delimiters (`loc.begin`/`loc.end`), which heredocs don't have. Inlining the formatted value would also have to remove the heredoc body lines, so heredocs are now skipped in this path.

Calling `format` with a heredoc and no further arguments is still registered and autocorrected, since replacing `format(<<~MESSAGE)` with `<<~MESSAGE` keeps the heredoc body in place.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
