### PR TITLE
Fix an incorrect autocorrect for `Style/PercentLiteralDelimiters`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_percent_literal_delimiters_20260628111534.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_percent_literal_delimiters_20260628111534.md
@@ -1,0 +1,1 @@
+* [#15366](https://github.com/rubocop/rubocop/pull/15366): Fix an incorrect autocorrect for `Style/PercentLiteralDelimiters` that produced invalid Ruby for a `%s` symbol whose content contains the preferred delimiter. ([@bbatsov][])

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -101,6 +101,8 @@ module RuboCop
         def string_source(node)
           if node.is_a?(String)
             node.scrub
+          elsif node.is_a?(Symbol)
+            node.to_s
           elsif node.respond_to?(:type) && node.type?(:str, :sym)
             node.source
           end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -319,6 +319,10 @@ RSpec.describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
         %s[symbol]
       RUBY
     end
+
+    it 'does not register an offense when the symbol contains the preferred delimiter' do
+      expect_no_offenses('%s([)')
+    end
   end
 
   context '`%x` interpolated system call' do


### PR DESCRIPTION
With a preferred delimiter like `[]`, a `%s` symbol whose content contains that delimiter character was rewritten to invalid Ruby:

```ruby
# Style/PercentLiteralDelimiters:
#   PreferredDelimiters:
#     default: '[]'

%s([)  # autocorrected to %s[[]  -> syntax error
```

String-type literals (`%q([)` etc.) were already guarded, because their content is a `String` that `contains_preferred_delimiter?` can scan. A `%s` literal's content is a bare `Symbol`, which `string_source` didn't recognize, so the guard never fired. The fix teaches `string_source` to read a bare symbol's content, so the cop leaves the literal alone when switching delimiters would clash.

Found while auditing the Style department.