### PR TITLE
Fix an incorrect autocorrect for `Style/For`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_for_20260625225936.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_for_20260625225936.md
@@ -1,0 +1,1 @@
+* [#15334](https://github.com/rubocop/rubocop/pull/15334): Fix an incorrect autocorrect for `Style/For`. ([@bbatsov][])

--- a/lib/rubocop/cop/correctors/each_to_for_corrector.rb
+++ b/lib/rubocop/cop/correctors/each_to_for_corrector.rb
@@ -27,7 +27,7 @@ module RuboCop
         if block_node.arguments?
           format(CORRECTION_WITH_ARGUMENTS,
                  collection: collection_node.source,
-                 variables: argument_node.children.first.source)
+                 variables: argument_node.children.map(&:source).join(', '))
         else
           format(CORRECTION_WITHOUT_ARGUMENTS, enumerable: collection_node.source)
         end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -455,6 +455,25 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
       RUBY
     end
 
+    it 'keeps all block arguments when each has multiple items' do
+      expect_offense(<<~RUBY)
+        def func
+          [[1, 2]].each do |a, b|
+          ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `for` over `each`.
+            puts a + b
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func
+          for a, b in [[1, 2]] do
+            puts a + b
+          end
+        end
+      RUBY
+    end
+
     context 'Ruby 2.7', :ruby27 do
       it 'registers an offense for each without an item and uses _ as the item' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Converting `each` to `for` (`EnforcedStyle: for`) only emitted the first block argument, so `[[1, 2]].each do |a, b|` was autocorrected to `for a in [[1, 2]] do`, silently dropping `b` and changing what `a` binds to. All block arguments are now kept, producing the equivalent `for a, b in [[1, 2]] do`.
