### PR TITLE
Fix an incorrect autocorrect for `Style/KeywordArgumentsMerging` with a block-pass argument

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_keyword_arguments_merging_with_a_20260626101614.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_keyword_arguments_merging_with_a_20260626101614.md
@@ -1,0 +1,1 @@
+* [#15340](https://github.com/rubocop/rubocop/pull/15340): Fix an incorrect autocorrect for `Style/KeywordArgumentsMerging` with a block-pass argument. ([@bbatsov][])

--- a/lib/rubocop/cop/style/keyword_arguments_merging.rb
+++ b/lib/rubocop/cop/style/keyword_arguments_merging.rb
@@ -37,6 +37,10 @@ module RuboCop
           return unless (ancestor = node.parent&.parent)
 
           merge_kwargs?(ancestor) do |merge_node, hash_node, other_hash_node|
+            # A block-pass argument (e.g. `merge(other, &block)`) has no keyword
+            # equivalent, so spreading it would produce invalid Ruby (`**&block`).
+            next if other_hash_node.any?(&:block_pass_type?)
+
             add_offense(merge_node) do |corrector|
               autocorrect(corrector, node, hash_node, other_hash_node)
             end

--- a/spec/rubocop/cop/style/keyword_arguments_merging_spec.rb
+++ b/spec/rubocop/cop/style/keyword_arguments_merging_spec.rb
@@ -89,4 +89,10 @@ RSpec.describe RuboCop::Cop::Style::KeywordArgumentsMerging, :config do
       foo(x, **options.merge!(other_options))
     RUBY
   end
+
+  it 'does not register an offense when `merge` has a block-pass argument' do
+    expect_no_offenses(<<~RUBY)
+      foo(**opts.merge(other, &my_proc))
+    RUBY
+  end
 end


### PR DESCRIPTION
`Style/KeywordArgumentsMerging` turned `foo(**opts.merge(other, &my_proc))` into `foo(**opts, **other, **&my_proc)`, a syntax error - a block-pass argument has no `**` equivalent. The cop now skips `merge` calls that carry a block-pass argument.
