### PR TITLE
Fix a false positive for `Style/InlineComment` with `rubocop:todo` directives

### DIFF
--- a/changelog/fix_a_false_positive_for_style_inline_comment_with_rubocop_todo_directives_20260626102746.md
+++ b/changelog/fix_a_false_positive_for_style_inline_comment_with_rubocop_todo_directives_20260626102746.md
@@ -1,0 +1,1 @@
+* [#15345](https://github.com/rubocop/rubocop/pull/15345): Fix a false positive for `Style/InlineComment` with `rubocop:todo` directives. ([@bbatsov][])

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -26,7 +26,7 @@ module RuboCop
         def on_new_investigation
           processed_source.comments.each do |comment|
             next if comment_line?(processed_source[comment.loc.line - 1]) ||
-                    comment.text.match?(/\A# rubocop:(enable|disable)/)
+                    comment.text.match?(/\A# rubocop:(enable|disable|todo)/)
 
             add_offense(comment)
           end

--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe RuboCop::Cop::Style::InlineComment, :config do
     RUBY
   end
 
+  it 'does not register an offense for a `rubocop:todo` directive' do
+    expect_no_offenses(<<~RUBY)
+      two = 1 + 1 # rubocop:todo Layout/ExtraSpacing
+    RUBY
+  end
+
   it 'does not register an offense for a standalone comment' do
     expect_no_offenses('# A standalone comment')
   end


### PR DESCRIPTION
`Style/InlineComment` skipped `# rubocop:enable`/`# rubocop:disable` directives but not `# rubocop:todo`, so a line like `foo # rubocop:todo Metrics/AbcSize` (the form RuboCop itself inserts when generating a todo) got flagged as a trailing inline comment. `todo` is now skipped too.
