### PR TITLE
Fix examples for `Layout/FirstHashElementIndentation`

### DIFF
--- a/lib/rubocop/cop/layout/first_hash_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_hash_element_indentation.rb
@@ -28,10 +28,10 @@ module RuboCop
       #   # bad
       #   hash = {
       #     key: :value
-      #   }
-      #   and_in_a_method_call({
-      #     no: :difference
-      #                        })
+      #          }
+      #   in_a_method_call({
+      #     foo: :bar
+      #   })
       #   takes_multi_pairs_hash(x: {
       #     a: 1,
       #     b: 2
@@ -42,13 +42,12 @@ module RuboCop
       #                          })
       #
       #   # good
-      #   special_inside_parentheses
       #   hash = {
       #     key: :value
       #   }
-      #   but_in_a_method_call({
-      #                          its_like: :this
-      #                        })
+      #   in_a_method_call({
+      #                      foo: :bar
+      #                    })
       #   takes_multi_pairs_hash(x: {
       #                            a: 1,
       #                            b: 2
@@ -67,17 +66,17 @@ module RuboCop
       #   # bad
       #   hash = {
       #     key: :value
-      #   }
-      #   but_in_a_method_call({
-      #                          its_like: :this
-      #                         })
+      #          }
+      #   in_a_method_call({
+      #                     foo: :bar
+      #                   })
       #
       #   # good
       #   hash = {
       #     key: :value
       #   }
-      #   and_in_a_method_call({
-      #     no: :difference
+      #   in_a_method_call({
+      #     foo: :bar
       #   })
       #
       #


### PR DESCRIPTION
Now the bad code is code that is actually flagged by the cop in that configuration, at least for the `hash` and `in_a_method_call` examples. I left `takes_multi_pairs_hash` and the `align_braces` examples because the autocorrect there interacts with `Layout/HashAlignment` and i'm not across the details enough to be confident in making any changes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
