### PR TITLE
Fix an incorrect autocorrect for `Style/HashConversion` with a splat argument

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_conversion_with_a_splat_argument_20260625161807.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_conversion_with_a_splat_argument_20260625161807.md
@@ -1,0 +1,1 @@
+* [#15328](https://github.com/rubocop/rubocop/pull/15328): Fix a false positive for `Style/HashConversion` with a splat argument, which previously produced an invalid hash literal. ([@bbatsov][])

--- a/lib/rubocop/cop/style/hash_conversion.rb
+++ b/lib/rubocop/cop/style/hash_conversion.rb
@@ -121,16 +121,24 @@ module RuboCop
         end
 
         def multi_argument(node)
+          # A splat argument can expand to any number of elements, so the pairs
+          # can't be built statically and there is no literal hash to suggest.
+          return if node.arguments.any?(&:splat_type?)
+
           if node.arguments.count.odd?
             add_offense(node, message: MSG_LITERAL_MULTI_ARG)
           else
-            add_offense(node, message: MSG_LITERAL_MULTI_ARG) do |corrector|
-              corrector.replace(node, args_to_hash(node.arguments))
+            correct_multi_argument(node)
+          end
+        end
 
-              parent = node.parent
-              if parent&.send_type? && !parent.method?(:to_h) && !parent.parenthesized?
-                add_parentheses(parent, corrector)
-              end
+        def correct_multi_argument(node)
+          add_offense(node, message: MSG_LITERAL_MULTI_ARG) do |corrector|
+            corrector.replace(node, args_to_hash(node.arguments))
+
+            parent = node.parent
+            if parent&.send_type? && !parent.method?(:to_h) && !parent.parenthesized?
+              add_parentheses(parent, corrector)
             end
           end
         end

--- a/spec/rubocop/cop/style/hash_conversion_spec.rb
+++ b/spec/rubocop/cop/style/hash_conversion_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe RuboCop::Cop::Style::HashConversion, :config do
     RUBY
   end
 
+  it 'does not register an offense for a splat argument' do
+    # A splat can expand to any number of elements, so no literal hash can be built.
+    expect_no_offenses(<<~RUBY)
+      Hash[*ary, x]
+    RUBY
+  end
+
   it 'reports different offense for hash argument Hash[]' do
     expect_offense(<<~RUBY)
       Hash[a: b, c: d]


### PR DESCRIPTION
`Hash[*ary, x]` was autocorrected to `{*ary => x}`, which is a SyntaxError. A splat can expand to any number of elements, so the pairs can't be built statically. Such calls now register the offense without an (impossible) correction, matching the existing odd-argument behavior.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.
