### PR TITLE
[Fix #11956] False positive for `Naming/FileName` with multiple acronyms

### DIFF
--- a/changelog/fix_a_false_positive_for_naming_file_name_with_multiple_acronyms.md
+++ b/changelog/fix_a_false_positive_for_naming_file_name_with_multiple_acronyms.md
@@ -1,0 +1,1 @@
+* [#11956](https://github.com/rubocop/rubocop/issues/11956): Fix a false positive for `Naming/FileName` when a class or module name contains multiple consecutive `AllowedAcronyms`. ([@camallen][])

--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -203,9 +203,10 @@ module RuboCop
 
         def match_acronym?(expected, name)
           expected = expected.to_s
-          name = name.to_s
-
-          allowed_acronyms.any? { |acronym| expected.gsub(acronym.capitalize, acronym) == name }
+          name = allowed_acronyms.reduce(name.to_s) do |result, acronym|
+            result.gsub(acronym, acronym.capitalize)
+          end
+          expected == name
         end
 
         def to_namespace(path) # rubocop:disable Metrics/AbcSize

--- a/spec/rubocop/cop/naming/file_name_spec.rb
+++ b/spec/rubocop/cop/naming/file_name_spec.rb
@@ -459,6 +459,33 @@ RSpec.describe RuboCop::Cop::Naming::FileName, :config do
     end
   end
 
+  context 'with multiple consecutive acronyms in class name' do
+    let(:cop_config) do
+      super().merge('ExpectMatchingDefinition' => true, 'AllowedAcronyms' => %w[FOO BAR])
+    end
+
+    it 'does not register an offense when all acronyms are uppercased' do
+      expect_no_offenses(<<~RUBY, '/lib/my_foo_bar.rb')
+        class MyFOOBAR
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when only the first acronym is uppercased' do
+      expect_no_offenses(<<~RUBY, '/lib/my_foo_bar.rb')
+        class MyFOOBar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when only the last acronym is uppercased' do
+      expect_no_offenses(<<~RUBY, '/lib/my_foo_bar.rb')
+        class MyFooBAR
+        end
+      RUBY
+    end
+  end
+
   context 'with dotfiles' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY, '.pryrc')


### PR DESCRIPTION
Fix #11956

Naming/FileName flagged class MyFOOBAR in my_foo_bar.rb even with AllowedAcronyms: [FOO, BAR] because match_acronym? only tried one acronym substitution at a time. 

This PR fixes it by reducing all allowed acronyms cumulatively before comparing.