### PR TITLE
[Fix #14401] Fix a false positive for `Layout/BlockAlignment`

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_block_alignment_20260615094236.md
+++ b/changelog/fix_a_false_positive_for_layout_block_alignment_20260615094236.md
@@ -1,0 +1,1 @@
+* [#14401](https://github.com/rubocop/rubocop/issues/14401): Fix a false positive for `Layout/BlockAlignment` with `EnforcedStyleAlignWith: start_of_line` when a block is passed as a method argument. ([@augustocbx][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -120,6 +120,7 @@ module RuboCop
           end_loc = block_node.loc.end
           return unless begins_its_line?(end_loc)
 
+          start_node = start_for_line_node(block_node) if style == :start_of_line
           start_loc = start_node.source_range
           return unless start_loc.column != end_loc.column || style == :start_of_block
 

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -743,6 +743,39 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
 
+    context 'when a block is passed as a method argument' do
+      it 'does not register an offense when `}` is aligned with the start of the line for a literal lambda' do
+        expect_no_offenses(<<~RUBY)
+          foo :x, ->(y) {
+            bar
+          }
+        RUBY
+      end
+
+      it 'does not register an offense when `}` is aligned with the start of the line for a brace block' do
+        expect_no_offenses(<<~RUBY)
+          foo :x, bar {
+            baz
+          }
+        RUBY
+      end
+
+      it 'registers an offense and corrects when `}` is not aligned with the start of the line' do
+        expect_offense(<<~RUBY)
+          foo :x, ->(y) {
+            bar
+            }
+            ^ `}` at 3, 2 is not aligned with `foo :x, ->(y) {` at 1, 0.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo :x, ->(y) {
+            bar
+          }
+        RUBY
+      end
+    end
+
     context 'inside a non-endless method' do
       it 'does not register an offense when `end` is aligned with the block start' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes a false positive for `Layout/BlockAlignment` with `EnforcedStyleAlignWith: start_of_line` when a block is passed as a method argument, such as a literal lambda or a brace block whose `{` sits in the middle of the line.

Detection measured alignment against the block's own start column (the position of the lambda or block call), while autocorrect already used the start of the line where the enclosing expression begins. When the block was an argument, those columns differed, so `}` aligned with the start of the line was reported as an offense and the autocorrect produced no change. Detection now uses the same start-of-line anchor as autocorrect.

Fixes #14401.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] The new code doesn't generate RuboCop offenses.
* [x] All specs are passing.
* [x] If this is a new feature, the cop is properly documented (the docs are generated automatically from the cop's source comments).
* [x] The PR description includes a [changelog entry][2].

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format