### PR TITLE
Fix two incorrect autocorrects for `Style/EmptyCaseCondition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_as_a_yield___super_20260625150823.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_as_a_yield___super_20260625150823.md
@@ -1,1 +1,1 @@
-* [#x](https://github.com/rubocop/rubocop/pull/x): Fix an incorrect autocorrect for `Style/EmptyCaseCondition` as a `yield`/`super` argument. ([@bbatsov][])
+* [#15323](https://github.com/rubocop/rubocop/pull/15323): Fix an incorrect autocorrect for `Style/EmptyCaseCondition` as a `yield`/`super` argument. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_as_a_yield___super_20260625150823.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_as_a_yield___super_20260625150823.md
@@ -1,0 +1,1 @@
+* [#x](https://github.com/rubocop/rubocop/pull/x): Fix an incorrect autocorrect for `Style/EmptyCaseCondition` as a `yield`/`super` argument. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_with_low_precedence_20260625151003.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_case_condition_with_low_precedence_20260625151003.md
@@ -1,0 +1,1 @@
+* [#15323](https://github.com/rubocop/rubocop/pull/15323): Fix an incorrect autocorrect for `Style/EmptyCaseCondition` with low-precedence `when` values. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -40,7 +40,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Do not use empty `case` condition, instead use an `if` expression.'
-        NOT_SUPPORTED_PARENT_TYPES = %i[return break next send csend].freeze
+        NOT_SUPPORTED_PARENT_TYPES = %i[return break next send csend yield super].freeze
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_case(case_node)

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -90,7 +90,17 @@ module RuboCop
             range = range_between(conditions.first.source_range.begin_pos,
                                   conditions.last.source_range.end_pos)
 
-            corrector.replace(range, conditions.map(&:source).join(' || '))
+            corrector.replace(range, conditions.map { |c| parenthesize_condition(c) }.join(' || '))
+          end
+        end
+
+        # A condition that binds looser than `||` (e.g. a ternary, range, or
+        # assignment) must be parenthesized so the joined `||` keeps its meaning.
+        def parenthesize_condition(condition)
+          if condition.assignment? || condition.type?(:if, :and, :or, :range)
+            "(#{condition.source})"
+          else
+            condition.source
           end
         end
 

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -289,6 +289,36 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
 
+    context 'when used as an argument of `yield`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            yield case
+                  when true
+                    1
+                  else
+                    2
+                  end
+          end
+        RUBY
+      end
+    end
+
+    context 'when used as an argument of `super`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+            super case
+                  when true
+                    1
+                  else
+                    2
+                  end
+          end
+        RUBY
+      end
+    end
+
     context 'when using `return` in `when` clause and assigning the return value of `case`' do
       it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -237,6 +237,24 @@ RSpec.describe RuboCop::Cop::Style::EmptyCaseCondition, :config do
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
 
+    context 'with comma-delimited alternatives that bind looser than `||`' do
+      it 'parenthesizes them so the `||` keeps its meaning' do
+        expect_offense(<<~RUBY)
+          case
+          ^^^^ Do not use empty `case` condition, instead use an `if` expression.
+          when x ? a : b, c
+            something
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if (x ? a : b) || c
+            something
+          end
+        RUBY
+      end
+    end
+
     context 'when used as an argument of a method without comment' do
       let(:source) do
         <<~RUBY


### PR DESCRIPTION
Two independent autocorrect bugs in the same cop, one commit each:

1. When the empty `case` was an argument to `yield` or `super`, the `case` -> `if` rewrite produced invalid Ruby (`yield if cond ... end`). `yield`/`super` parents are now skipped, like `send`/`csend`.
2. Comma-delimited `when` values were joined with `||` from their raw source, so a value binding looser than `||` (a ternary, range, or assignment) changed meaning - `when x ? a : b, c` became `if x ? a : b || c`. Such values are now parenthesized.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.