### PR TITLE
Fix invalid-Ruby autocorrects in Style/ParallelAssignment for %w/%i elements

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_a_i_element_20260626165345.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_a_i_element_20260626165345.md
@@ -1,0 +1,1 @@
+* [#15352](https://github.com/rubocop/rubocop/pull/15352): Fix an incorrect autocorrect for `Style/ParallelAssignment` with a `%i` element needing quoting. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_a_w_element_20260626165344.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_parallel_assignment_with_a_w_element_20260626165344.md
@@ -1,0 +1,1 @@
+* [#15352](https://github.com/rubocop/rubocop/pull/15352): Fix an incorrect autocorrect for `Style/ParallelAssignment` with a `%w` element needing escaping. ([@bbatsov][])

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -233,12 +233,18 @@ module RuboCop
           def source(node, loc)
             # __FILE__ is treated as a StrNode but has no begin
             if node.str_type? && loc.respond_to?(:begin) && loc.begin.nil?
-              "'#{node.source}'"
+              # `%w` elements have no per-element delimiter, so the value must be
+              # quoted and escaped to stay valid (e.g. `%w(it's)` -> `'it\'s'`).
+              quote(node.value)
             elsif node.sym_type? && !node.loc?(:begin)
               ":#{node.source}"
             else
               node.source
             end
+          end
+
+          def quote(string)
+            "'#{string.gsub(/[\\']/) { |char| "\\#{char}" }}'"
           end
 
           def extract_sources(node)

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -237,7 +237,10 @@ module RuboCop
               # quoted and escaped to stay valid (e.g. `%w(it's)` -> `'it\'s'`).
               quote(node.value)
             elsif node.sym_type? && !node.loc?(:begin)
-              ":#{node.source}"
+              # `%i` elements have no per-element delimiter, so a symbol that needs
+              # quoting must be emitted as `:"..."` (e.g. `%i(foo-bar)` -> `:"foo-bar"`),
+              # otherwise `:foo-bar` would parse as `:foo.-(bar)`.
+              node.value.inspect
             else
               node.source
             end

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -291,6 +291,18 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     RUBY
   end
 
+  it 'corrects when a word array element contains a single quote' do
+    expect_offense(<<~'RUBY')
+      a, b = %w(it's fine)
+      ^^^^^^^^^^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      a = 'it\'s'
+      b = 'fine'
+    RUBY
+  end
+
   it 'corrects when the right variable is a symbol array' do
     expect_offense(<<~RUBY)
       a, b, c = %i(a b c)

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
   end
 
   it 'corrects when a word array element contains a single quote' do
-    expect_offense(<<~'RUBY')
+    expect_offense(<<~RUBY)
       a, b = %w(it's fine)
       ^^^^^^^^^^^^^^^^^^^^ Do not use parallel assignment.
     RUBY
@@ -300,6 +300,18 @@ RSpec.describe RuboCop::Cop::Style::ParallelAssignment, :config do
     expect_correction(<<~'RUBY')
       a = 'it\'s'
       b = 'fine'
+    RUBY
+  end
+
+  it 'corrects when a symbol array element needs quoting' do
+    expect_offense(<<~RUBY)
+      a, b = %i(foo-bar baz)
+      ^^^^^^^^^^^^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a = :"foo-bar"
+      b = :baz
     RUBY
   end
 


### PR DESCRIPTION
`Style/ParallelAssignment` splits `a, b = %w(...)` / `%i(...)` into individual assignments, but it built each element by naively wrapping the raw source in quotes. Elements that need escaping then broke. Each fix is its own commit.

- `a, b = %w(it's fine)` produced `a = 'it's'`, a syntax error. Word-array elements are now properly single-quote escaped.
- `a, b = %i(foo-bar baz)` produced `a = :foo-bar`, which parses as `:foo.-(bar)` and raises at runtime. Symbol-array elements that need quoting are now emitted as `:"foo-bar"` (simple symbols stay `:baz`).
