### PR TITLE
Change `Lint/DuplicateMethods` to detect duplicates across files

### DIFF
--- a/changelog/change_duplicate_methods_to_check_across_files.md
+++ b/changelog/change_duplicate_methods_to_check_across_files.md
@@ -1,0 +1,1 @@
+* [#15317](https://github.com/rubocop/rubocop/pull/15317): Enable `Lint/DuplicateMethods` to use the project index for cross-file duplicate method detection. ([@tejasbubane][])

--- a/lib/rubocop/cop/lint/constant_reassignment.rb
+++ b/lib/rubocop/cop/lint/constant_reassignment.rb
@@ -215,15 +215,6 @@ module RuboCop
 
           add_offense(node, message: msg)
         end
-
-        def prior_definition_in_other_file(declaration)
-          current = processed_source.file_path
-
-          declaration.definitions.find do |definition|
-            other = definition.location.to_file_path
-            !File.identical?(other, current)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -119,6 +119,8 @@ module RuboCop
       #   end
       #
       class DuplicateMethods < Base # rubocop:disable Metrics/ClassLength
+        include ProjectIndexHelp
+
         MSG = 'Method `%<method>s` is defined at both %<defined>s and %<current>s.'
         RESTRICT_ON_SEND = %i[alias_method attr_reader attr_writer attr_accessor attr
                               delegate def_delegator def_instance_delegator def_delegators
@@ -341,6 +343,7 @@ module RuboCop
         end
 
         # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
         def found_method(node, method_name, scope_id: nil)
           key = method_key(node, method_name)
           key = "#{key}@#{scope_id}" if scope_id
@@ -358,9 +361,11 @@ module RuboCop
             add_offense(location(node), message: message)
           else
             @definitions[key] = node
+            check_cross_file_duplicate(node, method_name, key)
           end
         end
         # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
 
         def method_key(node, method_name)
           if (ancestor_def = node.each_ancestor(:any_def).first)
@@ -438,6 +443,49 @@ module RuboCop
           range = node.source_range
           path = smart_path(range.source_buffer.name)
           "#{path}:#{range.line}"
+        end
+
+        def check_cross_file_duplicate(node, method_name, key)
+          return unless project_index
+
+          declaration = find_declaration(method_name, key)
+          return unless declaration
+
+          prior = prior_definition_in_other_file(declaration)
+          return unless prior
+
+          # Rubydex method names for attr_reader and attr_writer are same
+          # Explicit check to not consider attr_reader and attr_writer as duplicates
+          return if prior.is_a?(Rubydex::AttrWriterDefinition) && !method_name.end_with?('=')
+
+          add_cross_file_offense(node, method_name, prior)
+        end
+
+        def find_declaration(method_name, key)
+          project_index.declarations.find do |candidate|
+            candidate.respond_to?(:name) &&
+              candidate.name.gsub('()', '') == method_name &&
+              same_owner_scope?(candidate, key)
+          end
+        end
+
+        def same_owner_scope?(declaration, key)
+          owner_name = key.sub(/[.#][^.#+]+\z/, '')
+          return true if owner_name == key
+
+          declaration.owner&.name == owner_name
+        end
+
+        def add_cross_file_offense(node, method_name, prior)
+          add_offense(
+            location(node),
+            message: format(
+              MSG,
+              method: method_name,
+              defined: prior.location,
+              current: source_location(node)
+            )
+          )
         end
       end
     end

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -25,6 +25,15 @@ module RuboCop
         )
       end
 
+      def prior_definition_in_other_file(declaration)
+        current = processed_source.file_path
+
+        declaration.definitions.find do |definition|
+          other = definition.location.to_file_path
+          !File.identical?(other, current)
+        end
+      end
+
       private
 
       def project_index_signature

--- a/spec/fixtures/cross_file_duplicate_methods/a.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/a.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class A
+  def some_method
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/b.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/b.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class A
+  def some_method
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/c.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/c.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class B
+  attr_reader :some_method
+end

--- a/spec/fixtures/cross_file_duplicate_methods/d.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/d.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class B
+  attr_writer :some_method
+end

--- a/spec/fixtures/cross_file_duplicate_methods/e.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/e.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class C
+  def some_method
+  end
+end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -816,6 +816,51 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         end
       RUBY
     end
+
+    context 'cross-file detection', :project_index do
+      let(:fixture_dir) do
+        File.expand_path('../../../fixtures/cross_file_duplicate_methods', __dir__)
+      end
+
+      def stage_fixture(tmpdir)
+        %w[a.rb b.rb c.rb d.rb e.rb].each do |name|
+          FileUtils.cp(File.join(fixture_dir, name), File.join(tmpdir, name))
+        end
+      end
+
+      def cop_offenses(tmpdir)
+        offenses = project_index_offenses(tmpdir)
+
+        offenses.select { |offense| offense['cop_name'] == 'Lint/DuplicateMethods' }
+      end
+
+      def run_with_config(body)
+        Dir.mktmpdir do |tmpdir|
+          stage_fixture(tmpdir)
+          write_rubocop_config(tmpdir, body)
+          cop_offenses(tmpdir)
+        end
+      end
+
+      it 'reports a duplicate method defined in another file when UseProjectIndex is enabled' do
+        offenses = run_with_config(
+          'AllCops' => { 'UseProjectIndex' => true },
+          'Lint/DuplicateMethods' => { 'Enabled' => true }
+        )
+
+        expect(offenses).not_to be_empty
+        expect(offenses.first['message']).to include('a.rb:4', 'b.rb:4')
+      end
+
+      it 'does not report a cross-file duplicate when UseProjectIndex is disabled' do
+        offenses = run_with_config(
+          'AllCops' => { 'UseProjectIndex' => false },
+          'Lint/DuplicateMethods' => { 'Enabled' => true }
+        )
+
+        expect(offenses).to be_empty
+      end
+    end
   end
 
   it_behaves_like('in scope', 'class', 'class A')


### PR DESCRIPTION
Use the new `rubydex` index to detect cases where class is opened in another file and duplicate methods are added there.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/