### PR TITLE
Fix an incorrect autocorrect for `Style/MinMaxComparison` with `unless`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_min_max_comparison_with_unless_20260626102154.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_min_max_comparison_with_unless_20260626102154.md
@@ -1,0 +1,1 @@
+* [#15343](https://github.com/rubocop/rubocop/pull/15343): Fix an incorrect autocorrect for `Style/MinMaxComparison` with `unless`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/min_max_comparison.rb
+++ b/lib/rubocop/cop/style/min_max_comparison.rb
@@ -55,8 +55,11 @@ module RuboCop
           lhs, operator, rhs = comparison_condition(node.condition)
           return unless operator
 
+          # For `unless`, the branches run opposite to an `if`, so swap them to
+          # keep the `max`/`min` decision correct.
           if_branch = node.if_branch
           else_branch = node.else_branch
+          if_branch, else_branch = else_branch, if_branch if node.unless?
           preferred_method = preferred_method(operator, lhs, rhs, if_branch, else_branch)
           return unless preferred_method
 

--- a/spec/rubocop/cop/style/min_max_comparison_spec.rb
+++ b/spec/rubocop/cop/style/min_max_comparison_spec.rb
@@ -131,6 +131,36 @@ RSpec.describe RuboCop::Cop::Style::MinMaxComparison, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `a > b` with `unless/else`' do
+    expect_offense(<<~RUBY)
+      unless a > b
+      ^^^^^^^^^^^^ Use `[a, b].min` instead.
+        a
+      else
+        b
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [a, b].min
+    RUBY
+  end
+
+  it 'registers and corrects an offense when using `a < b` with `unless/else`' do
+    expect_offense(<<~RUBY)
+      unless a < b
+      ^^^^^^^^^^^^ Use `[a, b].max` instead.
+        a
+      else
+        b
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      [a, b].max
+    RUBY
+  end
+
   it 'registers and corrects an offense when using `a < b a : b` with `elsif/else`' do
     expect_offense(<<~RUBY)
       if x


### PR DESCRIPTION
`Style/MinMaxComparison` treated `unless` branches as if they were `if` branches, so `unless a > b; a else b end` (which returns the minimum) was flagged and autocorrected to `[a, b].max`. The branches are now swapped for `unless`, giving the correct `[a, b].min`.
