### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantException` with a `nil` message

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_exception_with_a_nil_message_20260628115028.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_exception_with_a_nil_message_20260628115028.md
@@ -1,0 +1,1 @@
+* [#15371](https://github.com/rubocop/rubocop/pull/15371): Fix an incorrect autocorrect for `Style/RedundantException` that changed the exception message when raising `RuntimeError` with a `nil` message. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -38,6 +38,10 @@ module RuboCop
 
         def fix_exploded(node)
           exploded?(node) do |command, message|
+            # `raise RuntimeError, nil` uses the class name as the message, so
+            # rewriting it to `raise nil.to_s` (an empty message) would change it.
+            next if message.nil_type?
+
             add_offense(node, message: MSG_1) do |corrector|
               corrector.replace(node, replaced_exploded(node, command, message))
             end
@@ -56,6 +60,8 @@ module RuboCop
 
         def fix_compact(node)
           compact?(node) do |new_call, message|
+            next if message.nil_type?
+
             add_offense(node, message: MSG_2) do |corrector|
               corrector.replace(new_call, replaced_compact(message))
             end

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -93,6 +93,18 @@ RSpec.describe RuboCop::Cop::Style::RedundantException, :config do
     RUBY
   end
 
+  it 'does not register an offense for raise with RuntimeError and a `nil` message' do
+    expect_no_offenses(<<~RUBY)
+      raise RuntimeError, nil
+    RUBY
+  end
+
+  it 'does not register an offense for raise with RuntimeError.new and a `nil` message' do
+    expect_no_offenses(<<~RUBY)
+      raise RuntimeError.new(nil)
+    RUBY
+  end
+
   it 'registers an offense for raise with RuntimeError.new, Object.new and parans' do
     expect_offense(<<~RUBY)
       raise RuntimeError.new(Object.new)


### PR DESCRIPTION
`raise RuntimeError, nil` uses the class name as its message (`"RuntimeError"`), but the cop rewrote it to `raise nil.to_s`, i.e. `raise ""`, changing the message to empty. Same for the compact form `raise RuntimeError.new(nil)`.

There's no redundancy-free rewrite that preserves the message here, so the cop now skips a `nil` message. Non-`nil` arguments (including non-string ones like `Object.new`) are unaffected.

Found while auditing the Style department.