### PR TITLE
Fix `Style/DocumentationMethod` ignoring `AllowedMethods` for inline modifier defs

### DIFF
--- a/changelog/fix_style_documentation_method_ignoring_allowed_methods_for_inline_modifier_defs_20260625151421.md
+++ b/changelog/fix_style_documentation_method_ignoring_allowed_methods_for_inline_modifier_defs_20260625151421.md
@@ -1,0 +1,1 @@
+* [#15325](https://github.com/rubocop/rubocop/pull/15325): Fix `Style/DocumentationMethod` ignoring `AllowedMethods` for inline modifier defs. ([@bbatsov][])

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -140,7 +140,11 @@ module RuboCop
         end
 
         def method_allowed?(node)
-          allowed_methods.include?(node.method_name)
+          # For a modifier form like `module_function def foo; end`, `node` is the
+          # `module_function`/`ruby2_keywords` send; the real method name is on its
+          # `def`/`defs` argument, not the modifier itself.
+          method_name = node.send_type? ? node.first_argument.method_name : node.method_name
+          allowed_methods.include?(method_name)
         end
 
         def allowed_methods

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -1006,6 +1006,39 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
           RUBY
         end
       end
+
+      describe 'when AllowedMethods is configured for an inline modifier def' do
+        before do
+          config['Style/DocumentationMethod'] =
+            { 'AllowedMethods' => ['bar'], 'RequireForNonPublicMethods' => true }
+        end
+
+        it 'ignores an allowed `module_function` inline def' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              module_function def bar; end
+            end
+          RUBY
+        end
+
+        it 'ignores an allowed `ruby2_keywords` inline def' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              ruby2_keywords def bar; end
+            end
+          RUBY
+        end
+
+        it 'still registers an offense for a non-allowed `module_function` inline def' do
+          expect_offense(<<~RUBY)
+            module Foo
+              module_function def baz
+              ^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For a modifier form like `module_function def bar; end` (or `ruby2_keywords def bar; end`), `AllowedMethods` was silently ignored: the allow-list check read the modifier's name (`module_function`) rather than the actual method name. It now resolves the real name from the modifier's `def`/`defs` argument.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.