### PR TITLE
Fix an autocorrect conflict between `Style/IfUnlessModifier` and `Style/Next`

### DIFF
--- a/changelog/fix_an_autocorrect_conflict_between_if_unless_modifier_and_next_20260612.md
+++ b/changelog/fix_an_autocorrect_conflict_between_if_unless_modifier_and_next_20260612.md
@@ -1,0 +1,1 @@
+* [#15281](https://github.com/rubocop/rubocop/pull/15281): Fix an incorrect autocorrect when `Style/IfUnlessModifier` and `Style/Next` correct the same conditional. ([@fynsta][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -86,7 +86,7 @@ module RuboCop
         MSG_USE_NORMAL = 'Modifier form of `%<keyword>s` makes the line too long.'
 
         def self.autocorrect_incompatible_with
-          [Style::SoleNestedConditional]
+          [Style::Next, Style::SoleNestedConditional]
         end
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -529,6 +529,27 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/IfUnlessModifier` with `Style/Next`' do
+    source = <<~RUBY
+      [1, 2, 3].each do |i|
+        if i > 1
+          puts i
+        end
+      end
+    RUBY
+    create_file('example.rb', source)
+    create_file('.rubocop.yml', <<~YAML)
+      Style/Next:
+        MinBodyLength: 1
+    YAML
+    expect(cli.run(['--autocorrect-all', '--only', 'Style/IfUnlessModifier,Style/Next'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      [1, 2, 3].each do |i|
+        puts i if i > 1
+      end
+    RUBY
+  end
+
   it 'corrects `Style/SoleNestedConditional` with `Style/InverseMethods` and `Style/IfUnlessModifier`' do
     source = <<~RUBY
       unless foo.to_s == 'foo'


### PR DESCRIPTION
This fixes an incorrect autocorrect when `Style/IfUnlessModifier` and `Style/Next` correct the same conditional inside a loop, which happens when `Style/Next` is configured with a `MinBodyLength` low enough for both cops to register an offense. Both corrections were applied in the same pass and produced invalid syntax:

```console
$ cat example.rb
[1, 2, 3].each do |i|
  if i > 1
    puts i
  end
end

$ cat .rubocop.yml
Style/Next:
  MinBodyLength: 1

$ bundle exec rubocop -A example.rb --only Style/IfUnlessModifier,Style/Next
Inspecting 1 file
F

Offenses:

example.rb:2:3: C: [Corrected] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
  if i > 1
  ^^
example.rb:2:3: C: [Corrected] Style/Next: Use next to skip iteration.
  if i > 1
  ^^^^^^^^
example.rb:2:20: F: Lint/Syntax: unexpected token tIDENTIFIER
  next unless i > 1puts i if i > 1
                   ^^^^

1 file inspected, 4 offenses detected, 2 offenses corrected

$ cat example.rb
[1, 2, 3].each do |i|
  next unless i > 1puts i if i > 1
end
```

`Style/IfUnlessModifier` now declares `Style/Next` in `autocorrect_incompatible_with`, so the modifier correction is applied first and `Style/Next`'s correction is deferred to the next pass. The result converges to the modifier form, which `Style/Next` accepts because it does not register offenses for modifier conditionals:

```ruby
[1, 2, 3].each do |i|
  puts i if i > 1
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
