### PR TITLE
Fix an incorrect autocorrect for `Style/EmptyClassDefinition` with a namespaced constant

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_class_definition_with_a_namespaced_20260625150548.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_class_definition_with_a_namespaced_20260625150548.md
@@ -1,0 +1,1 @@
+* [#15322](https://github.com/rubocop/rubocop/pull/15322): Fix an incorrect autocorrect for `Style/EmptyClassDefinition` with a namespaced constant. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_class_definition.rb
+++ b/lib/rubocop/cop/style/empty_class_definition.rb
@@ -101,10 +101,17 @@ module RuboCop
 
         def autocorrect_class_new(corrector, node, class_new_node)
           indent = ' ' * node.loc.column
-          class_name = node.name
+          class_name = constant_name(node)
           parent_class_name = class_new_node.first_argument.source
 
           corrector.replace(node, "class #{class_name} < #{parent_class_name}\n#{indent}end")
+        end
+
+        # Preserve any namespace on the assigned constant (e.g. `Foo::Bar`),
+        # which `node.name` drops.
+        def constant_name(node)
+          namespace = node.namespace
+          namespace ? "#{namespace.source}::#{node.name}" : node.name
         end
 
         def autocorrect_class_definition(corrector, node)

--- a/spec/rubocop/cop/style/empty_class_definition_spec.rb
+++ b/spec/rubocop/cop/style/empty_class_definition_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe RuboCop::Cop::Style::EmptyClassDefinition, :config do
       RUBY
     end
 
+    it 'registers an offense for Class.new assignment to a namespaced constant' do
+      expect_offense(<<~RUBY)
+        Foo::BarError = Class.new(StandardError)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `class` keyword instead of `Class.new` to define an empty class.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo::BarError < StandardError
+        end
+      RUBY
+    end
+
     it 'does not register an offense for Class.new assignment to constant without parent class' do
       expect_no_offenses(<<~RUBY)
         MyClass = Class.new


### PR DESCRIPTION
With the default `class_keyword` style, `Foo::Bar = Class.new(StandardError)` was autocorrected to `class Bar < StandardError; end`, silently dropping the `Foo::` namespace and defining a different constant. The autocorrect built the name from `node.name` (just `:Bar`); it now preserves the full constant path.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.