### PR TITLE
[Fix #12276] Record pending cops options in the auto-gen-config command

### DIFF
--- a/changelog/fix_preserve_pending_cops_flags_in_auto_gen_config_command_20260615212631.md
+++ b/changelog/fix_preserve_pending_cops_flags_in_auto_gen_config_command_20260615212631.md
@@ -1,0 +1,1 @@
+* [#12276](https://github.com/rubocop/rubocop/issues/12276): Fix `--auto-gen-config` to record `--disable-pending-cops` and `--enable-pending-cops` in the generated `.rubocop_todo.yml` command so that `--regenerate-todo` preserves them. ([@augustocbx][])

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -91,12 +91,9 @@ module RuboCop
         command = 'rubocop --auto-gen-config'
 
         command += ' --auto-gen-only-exclude' if @options[:auto_gen_only_exclude]
-
-        if no_exclude_limit?
-          command += ' --no-exclude-limit'
-        elsif @exclude_limit_option
-          command += format(' --exclude-limit %<limit>d', limit: Integer(@exclude_limit_option))
-        end
+        command += ' --disable-pending-cops' if @options[:disable_pending_cops]
+        command += ' --enable-pending-cops' if @options[:enable_pending_cops]
+        command += exclude_limit_option
         command += ' --no-offense-counts' unless show_offense_counts?
 
         command += ' --no-auto-gen-timestamp' unless show_timestamp?
@@ -104,6 +101,16 @@ module RuboCop
         command += ' --no-auto-gen-enforced-style' unless auto_gen_enforced_style?
 
         command
+      end
+
+      def exclude_limit_option
+        if no_exclude_limit?
+          ' --no-exclude-limit'
+        elsif @exclude_limit_option
+          format(' --exclude-limit %<limit>d', limit: Integer(@exclude_limit_option))
+        else
+          ''
+        end
       end
 
       def timestamp

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -223,6 +223,36 @@ RSpec.describe RuboCop::Formatter::DisabledConfigFormatter, :isolated_environmen
     end
   end
 
+  context 'when disable_pending_cops option is passed' do
+    before do
+      formatter.started([])
+      formatter.finished([])
+    end
+
+    let(:formatter) { described_class.new(output, disable_pending_cops: true) }
+
+    let(:expected_heading_command) { 'rubocop --auto-gen-config --disable-pending-cops' }
+
+    it 'includes the option in the generation command' do
+      expect(output.string).to eq(heading)
+    end
+  end
+
+  context 'when enable_pending_cops option is passed' do
+    before do
+      formatter.started([])
+      formatter.finished([])
+    end
+
+    let(:formatter) { described_class.new(output, enable_pending_cops: true) }
+
+    let(:expected_heading_command) { 'rubocop --auto-gen-config --enable-pending-cops' }
+
+    it 'includes the option in the generation command' do
+      expect(output.string).to eq(heading)
+    end
+  end
+
   context 'when no files are inspected' do
     before do
       formatter.started([])


### PR DESCRIPTION
The command recorded in the `.rubocop_todo.yml` heading generated by `--auto-gen-config` omits the `--disable-pending-cops` and `--enable-pending-cops` options. These options change which cops run, and therefore the generated TODO, but they are not written into the "generated by" command.

Because `--regenerate-todo` re-parses that command to reproduce the run, the dropped options meant regeneration could silently produce a different TODO than the original invocation. This change records them alongside the other generation options so the round-trip is stable.

Options that do not affect TODO generation, such as `--fail-level`, are intentionally left out of the recorded command.

Fixes #12276.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/