### PR TITLE
Fix a false positive for `Style/LambdaCall` with a comment in the argument list

### DIFF
--- a/changelog/fix_style_lambda_call_dropping_comments_on_autocorrect_20260628114530.md
+++ b/changelog/fix_style_lambda_call_dropping_comments_on_autocorrect_20260628114530.md
@@ -1,0 +1,1 @@
+* [#15369](https://github.com/rubocop/rubocop/pull/15369): Fix a false positive for `Style/LambdaCall` when the argument list contains a comment, which the autocorrect would have dropped. ([@bbatsov][])

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -27,6 +27,9 @@ module RuboCop
 
         def on_send(node)
           return unless node.receiver
+          # Rewriting the call rebuilds it as a single expression, which would drop
+          # any comments inside the argument list, so leave it to be fixed manually.
+          return if comments_in_node?(node)
 
           if offense?(node)
             prefer = prefer(node)
@@ -47,6 +50,14 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def comments_in_node?(node)
+          range = node.source_range
+          processed_source.comments.any? do |comment|
+            range.begin_pos <= comment.source_range.begin_pos &&
+              comment.source_range.end_pos <= range.end_pos
+          end
+        end
 
         def offense?(node)
           (explicit_style? && node.implicit_call?) || (implicit_style? && !node.implicit_call?)

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -145,6 +145,16 @@ RSpec.describe RuboCop::Cop::Style::LambdaCall, :config do
       RUBY
     end
 
+    it 'does not register an offense when the argument list contains a comment' do
+      expect_no_offenses(<<~RUBY)
+        x.call(
+          a,
+          # important comment
+          b
+        )
+      RUBY
+    end
+
     it 'registers an offense for opposite + correct' do
       expect_offense(<<~RUBY)
         x.call(a, b)


### PR DESCRIPTION
The autocorrect rebuilds the call from the argument sources, so a comment inside a multiline argument list was silently dropped:

```ruby
# EnforcedStyle: braces
x.call(
  a,
  # important comment
  b
)
# autocorrected to `x.(a, b)` - comment gone
```

Both rewrite directions flatten the call, so neither can preserve an interior comment. The cop now skips a call that contains a comment inside its range (a trailing comment after the call is unaffected). Found while auditing the Style department.