### PR TITLE
Fix an incorrect autocorrect for `Style/HashSlice`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_slice_20260625230614.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_slice_20260625230614.md
@@ -1,0 +1,1 @@
+* [#15337](https://github.com/rubocop/rubocop/pull/15337): Fix an incorrect autocorrect for `Style/HashSlice`. ([@bbatsov][])

--- a/lib/rubocop/cop/mixin/hash_subset.rb
+++ b/lib/rubocop/cop/mixin/hash_subset.rb
@@ -182,8 +182,16 @@ module RuboCop
         return ":\"#{value.source}\"" if value.dsym_type?
         return "\"#{value.source}\"" if value.dstr_type?
         return ":#{value.source}" if value.sym_type?
+        # The element of a `%w` array can contain characters that are special
+        # inside a single-quoted string (e.g. a `'`), so escape them rather than
+        # wrapping the raw source.
+        return to_single_quoted(value.value) if value.str_type?
 
         "'#{value.source}'"
+      end
+
+      def to_single_quoted(string)
+        "'#{string.gsub(/['\\]/) { |character| "\\#{character}" }}'"
       end
 
       def except_key(node)

--- a/spec/rubocop/cop/style/hash_slice_spec.rb
+++ b/spec/rubocop/cop/style/hash_slice_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe RuboCop::Cop::Style::HashSlice, :config do
         RUBY
       end
 
+      it 'registers and corrects an offense when a `%w` element contains a single quote' do
+        expect_offense(<<~'RUBY')
+          {'a' => 1}.select { |k, v| %w[a'b cd].include?(k) }
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `slice('a\'b', 'cd')` instead.
+        RUBY
+
+        expect_correction(<<~'RUBY')
+          {'a' => 1}.slice('a\'b', 'cd')
+        RUBY
+      end
+
       it 'does not register an offense when using `select` and calling `!include?` method with variable' do
         expect_no_offenses(<<~RUBY)
           array = %i[foo bar]


### PR DESCRIPTION
`Style/HashSlice` (via the shared hash-subset logic) wrapped `%w`/`%W` array elements in single quotes verbatim, so `h.select { |k, v| %w[a'b cd].include?(k) }` was autocorrected to `h.slice('a'b', 'cd')`, which is a syntax error. Element values are now escaped before quoting, and escaped-space `%w` elements (`%w[a\ b]`) are handled correctly too.
