### PR TITLE
Fix an incorrect autocorrect for `Style/HashSyntax` with a multi-pair braceless `return`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax_with_a_multi_pair_braceless_20260625161458.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_syntax_with_a_multi_pair_braceless_20260625161458.md
@@ -1,0 +1,1 @@
+* [#15327](https://github.com/rubocop/rubocop/pull/15327): Fix an incorrect autocorrect for `Style/HashSyntax` with a multi-pair braceless `return`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -263,6 +263,8 @@ module RuboCop
 
           hash_node = pair_node.parent
           return unless hash_node.parent&.return_type? && !hash_node.braces?
+          # This runs once per pair, but the hash must only be wrapped once.
+          return unless pair_node.equal?(hash_node.pairs.first)
 
           corrector.wrap(hash_node, '{', '}')
         end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -207,6 +207,18 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
             return {key: value}
           RUBY
         end
+
+        it 'registers offenses and wraps a multi-pair braceless return only once' do
+          expect_offense(<<~RUBY)
+            return :a => 1, :b => 2
+                   ^^^^^ Use the new Ruby 1.9 hash syntax.
+                            ^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            return {a: 1, b: 2}
+          RUBY
+        end
       end
 
       it 'registers an offense for implicit `call` method' do


### PR DESCRIPTION
A braceless hash returned with `return` gets wrapped in braces during autocorrect, but the wrapping ran once per pair, so `return :a => 1, :b => 2` became `return {{a: 1, b: 2}}` (a SyntaxError). The hash is now wrapped exactly once.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.
