### PR TITLE
Fix an incorrect autocorrect for `Style/Semicolon` with heredocs

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_semicolon_with_heredocs_20260612.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_semicolon_with_heredocs_20260612.md
@@ -1,0 +1,1 @@
+* [#15279](https://github.com/rubocop/rubocop/pull/15279): Fix an incorrect autocorrect for `Style/Semicolon` when a heredoc is opened before the semicolon. ([@fynsta][])

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -128,7 +128,7 @@ module RuboCop
 
           add_offense(range) do |corrector|
             if after_expression
-              corrector.replace(range, "\n")
+              replace_semicolon_with_line_break(corrector, range)
             else
               # Prevents becoming one range instance with subsequent line when endless range
               # without parentheses.
@@ -147,6 +147,21 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+        def replace_semicolon_with_line_break(corrector, range)
+          # Replacing the semicolon with a newline would move the rest of the
+          # line into the body of a heredoc opened earlier on that line.
+          return if heredoc_opened_before_semicolon?(range)
+
+          corrector.replace(range, "\n")
+        end
+
+        def heredoc_opened_before_semicolon?(semicolon_range)
+          processed_source.ast.each_descendant(:any_str).select(&:heredoc?).any? do |heredoc|
+            heredoc.first_line == semicolon_range.line &&
+              heredoc.source_range.end_pos <= semicolon_range.begin_pos
+          end
+        end
 
         def expressions_per_line(exprs)
           # create a map matching lines to the number of expressions on them

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -26,6 +26,61 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
+  it 'registers an offense without autocorrect when a heredoc is opened before the semicolon' do
+    expect_offense(<<~RUBY)
+      x = <<~TEXT; y = 2
+                 ^ Do not use semicolons to terminate expressions.
+        text
+      TEXT
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense without autocorrect when heredocs are opened before and after the semicolon' do
+    expect_offense(<<~RUBY)
+      x = <<~ONE; y = <<~TWO
+                ^ Do not use semicolons to terminate expressions.
+        one
+      ONE
+        two
+      TWO
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense and corrects when a heredoc is opened after the semicolon' do
+    expect_offense(<<~RUBY)
+      x = 1; y = <<~TEXT
+           ^ Do not use semicolons to terminate expressions.
+        text
+      TEXT
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 1
+       y = <<~TEXT
+        text
+      TEXT
+    RUBY
+  end
+
+  it 'registers an offense and corrects a line-ending semicolon after a heredoc opening' do
+    expect_offense(<<~RUBY)
+      x = <<~TEXT;
+                 ^ Do not use semicolons to terminate expressions.
+        text
+      TEXT
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = <<~TEXT
+        text
+      TEXT
+    RUBY
+  end
+
   it 'registers an offense for one line method with two statements' do
     expect_offense(<<~RUBY)
       def foo(a) x(1); y(2); z(3); end


### PR DESCRIPTION
This fixes an incorrect autocorrect for `Style/Semicolon` when a heredoc is opened on the line before the semicolon. Replacing the semicolon with a newline moves the rest of the line to where the heredoc body starts, so it gets swallowed by the heredoc:

```console
$ cat example.rb
x = <<~A; y = 2
  text
A
puts x, y

$ bundle exec rubocop -A example.rb --only Style/Semicolon
Inspecting 1 file
C

Offenses:

example.rb:1:9: C: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
x = <<~A; y = 2
        ^

1 file inspected, 1 offense detected, 1 offense corrected

$ cat example.rb
x = <<~A
 y = 2
  text
A
puts x, y

$ ruby example.rb
example.rb:5:in '<main>': undefined local variable or method 'y' for main (NameError)
```

A correct line break would have to move the rest of the line below the heredoc terminator, which cannot be done in general (consider `x = <<~A; y = <<~B`, where the heredoc bodies would need to be reordered as well). The offense is still registered, but is no longer autocorrected when a heredoc is opened before the semicolon.

Semicolons before a heredoc start (`x = 1; y = <<~TEXT`) and line-ending semicolons after a heredoc start (`x = <<~TEXT;`) are still autocorrected, since those corrections do not split the line between a heredoc opening and its body.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
