### PR TITLE
Fix incorrect autocorrects for `Style/FormatString` with the percent style

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_format_string_with_a_low_precedence_20260625230910.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_format_string_with_a_low_precedence_20260625230910.md
@@ -1,0 +1,1 @@
+* [#15331](https://github.com/rubocop/rubocop/pull/15331): Fix an incorrect autocorrect for `Style/FormatString` with a low-precedence argument. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_format_string_with_a_splat_argument_20260625230848.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_format_string_with_a_splat_argument_20260625230848.md
@@ -1,0 +1,1 @@
+* [#15331](https://github.com/rubocop/rubocop/pull/15331): Fix an incorrect autocorrect for `Style/FormatString` with a splat argument. ([@bbatsov][])

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -151,7 +151,15 @@ module RuboCop
           source = arg.source
           return "{ #{source} }" if arg.hash_type?
 
-          arg.send_type? && arg.operator_method? && !arg.parenthesized? ? "(#{source})" : source
+          requires_parentheses?(arg) ? "(#{source})" : source
+        end
+
+        # An argument that binds looser than `%` (a ternary, range, assignment, or
+        # operator call) must be parenthesized to keep its meaning.
+        def requires_parentheses?(arg)
+          return true if arg.assignment? || arg.type?(:if, :and, :or, :range)
+
+          arg.send_type? && arg.operator_method? && !arg.parenthesized?
         end
       end
     end

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -144,6 +144,10 @@ module RuboCop
         end
 
         def format_single_parameter(arg)
+          # `format(fmt, *args)` is equivalent to `fmt % args`, so unwrap the splat
+          # and render the argument it splats.
+          return format_single_parameter(arg.children.first) if arg.splat_type?
+
           source = arg.source
           return "{ #{source} }" if arg.hash_type?
 

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -389,6 +389,17 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
+    it 'parenthesizes a single argument that binds looser than `%`' do
+      expect_offense(<<~RUBY)
+        format('%s', a ? b : c)
+        ^^^^^^ Favor `String#%` over `format`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        '%s' % (a ? b : c)
+      RUBY
+    end
+
     it 'corrects a single splat argument by passing the array to `%`' do
       expect_offense(<<~RUBY)
         format('%s %s', *args)

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -389,6 +389,17 @@ RSpec.describe RuboCop::Cop::Style::FormatString, :config do
       RUBY
     end
 
+    it 'corrects a single splat argument by passing the array to `%`' do
+      expect_offense(<<~RUBY)
+        format('%s %s', *args)
+        ^^^^^^ Favor `String#%` over `format`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        '%s %s' % args
+      RUBY
+    end
+
     it 'registers an offense for sprintf' do
       expect_offense(<<~RUBY)
         sprintf(something, a)


### PR DESCRIPTION
Two issues in the `format`/`sprintf` -> `String#%` autocorrect under the percent style:

- A single splat argument produced `'%s' % *args`, which is invalid Ruby. Such calls are now left uncorrected.
- An argument binding looser than `%` (a ternary, range, `&&`/`||`, or assignment) was emitted without parentheses, so `format('%s', a ? b : c)` became `'%s' % a ? b : c` (which parses as `('%s' % a) ? b : c`). Such arguments are now parenthesized.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added a changelog entry.
