### PR TITLE
Fix a false positive for `Style/EnvHome`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_env_home_20260625230117.md
+++ b/changelog/fix_a_false_positive_for_style_env_home_20260625230117.md
@@ -1,0 +1,1 @@
+* [#15335](https://github.com/rubocop/rubocop/pull/15335): Fix a false positive for `Style/EnvHome`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/env_home.rb
+++ b/lib/rubocop/cop/style/env_home.rb
@@ -45,6 +45,10 @@ module RuboCop
         def on_send(node)
           return unless env_home?(node)
           return if node.arguments.count == 2 && !node.arguments[1].nil_type?
+          # `ENV.fetch('HOME') { default }` supplies a fallback, just like
+          # `ENV.fetch('HOME', default)`. `Dir.home` ignores the block, so
+          # converting would silently drop it.
+          return if node.block_node
 
           add_offense(node) do |corrector|
             corrector.replace(node, 'Dir.home')

--- a/spec/rubocop/cop/style/env_home_spec.rb
+++ b/spec/rubocop/cop/style/env_home_spec.rb
@@ -62,4 +62,10 @@ RSpec.describe RuboCop::Cop::Style::EnvHome, :config do
       ENV.fetch('HOME', default)
     RUBY
   end
+
+  it "does not register an offense when using `ENV.fetch('HOME')` with a fallback block" do
+    expect_no_offenses(<<~RUBY)
+      ENV.fetch('HOME') { default }
+    RUBY
+  end
 end


### PR DESCRIPTION
`Style/EnvHome` flagged `ENV.fetch('HOME') { default }` and autocorrected it to `Dir.home { default }`, where `Dir.home` ignores the block and the fallback is silently dropped. A fallback block is equivalent to the `ENV.fetch('HOME', default)` form the cop already leaves alone, so it's now skipped too.
