### PR TITLE
[Fix #15300] Reduce perceived complexity of simple `case`/`in` patterns

### DIFF
--- a/changelog/change_perceived_complexity_simple_case_in.md
+++ b/changelog/change_perceived_complexity_simple_case_in.md
@@ -1,0 +1,1 @@
+* [#15300](https://github.com/rubocop/rubocop/issues/15300): Update `Metrics/PerceivedComplexity` to weight simple `case`/`in` pattern branches the same as `case`/`when` branches. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2844,7 +2844,7 @@ Metrics/PerceivedComplexity:
   Description: 'Checks that the perceived complexity of methods is not higher than the configured maximum.'
   Enabled: true
   VersionAdded: '0.25'
-  VersionChanged: '0.81'
+  VersionChanged: '<<next>>'
   AllowedMethods: []
   AllowedPatterns: []
   Max: 8

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -12,9 +12,15 @@ module RuboCop
       # nodes count. In contrast to the CyclomaticComplexity cop, this cop
       # considers `else` nodes as adding complexity.
       #
+      # A `case`/`in` branch whose pattern is a simple literal (e.g. `in 1`, `in "red"`, `in 1..10`)
+      # or a constant/type (e.g. `in Integer`) and has no guard is just as easy to read as a `when`
+      # branch, so it is discounted the same way. Branches with structural patterns (e.g. array,
+      # hash, or find patterns), bindings, alternatives, or a guard add the full complexity of
+      # a decision point.
+      #
       # @example
       #
-      #   def my_method                   # 1
+      #   def example_1                   # 1
       #     if cond                       # 1
       #       case var                    # 2 (0.8 + 4 * 0.2, rounded)
       #       when 1 then func_one
@@ -26,32 +32,57 @@ module RuboCop
       #       do_something until a && b   # 2
       #     end                           # ===
       #   end                             # 7 complexity points
+      #
+      #   def example_2                   # 1
+      #     case color                    # 1 (3 * 0.2, rounded)
+      #     in "red" then func_red
+      #     in "blue" then func_blue
+      #     in "green" then func_green
+      #     end                           # ===
+      #   end                             # 2 complexity points
       class PerceivedComplexity < CyclomaticComplexity
         MSG = 'Perceived complexity for `%<method>s` is too high. [%<complexity>d/%<max>d]'
 
-        COUNTED_NODES = (CyclomaticComplexity::COUNTED_NODES - [:when] + [:case]).freeze
+        COUNTED_NODES = (
+          CyclomaticComplexity::COUNTED_NODES - %i[when in_pattern] + %i[case case_match]
+        ).freeze
 
         private
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def complexity_score_for(node)
           case node.type
           when :case
-            # If cond is nil, that means each when has an expression that
-            # evaluates to true or false. It's just an alternative to
-            # if/elsif/elsif... so the when nodes count.
+            # If cond is nil, that means each when has an expression that evaluates to true or
+            # false. It's just an alternative to if/elsif/elsif... so the when nodes count.
             nb_branches = node.when_branches.length + (node.else_branch ? 1 : 0)
             if node.condition.nil?
               nb_branches
             else
-              # Otherwise, the case node gets 0.8 complexity points and each
-              # when gets 0.2.
+              # Otherwise, the case node gets 0.8 complexity points and each when gets 0.2.
               ((nb_branches * 0.2) + 0.8).round
             end
+          when :case_match
+            # Simple `in` branches are discounted like `when`, while structural patterns keep
+            # the full complexity of a decision point.
+            score = node.in_pattern_branches.sum { |branch| simple_in_pattern?(branch) ? 0.2 : 1 }
+            score += 0.2 if node.else_branch
+            score.round
           when :if
             node.else? && !node.elsif? ? 2 : 1
           else
             super
           end
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+        def simple_in_pattern?(in_pattern_node)
+          # `in_pattern_node.children[1]` is the guard (`if`/`unless`), or `nil`.
+          return false unless in_pattern_node.children[1].nil?
+
+          # A scalar literal, a literal range, or a constant/type is as easy to read as a `when`.
+          pattern = in_pattern_node.pattern
+          pattern.literal? || pattern.const_type?
         end
       end
     end

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -171,6 +171,81 @@ RSpec.describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
       RUBY
     end
 
+    it 'discounts a case/in block with simple literal patterns like case/when', :ruby27 do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for `method_name` is too high. [2/1]
+          case value
+          in 1 then call_foo_1
+          in 2 then call_foo_2
+          in 3 then call_foo_3
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'discounts a case/in block with constant/type patterns like case/when', :ruby27 do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for `method_name` is too high. [2/1]
+          case value
+          in Integer then call_foo_1
+          in String then call_foo_2
+          in Float then call_foo_3
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'counts case/in branches with structural patterns at full complexity', :ruby27 do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for `method_name` is too high. [4/1]
+          case value
+          in [1, a] then call_foo_1
+          in {b:} then call_foo_2
+          in String => c then call_foo_3
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'counts a guarded case/in branch at full complexity', :ruby27 do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for `method_name` is too high. [3/1]
+          case value
+          in Integer if value > 0 then call_foo_1
+          in Integer if value < 0 then call_foo_2
+          in Integer then call_foo_3
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'counts a mix of simple and structural case/in branches', :ruby27 do
+      expect_offense(<<~RUBY)
+        def method_name
+        ^^^^^^^^^^^^^^^ Perceived complexity for `method_name` is too high. [3/1]
+          case value
+          in [1, a] then call_foo_1
+          in {b:} then call_foo_2
+          in 3 then call_foo_3
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
     it 'registers an offense for &&' do
       expect_offense(<<~RUBY)
         def method_name


### PR DESCRIPTION
`Metrics/PerceivedComplexity` already discounts `case`/`when` branches because they are easy to scan, but it counted every `case`/`in` branch at full weight. As a result, rewriting an equivalent `case`/`when` as an exhaustive `case`/`in` made a method look more complex even though it is just as readable, discouraging the move to pattern matching.

Treat `case`/`in` branches whose pattern is a simple literal, a literal range, or a constant/type and that have no guard the same as `when` branches. Branches with structural patterns, bindings, alternatives, or a guard keep the full complexity of a decision point, so genuinely complex pattern matching is still reported.

Fixes #15300.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
