### PR TITLE
Fix a false positive for `Style/EmptyLiteral` with numbered and `it` block parameters

### DIFF
--- a/changelog/fix_a_false_positive_for_style_empty_literal_with_numbered_and_it_block_20260625161320.md
+++ b/changelog/fix_a_false_positive_for_style_empty_literal_with_numbered_and_it_block_20260625161320.md
@@ -1,0 +1,1 @@
+* [#15326](https://github.com/rubocop/rubocop/pull/15326): Fix a false positive for `Style/EmptyLiteral` with numbered and `it` block parameters. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -44,13 +44,18 @@ module RuboCop
         def_node_matcher :str_node, '(send (const {nil? cbase} :String) :new)'
 
         # @!method array_with_block(node)
-        def_node_matcher :array_with_block, '(block (send (const {nil? cbase} :Array) :new) args _)'
+        def_node_matcher :array_with_block, <<~PATTERN
+          {
+            (block (send (const {nil? cbase} :Array) :new) args _)
+            ({numblock itblock} (send (const {nil? cbase} :Array) :new) ...)
+          }
+        PATTERN
 
         # @!method hash_with_block(node)
         def_node_matcher :hash_with_block, <<~PATTERN
           {
             (block (send (const {nil? cbase} :Hash) :new) args _)
-            (numblock (send (const {nil? cbase} :Hash) :new) ...)
+            ({numblock itblock} (send (const {nil? cbase} :Hash) :new) ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -118,6 +118,20 @@ RSpec.describe RuboCop::Cop::Style::EmptyLiteral, :config do
       it 'does not register an offense for ::Hash.new { _1[_2] = [] }' do
         expect_no_offenses('test = ::Hash.new { _1[_2] = [] }')
       end
+
+      it 'does not register an offense for Array.new with a numbered-parameter block' do
+        expect_no_offenses('test = Array.new { _1 }')
+      end
+    end
+
+    context 'Ruby 3.4', :ruby34 do
+      it 'does not register an offense for Array.new with an `it`-block' do
+        expect_no_offenses('test = Array.new { it }')
+      end
+
+      it 'does not register an offense for Hash.new with an `it`-block' do
+        expect_no_offenses('test = Hash.new { it }')
+      end
     end
 
     it 'autocorrects Hash.new in block' do


### PR DESCRIPTION
`Array.new { _1 }`, `Array.new { it }`, and `Hash.new { it }` were flagged and autocorrected to `[] { ... }` / `{} { ... }`, which is invalid Ruby. The `Array` matcher didn't cover numbered-parameter or `it`-parameter blocks, and the `Hash` matcher missed `it`-blocks. All block forms are now handled.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.