### PR TITLE
Fix invalid-Ruby autocorrects in multiline Style cops

### DIFF
--- a/changelog/fix_a_false_positive_for_style_multiline_if_then_20260626161015.md
+++ b/changelog/fix_a_false_positive_for_style_multiline_if_then_20260626161015.md
@@ -1,0 +1,1 @@
+* [#15348](https://github.com/rubocop/rubocop/pull/15348): Fix a false positive for `Style/MultilineIfThen`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiline_memoization_with_20260626161015.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiline_memoization_with_20260626161015.md
@@ -1,0 +1,1 @@
+* [#15348](https://github.com/rubocop/rubocop/pull/15348): Fix an incorrect autocorrect for `Style/MultilineMemoization` with `rescue`/`ensure`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiline_method_signature_20260626161016.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiline_method_signature_20260626161016.md
@@ -1,0 +1,1 @@
+* [#15348](https://github.com/rubocop/rubocop/pull/15348): Fix an incorrect autocorrect for `Style/MultilineMethodSignature`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -36,7 +36,7 @@ module RuboCop
         private
 
         def non_modifier_then?(node)
-          node.then? && node.loc.begin.line != node.if_branch&.loc&.line
+          node.multiline? && node.then? && node.loc.begin.line != node.if_branch&.loc&.line
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -65,8 +65,14 @@ module RuboCop
           if style == :keyword
             rhs.begin_type?
           else
-            rhs.kwbegin_type?
+            # A `begin` block with `rescue`/`ensure` cannot be expressed with
+            # parentheses, so wrapping it in `(` and `)` is not possible.
+            rhs.kwbegin_type? && !contains_rescue_or_ensure?(rhs)
           end
+        end
+
+        def contains_rescue_or_ensure?(node)
+          node.each_child_node(:rescue, :ensure).any?
         end
 
         def keyword_autocorrect(node, corrector)

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -51,10 +51,12 @@ module RuboCop
           end
 
           arguments_range = range_with_surrounding_space(arguments_range(node), side: :left)
-          # If the method name isn't on the same line as def, move it directly after def
+          # If the method name isn't on the same line as `def`, pull the name and
+          # the opening parenthesis up next to `def` so the collapsed signature
+          # stays on a single line and remains valid Ruby.
           if arguments_range.first_line != opening_line(node)
-            corrector.remove(node.loc.name)
-            corrector.insert_after(node.loc.keyword, " #{node.loc.name.source}")
+            prefix_range = range_between(node.loc.keyword.end_pos, begin_of_arguments.begin_pos)
+            corrector.replace(prefix_range, " #{prefix_range.source.strip}")
           end
 
           corrector.remove(arguments_range)

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -136,4 +136,12 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen, :config do
       RUBY
     end.not_to raise_error
   end
+
+  it 'does not register an offense for a single-line `if cond then end`' do
+    expect_no_offenses('if cond then end')
+  end
+
+  it 'does not register an offense for a single-line `unless cond then end`' do
+    expect_no_offenses('unless cond then end')
+  end
 end

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -166,6 +166,26 @@ RSpec.describe RuboCop::Cop::Style::MultilineMemoization, :config do
                 )
             RUBY
           end
+
+          it 'does not register an offense for a begin block with a `rescue`' do
+            expect_no_offenses(<<~RUBY)
+              foo ||= begin
+                bar
+              rescue
+                baz
+              end
+            RUBY
+          end
+
+          it 'does not register an offense for a begin block with an `ensure`' do
+            expect_no_offenses(<<~RUBY)
+              foo ||= begin
+                bar
+              ensure
+                baz
+              end
+            RUBY
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          def foo
-          (bar)
+          def foo(bar)
           end
         RUBY
       end
@@ -66,10 +65,23 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          def foo
+          def foo(bar)
+          end
+        RUBY
+      end
 
+      it 'registers an offense and corrects when the signature with multiple arguments ' \
+         'spans lines after a `def` keyword on its own line' do
+        expect_offense(<<~RUBY)
+          def
+          ^^^ Avoid multi-line method signatures.
+          foo(bar,
+              baz)
+          end
+        RUBY
 
-          (bar)
+        expect_correction(<<~RUBY)
+          def foo(bar, baz)
           end
         RUBY
       end


### PR DESCRIPTION
Three related fixes for `Style/Multiline*` cops that either flag code they shouldn't or autocorrect it into invalid Ruby. Each cop is a separate commit with its own changelog entry.

- `Style/MultilineIfThen`: a single-line `if cond then end` (empty body) was flagged and "corrected" to `if cond end`, a syntax error. It now only applies to genuinely multiline `if`/`unless`.
- `Style/MultilineMemoization` (braces): `foo ||= begin … rescue … end` was rewritten to `foo ||= ( … rescue … )`, which is invalid since parentheses can't hold a bare `rescue`/`ensure`. Such blocks are no longer flagged.
- `Style/MultilineMethodSignature`: when the `def` keyword sat on its own line, the autocorrect left the parameter list orphaned on the next line (`def foo` / `(bar)`), producing a syntax error. It now collapses the whole signature onto the `def` line. (Two existing specs asserted the broken output and have been updated.)
