### PR TITLE
Fix an incorrect autocorrect for `Style/WordArray` with heredocs

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_word_array_with_heredocs_20260612.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_word_array_with_heredocs_20260612.md
@@ -1,0 +1,1 @@
+* [#15277](https://github.com/rubocop/rubocop/pull/15277): Fix an incorrect autocorrect for `Style/WordArray` when the array contains heredocs. ([@fynsta][])

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -93,6 +93,7 @@ module RuboCop
 
         def on_array(node)
           if bracketed_array_of?(:str, node)
+            return if node.values.any?(&:heredoc?)
             return if complex_content?(node.values)
             return if within_matrix_of_complex_content?(node)
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -148,6 +148,24 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_no_offenses("['-', '----']")
     end
 
+    it 'does not register an offense for array of heredocs' do
+      expect_no_offenses(<<~RUBY)
+        [<<~FOO, <<~BAR]
+          foo
+        FOO
+          bar
+        BAR
+      RUBY
+    end
+
+    it 'does not register an offense for array containing a heredoc among strings' do
+      expect_no_offenses(<<~RUBY)
+        ['foo', 'bar', <<~BAZ]
+          baz
+        BAZ
+      RUBY
+    end
+
     it 'registers an offense in a non-ambiguous block context' do
       expect_offense(<<~RUBY)
         foo(['bar', 'baz']) { qux }


### PR DESCRIPTION
This fixes an incorrect autocorrect for `Style/WordArray` when a bracketed array contains heredocs. The percent literal replacement inlined the heredoc values but left the heredoc bodies behind as bare expressions, so the corrected code raises `NameError` at runtime:

```console
$ cat example.rb
x = [<<~A, <<~B].join
  aaa
A
  bbb
B
puts x

$ bundle exec rubocop -A example.rb --only Style/WordArray
Inspecting 1 file
C

Offenses:

example.rb:1:5: C: [Corrected] Style/WordArray: Use %w or %W for an array of words.
x = [<<~A, <<~B].join
    ^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
x = %W[aaa\n bbb\n].join
  aaa
A
  bbb
B
puts x
```

Heredoc content cannot be represented in a percent array without restructuring the surrounding code, so arrays containing heredocs are no longer registered as offenses, in line with how arrays containing comments or complex content are already skipped.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
