### PR TITLE
Fix false positives for `Style/ItAssignment` before Ruby 3.4

### DIFF
--- a/changelog/fix_false_positives_for_style_it_assignment_before_ruby_3_4_20260626103124.md
+++ b/changelog/fix_false_positives_for_style_it_assignment_before_ruby_3_4_20260626103124.md
@@ -1,0 +1,1 @@
+* [#15346](https://github.com/rubocop/rubocop/pull/15346): Fix false positives for `Style/ItAssignment` before Ruby 3.4. ([@bbatsov][])

--- a/lib/rubocop/cop/style/it_assignment.rb
+++ b/lib/rubocop/cop/style/it_assignment.rb
@@ -73,7 +73,11 @@ module RuboCop
       #   def foo(&block)
       #   end
       class ItAssignment < Base
+        extend TargetRubyVersion
+
         MSG = '`it` is the default block parameter; consider another name.'
+
+        minimum_target_ruby_version 3.4
 
         def on_lvasgn(node)
           return unless node.name == :it

--- a/spec/rubocop/cop/style/it_assignment_spec.rb
+++ b/spec/rubocop/cop/style/it_assignment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Style::ItAssignment, :config do
+RSpec.describe RuboCop::Cop::Style::ItAssignment, :config, :ruby34 do
   it 'registers an offense when assigning a local `it` variable' do
     expect_offense(<<~RUBY)
       it = 5
@@ -155,6 +155,13 @@ RSpec.describe RuboCop::Cop::Style::ItAssignment, :config do
     it 'does not register an offense when calling `it` in a block' do
       expect_no_offenses(<<~RUBY)
         foo { puts it }
+      RUBY
+    end
+
+    it 'does not register an offense when assigning a local `it` variable' do
+      # Before Ruby 3.4, `it` has no special meaning as a block parameter.
+      expect_no_offenses(<<~RUBY)
+        it = 5
       RUBY
     end
   end


### PR DESCRIPTION
`Style/ItAssignment` flagged `it = 5` (and `it` parameter names) on projects targeting Ruby 3.3 or lower, where `it` has no special meaning as a block parameter. The cop is now gated with `minimum_target_ruby_version 3.4`, matching its companion `Style/ItBlockParameter`.
