### PR TITLE
Fix an incorrect autocorrect for `Style/ConditionalAssignment` with a single-line `case`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_conditional_assignment_with_single_line_case_20260612.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_conditional_assignment_with_single_line_case_20260612.md
@@ -1,0 +1,1 @@
+* [#15280](https://github.com/rubocop/rubocop/pull/15280): Fix an incorrect autocorrect for `Style/ConditionalAssignment` with `EnforcedStyle: assign_inside_condition` and a single-line `case`. ([@fynsta][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -657,6 +657,8 @@ module RuboCop
             remove_whitespace_in_branches(corrector, branch, condition, column)
 
             parent_keyword = branch.parent.loc.keyword
+            return if same_line?(parent_keyword, condition)
+
             corrector.remove_preceding(parent_keyword, parent_keyword.column - column)
           end
         end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -126,6 +126,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
       RUBY
     end
 
+    it 'registers an offense for assigning any variable type to a single-line case when' do
+      expect_offense(<<~RUBY, variable: variable)
+        %{variable} = case foo; when "a" then 1; else 2; end
+        ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        case foo; when "a" then #{variable} = 1; else #{variable} = 2; end
+      RUBY
+    end
+
     context '>= Ruby 2.7', :ruby27 do
       it 'registers an offense for assigning any variable type to case in' do
         expect_offense(<<~RUBY, variable: variable)
@@ -149,6 +160,17 @@ RSpec.describe RuboCop::Cop::Style::ConditionalAssignment, :config do
           else
             #{variable} = 3
           end
+        RUBY
+      end
+
+      it 'registers an offense for assigning any variable type to a single-line case in' do
+        expect_offense(<<~RUBY, variable: variable)
+          %{variable} = case foo; in "a" then 1; else 2; end
+          ^{variable}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assign variables inside of conditionals.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          case foo; in "a" then #{variable} = 1; else #{variable} = 2; end
         RUBY
       end
     end


### PR DESCRIPTION
This fixes an incorrect autocorrect for `Style/ConditionalAssignment` with `EnforcedStyle: assign_inside_condition` when the `case` statement is written on a single line:

```console
$ cat example.rb
r = case v; when String then :str; else :other; end

$ cat .rubocop.yml
Style/ConditionalAssignment:
  EnforcedStyle: assign_inside_condition

$ bundle exec rubocop -A example.rb --only Style/ConditionalAssignment
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/ConditionalAssignment: Assign variables inside of conditionals.
r = case v; when String then :str; else :other; end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
example.rb:1:1: F: Lint/Syntax: unexpected token when
when String then r = :str; else r = :other; end
^^^^

1 file inspected, 5 offenses detected, 1 offense corrected

$ cat example.rb
when String then r = :str; else r = :other; end
```

`CaseCorrector#move_branch_inside_condition` outdents each `when`/`in` keyword by removing `keyword.column - column` characters before it, assuming they are indentation. When the branch keyword is on the same line as the `case` keyword, those characters are the `case` expression itself, which got deleted. `IfCorrector` already guards its equivalent `else` outdent with a same-line check, so the same guard is applied here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
