### PR TITLE
Fix JRuby CI failure caused by rbs native extension build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem 'irb'
 gem 'mcp', '~> 0.16'
 gem 'memory_profiler', '!= 1.0.2', platform: :mri
 gem 'rake', '~> 13.0'
+# FIXME: rdoc 8.0+ depends on rbs, whose released C extension fails to build on JRuby.
+# rbs 4.1.0.pre.2 ships a `java` platform gem that works on JRuby, so pin to it there
+# until a stable release that supports JRuby ships.
+# https://github.com/ruby/rdoc/issues/1746
+gem 'rbs', '4.1.0.pre.2' if RUBY_ENGINE == 'jruby'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.26.0', require: false
 gem 'rubocop-rake', '~> 0.7.0', require: false


### PR DESCRIPTION
`rdoc` 8.0+ depends on `rbs`, whose released C extension fails to build on JRuby:

```console
Installing rbs 4.0.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
RuntimeError: The compiler failed to generate an executable file.
```

Pin `rbs` to 4.1.0.pre.2 on JRuby, which ships a `java` platform gem that works on JRuby without building the native extension.
https://github.com/ruby/rdoc/issues/1746#issuecomment-4811754066

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
