### PR TITLE
[Fix #15284] Fix a false positive for `Style/MutableConstant` with `Data.define`

### DIFF
--- a/changelog/fix_a_false_positive_for_mutable_constant_strict_with_data_define_20260613115108.md
+++ b/changelog/fix_a_false_positive_for_mutable_constant_strict_with_data_define_20260613115108.md
@@ -1,0 +1,1 @@
+* [#15284](https://github.com/rubocop/rubocop/issues/15284): Fix a false positive for `Style/MutableConstant` with `EnforcedStyle: strict` on `Data.define` in Ruby 3.2. ([@RYOTA-KOBA][])

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -28,6 +28,11 @@ module RuboCop
       # NOTE: From Ruby 3.0, this cop allows explicit freezing of constants when
       # the `shareable_constant_value` directive is used.
       #
+      # NOTE: From Ruby 3.2, constants assigned to `Data.define(...)` are
+      # treated as immutable in `strict` mode, consistent with `Struct.new`.
+      # `Data.define` is a DSL for defining immutable value classes whose
+      # instances are always frozen.
+      #
       # @safety
       #   This cop's autocorrection is unsafe since any mutations on objects that
       #   are made frozen will change from being accepted to raising `FrozenError`,
@@ -69,6 +74,9 @@ module RuboCop
       #       puts 1
       #     end
       #   end.freeze
+      #
+      #   # good
+      #   CONST = Data.define(:name, :age)
       #
       # @example
       #   # Magic comment - shareable_constant_value: literal
@@ -148,6 +156,7 @@ module RuboCop
         def strict_check(value)
           return if immutable_literal?(value)
           return if operation_produces_immutable_object?(value)
+          return if target_ruby_version >= 3.2 && data_define?(value)
           return if frozen_string_literal?(value)
           return if shareable_constant_value?(value)
 
@@ -233,6 +242,14 @@ module RuboCop
             (or (send (const {nil? cbase} :ENV) :[] _) _)
             (send _ {:count :length :size} ...)
             (block (send _ {:count :length :size} ...) ...)
+          }
+        PATTERN
+
+        # @!method data_define?(node)
+        def_node_matcher :data_define?, <<~PATTERN
+          {
+            (send (const {nil? cbase} :Data) :define ...)
+            (block (send (const {nil? cbase} :Data) :define ...) ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -481,6 +481,23 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       end
     RUBY
 
+    context 'Ruby 3.2 or higher', :ruby32 do
+      it_behaves_like 'immutable objects', 'Data.define'
+      it_behaves_like 'immutable objects', '::Data.define'
+      it_behaves_like 'immutable objects', 'Data.define(:name, :age)'
+      it_behaves_like 'immutable objects', <<~RUBY
+        Data.define(:name) do
+          def greeting
+            'hello'
+          end
+        end
+      RUBY
+    end
+
+    context 'Ruby 3.1 or lower', :ruby31, unsupported_on: :prism do
+      it_behaves_like 'mutable objects', 'Data.define(:name, :age)'
+    end
+
     it 'allows calls to freeze' do
       expect_no_offenses(<<~RUBY)
         CONST = [1].freeze


### PR DESCRIPTION
Resolves #15284.

This PR teaches `Style/MutableConstant` to treat `Data.define` (with or without a block) as an immutable constant assignment when `EnforcedStyle: strict` is enabled, consistent with how `Struct.new` is already handled by the same cop.

### Rationale

`Data.define` is a DSL (introduced in Ruby 3.2) for defining immutable value classes whose instances are always frozen:

```ruby
Data.define(:name, :age).new(name: "Alice", age: 30).frozen? # => true
```

The returned class object itself is not frozen (just like `Struct.new`), but calling `.freeze` on it is not an idiomatic pattern — `Data.define` is used to declare an immutable value type, not as a mutable container that needs explicit freezing. This is exactly the precedent already established for `Struct.new` in this cop.

### Changes

- Added a `data_define?` node matcher covering both `Data.define(...)` and `Data.define(...) do ... end` forms (matches `Data` and `::Data`).
- Gated the check on `target_ruby_version >= 3.2` so projects targeting older Ruby versions are unaffected — consistent with how `Style/ArgumentsForwarding` and `Lint/RedundantRequireStatement` gate Ruby 3.2 behavior.
- Added specs covering Ruby 3.2+ (immutable) and Ruby 3.1 and lower (still flagged).
- Updated the cop docs with a NOTE and an `@example` for the strict style.

### Before submitting the PR make sure the following are checked

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.