### PR TITLE
Fix a false positive for `Style/DirEmpty` with a block

### DIFF
--- a/changelog/fix_a_false_positive_for_style_dir_empty_with_a_block_20260625151223.md
+++ b/changelog/fix_a_false_positive_for_style_dir_empty_with_a_block_20260625151223.md
@@ -1,0 +1,1 @@
+* [#15324](https://github.com/rubocop/rubocop/pull/15324): Fix a false positive for `Style/DirEmpty` with a block. ([@bbatsov][])

--- a/lib/rubocop/cop/style/dir_empty.rb
+++ b/lib/rubocop/cop/style/dir_empty.rb
@@ -35,6 +35,10 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          # A trailing block (e.g. `Dir.each_child(path).none? { ... }`) changes
+          # the meaning and is not equivalent to `Dir.empty?`.
+          return if node.block_literal?
+
           offensive?(node) do |const_node, arg_node|
             replacement = "#{bang(node)}#{const_node.source}.empty?(#{arg_node.source})"
             add_offense(node, message: format(MSG, replacement: replacement)) do |corrector|

--- a/spec/rubocop/cop/style/dir_empty_spec.rb
+++ b/spec/rubocop/cop/style/dir_empty_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe RuboCop::Cop::Style::DirEmpty, :config do
       RUBY
     end
 
+    it 'does not register an offense for `Dir.each_child.none?` with a block' do
+      expect_no_offenses(<<~RUBY)
+        Dir.each_child('path/to/dir').none? { |f| f.start_with?('.') }
+      RUBY
+    end
+
     it 'does not register an offense for `Dir.empty?`' do
       expect_no_offenses('Dir.empty?("path/to/dir")')
     end


### PR DESCRIPTION
`Dir.each_child(path).none? { |f| ... }` was flagged and autocorrected to `Dir.empty?(path) { |f| ... }`, silently dropping the block. `none?` with a predicate block and `Dir.empty?` are not equivalent, so a call carrying a block is no longer treated as an offense.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.