### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantLineContinuation`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_line_continuation_20260628111318.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_line_continuation_20260628111318.md
@@ -1,0 +1,1 @@
+* [#15365](https://github.com/rubocop/rubocop/pull/15365): Fix an incorrect autocorrect for `Style/RedundantLineContinuation` that corrupted an earlier line when removing a line continuation at the end of a multi-line file. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -165,11 +165,11 @@ module RuboCop
         end
 
         def inspect_end_of_ruby_code_line_continuation
-          last_line = processed_source.lines[processed_source.ast.last_line - 1]
+          last_line_number = processed_source.ast.last_line
+          last_line = processed_source.lines[last_line_number - 1]
           return unless code_ends_with_continuation?(last_line)
 
-          last_column = last_line.length
-          line_continuation_range = range_between(last_column - 1, last_column)
+          line_continuation_range = trailing_line_continuation_range(last_line_number)
 
           add_offense(line_continuation_range) do |corrector|
             corrector.remove_trailing(line_continuation_range, 1)
@@ -180,6 +180,14 @@ module RuboCop
           return false if processed_source.line_with_comment?(processed_source.ast.last_line)
 
           last_line.end_with?(LINE_CONTINUATION)
+        end
+
+        # The backslash is the last character of the line; locate it by the line's
+        # position in the buffer rather than treating the column as an absolute offset
+        # (which corrupts an earlier line in multi-line files).
+        def trailing_line_continuation_range(line_number)
+          line_range = processed_source.buffer.line_range(line_number)
+          range_between(line_range.end_pos - 1, line_range.end_pos)
         end
 
         def inside_string_literal?(range, token)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -1002,6 +1002,23 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'registers an offense when there is a line continuation at the end of Ruby code in a multi-line file' do
+    expect_offense(<<~'RUBY')
+      def foo
+        bar
+      end
+      some_code \
+                ^ Redundant line continuation.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        bar
+      end
+      some_code#{trailing_whitespace}
+    RUBY
+  end
+
   it 'registers an offense when there is a line continuation at the end of Ruby code followed by `__END__` data' do
     expect_offense(<<~'RUBY')
       foo \


### PR DESCRIPTION
Removing a redundant line continuation at the very end of a file built the removal range from the line's *column* but passed it to `range_between`, which expects an absolute buffer offset. The two only coincide when the continuation is on line 1, so in any multi-line file the autocorrect deleted a character from some earlier line and produced invalid Ruby:

```ruby
def foo
  bar
end
some_code \
```

autocorrected to:

```ruby
def foo
  nd
some_code \
```

The fix locates the backslash via the buffer's line range instead of treating the column as an offset. Found while auditing the Style department.