### PR TITLE
Fix incorrect autocorrects for `Style/Lambda` with block-local arguments

### DIFF
--- a/changelog/fix_incorrect_autocorrects_for_style_lambda_with_block_local_arguments_20260626102542.md
+++ b/changelog/fix_incorrect_autocorrects_for_style_lambda_with_block_local_arguments_20260626102542.md
@@ -1,0 +1,1 @@
+* [#15344](https://github.com/rubocop/rubocop/pull/15344): Fix incorrect autocorrects for `Style/Lambda` with block-local arguments. ([@bbatsov][])

--- a/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
+++ b/lib/rubocop/cop/correctors/lambda_literal_to_method_corrector.rb
@@ -86,7 +86,13 @@ module RuboCop
       end
 
       def lambda_arg_string
-        arguments.children.map(&:source).join(', ')
+        # Block-local (shadow) arguments are separated from regular arguments by a
+        # `;`; joining everything with `,` would turn them into extra parameters
+        # and change the lambda's arity.
+        regular, shadow = arguments.children.partition { |arg| !arg.shadowarg_type? }
+        arg_string = regular.map(&:source).join(', ')
+        arg_string += "; #{shadow.map(&:source).join(', ')}" unless shadow.empty?
+        arg_string
       end
 
       def needs_separating_space?

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -118,7 +118,13 @@ module RuboCop
         end
 
         def lambda_arg_string(args)
-          args.children.map(&:source).join(', ')
+          # Block-local (shadow) arguments are separated from regular arguments by a
+          # `;`; joining everything with `,` would turn them into extra parameters
+          # and change the lambda's arity.
+          regular, shadow = args.children.partition { |arg| !arg.shadowarg_type? }
+          arg_string = regular.map(&:source).join(', ')
+          arg_string += "; #{shadow.map(&:source).join(', ')}" unless shadow.empty?
+          arg_string
         end
       end
     end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
         end
       end
 
+      context 'with block-local (shadow) arguments' do
+        it 'preserves the shadow argument separator' do
+          expect_offense(<<~RUBY)
+            f = ->(x; y) { x }
+                ^^ Use the `lambda` method for all lambdas.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = lambda { |x; y| x }
+          RUBY
+        end
+      end
+
       context 'without arguments' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
@@ -108,6 +121,19 @@ RSpec.describe RuboCop::Cop::Style::Lambda, :config do
 
           expect_correction(<<~RUBY)
             f = -> { x }
+          RUBY
+        end
+      end
+
+      context 'with block-local (shadow) arguments' do
+        it 'preserves the shadow argument separator' do
+          expect_offense(<<~RUBY)
+            f = lambda { |x; y| x }
+                ^^^^^^ Use the `-> { ... }` lambda literal syntax for all lambdas.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            f = ->(x; y) { x }
           RUBY
         end
       end


### PR DESCRIPTION
`Style/Lambda` rebuilt the argument list by joining every block argument with `,`, so a block-local (shadow) variable became an extra parameter: `lambda { |x; y| x }` (arity 1) corrected to `->(x, y) { x }` (arity 2), and the reverse direction had the same problem. Both directions now keep the `;` separator, preserving arity.
