### PR TITLE
[#9571] Fix a crash for `Layout/ClassStructure` with a single safe-navigation body

### DIFF
--- a/changelog/fix_a_crash_for_class_structure_with_a_single_safe_navigation_body_20260618161134.md
+++ b/changelog/fix_a_crash_for_class_structure_with_a_single_safe_navigation_body_20260618161134.md
@@ -1,0 +1,1 @@
+* [#9571](https://github.com/rubocop/rubocop/issues/9571): Fix a crash for `Layout/ClassStructure` when a class body is a single safe-navigation call (e.g. `test&.private_methods(def foo; end)`). ([@bbatsov][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -278,10 +278,14 @@ module RuboCop
 
           return [] unless class_def
 
-          if class_def.type?(:def, :send)
-            [class_def]
-          else
+          # Only a multi-statement body (`begin`/`kwbegin`) wraps several elements; any
+          # single statement (`def`, `send`, `csend`, `if`, ...) is itself the sole element.
+          # Exploding such a node into its children would yield non-node values (e.g. a
+          # method-name `Symbol` from a `csend`) and crash later checks.
+          if class_def.type?(:begin, :kwbegin)
             class_def.children.compact
+          else
+            [class_def]
           end
         end
 

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -136,6 +136,32 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     end
   end
 
+  context 'when the class body is a single non-def/send node' do
+    it 'does not get confused by (or crash on) a single safe-navigation call body' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          test&.private_methods(def foo; end)
+        end
+      RUBY
+    end
+
+    it 'does not get confused by a single conditional body' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          def foo; end if bar
+        end
+      RUBY
+    end
+
+    it 'does not get confused by a single block body' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          configure { |c| c.foo = 1 }
+        end
+      RUBY
+    end
+  end
+
   it 'registers an offense and corrects when public instance method is before class method' do
     expect_offense(<<~RUBY)
       class Foo


### PR DESCRIPTION
When a class body is a single `csend` (safe-navigation) call like `test&.private_methods(def foo; end)`, `class_elements` exploded the node into its children - which include the bare method-name `Symbol` - and `private_constant?` then blew up on `Symbol#casgn_type?`. The fix flips the check so only multi-statement `begin`/`kwbegin` bodies are split into children; any single statement is treated as the sole element.

This addresses the crash from #9571. The other case in that issue (`public`/`private` defs nested in `begin`/`kwbegin` blocks not being flagged) is a separate false negative that needs recursive begin-flattening with autocorrect implications, so I've left it for a follow-up and this doesn't close the issue.