### PR TITLE
[Fix #15302] Fix an incorrect autocorrect for `Bundler/OrderedGems`

### DIFF
--- a/changelog/fix_ordered_gems_missing_final_newline.md
+++ b/changelog/fix_ordered_gems_missing_final_newline.md
@@ -1,0 +1,1 @@
+* [#15302](https://github.com/rubocop/rubocop/issues/15302): Fix an incorrect autocorrect for `Bundler/OrderedGems` and `Gemspec/OrderedDependencies` when the last declaration has no trailing newline, which joined two declarations into a single line. ([@koic][])

--- a/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_gem_corrector.rb
@@ -18,7 +18,14 @@ module RuboCop
           current_range = declaration_with_comment(node)
           previous_range = declaration_with_comment(previous_declaration)
 
-          ->(corrector) { corrector.swap(current_range, previous_range) }
+          lambda do |corrector|
+            if current_range.source.end_with?("\n")
+              corrector.swap(current_range, previous_range)
+            else
+              corrector.insert_before(previous_range, "#{current_range.source}\n")
+              corrector.remove(current_range)
+            end
+          end
         end
 
         private

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
   end
 
+  context 'When the final newline is missing' do
+    it 'registers an offense and corrects without joining the declarations' do
+      expect_offense(<<~RUBY, chomp: true)
+        gem 'rubocop'
+        gem 'rspec'
+        ^^^^^^^^^^^ Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem `rspec` should appear before `rubocop`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        gem 'rspec'
+        gem 'rubocop'
+      RUBY
+    end
+  end
+
   context 'When each individual group of line is sorted' do
     it 'does not register any offenses' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
When the last gem declaration in a file had no trailing newline, autocorrecting the gem order joined two declarations into a single line (e.g. `gem 'a'gem 'b'`), producing code with a syntax error. This happened with format-on-save where files often lack a final newline.

The corrector swapped whole-line ranges that included the trailing newline. A range without a trailing newline (the last line) and one with it are not symmetric, so swapping them dropped the line separator.
Now the last declaration is moved up with a newline added, keeping the declarations on separate lines. `Gemspec/OrderedDependencies` shares the corrector and is fixed as well.

Fixes #15302.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
