### PR TITLE
Fix an incorrect autocorrect for `Style/MethodCallWithoutArgsParentheses` with `it()` in a numbered block

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_method_call_without_args_parentheses_with_20260626101934.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_method_call_without_args_parentheses_with_20260626101934.md
@@ -1,0 +1,1 @@
+* [#15342](https://github.com/rubocop/rubocop/pull/15342): Fix an incorrect autocorrect for `Style/MethodCallWithoutArgsParentheses` with `it()` in a numbered block. ([@bbatsov][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -88,8 +88,12 @@ module RuboCop
         #
         def parenthesized_it_method_in_block?(node)
           return false unless node.method?(:it)
-          return false unless (block_node = node.each_ancestor(:block).first)
-          return false unless block_node.arguments.empty_and_without_delimiters?
+          return false unless (block_node = node.each_ancestor(:any_block).first)
+          # Inside a numbered/`it` block, a bare `it` is a parse error (it conflicts
+          # with the implicit parameter), so `it()` must keep its parentheses.
+          if block_node.block_type? && !block_node.arguments.empty_and_without_delimiters?
+            return false
+          end
 
           !node.receiver && node.arguments.empty? && !node.block_literal?
         end

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
     RUBY
   end
 
+  it 'does not register an offense when using `it()` in a numbered parameter block' do
+    # A bare `it` is a parse error when a numbered parameter is used.
+    expect_no_offenses(<<~RUBY)
+      0.times { _1 + it() }
+    RUBY
+  end
+
   it 'registers an offense when using `foo.it()` in a single line block' do
     # `Lint/ItWithoutArgumentsInBlock` respects for this syntax.
     expect_offense(<<~RUBY)


### PR DESCRIPTION
`Style/MethodCallWithoutArgsParentheses` only skipped `it()` inside regular empty blocks. In a numbered-parameter block it still stripped the parens: `0.times { _1 + it() }` became `0.times { _1 + it }`, which Ruby 3.4 rejects (`'it' is not allowed when a numbered parameter is already used`). The guard now also covers numbered- and `it`-parameter blocks.
