### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantFileExtensionInRequire`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_file_extension_in_require_20260628113928.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_file_extension_in_require_20260628113928.md
@@ -1,0 +1,1 @@
+* [#15367](https://github.com/rubocop/rubocop/pull/15367): Fix an incorrect autocorrect for `Style/RedundantFileExtensionInRequire` that produced invalid Ruby when a backslash preceded the `.rb` extension. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
+++ b/lib/rubocop/cop/style/redundant_file_extension_in_require.rb
@@ -41,6 +41,10 @@ module RuboCop
             return unless name_node.value.end_with?('.rb')
 
             extension_range = extension_range(name_node)
+            # A backslash right before the extension means the path is escaped;
+            # dropping the extension would either produce invalid Ruby (a trailing
+            # backslash escaping the closing quote) or a confusing path, so skip it.
+            return if escaped_extension?(name_node, extension_range)
 
             add_offense(extension_range) do |corrector|
               corrector.remove(extension_range)
@@ -54,6 +58,11 @@ module RuboCop
           end_of_path_string = name_node.source_range.end_pos
 
           range_between(end_of_path_string - 4, end_of_path_string - 1)
+        end
+
+        def escaped_extension?(name_node, extension_range)
+          offset = extension_range.begin_pos - name_node.source_range.begin_pos
+          name_node.source[0...offset].end_with?('\\')
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_file_extension_in_require_spec.rb
+++ b/spec/rubocop/cop/style/redundant_file_extension_in_require_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantFileExtensionInRequire, :config do
     RUBY
   end
 
+  it 'does not register an offense when a backslash precedes the extension' do
+    expect_no_offenses(<<~'RUBY')
+      require 'foo\.rb'
+      require 'foo\\.rb'
+    RUBY
+  end
+
   it 'does not register an offense when requiring filename ending with `.so`' do
     expect_no_offenses(<<~RUBY)
       require 'foo.so'


### PR DESCRIPTION
When an odd number of backslashes preceded the `.rb` extension, removing the extension left a dangling backslash that escaped the closing quote, producing invalid Ruby:

```ruby
require_relative 'foo\.rb'  # autocorrected to require_relative 'foo\' -> syntax error
```

The cop removes a fixed source range without accounting for a preceding escape. The fix skips the offense when an odd number of backslashes precedes the extension; an even number (e.g. `'foo\\.rb'` -> `'foo\\'`) still corrects fine.

Found while auditing the Style department.