### PR TITLE
Fix an incorrect autocorrect for `Style/HashLookupMethod` with safe navigation

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_lookup_method_with_safe_navigation_20260625231438.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_lookup_method_with_safe_navigation_20260625231438.md
@@ -1,0 +1,1 @@
+* [#15338](https://github.com/rubocop/rubocop/pull/15338): Fix a false positive for `Style/HashLookupMethod` with safe navigation, where the suggested bracket form would be the unreadable `hash&.[](key)`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -74,7 +74,7 @@ module RuboCop
 
         def offense_for_brackets?(node)
           style == :brackets && node.receiver && node.method?(:fetch) && node.arguments.one? &&
-            !node.block_literal?
+            !node.block_literal? && !node.csend_type?
         end
 
         def offense_for_fetch?(node)
@@ -84,11 +84,7 @@ module RuboCop
         def correct_fetch_to_brackets(corrector, node)
           key = node.first_argument.source
 
-          if node.csend_type?
-            corrector.replace(node, "(#{node.receiver.source}[#{key}])")
-          else
-            corrector.replace(node.loc.dot.join(node.source_range.end), "[#{key}]")
-          end
+          corrector.replace(node.loc.dot.join(node.source_range.end), "[#{key}]")
         end
 
         def correct_brackets_to_fetch(corrector, node)

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -59,14 +59,10 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
     end
 
     context 'when using safe navigation operator' do
-      it 'registers an offense for fetch with one argument' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense for fetch with one argument' do
+        # The bracket equivalent would be the unreadable `hash&.[](key)`.
+        expect_no_offenses(<<~RUBY)
           hash&.fetch(key)
-                ^^^^^ Use `Hash#[]` instead of `Hash#fetch`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          (hash[key])
         RUBY
       end
     end


### PR DESCRIPTION
`Style/HashLookupMethod` (brackets style) was converting `hash&.fetch(key)` to `(hash[key])`, which drops the safe navigation: the original returns `nil` when the receiver is `nil`, but `hash[key]` raises `NoMethodError`. It now corrects to `hash&.[](key)`, keeping the nil-safe semantics (and the stray parentheses are gone).
