### PR TITLE
Fix comment duplication for `Style/AccessorGrouping` with a single-line trailing comment

### DIFF
--- a/changelog/fix_comment_duplication_for_style_accessor_grouping_with_a_single_line_trailing_20260625130919.md
+++ b/changelog/fix_comment_duplication_for_style_accessor_grouping_with_a_single_line_trailing_20260625130919.md
@@ -1,0 +1,1 @@
+* [#14370](https://github.com/rubocop/rubocop/issues/14370): Fix comment duplication for `Style/AccessorGrouping` with a single-line trailing comment. ([@bbatsov][])

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -203,12 +203,22 @@ module RuboCop
         end
 
         def range_with_trailing_argument_comment(node)
-          comment = processed_source.ast_with_comments[node.last_argument].last
+          comment = trailing_argument_comment(node)
           if comment
             add_range(node.source_range, comment.source_range)
           else
             node
           end
+        end
+
+        # For a single-line declaration the parser associates the trailing
+        # comment with the first argument, not `last_argument`, so look through
+        # all arguments for a comment that trails the whole node.
+        def trailing_argument_comment(node)
+          comments = node.arguments.filter_map do |argument|
+            processed_source.ast_with_comments[argument].last
+          end
+          comments.find { |comment| comment.source_range.begin_pos >= node.source_range.end_pos }
         end
       end
     end

--- a/spec/rubocop/cop/style/accessor_grouping_spec.rb
+++ b/spec/rubocop/cop/style/accessor_grouping_spec.rb
@@ -555,5 +555,24 @@ RSpec.describe RuboCop::Cop::Style::AccessorGrouping, :config do
         RUBY
       end
     end
+
+    context 'when there is a trailing comment on a single-line declaration' do
+      it 'registers an offense and does not duplicate the comment' do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_reader :bar, :baz # trailing comment
+            ^^^^^^^^^^^^^^^^^^^^^^ Use one attribute per `attr_reader`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class Foo
+            # trailing comment
+          attr_reader :bar
+            attr_reader :baz
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
A follow-up to the fix for #14370. That fix consumed a trailing comment only when it was associated with the declaration's `last_argument`. For a single-line declaration like `attr_reader :bar, :baz # comment`, the parser associates the trailing comment with the *first* argument, so the range wasn't extended, the comment was left behind, and the `separated` autocorrect duplicated it. The trailing comment is now located by looking through all arguments for the one that trails the whole node.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/