### PR TITLE
Fix an incorrect autocorrect for `Style/EvenOdd`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_even_odd_20260625225154.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_even_odd_20260625225154.md
@@ -1,0 +1,1 @@
+* [#15332](https://github.com/rubocop/rubocop/pull/15332): Fix an incorrect autocorrect for `Style/EvenOdd`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -34,13 +34,23 @@ module RuboCop
           even_odd_candidate?(node) do |base_number, method, arg|
             replacement_method = replacement_method(arg, method)
             add_offense(node, message: format(MSG, method: replacement_method)) do |corrector|
-              correction = "#{base_number.source}.#{replacement_method}?"
+              correction = "#{receiver_source(base_number)}.#{replacement_method}?"
               corrector.replace(node, correction)
             end
           end
         end
 
         private
+
+        def receiver_source(node)
+          # A binary or unary operator receiver (e.g. `a * b`, `-a`) binds looser
+          # than the appended method call, so it must be wrapped in parentheses.
+          if node.send_type? && node.operator_method? && !node.method?(:[])
+            "(#{node.source})"
+          else
+            node.source
+          end
+        end
 
         def replacement_method(arg, method)
           case arg

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -111,6 +111,39 @@ RSpec.describe RuboCop::Cop::Style::EvenOdd, :config do
     RUBY
   end
 
+  it 'wraps an operator receiver in parentheses when converting a * b % 2 == 0' do
+    expect_offense(<<~RUBY)
+      a * b % 2 == 0
+      ^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a * b).even?
+    RUBY
+  end
+
+  it 'wraps a unary operator receiver in parentheses' do
+    expect_offense(<<~RUBY)
+      -a % 2 == 0
+      ^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (-a).even?
+    RUBY
+  end
+
+  it 'does not add parentheses around an index receiver' do
+    expect_offense(<<~RUBY)
+      a[0] % 2 == 0
+      ^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a[0].even?
+    RUBY
+  end
+
   it 'accepts x % 2 == 2' do
     expect_no_offenses('x % 2 == 2')
   end


### PR DESCRIPTION
`Style/EvenOdd` was autocorrecting `a * b % 2 == 0` to `a * b.even?`. Since a method call binds tighter than `*`, that parses as `a * (b.even?)`, which multiplies by a boolean and raises at runtime.

The receiver of the appended `#even?`/`#odd?` needs parentheses whenever it's an operator expression (`a * b`, `-a`, etc.). Plain method chains and indexing are left untouched.
