### PR TITLE
[Fix #15318] Fix `--fail-fast` not reporting offenses

### DIFF
--- a/changelog/fix_fail_fast_not_reporting_offenses_20260627212027.md
+++ b/changelog/fix_fail_fast_not_reporting_offenses_20260627212027.md
@@ -1,0 +1,1 @@
+* [#15318](https://github.com/rubocop/rubocop/issues/15318): Fix `--fail-fast` not reporting offenses and exiting with a zero status when offenses are found. ([@koic][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -120,7 +120,6 @@ module RuboCop
       file_iterator(files) do |file|
         offenses = process_file(file)
         succeeded = offenses.none? { |o| considered_failure?(o) && offense_displayed?(o) }
-        raise Parallel::Break if @options[:fail_fast] && !succeeded
 
         [offenses, succeeded]
       end
@@ -211,8 +210,11 @@ module RuboCop
         on_start.call(file, index)
         result = yield file
         on_finish.call(file, index, result)
-      rescue Parallel::Break
-        break
+
+        # Report and count the offending file before stopping so `--fail-fast`
+        # still shows its offenses and exits with a failing status.
+        _offenses, succeeded = result
+        break if @options[:fail_fast] && !succeeded
       end
     end
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1922,6 +1922,37 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
     end
   end
 
+  describe '--fail-fast option' do
+    it 'reports offenses in the offending file and exits with a failing status' do
+      create_file('example.rb', <<~RUBY)
+        def f
+         x
+        end
+      RUBY
+
+      expect(cli.run(['--fail-fast', '--only', 'Layout/IndentationWidth', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Layout/IndentationWidth')
+      expect($stdout.string).to include('1 file inspected, 1 offense detected')
+    end
+
+    it 'stops after the first offending file but still reports it' do
+      create_file('a.rb', <<~RUBY)
+        def f
+         x
+        end
+      RUBY
+      create_file('b.rb', <<~RUBY)
+        def g
+         y
+        end
+      RUBY
+
+      expect(cli.run(['--fail-fast', '--only', 'Layout/IndentationWidth', 'a.rb', 'b.rb'])).to eq(1)
+      expect($stdout.string).to include('Layout/IndentationWidth')
+      expect($stdout.string).to include('1 file inspected, 1 offense detected')
+    end
+  end
+
   describe '--fail-level option' do
     let(:target_file) { 'example.rb' }
 


### PR DESCRIPTION
When `--fail-fast` stopped after the first offending file, the file's offenses were neither reported nor counted, and the run exited with a zero status. The break was raised from inside the file iterator block before `on_finish` ran, so the offending file was silently dropped.

Move the fail-fast break out of the block and into `serial_file_iterator` so it stops only after the offending file has been reported and counted, restoring a failing exit status.

Fixes #15318.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
