### PR TITLE
Fix an incorrect autocorrect for `Style/IfWithSemicolon`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_20260628114135.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_if_with_semicolon_20260628114135.md
@@ -1,0 +1,1 @@
+* [#15368](https://github.com/rubocop/rubocop/pull/15368): Fix an incorrect autocorrect for `Style/IfWithSemicolon` that changed semantics when the condition was an assignment, by parenthesizing it in the resulting ternary. ([@bbatsov][])

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -82,7 +82,7 @@ module RuboCop
 
           then_code, else_code = else_code, then_code if node.unless?
 
-          "#{node.condition.source} ? #{then_code} : #{else_code}"
+          "#{ternary_condition(node)} ? #{then_code} : #{else_code}"
         end
 
         def correct_elsif(node)
@@ -101,6 +101,14 @@ module RuboCop
           arguments = expr.first_argument.source_range.begin.join(expr.source_range.end)
 
           "#{method.source}(#{arguments.source})"
+        end
+
+        # An assignment used as the condition must be parenthesized, otherwise the
+        # assignment would capture the whole ternary (`a = b ? c : d` instead of
+        # `(a = b) ? c : d`), changing what gets assigned.
+        def ternary_condition(node)
+          condition = node.condition
+          condition.assignment? ? "(#{condition.source})" : condition.source
         end
 
         def build_else_branch(second_condition)

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Style::IfWithSemicolon, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when the condition is an assignment' do
+    expect_offense(<<~RUBY)
+      if a = b; run else dont end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `if a = b;` - use a ternary operator instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a = b) ? run : dont
+    RUBY
+  end
+
   it 'registers an offense and corrects for one line if/;/end without then body' do
     expect_offense(<<~RUBY)
       if cond; else dont end


### PR DESCRIPTION
When the condition is an assignment, the ternary rewrite let the assignment swallow the whole ternary, changing what gets assigned:

```ruby
if a = some_call; do_thing end
# autocorrected to (a now gets the ternary result, not some_call):
a = some_call ? do_thing : nil
```

The fix parenthesizes an assignment condition so the original semantics are preserved: `(a = some_call) ? do_thing : nil`. Plain conditions are unchanged.

Found while auditing the Style department.