### PR TITLE
[Fix #15298] Fix an incorrect autocorrect for `Lint/LiteralInInterpolation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_literal_in_interpolation_20260620174155.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_literal_in_interpolation_20260620174155.md
@@ -1,0 +1,1 @@
+* [#15298](https://github.com/rubocop/rubocop/issues/15298): Fix an incorrect autocorrect for `Lint/LiteralInInterpolation`. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -163,7 +163,7 @@ module RuboCop
           when :float
             node.children.last.to_f.to_s
           when :str
-            "\\\"#{node.value.to_s.gsub('"') { '\\\\\"' }}\\\""
+            escape_string_content(node.value.inspect)
           when :sym
             autocorrected_value_in_hash_for_symbol(node)
           when :array

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -190,6 +190,53 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation, :config do
                     '{:array=>{:key=>[\"s1\", \"s2\"]}}')
     it_behaves_like('literal interpolation', '{ array: { key: %i[ s1   s2 ] } }',
                     '{:array=>{:key=>[\"s1\", \"s2\"]}}')
+
+    # String content of nested hash values must be escaped the same way as
+    # top-level interpolated strings, otherwise escaped `#{}`/`#@`/backslashes
+    # become live in the resulting literal and change the output.
+    it 'keeps escaped interpolation in a hash string value escaped' do
+      expect_offense(<<~'RUBY')
+        x = "#{ { foo: "\#{bar}" } }"
+                ^^^^^^^^^^^^^^^^^^ Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = "{:foo=>\"\\\#{bar}\"}"
+      RUBY
+    end
+
+    it 'keeps escaped interpolation in a hash string key escaped' do
+      expect_offense(<<~'RUBY')
+        x = "#{ { "\#{bar}" => 1 } }"
+                ^^^^^^^^^^^^^^^^^^ Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = "{\"\\\#{bar}\"=>1}"
+      RUBY
+    end
+
+    it 'keeps backslashes in a hash string value intact' do
+      expect_offense(<<~'RUBY')
+        x = "#{ { foo: "\\bar" } }"
+                ^^^^^^^^^^^^^^^^ Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = "{:foo=>\"\\\\bar\"}"
+      RUBY
+    end
+
+    it 'keeps escaped instance variable interpolation in a hash string value escaped' do
+      expect_offense(<<~'RUBY')
+        x = "#{ { foo: "\#@bar" } }"
+                ^^^^^^^^^^^^^^^^^ Literal interpolation detected.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        x = "{:foo=>\"\\\#@bar\"}"
+      RUBY
+    end
   end
 
   describe 'type else' do


### PR DESCRIPTION
When autocorrecting interpolated hash literals, nested string keys/values were serialized with narrower escaping than top-level interpolated strings. Escaped interpolation markers (`\#{...}`, `\#@...`) and backslashes inside those strings became live after autocorrect, raising `NameError` or silently changing the output.

The hash string serialization now reuses the same `escape_string_content` (via `String#inspect`) that the top-level path already uses, so the corrected literal preserves the original output.

Fixes #15298