### PR TITLE
Fix an incorrect autocorrect for `Style/ExactRegexpMatch` with a single quote

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_exact_regexp_match_with_a_single_quote_20260625162112.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_exact_regexp_match_with_a_single_quote_20260625162112.md
@@ -1,0 +1,1 @@
+* [#15329](https://github.com/rubocop/rubocop/pull/15329): Fix an incorrect autocorrect for `Style/ExactRegexpMatch` with a single quote. ([@bbatsov][])

--- a/lib/rubocop/cop/style/exact_regexp_match.rb
+++ b/lib/rubocop/cop/style/exact_regexp_match.rb
@@ -43,7 +43,8 @@ module RuboCop
           return unless (parsed_regexp = parse_regexp(regexp))
           return unless exact_match_pattern?(parsed_regexp)
 
-          prefer = "#{receiver.source} #{new_method(node)} '#{parsed_regexp[1].text}'"
+          string = escape_single_quotes(parsed_regexp[1].text)
+          prefer = "#{receiver.source} #{new_method(node)} '#{string}'"
 
           add_offense(node, message: format(MSG, prefer: prefer)) do |corrector|
             corrector.replace(node, prefer)
@@ -52,6 +53,12 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        # Escape characters that are special inside a single-quoted string so the
+        # generated literal (e.g. for `/\Afoo'bar\z/`) stays valid Ruby.
+        def escape_single_quotes(text)
+          text.gsub(/['\\]/) { |char| "\\#{char}" }
+        end
 
         def exact_match_pattern?(parsed_regexp)
           tokens = parsed_regexp.map(&:token)

--- a/spec/rubocop/cop/style/exact_regexp_match_spec.rb
+++ b/spec/rubocop/cop/style/exact_regexp_match_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::ExactRegexpMatch, :config do
     RUBY
   end
 
+  it 'escapes single quotes in the corrected string literal' do
+    expect_offense(<<~'RUBY')
+      string =~ /\Afoo'bar\z/
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use `string == 'foo\'bar'`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      string == 'foo\'bar'
+    RUBY
+  end
+
   it 'registers an offense when using `string === /\Astring\z/`' do
     expect_offense(<<~'RUBY')
       string === /\Astring\z/


### PR DESCRIPTION
`string =~ /\Afoo'bar\z/` was autocorrected to `string == 'foo'bar'`, which is a SyntaxError. Single quotes and backslashes in the matched literal are now escaped in the generated single-quoted string.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.
