### PR TITLE
Fix an incorrect autocorrect for `Lint/UselessTimes` with a single non-simple block argument

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_useless_times_with_a_single_non_simple_20260615141453.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_useless_times_with_a_single_non_simple_20260615141453.md
@@ -1,0 +1,1 @@
+* [#15288](https://github.com/rubocop/rubocop/pull/15288): Fix an incorrect autocorrect for `Lint/UselessTimes` when a `1.times` block takes a single destructured (`|(a, b)|`) or splat (`|*a|`) argument, which produced a body referencing an undefined variable. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_times.rb
+++ b/lib/rubocop/cop/lint/useless_times.rb
@@ -82,18 +82,27 @@ module RuboCop
         end
 
         def autocorrect_block(corrector, node)
-          # A block with multiple arguments can't be reduced to its body (the extra arguments
-          # would become undefined references), and `next`/`break`/`redo` bound to the block
-          # become orphaned (a syntax error) once the block is removed.
-          return if node.arguments.size > 1 || orphans_loop_control_keyword?(node)
-
           block_arg = block_arg(node)
-          return if block_reassigns_arg?(node, block_arg)
+          return unless reducible_to_body?(node, block_arg)
 
           source = node.body.source
           source.gsub!(/\b#{block_arg}\b/, '0') if block_arg
 
           corrector.replace(node, fix_indentation(source, node.loc.column...node.body.loc.column))
+        end
+
+        def reducible_to_body?(node, block_arg)
+          # A block with multiple arguments can't be reduced to its body (the extra arguments
+          # would become undefined references), and `next`/`break`/`redo` bound to the block
+          # become orphaned (a syntax error) once the block is removed.
+          return false if node.arguments.size > 1 || orphans_loop_control_keyword?(node)
+
+          # A lone non-simple argument (destructuring `|(a, b)|` or a splat `|*a|`) can't be
+          # substituted either, so reducing to the body would leave it referencing an
+          # undefined variable.
+          return false if node.arguments.one? && block_arg.nil?
+
+          !block_reassigns_arg?(node, block_arg)
         end
 
         def orphans_loop_control_keyword?(node)

--- a/spec/rubocop/cop/lint/useless_times_spec.rb
+++ b/spec/rubocop/cop/lint/useless_times_spec.rb
@@ -322,10 +322,37 @@ RSpec.describe RuboCop::Cop::Lint::UselessTimes, :config do
         expect_no_corrections
       end
 
+      it 'does not correct a block whose body uses `redo`' do
+        expect_offense(<<~RUBY)
+          1.times { redo }
+          ^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
       it 'does not correct a block with multiple arguments' do
         expect_offense(<<~RUBY)
           1.times { |i, j| do_something(i, j) }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not correct a block with a single destructured argument' do
+        expect_offense(<<~RUBY)
+          1.times { |(a, b)| do_something(a, b) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not correct a block with a single splat argument' do
+        expect_offense(<<~RUBY)
+          1.times { |*a| do_something(a) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Useless call to `1.times` detected.
         RUBY
 
         expect_no_corrections


### PR DESCRIPTION
Follow-up to #15241. That PR stopped `Lint/UselessTimes` from generating broken corrections for multi-argument blocks and orphaned `next`/`break`/`redo`, but a *single* non-simple block argument still slipped through: `1.times { |(a, b)| ... }` and `1.times { |*a| ... }` were autocorrected to a body referencing an undefined variable (a `NameError`). Those single-argument forms aren't substitutable, so they're now left uncorrected. Also adds the missing `redo` spec.