### PR TITLE
[Fix #15307] Fix a false positive for `Lint/UnescapedBracketInRegexp`

### DIFF
--- a/changelog/fix_unescaped_bracket_in_regexp_negated_bare_bracket.md
+++ b/changelog/fix_unescaped_bracket_in_regexp_negated_bare_bracket.md
@@ -1,0 +1,1 @@
+* [#15307](https://github.com/rubocop/rubocop/issues/15307): Fix a false positive for `Lint/UnescapedBracketInRegexp` when a character class starts with a bare `]` (e.g. `/[^]]/`). ([@koic][])

--- a/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
+++ b/lib/rubocop/cop/lint/unescaped_bracket_in_regexp.rb
@@ -44,9 +44,7 @@ module RuboCop
 
         def on_regexp(node)
           RuboCop::Util.silence_warnings do
-            node.parsed_tree&.each_expression do |expr|
-              detect_offenses(node, expr)
-            end
+            detect_offenses_in_tree(node, node.parsed_tree)
           end
         end
 
@@ -55,19 +53,43 @@ module RuboCop
           return if node.each_descendant(:dstr).any?
 
           regexp_constructor(node) do |text|
-            parse_regexp(text.value)&.each_expression do |expr|
-              detect_offenses(text, expr)
-            end
+            detect_offenses_in_tree(text, parse_regexp(text.value))
           end
         end
 
         private
 
-        def detect_offenses(node, expr)
-          return unless expr.type?(:literal)
+        # When a character class opens with a bare `]` (e.g. `[^]]`), `regexp_parser` parses
+        # `[^]` / `[]` as an empty set and reports the closing `]` as a separate literal.
+        # Ruby treats that `]` as the end of the class, not as an unescaped bracket,
+        # so the first `]` following an empty set must be skipped.
+        def detect_offenses_in_tree(node, tree)
+          return unless tree
 
+          skip_class_closer = false
+          tree.each_expression do |expr|
+            if empty_character_set?(expr)
+              skip_class_closer = true
+            elsif expr.type?(:literal)
+              skip_class_closer = detect_offenses(node, expr, skip_class_closer)
+            end
+          end
+        end
+
+        def empty_character_set?(expr)
+          expr.type?(:set) && expr.expressions.empty?
+        end
+
+        def detect_offenses(node, expr, skip_class_closer)
           expr.text.scan(/(?<!\\)\]/) do
             pos = Regexp.last_match.begin(0)
+
+            # The first `]` following an empty `[^]` / `[]` set closes the character class.
+            if skip_class_closer
+              skip_class_closer = false
+              next
+            end
+
             # If the unescaped bracket is the first character of the regexp, Ruby does not warn.
             # `pos` is relative to the sub-expression, so add its start offset (`expr.ts`).
             next if (expr.ts + pos).zero?
@@ -78,6 +100,8 @@ module RuboCop
               corrector.replace(location, '\]')
             end
           end
+
+          skip_class_closer
         end
 
         def range_at_index(node, index, offset)

--- a/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
+++ b/spec/rubocop/cop/lint/unescaped_bracket_in_regexp_spec.rb
@@ -82,6 +82,56 @@ RSpec.describe RuboCop::Cop::Lint::UnescapedBracketInRegexp, :config do
       end
     end
 
+    context 'negated character class with a bare `]` as the first element' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          /[^]]/
+        RUBY
+      end
+
+      it 'does not register an offense when the class contains other elements' do
+        expect_no_offenses(<<~RUBY)
+          /[^]x]/
+        RUBY
+      end
+
+      it 'does not register an offense when surrounded by other characters' do
+        expect_no_offenses(<<~RUBY)
+          /foo[^]]bar/
+        RUBY
+      end
+
+      it 'does not register an offense when followed by an escaped bracket' do
+        expect_no_offenses(<<~'RUBY')
+          /[^]\]]/
+        RUBY
+      end
+
+      it 'registers an offense only for a genuine unescaped bracket after the class' do
+        expect_offense(<<~RUBY)
+          /[^]]x]/
+                ^ Regular expression has `]` without escape.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /[^]]x\]/
+        RUBY
+      end
+    end
+
+    context 'character class followed by an unescaped bracket' do
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          /[a]]/
+              ^ Regular expression has `]` without escape.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          /[a]\]/
+        RUBY
+      end
+    end
+
     context 'character class in lookbehind' do
       # See https://github.com/ammar/regexp_parser/issues/93
       it 'does not register an offense' do


### PR DESCRIPTION
This cop emulates Ruby's "regular expression has ']' without escape" warning, which is about a `]` outside a character class. A character class that opens with a bare `]` (e.g. `/[^]]/`) is valid and does not trigger that warning, yet the cop reported it and even autocorrected to an unnecessary escape.

The cause is that `regexp_parser` treats `[^]` and `[]` as an empty set and reports the real closing `]` as a separate literal. Ruby instead reads that `]` as the end of the character class, so the first `]` following an empty set is now skipped. A genuine unescaped `]` after the class (e.g. the trailing `]` in `/[^]]x]/`) is still reported.

Fixes #15307.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
