### PR TITLE
Fix precedence-sensitive autocorrects in negation/comparison cops

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_nested_modifier_20260626160118.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_nested_modifier_20260626160118.md
@@ -1,0 +1,1 @@
+* [#15347](https://github.com/rubocop/rubocop/pull/15347): Fix an incorrect autocorrect for `Style/NestedModifier`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_non_nil_check_20260626155521.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_non_nil_check_20260626155521.md
@@ -1,0 +1,1 @@
+* [#15347](https://github.com/rubocop/rubocop/pull/15347): Fix an incorrect autocorrect for `Style/NonNilCheck`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_not_with_a_flip_flop_or_assignment_20260626155351.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_not_with_a_flip_flop_or_assignment_20260626155351.md
@@ -1,0 +1,1 @@
+* [#15347](https://github.com/rubocop/rubocop/pull/15347): Fix an incorrect autocorrect for `Style/Not` with a flip-flop or assignment. ([@bbatsov][])

--- a/changelog/fix_incorrect_autocorrects_for_style_nil_comparison_with_precedence_sensitive_20260626155830.md
+++ b/changelog/fix_incorrect_autocorrects_for_style_nil_comparison_with_precedence_sensitive_20260626155830.md
@@ -1,0 +1,1 @@
+* [#15347](https://github.com/rubocop/rubocop/pull/15347): Fix incorrect autocorrects for `Style/NilComparison` with precedence-sensitive operands. ([@bbatsov][])

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -70,6 +70,7 @@ module RuboCop
 
         def right_hand_operand(node, left_hand_keyword)
           condition = node.condition
+          negated = left_hand_keyword != node.keyword
 
           expr = if condition.send_type? && !condition.arguments.empty? &&
                     !condition.operator_method?
@@ -77,8 +78,8 @@ module RuboCop
                  else
                    condition.source
                  end
-          expr = "(#{expr})" if requires_parens?(condition)
-          expr = "!#{expr}" unless left_hand_keyword == node.keyword
+          expr = "(#{expr})" if requires_parens?(condition, negated)
+          expr = "!#{expr}" if negated
           expr
         end
 
@@ -91,8 +92,12 @@ module RuboCop
           expr
         end
 
-        def requires_parens?(node)
-          node.or_type? || !(RuboCop::AST::Node::COMPARISON_OPERATORS & node.children).empty?
+        def requires_parens?(node, negated)
+          # A negated `&&`/`||` operand must be wrapped so the `!` applies to the
+          # whole expression (e.g. `!(a && b)`, not `!a && b`).
+          (negated && node.operator_keyword?) ||
+            node.or_type? ||
+            !(RuboCop::AST::Node::COMPARISON_OPERATORS & node.children).empty?
         end
       end
     end

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -42,28 +42,55 @@ module RuboCop
         # @!method nil_check?(node)
         def_node_matcher :nil_check?, '(send _ :nil?)'
 
-        # rubocop:disable Metrics/AbcSize
         def on_send(node)
           return unless node.receiver
 
           style_check?(node) do
             add_offense(node.loc.selector) do |corrector|
               if prefer_comparison?
-                range = node.loc.dot.join(node.loc.selector.end)
-                corrector.replace(range, ' == nil')
+                autocorrect_to_comparison(corrector, node)
               else
-                range = node.receiver.source_range.end.join(node.source_range.end)
-                corrector.replace(range, '.nil?')
+                autocorrect_to_predicate(corrector, node)
               end
-
-              parent = node.parent
-              corrector.wrap(node, '(', ')') if parent.respond_to?(:method?) && parent.method?(:!)
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
+
+        def autocorrect_to_comparison(corrector, node)
+          range = node.loc.dot.join(node.loc.selector.end)
+          corrector.replace(range, ' == nil')
+          # The new `== nil` binds looser than an enclosing operator (e.g. `<<`,
+          # `!`), so wrap it to keep the original precedence.
+          corrector.wrap(node, '(', ')') if operator_expression?(node.parent)
+        end
+
+        def autocorrect_to_predicate(corrector, node)
+          receiver = node.receiver
+          if operator_expression?(receiver)
+            # A looser-binding receiver (e.g. `!x`, `a + b`) must be parenthesized
+            # so the appended `.nil?` applies to the whole expression.
+            corrector.replace(node, "(#{receiver.source}).nil?")
+          else
+            range = receiver.source_range.end.join(node.source_range.end)
+            corrector.replace(range, '.nil?')
+          end
+        end
+
+        def operator_expression?(node)
+          return false unless node
+
+          operator_send?(node) ||
+            node.operator_keyword? ||
+            (node.if_type? && node.ternary?) ||
+            node.type?(:range, :iflipflop, :eflipflop) ||
+            node.assignment?
+        end
+
+        def operator_send?(node)
+          node.send_type? && node.operator_method? && !node.method?(:[]) && !node.method?(:[]=)
+        end
 
         def message(_node)
           prefer_comparison? ? EXPLICIT_MSG : PREDICATE_MSG

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -42,27 +42,55 @@ module RuboCop
         # @!method nil_check?(node)
         def_node_matcher :nil_check?, '(send _ :nil?)'
 
-        # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
           return unless node.receiver
 
           style_check?(node) do
             add_offense(node.loc.selector) do |corrector|
               if prefer_comparison?
-                range = node.loc.dot.join(node.loc.selector.end)
-                corrector.replace(range, ' == nil')
+                autocorrect_to_comparison(corrector, node)
               else
-                range = node.receiver.source_range.end.join(node.source_range.end)
-                corrector.replace(range, '.nil?')
+                autocorrect_to_predicate(corrector, node)
               end
-
-              parent = node.parent
-              corrector.wrap(node, '(', ')') if parent.respond_to?(:method?) && parent.method?(:!)
             end
           end
         end
 
         private
+
+        def autocorrect_to_comparison(corrector, node)
+          range = node.loc.dot.join(node.loc.selector.end)
+          corrector.replace(range, ' == nil')
+          # The new `== nil` binds looser than an enclosing operator (e.g. `<<`,
+          # `!`), so wrap it to keep the original precedence.
+          corrector.wrap(node, '(', ')') if operator_expression?(node.parent)
+        end
+
+        def autocorrect_to_predicate(corrector, node)
+          receiver = node.receiver
+          if operator_expression?(receiver)
+            # A looser-binding receiver (e.g. `!x`, `a + b`) must be parenthesized
+            # so the appended `.nil?` applies to the whole expression.
+            corrector.replace(node, "(#{receiver.source}).nil?")
+          else
+            range = receiver.source_range.end.join(node.source_range.end)
+            corrector.replace(range, '.nil?')
+          end
+        end
+
+        def operator_expression?(node)
+          return false unless node
+
+          operator_send?(node) ||
+            node.operator_keyword? ||
+            (node.if_type? && node.ternary?) ||
+            node.type?(:range, :iflipflop, :eflipflop) ||
+            node.assignment?
+        end
+
+        def operator_send?(node)
+          node.send_type? && node.operator_method? && !node.method?(:[]) && !node.method?(:[]=)
+        end
 
         def message(_node)
           prefer_comparison? ? EXPLICIT_MSG : PREDICATE_MSG

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -109,7 +109,7 @@ module RuboCop
 
         def message(node)
           if node.method?(:!=) && !include_semantic_changes?
-            prefer = "!#{node.receiver.source}.nil?"
+            prefer = non_nil_check_replacement(node)
             format(MSG_FOR_REPLACEMENT, prefer: prefer, current: node.source)
           else
             MSG_FOR_REDUNDANCY
@@ -120,11 +120,27 @@ module RuboCop
           cop_config['IncludeSemanticChanges']
         end
 
+        # An operator-expression receiver (e.g. `a + b`) binds looser than the
+        # appended `.nil?`, so it must be parenthesized: `!(a + b).nil?`.
+        def non_nil_check_replacement(node)
+          receiver = node.receiver
+          source = operator_expression?(receiver) ? "(#{receiver.source})" : receiver.source
+          "!#{source}.nil?"
+        end
+
+        def operator_expression?(node)
+          node.operator_keyword? ||
+            (node.send_type? && node.binary_operation?) ||
+            (node.if_type? && node.ternary?) ||
+            node.type?(:range, :iflipflop, :eflipflop) ||
+            node.assignment?
+        end
+
         def autocorrect_comparison(corrector, node)
           if include_semantic_changes?
             corrector.replace(node, node.receiver.source)
           else
-            corrector.replace(node, "!#{node.receiver.source}.nil?")
+            corrector.replace(node, non_nil_check_replacement(node))
           end
         end
 

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -56,7 +56,9 @@ module RuboCop
         def requires_parens?(child)
           child.operator_keyword? ||
             (child.send_type? && child.binary_operation?) ||
-            (child.if_type? && child.ternary?)
+            (child.if_type? && child.ternary?) ||
+            child.type?(:range, :iflipflop, :eflipflop) ||
+            child.assignment?
         end
 
         def correct_opposite_method(corrector, range, child)

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe RuboCop::Cop::Style::NestedModifier, :config do
     RUBY
   end
 
+  it 'parenthesizes a negated `&&` operand in autocorrection' do
+    expect_offense(<<~RUBY)
+      something if a && b unless c
+                ^^ Avoid using nested modifiers.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something unless c || !(a && b)
+    RUBY
+  end
+
   it 'adds parentheses when needed in autocorrection' do
     expect_offense(<<~RUBY)
       something if a || b if c || d

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
         x.nil?
       RUBY
     end
+
+    it 'parenthesizes an operator-expression receiver' do
+      expect_offense(<<~RUBY)
+        !x == nil
+           ^^ Prefer the use of the `nil?` predicate.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (!x).nil?
+      RUBY
+    end
   end
 
   context 'configured with comparison preferred' do
@@ -82,6 +93,17 @@ RSpec.describe RuboCop::Cop::Style::NilComparison, :config do
 
       expect_correction(<<~RUBY)
         !(x == nil)
+      RUBY
+    end
+
+    it 'wraps the comparison when it is an operand of a tighter operator' do
+      expect_offense(<<~RUBY)
+        ary << x.nil?
+                 ^^^^ Prefer the use of the `==` comparison.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ary << (x == nil)
       RUBY
     end
 

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RuboCop::Cop::Style::NonNilCheck, :config do
       RUBY
     end
 
+    it 'parenthesizes an operator-expression receiver' do
+      expect_offense(<<~RUBY)
+        a + b != nil
+        ^^^^^^^^^^^^ Prefer `!(a + b).nil?` over `a + b != nil`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        !(a + b).nil?
+      RUBY
+    end
+
     it 'does not register an offense for != 0' do
       expect_no_offenses('x != 0')
     end

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe RuboCop::Cop::Style::Not, :config do
     RUBY
   end
 
+  it 'parenthesizes when `not` is applied to a flip-flop' do
+    expect_offense(<<~RUBY)
+      x if not 1..5
+           ^^^ Use `!` instead of `not`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x if !(1..5)
+    RUBY
+  end
+
+  it 'parenthesizes when `not` is applied to an assignment' do
+    expect_offense(<<~RUBY)
+      x if not a = 5
+           ^^^ Use `!` instead of `not`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x if !(a = 5)
+    RUBY
+  end
+
   it 'parenthesizes when `not` is applied to or' do
     expect_offense(<<~RUBY)
       not a || b


### PR DESCRIPTION
A batch of related autocorrect fixes for the same bug class: rewrites that wrap or negate an expression without parenthesizing a looser-binding operand, so the corrected code changes meaning.

Each cop is a separate commit with its own changelog entry:

- `Style/Not`: `x if not 1..5` was corrected to `x if !1..5` (now `!(1..5)`); same for assignments like `not a = 5`.
- `Style/NonNilCheck`: `a + b != nil` was corrected to `!a + b.nil?` (now `!(a + b).nil?`).
- `Style/NilComparison`: predicate style turned `!x == nil` into `(!x).nil?` and comparison style turned `ary << x.nil?` into `ary << (x == nil)` (both were previously misgrouped).
- `Style/NestedModifier`: `something if a && b unless c` was corrected to `something unless c || !a && b` (now `!(a && b)`).
