### PR TITLE
Support autocorrection for tab indentation in `Layout/IndentationWidth` and `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/new_support_tab_indentation_autocorrect.md
+++ b/changelog/new_support_tab_indentation_autocorrect.md
@@ -1,0 +1,1 @@
+* [#9373](https://github.com/rubocop/rubocop/issues/9373): Support autocorrection for tab indentation in `Layout/IndentationWidth` and `Style/ClassAndModuleChildren`. ([@ioquatix][], [@koic][])

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -12,20 +12,28 @@ module RuboCop
       class << self
         attr_reader :processed_source
 
-        def correct(corrector, processed_source, node, column_delta)
+        # `tab_indentation` may only be set by callers whose `column_delta` represents
+        # whole indentation levels (e.g. `Layout/IndentationWidth`).
+        # Alignment to an arbitrary column cannot be expressed with tabs, so those callers
+        # leave tab correction disabled to avoid producing a never-converging correction.
+        def correct(corrector, processed_source, node, column_delta, tab_indentation: false)
           return unless node
 
           @processed_source = processed_source
-          # Disable autocorrection for tabs as it requires special handling
-          return if using_tabs?
 
           expr = node.respond_to?(:loc) ? node.source_range : node
           return if block_comment_within?(expr)
 
           taboo_ranges = inside_string_ranges(node)
 
-          each_line(expr) do |line_begin_pos|
-            autocorrect_line(corrector, line_begin_pos, expr, column_delta, taboo_ranges)
+          if using_tabs?
+            return unless tab_indentation
+
+            correct_tab_indentation(corrector, expr, column_delta, taboo_ranges)
+          else
+            each_line(expr) do |line_begin_pos|
+              autocorrect_line(corrector, line_begin_pos, expr, column_delta, taboo_ranges)
+            end
           end
         end
 
@@ -56,6 +64,48 @@ module RuboCop
           elsif /\A[ \t]+\z/.match?(range.source)
             corrector.remove(range)
           end
+        end
+
+        # Tab indentation is corrected by rewriting each line's leading whitespace to
+        # the target number of tabs. Working in whole tabs rather than applying a column delta
+        # keeps the result idempotent, which avoids the infinite loops that delta-based correction
+        # caused for tabs.
+        def correct_tab_indentation(corrector, expr, column_delta, taboo_ranges)
+          buffer = expr.source_buffer
+
+          each_line(expr) do |line_begin_pos|
+            line_range = buffer.line_range(buffer.line_for_position(line_begin_pos))
+            correct_tab_line(corrector, line_range, column_delta, taboo_ranges)
+          end
+        end
+
+        def correct_tab_line(corrector, line_range, column_delta, taboo_ranges)
+          leading = line_range.source[/\A[ \t]*/]
+          return if leading.length == line_range.source.length # blank line
+
+          leading_range = range_between(line_range.begin_pos, line_range.begin_pos + leading.length)
+          return if taboo_ranges.any? { |t| within?(leading_range, t) }
+
+          target = target_tab_indentation(leading, column_delta)
+          corrector.replace(leading_range, target) unless leading == target
+        end
+
+        def target_tab_indentation(leading, column_delta)
+          width = configured_indentation_width
+          return leading unless width.positive?
+
+          visual_width = leading.chars.sum { |char| char == "\t" ? width : 1 }
+
+          "\t" * ([visual_width + column_delta, 0].max / width)
+        end
+
+        # The number of columns a single tab spans. This must match the width
+        # `Layout/IndentationWidth` uses to compute `column_delta`, otherwise
+        # the division below would not land on a tab boundary. `Layout/IndentationStyle`
+        # has its own `IndentationWidth`, but that only governs how that cop replaces tabs
+        # with spaces, so it must not be consulted here.
+        def configured_indentation_width
+          processed_source.config.for_cop('Layout/IndentationWidth')['Width'] || 2
         end
 
         def inside_string_ranges(node)

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -206,7 +206,9 @@ module RuboCop
         def autocorrect(corrector, node)
           return unless node
 
-          AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)
+          AlignmentCorrector.correct(
+            corrector, processed_source, node, @column_delta, tab_indentation: true
+          )
         end
 
         # Returns a range at the first non-space column of the line the opening parenthesis is on,

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -162,21 +162,22 @@ module RuboCop
           column_delta = configured_indentation_width - spaces_size(last_child_leading_spaces)
           return if column_delta.zero?
 
-          AlignmentCorrector.correct(corrector, processed_source, node, column_delta)
+          AlignmentCorrector.correct(
+            corrector, processed_source, node, column_delta, tab_indentation: true
+          )
         end
 
         def leading_spaces(node)
           node.source_range.source_line[/\A\s*/]
         end
 
+        # A tab counts as `configured_indentation_width` columns, matching the
+        # width `AlignmentCorrector` uses to convert `column_delta` back into
+        # tabs. Using `Layout/IndentationStyle`'s own `IndentationWidth` here
+        # would make the delta and the correction disagree.
         def spaces_size(spaces_string)
-          mapping = { "\t" => tab_indentation_width }
+          mapping = { "\t" => configured_indentation_width }
           spaces_string.chars.sum { |character| mapping.fetch(character, 1) }
-        end
-
-        def tab_indentation_width
-          config.for_cop('Layout/IndentationStyle')['IndentationWidth'] ||
-            configured_indentation_width
         end
 
         def check_style(node, body, style)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4211,7 +4211,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
     class SomeClient
     \tconversation_request.get_messages(session_id, time_before).map do |message|
-    \t\t\t\tConversationMessagesResponse.new message
+    \t\tConversationMessagesResponse.new message
     \tend
     end
     RUBY
@@ -4244,6 +4244,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     \tend
     end
     RUBY
+  end
+
+  it 'does not autocorrect or loop with Layout/ArrayAlignment when tab indentation is enforced' do
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/IndentationStyle:
+        EnforcedStyle: tabs
+    YAML
+
+    source = <<-RUBY.gsub(/^    /, '')
+    foo = [1,
+    \t2]
+    RUBY
+    source_file = Pathname('example.rb')
+    create_file(source_file, source)
+
+    status = cli.run(['--autocorrect-all', '--only', 'Layout/ArrayAlignment'])
+    expect(status).to eq(1)
+    expect($stderr.string).to eq('')
+
+    # Aligning to an arbitrary column cannot be expressed with tabs, so the offense is reported
+    # but left uncorrected instead of looping endlessly.
+    expect(source_file.read).to eq(source)
   end
 
   it 'does not cause an infinite loop for Layout/LineLength with SplitStrings' do

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
-      it 'detects excessive tab indentation in if statement' do
+      it 'detects and corrects excessive tab indentation in if statement' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         if cond
         \t\tfunc
@@ -115,10 +115,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        if cond
+        \tfunc
+        end
+        RUBY
       end
 
-      it 'detects insufficient tab indentation in class' do
+      it 'detects and corrects insufficient tab indentation in class' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         class A
         def test
@@ -127,10 +131,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        class A
+        \tdef test
+        \tend
+        end
+        RUBY
       end
 
-      it 'detects excessive tab indentation' do
+      it 'detects and corrects excessive tab indentation' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         def test
         \t\t\tputs 'hello'
@@ -138,7 +147,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        def test
+        \tputs 'hello'
+        end
+        RUBY
       end
     end
 
@@ -2410,7 +2423,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
-      it 'detects excessive tab indentation in if statement' do
+      it 'detects and corrects excessive tab indentation in if statement' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         if cond
         \t\tfunc
@@ -2418,10 +2431,14 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        if cond
+        \tfunc
+        end
+        RUBY
       end
 
-      it 'detects insufficient tab indentation in class' do
+      it 'detects and corrects insufficient tab indentation in class' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         class A
         def test
@@ -2430,10 +2447,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        class A
+        \tdef test
+        \tend
+        end
+        RUBY
       end
 
-      it 'detects excessive tab indentation' do
+      it 'detects and corrects excessive tab indentation' do
         expect_offense(<<-RUBY.gsub(/^        /, ''))
         def test
         \t\t\tputs 'hello'
@@ -2441,7 +2463,70 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         end
         RUBY
 
-        expect_no_corrections
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        def test
+        \tputs 'hello'
+        end
+        RUBY
+      end
+
+      it 'detects and corrects excessive tab indentation in nested modules' do
+        expect_offense(<<-RUBY.gsub(/^        /, ''))
+        module Foo
+        \t\tmodule Bar
+        ^^ Use 1 (not 2) tabs for indentation.
+        \t\t\tbaz = 1
+        \t\tend
+        \tend
+        RUBY
+
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        module Foo
+        \tmodule Bar
+        \t\tbaz = 1
+        \tend
+        \tend
+        RUBY
+      end
+
+      context "when `Layout/IndentationStyle` has a different `IndentationWidth` than this cop's `Width`" do
+        let(:indentation_style_config) { { 'EnforcedStyle' => 'tabs', 'IndentationWidth' => 4 } }
+
+        it 'corrects based on the indentation width of this cop' do
+          expect_offense(<<-RUBY.gsub(/^          /, ''))
+          class A
+          def test
+          ^{} Use 1 (not 0) tabs for indentation.
+          end
+          end
+          RUBY
+
+          expect_correction(<<-RUBY.gsub(/^          /, ''))
+          class A
+          \tdef test
+          \tend
+          end
+          RUBY
+        end
+      end
+
+      context 'when `Layout/IndentationStyle` has an `IndentationWidth` of zero' do
+        let(:indentation_style_config) { { 'EnforcedStyle' => 'tabs', 'IndentationWidth' => 0 } }
+
+        it 'corrects without raising a division error' do
+          expect_offense(<<-RUBY.gsub(/^          /, ''))
+          if cond
+          \t\tfunc
+          ^^ Use 1 (not 2) tabs for indentation.
+          end
+          RUBY
+
+          expect_correction(<<-RUBY.gsub(/^          /, ''))
+          if cond
+          \tfunc
+          end
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -458,6 +458,57 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       RUBY
     end
 
+    context 'with tab indentation enforced' do
+      let(:other_cops) { { 'Layout/IndentationStyle' => { 'EnforcedStyle' => 'tabs' } } }
+
+      it 'registers an offense and corrects tab-intended nested children' do
+        expect_offense(<<~RUBY)
+          module A
+                 ^ Use compact module/class definition instead of nested style.
+          \tmodule B
+          \t\tmodule C
+          \t\t\tbody
+          \t\tend
+          \tend
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module A::B::C
+          \tbody
+          end
+        RUBY
+      end
+
+      context "when `Layout/IndentationStyle` has a different `IndentationWidth` than `Layout/IndentationWidth`'s `Width`" do
+        let(:other_cops) do
+          {
+            'Layout/IndentationStyle' => { 'EnforcedStyle' => 'tabs', 'IndentationWidth' => 4 },
+            'Layout/IndentationWidth' => { 'Width' => 2 }
+          }
+        end
+
+        it 'indents the compacted body based on `Layout/IndentationWidth`' do
+          expect_offense(<<~RUBY)
+            module A
+                   ^ Use compact module/class definition instead of nested style.
+            \tmodule B
+            \t\tmodule C
+            \t\t\tbody
+            \t\tend
+            \tend
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            module A::B::C
+            \tbody
+            end
+          RUBY
+        end
+      end
+    end
+
     context 'with unindented nested nodes' do
       it 'registers an offense and autocorrects unindented class' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Autocorrection for tab indentation was disabled in `AlignmentCorrector` because applying a display-column delta to tab indentation could produce a never-converging correction (https://github.com/rubocop/rubocop/issues/9373).

Re-enable it only for callers whose `column_delta` represents whole indentation levels, via a `tab_indentation:` opt-in. For those callers, each line's leading whitespace is rewritten to the target number of tabs instead of adjusting it by a column delta. Snapping to whole tabs keeps the result idempotent, so the correction converges in a single pass.

Alignment cops that align to an arbitrary column do not opt in, since that target cannot be expressed with tabs and would loop.

This is based on the original work in https://github.com/rubocop/rubocop/pull/15003, reworked to keep the correction idempotent and scoped to indentation-level callers.

cc @samuel-williams-shopify

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
