### PR TITLE
Fix an incorrect autocorrect for `Style/ParallelAssignment` with heredocs

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_heredocs_20260612.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_heredocs_20260612.md
@@ -1,0 +1,1 @@
+* [#15278](https://github.com/rubocop/rubocop/pull/15278): Fix an incorrect autocorrect for `Style/ParallelAssignment` when the right-hand side contains a heredoc. ([@fynsta][])

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -38,7 +38,7 @@ module RuboCop
           rhs_elements = Array(rhs).compact # edge case for one constant
 
           return if allowed_lhs?(node.assignments) || allowed_rhs?(rhs) ||
-                    allowed_masign?(node.assignments, rhs_elements)
+                    allowed_masign?(node.assignments, rhs_elements) || contains_heredoc?(rhs)
 
           range = node.source_range.begin.join(rhs.source_range.end)
 
@@ -75,6 +75,13 @@ module RuboCop
 
           # Account for edge case of `Constant::CONSTANT`
           !node.array_type? || elements.any?(&:splat_type?)
+        end
+
+        # Autocorrection splits the assignment into single assignments on
+        # consecutive lines, which would put following assignments into the
+        # heredoc body unless the heredoc bodies were moved along.
+        def contains_heredoc?(node)
+          node.each_descendant(:any_str).any?(&:heredoc?)
         end
 
         def assignment_corrector(node, rhs, order)

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -742,6 +742,32 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
+  it 'allows assigning heredocs' do
+    expect_no_offenses(<<~RUBY)
+      a, b = <<~A, <<~B
+        one
+      A
+        two
+      B
+    RUBY
+  end
+
+  it 'allows assigning an expression containing a heredoc' do
+    expect_no_offenses(<<~RUBY)
+      a, b = foo(<<~A), 2
+        text
+      A
+    RUBY
+  end
+
+  it 'allows assigning heredocs in a modifier statement' do
+    expect_no_offenses(<<~RUBY)
+      a, b = 1, <<~B if condition
+        two
+      B
+    RUBY
+  end
+
   describe 'using custom indentation width' do
     let(:config) do
       RuboCop::Config.new('Style/ParallelAssignment' => {


### PR DESCRIPTION
This fixes an incorrect autocorrect for `Style/ParallelAssignment` when the right-hand side contains a heredoc. The correction splits the parallel assignment into single assignments on consecutive lines, but the heredoc bodies stay where they were, so following assignments end up inside the first heredoc's body and their variables are never assigned:

```console
$ cat example.rb
a, b = <<~A, <<~B
  one
A
  two
B
puts a, b

$ bundle exec rubocop -A example.rb --only Style/ParallelAssignment
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Style/ParallelAssignment: Do not use parallel assignment.
a, b = <<~A, <<~B
^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
a = <<~A
b = <<~B
  one
A
  two
B
puts a, b

$ ruby example.rb
example.rb:5:in '<main>': undefined local variable or method 'two' for main (NameError)
```

The same happens with a heredoc nested in an expression (`a, b = foo(<<~A), 2`), and the modifier and rescue corrector forms additionally wrap the assignments in `if`/`begin` blocks whose keywords end up inside the heredoc body. A correct autocorrect would have to move the heredoc bodies between the split assignments, so parallel assignments whose right-hand side contains a heredoc are no longer registered as offenses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
