### PR TITLE
[Fix #15360] Fix an incorrect autocorrect for `Style/ArgumentsForwarding` and `Style/MethodDefParentheses`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_arguments_forwarding_and_method_def_parentheses.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_arguments_forwarding_and_method_def_parentheses.md
@@ -1,0 +1,1 @@
+* [#15360](https://github.com/rubocop/rubocop/issues/15360): Fix an incorrect autocorrect for `Style/ArgumentsForwarding` and `Style/MethodDefParentheses` when autocorrection conflicts while adding parentheses to method definition arguments. ([@koic][])

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -153,7 +153,7 @@ module RuboCop
         BLOCK_MSG = 'Use anonymous block arguments forwarding (`&`).'
 
         def self.autocorrect_incompatible_with
-          [Naming::BlockForwarding]
+          [Naming::BlockForwarding, Style::MethodDefParentheses]
         end
 
         def on_def(node)

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -102,6 +102,10 @@ module RuboCop
         MSG_PRESENT = 'Use def without parentheses.'
         MSG_MISSING = 'Use def with parentheses when there are parameters.'
 
+        def self.autocorrect_incompatible_with
+          [Style::ArgumentsForwarding]
+        end
+
         def on_def(node)
           args = node.arguments
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -680,6 +680,50 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/ArgumentsForwarding` with `Style/MethodDefParentheses`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.2
+    YAML
+    source = <<~RUBY
+      def draw_point **opts
+        draw_rect(**opts)
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Style/ArgumentsForwarding,Style/MethodDefParentheses'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def draw_point(**)
+        draw_rect(**)
+      end
+    RUBY
+  end
+
+  it 'corrects `Style/ArgumentsForwarding` with `Style/MethodDefParentheses` for positional and block arguments' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.2
+    YAML
+    source = <<~RUBY
+      def draw_point *args, &block
+        draw_rect(*args, &block)
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Style/ArgumentsForwarding,Style/MethodDefParentheses'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def draw_point(*, &)
+        draw_rect(*, &)
+      end
+    RUBY
+  end
+
   describe 'trailing comma cops' do
     let(:source) do
       <<~RUBY


### PR DESCRIPTION
Running autocorrect with both `Style/ArgumentsForwarding` and `Style/MethodDefParentheses` enabled produced syntactically invalid Ruby such as `def draw_point(**)); draw_rect(**); end`.

Both cops independently add parentheses around the same method definition argument list in a single correction pass. The opening parenthesis is deduplicated by the rewriter, but the two closing parentheses are concatenated, and because the duplication never triggers a clobbering error there is no second pass to clean it up.

This declares the two cops mutually incompatible for autocorrect, so the framework applies one of them per pass and resolves the remaining offense on a later pass, the same approach already used between `Style/ArgumentsForwarding` and `Naming/BlockForwarding`.

Fixes #15360.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
