### PR TITLE
Fix an incorrect autocorrect for `Style/PerlBackrefs` with `$+`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_perl_backrefs_with__20260628114817.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_perl_backrefs_with__20260628114817.md
@@ -1,0 +1,1 @@
+* [#15370](https://github.com/rubocop/rubocop/pull/15370): Fix an incorrect autocorrect for `Style/PerlBackrefs` that rewrote `$+`/`$LAST_PAREN_MATCH` to the non-equivalent `Regexp.last_match(-1)`; these are no longer flagged. ([@bbatsov][])

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # Looks for uses of Perl-style regexp match
       # backreferences and their English versions like
-      # $1, $2, $&, &+, $MATCH, $PREMATCH, etc.
+      # $1, $2, $&, $MATCH, $PREMATCH, etc.
       #
       # @example
       #   # bad
@@ -69,6 +69,10 @@ module RuboCop
         # @return [String, nil]
         def preferred_expression_to(node)
           first = node.to_a.first
+          # NOTE: `$+` / `$LAST_PAREN_MATCH` is deliberately not converted. It
+          # refers to the last group that actually matched, which has no concise
+          # `Regexp.last_match` equivalent (`Regexp.last_match(-1)` is the last
+          # group in the pattern, which may be `nil`).
           case first
           when ::Integer
             "Regexp.last_match(#{first})"
@@ -78,8 +82,6 @@ module RuboCop
             'Regexp.last_match.pre_match'
           when :$', :$POSTMATCH
             'Regexp.last_match.post_match'
-          when :$+, :$LAST_PAREN_MATCH
-            'Regexp.last_match(-1)'
           end
         end
 

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -56,14 +56,9 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'autocorrects $+ to Regexp.last_match(-1)' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for $+, which has no concise equivalent' do
+    expect_no_offenses(<<~RUBY)
       $+
-      ^^ Prefer `Regexp.last_match(-1)` over `$+`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      Regexp.last_match(-1)
     RUBY
   end
 
@@ -100,14 +95,9 @@ RSpec.describe RuboCop::Cop::Style::PerlBackrefs, :config do
     RUBY
   end
 
-  it 'autocorrects $LAST_PAREN_MATCH to Regexp.last_match(-1)' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for $LAST_PAREN_MATCH, which has no concise equivalent' do
+    expect_no_offenses(<<~RUBY)
       $LAST_PAREN_MATCH
-      ^^^^^^^^^^^^^^^^^ Prefer `Regexp.last_match(-1)` over `$LAST_PAREN_MATCH`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      Regexp.last_match(-1)
     RUBY
   end
 


### PR DESCRIPTION
`Style/PerlBackrefs` rewrote `$+` (and `$LAST_PAREN_MATCH`) to `Regexp.last_match(-1)`, but they aren't equivalent. `$+` is the last group that *actually matched*, while `Regexp.last_match(-1)` is the last group in the pattern, which can be `nil`:

```ruby
'a' =~ /(a)|(b)/
$+                     # => "a"
Regexp.last_match(-1)  # => nil
```

There's no concise `Regexp.last_match` form for `$+`, so rather than emit a semantically different correction from a cop whose autocorrect is considered safe, this stops flagging `$+`/`$LAST_PAREN_MATCH` altogether. The other backrefs (`$1`, `$&`, `$PREMATCH`, ...) are unaffected.

Open to other directions here if you'd prefer to keep flagging them with a different (necessarily more verbose) replacement. Found while auditing the Style department.