### PR TITLE
[Fix #15290] Fix a false negative for Lint/ToEnumArguments with a braced hash

### DIFF
--- a/changelog/fix_a_false_negative_for_to_enum_arguments_with_a_braced_hash_20260616150000.md
+++ b/changelog/fix_a_false_negative_for_to_enum_arguments_with_a_braced_hash_20260616150000.md
@@ -1,0 +1,1 @@
+* [#15290](https://github.com/rubocop/rubocop/issues/15290): Fix a false negative for `Lint/ToEnumArguments` when a braced hash is passed to keyword parameters (e.g. `to_enum(:m, { required: required })`), which raises `ArgumentError` when the enumerator is used. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -109,9 +109,11 @@ module RuboCop
           when :optarg
             send_arg.source == def_arg_name.to_s
           when :kwoptarg, :kwarg
-            send_arg.hash_type? &&
+            keyword_hash_argument?(send_arg) &&
               send_arg.pairs.any? { |pair| passing_keyword_arg?(pair, def_arg_name) }
           when :kwrestarg
+            return false unless keyword_hash_argument?(send_arg)
+
             send_arg.each_child_node(:kwsplat, :forwarded_kwrestarg).any? do |child|
               child.source == def_arg.source
             end
@@ -120,6 +122,10 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+        def keyword_hash_argument?(send_arg)
+          send_arg.hash_type? && !send_arg.braces?
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
+++ b/spec/rubocop/cop/lint/to_enum_arguments_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe RuboCop::Cop::Lint::ToEnumArguments, :config do
     RUBY
   end
 
+  it 'registers an offense when a braced hash is passed for keyword arguments' do
+    expect_offense(<<~RUBY)
+      def m(required:)
+        return to_enum(:m, { required: required }) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a braced hash is passed for keyword rest arguments' do
+    expect_offense(<<~RUBY)
+      def m(**kwargs)
+        return to_enum(:m, { **kwargs }) unless block_given?
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure you correctly provided all the arguments.
+      end
+    RUBY
+  end
+
   it 'does not register an offense when not inside method definition' do
     expect_no_offenses(<<~RUBY)
       to_enum(:m)


### PR DESCRIPTION
## Description:

Issue #15290 reported that `Lint/ToEnumArguments` accepted a braced hash as if it were a keyword argument or keyword rest argument.

In Ruby, `to_enum(__method__, { limit: limit })` passes a positional hash, so the enumerator re-invokes the method with the wrong argument shape and raises `ArgumentError`.

This PR updates `Lint/ToEnumArguments` to treat only unbraced hashes as keyword argument forwarding, so braced hashes no longer satisfy keyword parameters or keyword rest parameters.

It also adds regression tests for braced hashes passed to keyword arguments and keyword rest arguments.

Closes #15290.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/lint/to_enum_arguments.rb spec/rubocop/cop/lint/to_enum_arguments_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/lint/to_enum_arguments_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:

```ruby
def each_item(limit:)
  return to_enum(__method__, { limit: limit }) unless block_given?
end
```

`Lint/ToEnumArguments` reported no offense for this code, but using the enumerator raised:

```text
ArgumentError
wrong number of arguments (given 1, expected 0; required keyword: limit)
```

<img width="1095" height="353" alt="image" src="https://github.com/user-attachments/assets/6a8733a0-0545-490d-96de-3c4f8a64b481" />

### After the fix:

`Lint/ToEnumArguments` now registers an offense for the braced-hash case, so code that would raise at runtime is flagged correctly.

<img width="1184" height="382" alt="image" src="https://github.com/user-attachments/assets/426d3df4-9851-4d74-8f43-cff85f232416" />
