### PR TITLE
Fix an incorrect autocorrect for `Style/EmptyHeredoc`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_empty_heredoc_20260625230318.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_empty_heredoc_20260625230318.md
@@ -1,0 +1,1 @@
+* [#15336](https://github.com/rubocop/rubocop/pull/15336): Fix an incorrect autocorrect for `Style/EmptyHeredoc`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/empty_heredoc.rb
+++ b/lib/rubocop/cop/style/empty_heredoc.rb
@@ -42,6 +42,10 @@ module RuboCop
         MSG = 'Use an empty string literal instead of heredoc.'
 
         def on_heredoc(node)
+          # A backtick heredoc (`<<~`CMD``) executes a command, so it cannot be
+          # replaced with an empty string literal.
+          return if node.xstr_type?
+
           heredoc_body = node.loc.heredoc_body
 
           return unless heredoc_body.source.empty?

--- a/spec/rubocop/cop/style/empty_heredoc_spec.rb
+++ b/spec/rubocop/cop/style/empty_heredoc_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe RuboCop::Cop::Style::EmptyHeredoc, :config do
     RUBY
   end
 
+  it 'does not register an offense when using an empty backtick heredoc' do
+    expect_no_offenses(<<~RUBY)
+      foo(<<~`SH`)
+      SH
+    RUBY
+  end
+
   context 'when double-quoted string literals are preferred' do
     let(:other_cops) do
       super().merge('Style/StringLiterals' => { 'EnforcedStyle' => 'double_quotes' })


### PR DESCRIPTION
`Style/EmptyHeredoc` was autocorrecting an empty backtick heredoc (`<<~`SH`...`) to `''`. A backtick heredoc runs a command, so replacing it with an empty string literal changes behavior. These are now left alone.
