### PR TITLE
Add hk integration docs

### DIFF
--- a/docs/modules/ROOT/pages/integration_with_other_tools.adoc
+++ b/docs/modules/ROOT/pages/integration_with_other_tools.adoc
@@ -126,6 +126,11 @@ entries in `additional_dependencies`:
 
 RuboCop supports pre-commit hook integration since version 1.9.
 
+== Git hook integration with hk
+
+https://hk.jdx.dev/[hk] is a fast, polyglot Git hooks manager with
+https://hk.jdx.dev/builtins.html#rubocop[built-in RuboCop support].
+
 == Guard integration
 
 If you're fond of https://github.com/guard/guard[Guard] you might


### PR DESCRIPTION
Document hk as a Git hook manager option, since it has built-in RuboCop support (https://hk.jdx.dev/builtins.html#rubocop).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. (docs-only change, no tests needed)
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the changelog folder. (not user-observable in the gem itself)

[1]: https://chris.beams.io/posts/git-commit/