### PR TITLE
Add `Lint/ImplicitTypeCoercion` cop

### DIFF
--- a/changelog/new_add_lint_implicit_type_coercion_cop.md
+++ b/changelog/new_add_lint_implicit_type_coercion_cop.md
@@ -1,0 +1,1 @@
+* [#15304](https://github.com/rubocop/rubocop/pull/15304): Add `Lint/ImplicitTypeCoercion` cop. ([@zopolis4][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2064,6 +2064,12 @@ Lint/ImplicitStringConcatenation:
   Enabled: true
   VersionAdded: '0.36'
 
+Lint/ImplicitTypeCoercion:
+  Description: 'Checks for mathematical operations that do nothing except implicitly changing the type of the receiver.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '<<next>>'
+
 Lint/IncompatibleIoSelectWithFiberScheduler:
   Description: 'Checks for `IO.select` that is incompatible with Fiber Scheduler.'
   Enabled: pending

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -54,6 +54,7 @@ module RuboCop
       register_cop :EmptyInterpolation, "#{__dir__}/lint/empty_interpolation"
       register_cop :EmptyWhen, "#{__dir__}/lint/empty_when"
       register_cop :EnsureReturn, "#{__dir__}/lint/ensure_return"
+      register_cop :ImplicitTypeCoercion, "#{__dir__}/lint/implicit_type_coercion"
       register_cop :SharedMutableDefault, "#{__dir__}/lint/shared_mutable_default"
       register_cop :ErbNewArguments, "#{__dir__}/lint/erb_new_arguments"
       register_cop :FlipFlop, "#{__dir__}/lint/flip_flop"

--- a/lib/rubocop/cop/lint/implicit_type_coercion.rb
+++ b/lib/rubocop/cop/lint/implicit_type_coercion.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for operations that mathematically do nothing, but nevertheless
+      # implicitly change the type of the receiver. These should be replaced
+      # with explicit type conversions.
+      #
+      # @safety
+      #   This cop is unsafe if the receiver is a complex number, as only the
+      #   real part of the number has its type coerced.
+      #
+      # @example
+      #
+      #   # bad
+      #   x + 0.0
+      #   x - 0.0
+      #   x * 1.0
+      #   x / 1.0
+      #   x ** 1.0
+      #
+      #   # good
+      #   x.to_f
+      #
+      #   # bad
+      #   x + 0r
+      #   x - 0r
+      #   x * 1r
+      #   x / 1r
+      #   x ** 1r
+      #
+      #   # good
+      #   x.to_r
+      #
+      #   # bad
+      #   x + 0i
+      #   x - 0i
+      #
+      #   # good
+      #   x.to_c
+      #
+      class ImplicitTypeCoercion < Base
+        extend AutoCorrector
+
+        RESTRICT_ON_SEND = %i[+ - * / **].freeze
+        TYPE_MAPPINGS = { 0.0 => '.to_f', 0r => '.to_r', 0i => '.to_c',
+                          1.0 => '.to_f', 1r => '.to_r' }.freeze
+
+        # @!method implicit_type_coercion?(node)
+        def_node_matcher :implicit_type_coercion?,
+                         '(call (call nil? $_) $_ { (float $_) | (rational $_) | (complex $_) })'
+
+        def on_send(node)
+          return unless implicit_type_coercion?(node)
+
+          variable, operation, number = implicit_type_coercion?(node)
+
+          type = type_coercion?(operation, number)
+          return unless type
+
+          add_offense(node,
+                      message: 'This operation is mathematically inconsequential, ' \
+                               'but it implicitly changes the type of the receiver. ' \
+                               "Use #{type} instead.") do |corrector|
+            corrector.replace(node, variable.to_s + type)
+          end
+        end
+        alias on_csend on_send
+
+        private
+
+        def type_coercion?(operation, number)
+          if number.zero?
+            TYPE_MAPPINGS[number] if %i[+ -].include?(operation)
+          elsif number == 1
+            TYPE_MAPPINGS[number] if %i[* / **].include?(operation)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/implicit_type_coercion_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_type_coercion_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::ImplicitTypeCoercion, :config do
+  { '0.0' => '.to_f', '0r' => '.to_r', '0i' => '.to_c' }.each do |zero, type|
+    it "registers an offense on x + #{zero}" do
+      expect_offense(<<~RUBY, zero: zero, type: type)
+        x + #{zero}
+        ^^^^^{zero} This operation is mathematically inconsequential, but it implicitly changes the type of the receiver. Use #{type} instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x#{type}
+      RUBY
+    end
+
+    it "registers an offense on x - #{zero}" do
+      expect_offense(<<~RUBY, zero: zero, type: type)
+        x - #{zero}
+        ^^^^^{zero} This operation is mathematically inconsequential, but it implicitly changes the type of the receiver. Use #{type} instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x#{type}
+      RUBY
+    end
+  end
+
+  { '1.0' => '.to_f', '1r' => '.to_r' }.each do |one, type|
+    it "registers an offense on x * #{one}" do
+      expect_offense(<<~RUBY, one: one, type: type)
+        x * #{one}
+        ^^^^^{one} This operation is mathematically inconsequential, but it implicitly changes the type of the receiver. Use #{type} instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x#{type}
+      RUBY
+    end
+
+    it "registers an offense on x / #{one}" do
+      expect_offense(<<~RUBY, one: one, type: type)
+        x / #{one}
+        ^^^^^{one} This operation is mathematically inconsequential, but it implicitly changes the type of the receiver. Use #{type} instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x#{type}
+      RUBY
+    end
+
+    it "registers an offense on x ** #{one}" do
+      expect_offense(<<~RUBY, one: one, type: type)
+        x ** #{one}
+        ^^^^^^{one} This operation is mathematically inconsequential, but it implicitly changes the type of the receiver. Use #{type} instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x#{type}
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Basically the cousin of `Lint/UselessNumericOperation`, but for cases where the only thing being achieved is type coercion. 

Would appreciate some double checking on the actual validity of some of these cases from someone more familiar with the behavior of `Rational` and `Complex`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
