### PR TITLE
[Fix #15312] Fix false positives in `Layout/BlockAlignment`

### DIFF
--- a/changelog/fix_false_positives_for_layout_block_alignment.md
+++ b/changelog/fix_false_positives_for_layout_block_alignment.md
@@ -1,0 +1,1 @@
+* [#15312](https://github.com/rubocop/rubocop/issues/15312): Fix false positives for `Layout/BlockAlignment` when `EnforcedStyleAlignWith: start_of_block` is used and `do` is on a continuation line of a parenthesisless multiline method call. ([@koic][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -281,14 +281,31 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def do_line_begins_inside_argument?(node, do_loc)
           line_begin_pos = do_loc.begin_pos - do_loc.column
           first_char_pos = line_begin_pos + (do_loc.source_line =~ /\S/)
+          return false unless inside_parentheses?(node, first_char_pos)
 
           (node.send_node.arguments + node.arguments).any? do |argument|
             argument.source_range.begin_pos <= first_char_pos &&
               first_char_pos < argument.source_range.end_pos
           end
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        # The continuation line indentation is only an unmeaningful alignment target when
+        # it is dictated by an opening delimiter, i.e. the line begins inside `(` or `[`.
+        # For a bare argument list without parentheses the indentation is the author's
+        # deliberate alignment, so the anchor must not move to the method dispatch line.
+        def inside_parentheses?(node, pos)
+          preceding_tokens = processed_source.tokens.select do |token|
+            token.begin_pos >= node.source_range.begin_pos && token.begin_pos < pos
+          end
+          opens = preceding_tokens.count { |token| token.left_parens? || token.left_bracket? }
+          closes = preceding_tokens.count { |token| token.right_parens? || token.right_bracket? }
+
+          opens > closes
         end
       end
     end

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -981,6 +981,35 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
           }
         RUBY
       end
+
+      it 'allows when `end` is aligned with the line where the `do` is and the method has no parentheses' do
+        expect_no_offenses(<<~RUBY)
+          foo bar,
+            baz,
+            key: value do |x|
+              process(x)
+            end
+        RUBY
+      end
+
+      it 'errors when `end` is misaligned and the method has no parentheses' do
+        expect_offense(<<~RUBY)
+          foo bar,
+            baz,
+            key: value do |x|
+              process(x)
+                end
+                ^^^ `end` at 5, 6 is not aligned with `key: value do |x|` at 3, 2.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo bar,
+            baz,
+            key: value do |x|
+              process(x)
+            end
+        RUBY
+      end
     end
 
     context 'inside a non-endless method' do


### PR DESCRIPTION
With `EnforcedStyleAlignWith: start_of_block`, the alignment anchor moved to the method dispatch line whenever the `do` or `{` sat on an argument continuation line. That heuristic only makes sense when the continuation indentation is dictated by an opening delimiter, such as arguments aligned under `(`. For a parenthesisless multiline method call the continuation indentation is the author's deliberate alignment, so moving the anchor collapsed `start_of_block` into `start_of_line` and reported previously accepted code as an offense.

The anchor now moves only when the line holding the `do` or `{` begins inside an open `(` or `[`, so parenthesisless calls keep aligning the `end` with the start of the line where the `do` or `{` appears.

Fixes #15312.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
