### PR TITLE
[Fix #15298] Fix hash string escaping in interpolated hashes

### DIFF
--- a/changelog/fix_literal_in_interpolation_hash_string_escaping_20260617000000.md
+++ b/changelog/fix_literal_in_interpolation_hash_string_escaping_20260617000000.md
@@ -1,0 +1,1 @@
+* [#15298](https://github.com/rubocop/rubocop/issues/15298): Fix incorrect autocorrects for `Lint/LiteralInInterpolation` when interpolated hashes contain string keys or values that require escaping in the surrounding string. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -139,6 +139,10 @@ module RuboCop
           escape_string_content(node.value.inspect)
         end
 
+        def autocorrected_value_in_hash_for_string(node)
+          escape_string_content(node.value.inspect)
+        end
+
         def autocorrected_value_for_array(node)
           return node.source.gsub('"', '\"') unless node.percent_literal?
 
@@ -155,7 +159,7 @@ module RuboCop
           "{#{hash_string}}"
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
         def autocorrected_value_in_hash(node)
           case node.type
           when :int
@@ -163,7 +167,7 @@ module RuboCop
           when :float
             node.children.last.to_f.to_s
           when :str
-            "\\\"#{node.value.to_s.gsub('"') { '\\\\\"' }}\\\""
+            autocorrected_value_in_hash_for_string(node)
           when :sym
             autocorrected_value_in_hash_for_symbol(node)
           when :array
@@ -174,7 +178,7 @@ module RuboCop
             node.source.gsub('"', '\"')
           end
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
 
         # Does node print its own source when converted to a string?
         def prints_as_self?(node)

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -190,6 +190,58 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
                     '{:array=>{:key=>[\"s1\", \"s2\"]}}')
     it_behaves_like('literal interpolation', '{ array: { key: %i[ s1   s2 ] } }',
                     '{:array=>{:key=>[\"s1\", \"s2\"]}}')
+
+    it 'handles escaped interpolation text in hash values when autocorrecting' do
+      literal = '{ foo: "\#{bar}" }'
+
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}}"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "this is the {:foo=>\"\\\#{bar}\"}"
+      RUBY
+    end
+
+    it 'handles escaped interpolation text in hash keys when autocorrecting' do
+      literal = '{ "\#{bar}" => 1 }'
+
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}}"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "this is the {\"\\\#{bar}\"=>1}"
+      RUBY
+    end
+
+    it 'handles backslashes in hash string values when autocorrecting' do
+      literal = '{ foo: "\\bar" }'
+
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}}"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "this is the {:foo=>\"\\bar\"}"
+      RUBY
+    end
+
+    it 'handles escaped instance variable interpolation text in hash values when autocorrecting' do
+      literal = '{ foo: "\#@bar" }'
+
+      expect_offense(<<~'RUBY', literal: literal)
+        "this is the #{%{literal}}"
+                       ^{literal} Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        "this is the {:foo=>\"\\\#@bar\"}"
+      RUBY
+    end
   end
 
   describe 'type else' do


### PR DESCRIPTION
## Description:

Issue #15298 reported that `Lint/LiteralInInterpolation` could produce incorrect autocorrects for interpolated hashes when nested string keys or values contained escaped interpolation text or backslashes.

This PR updates the hash string serialization path to reuse the existing escaping helper for string keys and values inside interpolated hashes, preserving the stringified hash output during autocorrect.

It also adds regression tests for escaped interpolation text in hash values, escaped interpolation text in hash keys, backslashes in hash string values, and escaped instance variable interpolation text in hash values.

Closes #15298.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/lint/literal_in_interpolation.rb spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/lint/literal_in_interpolation_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake`.

### Before the fix:

`Lint/LiteralInInterpolation` autocorrect could turn escaped interpolation text in interpolated hash string keys or values into live interpolation, and could reinterpret backslashes in nested hash strings.

<img width="917" height="440" alt="image" src="https://github.com/user-attachments/assets/785665f3-c3ba-427f-8bd4-363a5851de9e" />

<img width="1076" height="395" alt="image" src="https://github.com/user-attachments/assets/b9f5e2fe-d66f-4277-b2d1-c64528534724" />

### After the fix:

Autocorrect preserves escaped interpolation text and backslashes for string keys and values inside interpolated hashes.

<img width="985" height="404" alt="image" src="https://github.com/user-attachments/assets/85532c5a-e17d-4f70-9b39-e501391210bb" />

<img width="952" height="398" alt="image" src="https://github.com/user-attachments/assets/3eb348d9-f4b5-44be-bc93-97f4dcd51ea0" />
