### PR TITLE
Fix an incorrect autocorrect for `Style/MultipleComparison`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_multiple_comparison_20260628111038.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_multiple_comparison_20260628111038.md
@@ -1,0 +1,1 @@
+* [#15364](https://github.com/rubocop/rubocop/pull/15364): Fix an incorrect autocorrect for `Style/MultipleComparison` that dropped an allowed method comparison appearing between the compared values. ([@bbatsov][])

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -70,48 +70,59 @@ module RuboCop
           (send $_ :== ${lvar call})
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
         def on_or(node)
-          root_of_or_node = root_of_or_node(node)
-          return unless node == root_of_or_node
+          return unless node == root_of_or_node(node)
           return unless nested_comparison?(node)
-
-          return unless (variable, values = find_offending_var(node))
+          return unless (variable, values, skipped = find_offending_var(node))
           return if values.size < comparisons_threshold
 
           range = offense_range(values)
+          # Bail when an allowed method comparison sits between the collected
+          # values: collapsing them into a single `include?` would drop it.
+          return if skipped_within_range?(skipped, range)
 
           add_offense(range) do |corrector|
-            elements = values.map(&:source).join(', ')
-            argument = variable.lvar_type? ? variable_name(variable) : variable.source
-            prefer_method = "[#{elements}].include?(#{argument})"
-
-            corrector.replace(range, prefer_method)
+            corrector.replace(range, preferred_method(variable, values))
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        def find_offending_var(node, variables = Set.new, values = [])
+        def skipped_within_range?(skipped, range)
+          skipped.any? { |node_part| range.contains?(node_part.source_range) }
+        end
+
+        def preferred_method(variable, values)
+          elements = values.map(&:source).join(', ')
+          argument = variable.lvar_type? ? variable_name(variable) : variable.source
+          "[#{elements}].include?(#{argument})"
+        end
+
+        def find_offending_var(node, variables = Set.new, values = [], skipped = [])
           if node.or_type?
-            find_offending_var(node.lhs, variables, values)
-            find_offending_var(node.rhs, variables, values)
+            find_offending_var(node.lhs, variables, values, skipped)
+            find_offending_var(node.rhs, variables, values, skipped)
           elsif simple_double_comparison?(node)
             return
-          elsif (var, obj = simple_comparison(node))
-            return if allow_method_comparison? && obj.call_type?
-
-            variables << var
-            return if variables.size > 1
-
-            values << obj
+          elsif (comparison = simple_comparison(node))
+            collect_comparison(node, comparison, variables, values, skipped)
           end
 
-          [variables.first, values] if variables.any?
+          [variables.first, values, skipped] if variables.any?
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def collect_comparison(node, comparison, variables, values, skipped)
+          var, obj = comparison
+          if allow_method_comparison? && obj.call_type?
+            skipped << node
+            return
+          end
+
+          variables << var
+          return if variables.size > 1
+
+          values << obj
+        end
 
         def offense_range(values)
           values.first.parent.source_range.begin.join(values.last.parent.source_range.end)

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe RuboCop::Cop::Style::MultipleComparison, :config do
       RUBY
     end
 
+    it 'does not register an offense when an allowed method comparison sits between the compared values' do
+      expect_no_offenses(<<~RUBY)
+        var = do_something
+        var == 'bar' || var == foo || var == 'baz'
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the allowed method comparison trails the compared values' do
+      expect_offense(<<~RUBY)
+        var = do_something
+        var == 'bar' || var == 'baz' || var == foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid comparing a variable with multiple items in a conditional, use `Array#include?` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = do_something
+        ['bar', 'baz'].include?(var) || var == foo
+      RUBY
+    end
+
     it 'registers an offense and corrects when comparing with hash access on rhs' do
       expect_offense(<<~RUBY)
         if a[:key] == 'a' || a[:key] == 'b'


### PR DESCRIPTION
When `AllowMethodComparison` is true (the default) and a method comparison sits *between* two literal comparisons of the same variable, the autocorrect collapsed the whole span into a single `include?` and silently dropped the method comparison:

```ruby
# before
a == 1 || a == foo || a == 2
# autocorrected to (a == foo is gone!)
[1, 2].include?(a)
```

Leading and trailing method comparisons were already handled correctly (the offense range didn't cover them), so only the in-between case was broken. The fix bails out of the offense when an allowed method comparison falls inside the range we'd collapse, since there's no safe single-`include?` rewrite for non-contiguous values.

Found while auditing the Style department.