### PR TITLE
Fix incorrect autocorrects for hash transform cops with a splat

### DIFF
--- a/changelog/fix_incorrect_autocorrects_for_style_hash_transform_keys_and_20260626101504.md
+++ b/changelog/fix_incorrect_autocorrects_for_style_hash_transform_keys_and_20260626101504.md
@@ -1,0 +1,1 @@
+* [#15339](https://github.com/rubocop/rubocop/pull/15339): Fix incorrect autocorrects for `Style/HashTransformKeys` and `Style/HashTransformValues` with a splat. ([@bbatsov][])

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -94,6 +94,10 @@ module RuboCop
 
         return unless captures.use_transformed_argname?
 
+        # A splat transforming expression (e.g. `[k, *v]`) can't be used as a
+        # standalone block return value, so the rewrite would produce invalid Ruby.
+        return if captures.transforming_body_expr.splat_type?
+
         message = "Prefer `#{new_method_name}` over `#{match_desc}`."
         add_offense(node, message: message) do |corrector|
           correction = prepare_correction(node)

--- a/spec/rubocop/cop/style/hash_transform_keys_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_keys_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe RuboCop::Cop::Style::HashTransformKeys, :config do
       RUBY
     end
 
+    it 'does not flag map.to_h when the key expression is a splat' do
+      expect_no_offenses('{a: 1}.map { |k, v| [*k, v] }.to_h')
+    end
+
+    it 'does not flag to_h {...} when the key expression is a splat', :ruby26 do
+      expect_no_offenses('{a: 1}.to_h { |k, v| [*k, v] }')
+    end
+
     it 'does not flag each_with_object when key transformation uses value' do
       expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[foo(v)] = v}')
     end

--- a/spec/rubocop/cop/style/hash_transform_values_spec.rb
+++ b/spec/rubocop/cop/style/hash_transform_values_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe RuboCop::Cop::Style::HashTransformValues, :config do
       RUBY
     end
 
+    it 'does not flag map.to_h when the value expression is a splat' do
+      expect_no_offenses('{a: 1}.map { |k, v| [k, *v] }.to_h')
+    end
+
+    it 'does not flag to_h {...} when the value expression is a splat', :ruby26 do
+      expect_no_offenses('{a: 1}.to_h { |k, v| [k, *v] }')
+    end
+
     it 'does not flag each_with_object when value transformation uses key' do
       expect_no_offenses('{a: 1, b: 2}.each_with_object({}) {|(k, v), h| h[k] = k.to_s}')
     end


### PR DESCRIPTION
`Style/HashTransformKeys` and `Style/HashTransformValues` produced invalid Ruby when the transforming expression was a splat. `{a: 1}.map { |k, v| [k, *v] }.to_h` autocorrected to `{a: 1}.transform_values { |v| *v }`, where a bare splat isn't a valid standalone block return value (`unexpected token tRCURLY`). The shared mixin now skips the offense for a splat transforming expression, covering both cops and both the `map {...}.to_h` and `to_h {...}` forms.
