### PR TITLE
[Fix #15291] Fix an incorrect autocorrect for Lint/LiteralInInterpolation with quoted symbols in hashes

### DIFF
--- a/changelog/fix_literal_in_interpolation_quoted_symbols_in_hashes_20260616151000.md
+++ b/changelog/fix_literal_in_interpolation_quoted_symbols_in_hashes_20260616151000.md
@@ -1,0 +1,1 @@
+* [#15291](https://github.com/rubocop/rubocop/issues/15291): Fix an incorrect autocorrect for `Lint/LiteralInInterpolation` when interpolated hashes contain symbols that require quoted syntax, such as `:'foo-bar'`. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -136,12 +136,7 @@ module RuboCop
         end
 
         def autocorrected_value_in_hash_for_symbol(node)
-          # TODO: We need to detect symbol unacceptable names more correctly
-          if / |"|'/.match?(node.value.to_s)
-            ":\\\"#{node.value.to_s.gsub('"') { '\\\\\"' }}\\\""
-          else
-            ":#{node.value}"
-          end
+          escape_string_content(node.value.inspect)
         end
 
         def autocorrected_value_for_array(node)

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -160,6 +160,9 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
                     '{:symbol=>{:key=>:symbol}}')
     it_behaves_like('literal interpolation', '{ symbol: { key: :"symbol" } }',
                     '{:symbol=>{:key=>:symbol}}')
+    it_behaves_like('literal interpolation', "{ :'foo-bar' => 1 }", '{:\"foo-bar\"=>1}')
+    it_behaves_like('literal interpolation', '{ symbol: { key: :"foo-bar" } }',
+                    '{:symbol=>{:key=>:\"foo-bar\"}}')
     it_behaves_like('literal interpolation',
                     '{ single_quot_symbol: { key: :"single_quot_in_symbol: \'" } }',
                     '{:single_quot_symbol=>{:key=>:\"single_quot_in_symbol: \'\"}}')


### PR DESCRIPTION
## Description:

Issue #15291 reported that `Lint/LiteralInInterpolation` could serialize quoted symbols incorrectly when autocorrecting interpolated hashes.

The hash serializer only special-cased spaces and quote characters, so symbols like `:'foo-bar'` were rewritten as `:foo-bar`, which changed the resulting string.

This PR updates the hash symbol serialization path to reuse `Symbol#inspect` together with the existing escaping helper, preserving Ruby's quoted-symbol representation for symbols that require quoted syntax.

It also adds regression tests for both hash keys and hash values that use quoted symbols such as `:'foo-bar'`.

Closes #15291.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have added a changelog entry for this fix.
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/lint/literal_in_interpolation.rb spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:

```ruby
puts "#{ { :'foo-bar' => 1 } }"
```

This was autocorrected to:

```ruby
puts "{:foo-bar=>1}"
```

which changed the runtime output from:

```text
{:"foo-bar"=>1}
```

to:

```text
{:foo-bar=>1}
```

### After the fix:

The autocorrect now preserves the quoted-symbol representation:

```ruby
puts "{:\"foo-bar\"=>1}"
```

and the runtime output remains:

```text
{:"foo-bar"=>1}
```
