### PR TITLE
[Fix #15269] Fix a false positive where cop `Include` patterns matched parent directories

### DIFF
--- a/changelog/fix_cop_include_patterns_matching_parent_directories_20260612144207.md
+++ b/changelog/fix_cop_include_patterns_matching_parent_directories_20260612144207.md
@@ -1,0 +1,1 @@
+* [#15269](https://github.com/rubocop/rubocop/issues/15269): Fix a false positive where a cop's relative `Include` pattern could match directories above the project root. ([@augustocbx][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -498,8 +498,23 @@ module RuboCop
         patterns = cop_config[parameter]
         return default_result unless patterns
 
-        patterns = FilePatterns.from(patterns)
-        patterns.match?(config.path_relative_to_config(file)) || patterns.match?(file)
+        file_patterns = FilePatterns.from(patterns)
+        relative_file_path = config.path_relative_to_config(file)
+        return true if file_patterns.match?(relative_file_path)
+
+        if parameter == 'Include' && !relative_file_path.start_with?('..')
+          matches_absolute_include_pattern?(patterns, file)
+        else
+          file_patterns.match?(file)
+        end
+      end
+
+      def matches_absolute_include_pattern?(patterns, file)
+        absolute_file_path = absolute?(file) ? file : File.expand_path(file)
+        patterns.any? do |pattern|
+          (absolute?(pattern.to_s) || pattern.to_s.start_with?('..')) &&
+            match_path?(pattern, absolute_file_path)
+        end
       end
 
       def enabled_line?(line_number)

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -462,6 +462,57 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       it { is_expected.to be(true) }
     end
 
+    context 'when an Include pattern matches a directory above the project root' do
+      let(:cop_config) { { 'Include' => ['**/app/**/*.rb'] } }
+
+      before do
+        allow(config).to receive(:base_dir_for_path_parameters).and_return('/app/myproject')
+      end
+
+      context 'and the file is in an `app` subdirectory of the project' do
+        let(:file) { '/app/myproject/lib/app/file.rb' }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'and the file is not in an `app` subdirectory of the project' do
+        let(:file) { '/app/myproject/spec/file.rb' }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context 'when the Include configuration contains an absolute pattern' do
+      let(:cop_config) { { 'Include' => ['/app/myproject/lib/**/*.rb'] } }
+
+      before do
+        allow(config).to receive(:base_dir_for_path_parameters).and_return('/app/myproject')
+      end
+
+      context 'and the file matches the pattern' do
+        let(:file) { '/app/myproject/lib/file.rb' }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'and the file doesn\'t match the pattern' do
+        let(:file) { '/app/myproject/spec/file.rb' }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context 'when the file is outside of the configuration directory' do
+      let(:cop_config) { { 'Include' => ['**/foo.rb'] } }
+      let(:file) { '/elsewhere/foo.rb' }
+
+      before do
+        allow(config).to receive(:base_dir_for_path_parameters).and_return('/app/myproject')
+      end
+
+      it { is_expected.to be(true) }
+    end
+
     describe 'for a cop with gem version requirements', :restore_registry do
       subject { cop.relevant_file?(file) }
 


### PR DESCRIPTION
Fixes #15269.

When a cop has a relative `Include` pattern such as `**/app/**/*.rb` (as rubocop-rails uses for many cops), the pattern was matched against the absolute path of the inspected file as well as the path relative to the configuration. Because of that, a project checked out under a path like `/usr/src/app` had every file satisfy the pattern through the parent directory, so the cop ran on files it should not cover, and the results changed depending on where the project happened to be checked out.

The root cause is in `Cop::Base#file_name_matches_any?`, which unconditionally fell back to matching the raw absolute path. That fallback exists for `Exclude` entries, which are converted to absolute paths when the configuration is loaded. This change keeps that behavior for `Exclude`, but for `Include` it only matches the absolute path against patterns that are themselves absolute (or that escape the configuration directory). This mirrors the semantics `Config#file_to_include?` already applies to `AllCops`-level patterns since #14361, which fixed the same problem at that level.

Intentionally preserved: absolute `Include` patterns still match, and files outside the configuration directory (whose relative path starts with `..`) are still matched against their absolute path.