### PR TITLE
Fix an incorrect autocorrect for `Style/FileNull`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_file_null_20260625225754.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_file_null_20260625225754.md
@@ -1,0 +1,1 @@
+* [#15333](https://github.com/rubocop/rubocop/pull/15333): Fix an incorrect autocorrect for `Style/FileNull`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/file_null.rb
+++ b/lib/rubocop/cop/style/file_null.rb
@@ -78,10 +78,12 @@ module RuboCop
 
         def acceptable?(node)
           # Using a hardcoded null device is acceptable when inside an array or
-          # inside a hash to ensure behavior doesn't change.
+          # inside a hash to ensure behavior doesn't change. A `str` that is part of
+          # an interpolated or concatenated string (`dstr`) is not a standalone null
+          # device either, and replacing it would corrupt the surrounding string.
           return false unless node.parent
 
-          node.parent.type?(:array, :pair)
+          node.parent.type?(:array, :pair, :dstr)
         end
       end
     end

--- a/spec/rubocop/cop/style/file_null_spec.rb
+++ b/spec/rubocop/cop/style/file_null_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe RuboCop::Cop::Style::FileNull, :config do
     RUBY
   end
 
+  it 'does not register an offense for a string with interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      path = "/dev/null#{suffix}"
+    RUBY
+  end
+
+  it 'does not register an offense for adjacent string literal concatenation' do
+    expect_no_offenses(<<~RUBY)
+      path = "/dev/null" "more"
+    RUBY
+  end
+
   it 'does not register an offense for a string within an array' do
     expect_no_offenses(<<~RUBY)
       ['/dev/null', 'NUL']


### PR DESCRIPTION
`Style/FileNull` was matching the `str` part of an interpolated or concatenated string as if it were a standalone null device. So `"/dev/null#{x}"` got autocorrected to `"File::NULL#{x}"`, which is just the literal text `File::NULL` followed by the interpolation, not the constant.

Such `str` nodes (children of a `dstr`) are now treated the same as those inside arrays/hashes and left alone.
