### PR TITLE
Fix an incorrect autocorrect for `Style/MapIntoArray` with a block-pass argument

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_map_into_array_with_a_block_pass_argument_20260626101736.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_map_into_array_with_a_block_pass_argument_20260626101736.md
@@ -1,0 +1,1 @@
+* [#15341](https://github.com/rubocop/rubocop/pull/15341): Fix an incorrect autocorrect for `Style/MapIntoArray` with a block-pass argument. ([@bbatsov][])

--- a/lib/rubocop/cop/style/map_into_array.rb
+++ b/lib/rubocop/cop/style/map_into_array.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         # @!method suitable_argument_node?(node)
         def_node_matcher :suitable_argument_node?, <<-PATTERN
-          !{splat forwarded-restarg forwarded-args (hash (forwarded-kwrestarg)) (block-pass nil?)}
+          !{splat forwarded-restarg forwarded-args (hash (forwarded-kwrestarg)) block-pass}
         PATTERN
 
         # @!method each_block_with_push?(node)

--- a/spec/rubocop/cop/style/map_into_array_spec.rb
+++ b/spec/rubocop/cop/style/map_into_array_spec.rb
@@ -418,6 +418,13 @@ RSpec.describe RuboCop::Cop::Style::MapIntoArray, :config do
     RUBY
   end
 
+  it 'does not register an offense when pushing a named block-pass argument' do
+    expect_no_offenses(<<~RUBY)
+      dest = []
+      src.each { |e| dest.push(&method(:foo)) }
+    RUBY
+  end
+
   it 'does not register an offense when pushing anonymously-forwarded restarg', :ruby32 do
     expect_no_offenses(<<~RUBY)
       def foo(*)


### PR DESCRIPTION
`Style/MapIntoArray` only excluded the anonymous block-pass (`&`) when checking the push argument, so a named one slipped through: `src.each { |e| dest.push(&method(:foo)) }` autocorrected to `dest = src.map { |e| &method(:foo) }`, a syntax error. The matcher now excludes all block-pass arguments.
