### PR TITLE
Fix a false negative for `Layout/IndentationWidth`

### DIFF
--- a/changelog/fix_indentation_width_grouped_expression.md
+++ b/changelog/fix_indentation_width_grouped_expression.md
@@ -1,0 +1,1 @@
+* [#15311](https://github.com/rubocop/rubocop/pull/15311): Fix a false negative for `Layout/IndentationWidth` when the body of a multiline grouped expression in parentheses is not indented. ([@koic][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -25,6 +25,17 @@ module RuboCop
       #     end
       #   end
       #
+      # @example
+      #   # bad
+      #   value = (
+      #   foo - bar
+      #   )
+      #
+      #   # good
+      #   value = (
+      #     foo - bar
+      #   )
+      #
       # @example AllowedPatterns: ['^\s*module']
       #   # bad
       #   module A
@@ -93,6 +104,16 @@ module RuboCop
           return unless begins_its_line?(node.loc.end)
 
           check_indentation(node.loc.end, node.children.first)
+        end
+
+        def on_begin(node)
+          # Only a parenthesized grouping expression (e.g. `(\n  foo\n)`) has
+          # explicit delimiters. Indent the body one step from the line
+          # the opening parenthesis is on, but only when the closing parenthesis is
+          # first on its line (a body on the opening line is skipped downstream).
+          return unless parentheses?(node) && begins_its_line?(node.loc.end)
+
+          check_indentation(opening_line_start(node.loc.begin), node.children.first)
         end
 
         def on_block(node)
@@ -186,6 +207,13 @@ module RuboCop
           return unless node
 
           AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)
+        end
+
+        # Returns a range at the first non-space column of the line the opening parenthesis is on,
+        # used as the base to indent the body from.
+        def opening_line_start(begin_loc)
+          column = begin_loc.source_line =~ /\S/
+          source_range(processed_source.buffer, begin_loc.line, column)
         end
 
         def check_members(base, members)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -1192,6 +1192,59 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
       end
     end
 
+    context 'with grouped expression' do
+      it 'registers an offense for bad indentation of a parenthesized body' do
+        expect_offense(<<~RUBY)
+          x = (
+          foo - bar
+          ^{} Use 2 (not 0) spaces for indentation.
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x = (
+            foo - bar
+          )
+        RUBY
+      end
+
+      it 'registers an offense for a parenthesized body with a trailing method call' do
+        expect_offense(<<~RUBY)
+          x = (
+          foo - bar
+          ^{} Use 2 (not 0) spaces for indentation.
+          ).freeze
+        RUBY
+
+        expect_correction(<<~RUBY)
+          x = (
+            foo - bar
+          ).freeze
+        RUBY
+      end
+
+      it 'accepts a correctly indented parenthesized body' do
+        expect_no_offenses(<<~RUBY)
+          x = (
+            foo - bar
+          )
+        RUBY
+      end
+
+      it 'accepts a single-line grouped expression' do
+        expect_no_offenses(<<~RUBY)
+          x = (foo - bar)
+        RUBY
+      end
+
+      it 'accepts a body that begins on the opening parenthesis line' do
+        expect_no_offenses(<<~RUBY)
+          x = (foo +
+               bar)
+        RUBY
+      end
+    end
+
     context 'with while/until' do
       it 'registers an offense for bad indentation of a while body' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
`Layout/IndentationWidth` checked the body indentation of method definitions, blocks, `begin`/`end`, `case`, and similar constructs, but not the body of a multiline grouping expression in parentheses. As a result, code like the following went unreported even though the body is not indented:

```ruby
value = (
foo - bar
)
```

Add an `on_begin` handler that indents the body one step from the line the opening parenthesis is on. The closing parenthesis is left to `Layout/ClosingParenthesisIndentation`, mirroring how `on_kwbegin` relies on `Layout/EndAlignment` for the `end` keyword. Only parenthesized grouping expressions whose closing parenthesis is first on its line are checked, so a body that begins on the opening line is left alone.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
