### PR TITLE
[Fix #12017] Don't autocorrect a constant used in a void context

### DIFF
--- a/changelog/fix_an_unsafe_autocorrect_for_lint_void_with_a_constant_20260619.md
+++ b/changelog/fix_an_unsafe_autocorrect_for_lint_void_with_a_constant_20260619.md
@@ -1,0 +1,1 @@
+* [#12017](https://github.com/rubocop/rubocop/issues/12017): Fix `Lint/Void` to no longer autocorrect a constant used in a void context, since removing it can change behavior through constant autoloading side effects. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -22,6 +22,10 @@ module RuboCop
       # the return value or rename the method to something more appropriate should be left to
       # the user.
       #
+      # NOTE: A constant used in a void context is flagged but not autocorrected, since
+      # referencing a constant can trigger autoloading side effects (e.g. forcing a file to
+      # load before a monkey-patch), so removing it may change behavior.
+      #
       # @example CheckForMethodsWithNoSideEffects: false (default)
       #   # bad
       #   def some_method
@@ -258,6 +262,10 @@ module RuboCop
         end
 
         def autocorrect_void_expression(corrector, node)
+          # Referencing a constant can trigger autoloading side effects (e.g. forcing a file
+          # to load before a monkey-patch), so removing it may change behavior. Flag but don't
+          # autocorrect, leaving it to the user.
+          return if node.const_type? && !node.special_keyword?
           return if node.parent.type?(:if, :case, :when, :case_match, :in_pattern)
           return if (def_node = node.each_ancestor(:any_def).first) && def_node.assignment_method?
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -248,10 +248,21 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       top
     RUBY
 
-    expect_correction(<<~RUBY)
-      CONST = 5
-      top
+    # Referencing a constant can trigger autoloading side effects, so removing it may
+    # change behavior; the offense is reported but not autocorrected.
+    expect_no_corrections
+  end
+
+  it 'registers an offense but does not autocorrect a qualified constant in void context' do
+    expect_offense(<<~RUBY)
+      Foo::Bar
+      ^^^^^^^^ Constant `Foo::Bar` used in void context.
+
+      class Foo::Bar
+      end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'registers an offense for void constant `CONST` with guard condition if not on last line' do


### PR DESCRIPTION
`Lint/Void` flagged a bare constant in void context (e.g. `Foo::Bar` on its own line) and removed it under safe `-a`. That's unsafe: referencing a constant can trigger autoloading side effects (e.g. forcing a file to load before a monkey-patch), so dropping it can change behavior.

Now the offense is still reported but no longer autocorrected, matching how the cop already handles assignment-method return values and constants inside conditionals/ternaries. Variables, literals, `self`, and special-keyword pseudo-constants are unaffected.

Fixes #12017.