### PR TITLE
[Fix #15284] Fix a false positive for `Style/MutableConstant` with `Data.define`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_mutable_constant_with_data_define_20260620162212.md
+++ b/changelog/fix_a_false_positive_for_style_mutable_constant_with_data_define_20260620162212.md
@@ -1,0 +1,1 @@
+* [#15284](https://github.com/rubocop/rubocop/issues/15284): Fix a false positive for `Style/MutableConstant` with `Data.define`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -89,6 +89,9 @@ module RuboCop
       #     end
       #   end.freeze
       #
+      #   # good - `Data.define` declares an immutable value type
+      #   CONST = Data.define(:foo, :bar)
+      #
       # @example
       #   # Magic comment - shareable_constant_value: literal
       #
@@ -319,6 +322,8 @@ module RuboCop
             (const _ _)
             (send (const {nil? cbase} :Struct) :new ...)
             (block (send (const {nil? cbase} :Struct) :new ...) ...)
+            (send (const {nil? cbase} :Data) :define ...)
+            (block (send (const {nil? cbase} :Data) :define ...) ...)
             (send _ :freeze)
             (send {float int} {:+ :- :* :** :/ :% :<<} _)
             (send _ {:+ :- :* :** :/ :%} {float int})

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -480,6 +480,16 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
         end
       end
     RUBY
+    it_behaves_like 'immutable objects', 'Data.define'
+    it_behaves_like 'immutable objects', '::Data.define'
+    it_behaves_like 'immutable objects', 'Data.define(:a, :b)'
+    it_behaves_like 'immutable objects', <<~RUBY
+      Data.define(:node) do
+        def assignment?
+          true
+        end
+      end
+    RUBY
 
     it 'allows calls to freeze' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
`Data.define` (Ruby 3.2+) declares an immutable value type, just like `Struct.new`, which this cop already treats as immutable. With `EnforcedStyle: strict` it was being flagged as needing `.freeze`. This extends the existing `Struct.new` handling to cover `Data.define` (including `::Data.define` and the block form).

Fixes #15284