### PR TITLE
Fix two incorrect autocorrects in Style/RedundantFormat

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_format_with_a_lone_format_sequence_20260626164716.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_format_with_a_lone_format_sequence_20260626164716.md
@@ -1,0 +1,1 @@
+* [#15350](https://github.com/rubocop/rubocop/pull/15350): Fix a false positive for `Style/RedundantFormat` with a lone format sequence. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_format_with_a_nil_argument_20260626164716.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_format_with_a_nil_argument_20260626164716.md
@@ -1,0 +1,1 @@
+* [#15350](https://github.com/rubocop/rubocop/pull/15350): Fix an incorrect autocorrect for `Style/RedundantFormat` with a `nil` argument. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -266,6 +266,14 @@ module RuboCop
         def argument_value(argument)
           argument = argument.children.first if argument.begin_type?
 
+          # `nil` formats to an empty string (`format('%s', nil) == ''`), not the
+          # literal `'nil'` that `argument.source` would return.
+          return if argument.nil_type?
+
+          typed_argument_value(argument)
+        end
+
+        def typed_argument_value(argument)
           if argument.dsym_type?
             dsym_value(argument)
           elsif argument.hash_type?

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -89,6 +89,8 @@ module RuboCop
 
         def on_send(node)
           format_without_additional_args?(node) do |value|
+            next if string_with_format_sequence?(value)
+
             replacement = escape_control_chars(value.source)
 
             add_offense(node, message: message(node, replacement)) do |corrector|
@@ -101,6 +103,24 @@ module RuboCop
         end
 
         private
+
+        # A single-argument `format` whose string still contains a format sequence is
+        # not redundant: `format('%s')` raises at runtime, and `format('%%')` returns
+        # `'%'`, so replacing it with the literal would change behavior.
+        def string_with_format_sequence?(node)
+          string = static_string_value(node)
+          return false unless string
+
+          RuboCop::Cop::Utils::FormatString.new(string).format_sequences.any?
+        end
+
+        def static_string_value(node)
+          if node.str_type?
+            node.value
+          elsif node.dstr_type?
+            node.children.select(&:str_type?).map(&:value).join
+          end
+        end
 
         def message(node, prefer)
           format(MSG, prefer: prefer, method_name: node.method_name)

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -95,6 +95,14 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             "\n"
           RUBY
         end
+
+        it 'does not register an offense when the string contains a `%%` sequence' do
+          expect_no_offenses("#{method}('%%')")
+        end
+
+        it 'does not register an offense when the string contains a format specifier' do
+          expect_no_offenses("#{method}('%s')")
+        end
       end
 
       context 'with literal arguments' do

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
         it_behaves_like 'offending format specifier', '%s', '1i', "'0+1i'"
         it_behaves_like 'offending format specifier', '%s', 'true', "'true'"
         it_behaves_like 'offending format specifier', '%s', 'false', "'false'"
-        it_behaves_like 'offending format specifier', '%s', 'nil', "'nil'"
+        it_behaves_like 'offending format specifier', '%s', 'nil', "''"
 
         it_behaves_like 'non-offending format specifier', '%s', 'foo'
         it_behaves_like 'non-offending format specifier', '%s', '[]'


### PR DESCRIPTION
Two related autocorrect bugs in `Style/RedundantFormat`, each in its own commit.

- A single-argument `format`/`sprintf` whose string still contains a format sequence was wrongly treated as redundant. `format('%s')` actually raises `ArgumentError` (the cop silenced a real error), and `format('%%')` returns `'%'`, not `'%%'`. Such strings are no longer flagged.
- `format('%s', nil)` returns `''` (since `nil.to_s == ''`), but the cop computed the literal `'nil'` and corrected to that. A `nil` argument now maps to the Ruby `nil` value, so it corrects to `''`. (Updated the spec that had locked in the wrong `'nil'` output.)
