### PR TITLE
Fix a crash for Style/OpenStructUse with a bare OpenStruct root node

### DIFF
--- a/changelog/fix_a_crash_for_style_open_struct_use_with_a_bare_open_struct_root_node_20260626164917.md
+++ b/changelog/fix_a_crash_for_style_open_struct_use_with_a_bare_open_struct_root_node_20260626164917.md
@@ -1,0 +1,1 @@
+* [#15351](https://github.com/rubocop/rubocop/pull/15351): Fix a crash for `Style/OpenStructUse` with a bare `OpenStruct` root node. ([@bbatsov][])

--- a/lib/rubocop/cop/style/open_struct_use.rb
+++ b/lib/rubocop/cop/style/open_struct_use.rb
@@ -61,7 +61,7 @@ module RuboCop
         def custom_class_or_module_definition?(node)
           parent = node.parent
 
-          parent.type?(:class, :module) && node.left_siblings.empty?
+          parent&.type?(:class, :module) && node.left_siblings.empty?
         end
       end
     end

--- a/spec/rubocop/cop/style/open_struct_use_spec.rb
+++ b/spec/rubocop/cop/style/open_struct_use_spec.rb
@@ -79,4 +79,13 @@ RSpec.describe RuboCop::Cop::Style::OpenStructUse, :config do
       expect_no_offenses('a = 42')
     end
   end
+
+  context 'when a bare `OpenStruct` constant is the root node' do
+    it 'registers an offense without crashing' do
+      expect_offense(<<~RUBY)
+        OpenStruct
+        ^^^^^^^^^^ Avoid using `OpenStruct`; use `Struct`, `Hash`, a class or test doubles instead.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/OpenStructUse` crashed with `NoMethodError: undefined method 'type?' for nil` when a file's only expression was a bare `OpenStruct` constant (the root node has no parent). Guard the parent access with safe navigation.
