### PR TITLE
Fix invalid-Ruby autocorrects in Style/Redundant* cops

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class_with_8____9_20260626161927.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_regexp_character_class_with_8____9_20260626161927.md
@@ -1,0 +1,1 @@
+* [#15349](https://github.com/rubocop/rubocop/pull/15349): Fix a false positive for `Style/RedundantRegexpCharacterClass` with `\8`/`\9`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces_with_a_20260626161928.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_double_splat_hash_braces_with_a_20260626161928.md
@@ -1,0 +1,1 @@
+* [#15349](https://github.com/rubocop/rubocop/pull/15349): Fix an incorrect autocorrect for `Style/RedundantDoubleSplatHashBraces` with a braced `merge` argument. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_parentheses_around_and___or_20260626161929.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_parentheses_around_and___or_20260626161929.md
@@ -1,0 +1,1 @@
+* [#15349](https://github.com/rubocop/rubocop/pull/15349): Fix an incorrect autocorrect for `Style/RedundantParentheses` around `and`/`or`. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_constructor_with_r_20260626161927.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_constructor_with_r_20260626161927.md
@@ -1,0 +1,1 @@
+* [#15349](https://github.com/rubocop/rubocop/pull/15349): Fix an incorrect autocorrect for `Style/RedundantRegexpConstructor` with `%r{}` delimiters. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -116,6 +116,14 @@ module RuboCop
           end
         end
 
+        def mergeable?(node)
+          return true unless node.call_type?
+          return false unless MERGE_METHODS.include?(node.method_name)
+          return true unless (parent = node.parent)
+
+          mergeable?(parent)
+        end
+
         # A braced hash literal passed to `merge` must have its braces stripped so
         # its pairs join the surrounding keyword arguments. Keeping the braces would
         # produce a positional hash after keyword arguments, which is invalid Ruby.
@@ -123,14 +131,6 @@ module RuboCop
           return hash.source unless hash.braces?
 
           hash.pairs.map(&:source).join(', ')
-        end
-
-        def mergeable?(node)
-          return true unless node.call_type?
-          return false unless MERGE_METHODS.include?(node.method_name)
-          return true unless (parent = node.parent)
-
-          mergeable?(parent)
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -109,11 +109,20 @@ module RuboCop
 
           node.arguments.map do |arg|
             if arg.hash_type?
-              arg.source
+              hash_argument_source(arg)
             else
               "**#{arg.source}"
             end
           end
+        end
+
+        # A braced hash literal passed to `merge` must have its braces stripped so
+        # its pairs join the surrounding keyword arguments. Keeping the braces would
+        # produce a positional hash after keyword arguments, which is invalid Ruby.
+        def hash_argument_source(hash)
+          return hash.source unless hash.braces?
+
+          hash.pairs.map(&:source).join(', ')
         end
 
         def mergeable?(node)

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -109,7 +109,7 @@ module RuboCop
 
           node.arguments.map do |arg|
             if arg.hash_type?
-              arg.source
+              hash_argument_source(arg)
             else
               "**#{arg.source}"
             end
@@ -122,6 +122,15 @@ module RuboCop
           return true unless (parent = node.parent)
 
           mergeable?(parent)
+        end
+
+        # A braced hash literal passed to `merge` must have its braces stripped so
+        # its pairs join the surrounding keyword arguments. Keeping the braces would
+        # produce a positional hash after keyword arguments, which is invalid Ruby.
+        def hash_argument_source(hash)
+          return hash.source unless hash.braces?
+
+          hash.pairs.map(&:source).join(', ')
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -205,13 +205,6 @@ module RuboCop
           parent.call_type? && parent.parenthesized? && parent.receiver != begin_node
         end
 
-        # `and`/`or` keyword operators bind looser than the method-argument
-        # boundary, so `foo((x and y))` cannot drop its parentheses without
-        # becoming a syntax error (unlike `&&`/`||`).
-        def keyword_logical_operator?(node)
-          node.operator_keyword? && node.semantic_operator?
-        end
-
         def oneline_rescue_parentheses_required?(begin_node, node)
           return false unless node.rescue_type?
           return false unless (parent = begin_node.parent)
@@ -291,6 +284,13 @@ module RuboCop
             (node.end.nil? && begin_node == parent.children.last)
         end
         # rubocop:enable Metrics/CyclomaticComplexity
+
+        # `and`/`or` keyword operators bind looser than the method-argument
+        # boundary, so `foo((x and y))` cannot drop its parentheses without
+        # becoming a syntax error (unlike `&&`/`||`).
+        def keyword_logical_operator?(node)
+          node.operator_keyword? && node.semantic_operator?
+        end
 
         def disallowed_one_line_pattern_matching?(begin_node, node)
           if (parent = begin_node.parent)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -169,7 +169,10 @@ module RuboCop
             return 'a one-line pattern matching'
           end
           return 'an interpolated expression' if interpolation?(begin_node)
-          return 'a method argument' if argument_of_parenthesized_method_call?(begin_node, node)
+          if argument_of_parenthesized_method_call?(begin_node, node) &&
+             !keyword_logical_operator?(node)
+            return 'a method argument'
+          end
           return 'a one-line rescue' if oneline_rescue_parentheses_required?(begin_node, node)
 
           return if begin_node.chained?
@@ -200,6 +203,13 @@ module RuboCop
           return false unless (parent = begin_node.parent)
 
           parent.call_type? && parent.parenthesized? && parent.receiver != begin_node
+        end
+
+        # `and`/`or` keyword operators bind looser than the method-argument
+        # boundary, so `foo((x and y))` cannot drop its parentheses without
+        # becoming a syntax error (unlike `&&`/`||`).
+        def keyword_logical_operator?(node)
+          node.operator_keyword? && node.semantic_operator?
         end
 
         def oneline_rescue_parentheses_required?(begin_node, node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -169,7 +169,10 @@ module RuboCop
             return 'a one-line pattern matching'
           end
           return 'an interpolated expression' if interpolation?(begin_node)
-          return 'a method argument' if argument_of_parenthesized_method_call?(begin_node, node)
+          if argument_of_parenthesized_method_call?(begin_node, node) &&
+             !keyword_logical_operator?(node)
+            return 'a method argument'
+          end
           return 'a one-line rescue' if oneline_rescue_parentheses_required?(begin_node, node)
 
           return if begin_node.chained?
@@ -281,6 +284,13 @@ module RuboCop
             (node.end.nil? && begin_node == parent.children.last)
         end
         # rubocop:enable Metrics/CyclomaticComplexity
+
+        # `and`/`or` keyword operators bind looser than the method-argument
+        # boundary, so `foo((x and y))` cannot drop its parentheses without
+        # becoming a syntax error (unlike `&&`/`||`).
+        def keyword_logical_operator?(node)
+          node.operator_keyword? && node.semantic_operator?
+        end
 
         def disallowed_one_line_pattern_matching?(begin_node, node)
           if (parent = begin_node.parent)

--- a/lib/rubocop/cop/style/redundant_regexp_character_class.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_character_class.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           non_redundant =
             whitespace_in_free_space_mode?(node, class_elem) ||
-            backslash_b?(class_elem) || octal_requiring_char_class?(class_elem) ||
+            backslash_b?(class_elem) || backreference_requiring_char_class?(class_elem) ||
             requires_escape_outside_char_class?(class_elem)
 
           !non_redundant
@@ -104,10 +104,11 @@ module RuboCop
           elem == '\b'
         end
 
-        def octal_requiring_char_class?(elem)
-          # The octal escapes \1 to \7 only work inside a character class
-          # because they would be a backreference outside it.
-          elem.match?(/\A\\[1-7]\z/)
+        def backreference_requiring_char_class?(elem)
+          # `\1` to `\9` only match a literal digit inside a character class;
+          # outside it they are backreferences (and a syntax error when the
+          # referenced group does not exist), so the class is not redundant.
+          elem.match?(/\A\\[1-9]\z/)
         end
 
         def requires_escape_outside_char_class?(elem)

--- a/lib/rubocop/cop/style/redundant_regexp_constructor.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_constructor.rb
@@ -27,17 +27,17 @@ module RuboCop
         def_node_matcher :redundant_regexp_constructor, <<~PATTERN
           (send
             (const {nil? cbase} :Regexp) {:new :compile}
-            (regexp $... (regopt $...)))
+            $(regexp _* (regopt _*)))
         PATTERN
 
         def on_send(node)
-          return unless (regexp, regopt = redundant_regexp_constructor(node))
+          return unless (regexp = redundant_regexp_constructor(node))
 
           add_offense(node, message: format(MSG, method: node.method_name)) do |corrector|
-            pattern = regexp.map(&:source).join
-            regopt = regopt.join
-
-            corrector.replace(node, "/#{pattern}/#{regopt}")
+            # Reuse the inner literal's own source so its delimiters are preserved.
+            # Forcing `/.../` would break patterns like `%r{foo/bar}` that contain
+            # an unescaped slash.
+            corrector.replace(node, regexp.source)
           end
         end
       end

--- a/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
+++ b/spec/rubocop/cop/style/redundant_double_splat_hash_braces_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantDoubleSplatHashBraces, :config do
     RUBY
   end
 
+  it 'registers an offense when using double splat hash braces with a braced hash `merge` argument' do
+    expect_offense(<<~RUBY)
+      do_something(**{foo: bar}.merge({baz: qux}))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant double splat and braces, use keyword arguments directly.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      do_something(foo: bar, baz: qux)
+    RUBY
+  end
+
   it 'registers an offense when using double splat hash braces with `merge` safe navigation method call' do
     expect_offense(<<~RUBY)
       do_something(**{foo: bar, baz: qux}&.merge(options))

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -203,6 +203,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
   it_behaves_like 'plausible', 'until (var = 42); end'
   it_behaves_like 'plausible', '(var + 42) > do_something'
   it_behaves_like 'plausible', 'foo((bar rescue baz))'
+  it_behaves_like 'plausible', 'foo((x and y))'
+  it_behaves_like 'plausible', 'foo((x or y))'
 
   it_behaves_like 'redundant', '(!x)', '!x', 'a unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'a unary operation'

--- a/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_character_class_spec.rb
@@ -333,6 +333,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpCharacterClass, :config do
     end
   end
 
+  context 'with a character class containing a `\8` or `\9` escape' do
+    # `\8` and `\9` match a literal digit inside a character class but are
+    # backreferences outside it (a syntax error when the group does not exist).
+    it 'does not register an offense for `\8`' do
+      expect_no_offenses('foo = /[\8]/')
+    end
+
+    it 'does not register an offense for `\9`' do
+      expect_no_offenses('foo = /[\9]/')
+    end
+  end
+
   context 'with a character class containing a character requiring escape outside' do
     # Not implemented for now, since we would have to escape on autocorrect, and the cop message
     # would need to be dynamic to not be misleading.

--- a/spec/rubocop/cop/style/redundant_regexp_constructor_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_constructor_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpConstructor, :config do
     RUBY
   end
 
+  it 'registers an offense and preserves the delimiters when wrapping `%r{foo/bar}`' do
+    expect_offense(<<~RUBY)
+      Regexp.new(%r{foo/bar})
+      ^^^^^^^^^^^^^^^^^^^^^^^ Remove the redundant `Regexp.new`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      %r{foo/bar}
+    RUBY
+  end
+
   it 'does not register an offense when wrapping a string literal with `Regexp.new`' do
     expect_no_offenses(<<~RUBY)
       Regexp.new('regexp')


### PR DESCRIPTION
Four `Style/Redundant*` cops that autocorrect valid code into invalid (or semantically different) Ruby. Each cop is a separate commit with its own changelog entry.

- `Style/RedundantRegexpCharacterClass`: `/[\8]/` and `/[\9]/` were treated as redundant and "corrected" to `/\8/` / `/\9/`. Outside a character class those are backreferences (a syntax error when the group doesn't exist, a different match when it does). Only `\1`-`\7` were guarded before; now `\8`/`\9` are too.
- `Style/RedundantRegexpConstructor`: `Regexp.new(%r{foo/bar})` became `/foo/bar/`, a parse error. The autocorrect now reuses the inner literal's own source so its delimiters are preserved.
- `Style/RedundantDoubleSplatHashBraces`: `foo(**{a: 1}.merge({b: 2}))` became `foo(a: 1, { b: 2 })`, a positional hash after keyword args. A braced hash `merge` argument now has its braces stripped: `foo(a: 1, b: 2)`.
- `Style/RedundantParentheses`: `foo((x and y))` became `foo(x and y)`, a syntax error, because keyword `and`/`or` bind looser than the argument boundary (unlike `&&`/`||`). Those parens are no longer flagged.
