### PR TITLE
Fix a crash for `Style/EmptyStringInsideInterpolation` with a modifier conditional

### DIFF
--- a/changelog/fix_a_crash_for_style_empty_string_inside_interpolation_with_a_modifier_20260625162358.md
+++ b/changelog/fix_a_crash_for_style_empty_string_inside_interpolation_with_a_modifier_20260625162358.md
@@ -1,0 +1,1 @@
+* [#15330](https://github.com/rubocop/rubocop/pull/15330): Fix a crash for `Style/EmptyStringInsideInterpolation` with a modifier conditional. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
+++ b/lib/rubocop/cop/style/empty_string_inside_interpolation.rb
@@ -45,35 +45,45 @@ module RuboCop
         MSG_TRAILING_CONDITIONAL = 'Do not use trailing conditionals in string interpolation.'
         MSG_TERNARY = 'Do not return empty strings in string interpolation.'
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_interpolation(node)
           node.each_child_node(:if) do |child_node|
             if style == :trailing_conditional
-              if empty_if_outcome?(child_node)
-                ternary_style_autocorrect(child_node, child_node.else_branch.source, 'unless')
-              end
-
-              if empty_else_outcome?(child_node)
-                ternary_style_autocorrect(child_node, child_node.if_branch.source, 'if')
-              end
+              trailing_conditional_correction(child_node)
             elsif style == :ternary
-              next unless child_node.modifier_form?
-
-              ternary_component = if child_node.unless?
-                                    "'' : #{child_node.if_branch.source}"
-                                  else
-                                    "#{child_node.if_branch.source} : ''"
-                                  end
-
-              add_offense(node, message: MSG_TRAILING_CONDITIONAL) do |corrector|
-                corrector.replace(node, "\#{#{child_node.condition.source} ? #{ternary_component}}")
-              end
+              ternary_correction(node, child_node)
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         private
+
+        def trailing_conditional_correction(child_node)
+          # A modifier `if`/`unless` is already a trailing conditional and has
+          # no `else` branch, so the ternary-to-trailing rewrite does not apply.
+          return if child_node.modifier_form?
+
+          if empty_if_outcome?(child_node)
+            ternary_style_autocorrect(child_node, child_node.else_branch.source, 'unless')
+          end
+
+          return unless empty_else_outcome?(child_node)
+
+          ternary_style_autocorrect(child_node, child_node.if_branch.source, 'if')
+        end
+
+        def ternary_correction(node, child_node)
+          return unless child_node.modifier_form?
+
+          ternary_component = if child_node.unless?
+                                "'' : #{child_node.if_branch.source}"
+                              else
+                                "#{child_node.if_branch.source} : ''"
+                              end
+
+          add_offense(node, message: MSG_TRAILING_CONDITIONAL) do |corrector|
+            corrector.replace(node, "\#{#{child_node.condition.source} ? #{ternary_component}}")
+          end
+        end
 
         def empty_if_outcome?(node)
           empty_branch_outcome?(node.if_branch)

--- a/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/empty_string_inside_interpolation_spec.rb
@@ -83,6 +83,18 @@ RSpec.describe RuboCop::Cop::Style::EmptyStringInsideInterpolation, :config do
           "#{'foo' if condition}"
         RUBY
       end
+
+      it 'does not register an offense (or crash) for a trailing if with an empty string' do
+        expect_no_offenses(<<~'RUBY')
+          "#{'' if condition}"
+        RUBY
+      end
+
+      it 'does not register an offense (or crash) for a trailing unless with an empty string' do
+        expect_no_offenses(<<~'RUBY')
+          "#{'' unless condition}"
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
With `EnforcedStyle: trailing_conditional`, an empty string in a modifier `if`/`unless` (e.g. `"#{'' if condition}"`) crashed with a `NoMethodError` because the autocorrect read `else_branch.source` on a branch that doesn't exist. A modifier conditional is already a trailing conditional, so it's now skipped.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.
