### PR TITLE
[Fix #15356] Fix an infinite loop for `Lint/AssignmentInCondition`

### DIFF
--- a/changelog/fix_an_infinite_loop_for_lint_assignment_in_condition.md
+++ b/changelog/fix_an_infinite_loop_for_lint_assignment_in_condition.md
@@ -1,0 +1,1 @@
+* [#15356](https://github.com/rubocop/rubocop/issues/15356): Fix an infinite loop between `Lint/AssignmentInCondition` and `Style/RedundantParentheses` when an assignment is a statement of a multi-statement `begin` in a condition. ([@koic][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -78,11 +78,23 @@ module RuboCop
         end
 
         def allowed_construct?(asgn_node)
-          asgn_node.begin_type? || conditional_assignment?(asgn_node)
+          return true if asgn_node.begin_type?
+
+          conditional_assignment?(asgn_node) || discarded_assignment?(asgn_node)
         end
 
         def conditional_assignment?(asgn_node)
           !asgn_node.loc.operator
+        end
+
+        # An assignment that is a statement of a multi-statement `begin`
+        # (e.g. `(foo = bar; baz)`) has its value discarded, so it is not used
+        # as the condition. Wrapping it in parentheses would only conflict with
+        # `Style/RedundantParentheses`, so it is left alone.
+        def discarded_assignment?(asgn_node)
+          parent = asgn_node.parent
+
+          parent&.begin_type? && parent.children.size > 1
         end
 
         def skip_children?(asgn_node)

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -161,6 +161,50 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     RUBY
   end
 
+  it 'accepts an assignment that is a statement of a multi-statement begin in a condition' do
+    expect_no_offenses(<<~RUBY)
+      if !a || (
+        b = c
+        b == 'd'
+      )
+        foo
+      end
+    RUBY
+  end
+
+  it 'accepts an assignment as the last statement of a multi-statement begin in a condition' do
+    expect_no_offenses(<<~RUBY)
+      if a || (
+        foo
+        b = c
+      )
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts an assignment method as a statement of a multi-statement begin in a condition' do
+    expect_no_offenses(<<~RUBY)
+      if a || (
+        obj.foo = c
+        obj.foo == 'd'
+      )
+        bar
+      end
+    RUBY
+  end
+
+  it 'accepts an assignment in a multi-statement begin used directly as a condition' do
+    expect_no_offenses(<<~RUBY)
+      if (
+        b = c
+        b == 'd'
+      )
+        foo
+      end
+    RUBY
+  end
+
   it 'registers an offense for = in condition inside a block' do
     expect_offense(<<~RUBY)
       foo { x if y = z }


### PR DESCRIPTION
Autocorrecting an assignment that appears as a statement inside a multi-statement `begin` in a condition looped forever between `Lint/AssignmentInCondition` and `Style/RedundantParentheses`:

```ruby
if !a || (
  b = c
  b == 'd'
)
  puts 1
end
```

`Lint/AssignmentInCondition` wrapped `b = c` in parentheses as a safe-assignment marker, and `Style/RedundantParentheses` then removed them again as redundant, with each correction undoing the other.

Such an assignment is just a statement of the sequence and its value is discarded, so it is not actually used as the condition. It is not the `if x = 5` mistake this cop is meant to catch, so it is no longer reported.

Fixes #15356.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
