### PR TITLE
Fix an incorrect autocorrect for `Style/DataInheritance` with a brace block

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_data_inheritance_with_a_brace_block_20260625132145.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_data_inheritance_with_a_brace_block_20260625132145.md
@@ -1,0 +1,1 @@
+* [#15319](https://github.com/rubocop/rubocop/pull/15319): Fix an incorrect autocorrect for `Style/DataInheritance` with a brace block. ([@bbatsov][])

--- a/lib/rubocop/cop/style/data_inheritance.rb
+++ b/lib/rubocop/cop/style/data_inheritance.rb
@@ -61,6 +61,10 @@ module RuboCop
 
         def correct_parent(parent, corrector)
           if parent.block_type?
+            # Convert a brace block to `do`, so the class's own `end` closes it
+            # once the closing delimiter is removed; otherwise a dangling `{` is
+            # left behind, producing invalid Ruby.
+            corrector.replace(parent.loc.begin, 'do') if parent.braces?
             corrector.remove(range_with_surrounding_space(parent.loc.end, newlines: false))
           elsif (class_node = parent.parent).body.nil?
             corrector.remove(range_for_empty_class_body(class_node, parent))

--- a/spec/rubocop/cop/style/data_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/data_inheritance_spec.rb
@@ -45,6 +45,32 @@ RSpec.describe RuboCop::Cop::Style::DataInheritance, :config do
       RUBY
     end
 
+    it 'registers an offense when extending instance of `Data.define` with an empty brace block' do
+      expect_offense(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name) { }
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Data.define`. Use a block to customize the class.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Person = Data.define(:first_name, :last_name) do
+        end
+      RUBY
+    end
+
+    it 'registers an offense when extending instance of `Data.define` with a brace block' do
+      expect_offense(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name) { def age = 42 }
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Data.define`. Use a block to customize the class.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Person = Data.define(:first_name, :last_name) do def age = 42
+        end
+      RUBY
+    end
+
     it 'registers an offense when extending instance of `Data.define` without `do` ... `end` and class body is empty' do
       expect_offense(<<~RUBY)
         class Person < Data.define(:first_name, :last_name)


### PR DESCRIPTION
When the `Data.define` parent of a class used a brace block, e.g. `class Person < Data.define(:first_name) { }`, the autocorrect removed only the closing `}` and left a dangling `{` behind, producing invalid Ruby. It now converts the block's opening delimiter to `do` so the class's own `end` closes it, matching the existing `do`/`end` handling.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/