### PR TITLE
Fix false negative for Lint/AmbiguousAssignment on send assignments

### DIFF
--- a/changelog/fix_false_negative_for_lint_ambiguous_assignment_send_assignment.md
+++ b/changelog/fix_false_negative_for_lint_ambiguous_assignment_send_assignment.md
@@ -1,0 +1,1 @@
+* [#15357](https://github.com/rubocop/rubocop/pull/15357): Fix a false negative for `Lint/AmbiguousAssignment` when using attribute or index assignment. ([@sngsmz][])

--- a/lib/rubocop/cop/lint/ambiguous_assignment.rb
+++ b/lib/rubocop/cop/lint/ambiguous_assignment.rb
@@ -19,25 +19,27 @@ module RuboCop
       #   x != y # or x = !y
       #
       class AmbiguousAssignment < Base
+        include CheckAssignment
         include RangeHelp
 
         MSG = 'Suspicious assignment detected. Did you mean `%<op>s`?'
 
-        SIMPLE_ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn casgn].freeze
-
         MISTAKES = { '=-' => '-=', '=+' => '+=', '=*' => '*=', '=!' => '!=' }.freeze
 
-        def on_asgn(node)
-          return unless (rhs = node.expression)
+        alias on_csend on_send
 
-          range = range_between(node.loc.operator.end_pos - 1, rhs.source_range.begin_pos + 1)
+        private
+
+        def check_assignment(node, rhs)
+          return unless rhs
+          return unless (operator = node.loc.operator)
+
+          range = range_between(operator.end_pos - 1, rhs.source_range.begin_pos + 1)
           source = range.source
           return unless MISTAKES.key?(source)
 
           add_offense(range, message: format(MSG, op: MISTAKES[source]))
         end
-
-        SIMPLE_ASSIGNMENT_TYPES.each { |asgn_type| alias_method :"on_#{asgn_type}", :on_asgn }
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_assignment_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::AmbiguousAssignment, :config do
+  assignment_targets = %w[x @x @@x $x X obj.foo arr[0] hash[:key] self.foo obj&.foo h[k]].freeze
+
   described_class::MISTAKES.each_key do |mistake|
     operator = mistake[1]
 
-    %i[x @x @@x $x X].each do |lhs|
+    assignment_targets.each do |lhs|
       it "registers an offense when using `#{operator}` with `#{lhs}`" do
         expect_offense(<<~RUBY, operator: operator, lhs: lhs)
           %{lhs} =%{operator} y
@@ -12,10 +14,10 @@ RSpec.describe RuboCop::Cop::Lint::AmbiguousAssignment, :config do
         RUBY
       end
 
-      it 'does not register an offense when no mistype assignments' do
+      it "does not register an offense when using `#{operator}` correctly with `#{lhs}`" do
         expect_no_offenses(<<~RUBY)
-          x #{operator}= y
-          x = #{operator}y
+          #{lhs} #{operator}= y
+          #{lhs} = #{operator}y
         RUBY
       end
     end


### PR DESCRIPTION
## Summary
Extend `Lint/AmbiguousAssignment` to detect mistyped assignments on send/csend assignments (e.g. `obj.foo =- y`, `arr[0] =- y`).

## Details
`Lint/AmbiguousAssignment` flags mistyped shorthand assignments such as `=-`, `=+`, `=*`, and `=!` (e.g. `x =- y` instead of `x -= y` or `x = -y`).
Before this change, the cop only handled simple assignment nodes (`lvasgn`, `ivasgn`, etc.). Attribute and index assignments are parsed as `:send`/`:csend` nodes (e.g. `obj.foo = y`, `arr[0] = y`), so mistyped forms like `obj.foo =- y` or `arr[0] =- y` were not reported.
This PR includes the `CheckAssignment` mixin and moves the detection logic into `check_assignment(node, rhs)`. That lets the cop reuse the same check for both simple assignments and send/csend assignments. Safe navigation assignment (`obj&.foo =- y`) is covered via `alias on_csend on_send`.
The set of detected patterns is unchanged (`=-`, `=+`, `=*`, `=!`). No autocorrect is added.

## Test plan
- [x] `bundle exec rspec spec/rubocop/cop/lint/ambiguous_assignment_spec.rb`
- [x] `bundle exec rake`
- [x] `yamllint .`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
