### PR TITLE
Fix incorrect autocorrects for `Style/InvertibleUnlessCondition`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_invertible_unless_condition_with_a_20260628115706.md
+++ b/changelog/fix_a_false_positive_for_style_invertible_unless_condition_with_a_20260628115706.md
@@ -1,0 +1,1 @@
+* [#15372](https://github.com/rubocop/rubocop/pull/15372): Fix a false positive for `Style/InvertibleUnlessCondition` with a multi-statement begin condition. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_style_invertible_unless_condition_with_mixed__20260628115722.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_invertible_unless_condition_with_mixed__20260628115722.md
@@ -1,0 +1,1 @@
+* [#15372](https://github.com/rubocop/rubocop/pull/15372): Fix an incorrect autocorrect for `Style/InvertibleUnlessCondition` with mixed `&&`/`||` conditions, which lost the required parentheses when inverting. ([@bbatsov][])

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -75,7 +75,9 @@ module RuboCop
         def invertible?(node) # rubocop:disable Metrics/CyclomaticComplexity
           case node&.type
           when :begin
-            invertible?(node.children.first)
+            # A multi-statement `begin` evaluates to its last expression, so it
+            # cannot be inverted by negating a single child.
+            node.children.one? && invertible?(node.children.first)
           when :send
             return false if inheritance_check?(node)
 

--- a/lib/rubocop/cop/style/invertible_unless_condition.rb
+++ b/lib/rubocop/cop/style/invertible_unless_condition.rb
@@ -126,10 +126,15 @@ module RuboCop
         end
 
         def preferred_logical_condition(node)
-          preferred_lhs = preferred_condition(node.lhs)
-          preferred_rhs = preferred_condition(node.rhs)
+          preferred_lhs = preferred_operand(node, node.lhs)
+          preferred_rhs = preferred_operand(node, node.rhs)
 
           "#{preferred_lhs} #{node.inverse_operator} #{preferred_rhs}"
+        end
+
+        def preferred_operand(node, operand)
+          preferred = preferred_condition(operand)
+          parenthesize_inverted_operand?(node, operand) ? "(#{preferred})" : preferred
         end
 
         def autocorrect(corrector, node)
@@ -140,9 +145,22 @@ module RuboCop
             autocorrect_send_node(corrector, node)
           when :or, :and
             corrector.replace(node.loc.operator, node.inverse_operator)
-            autocorrect(corrector, node.lhs)
-            autocorrect(corrector, node.rhs)
+            autocorrect_operand(corrector, node, node.lhs)
+            autocorrect_operand(corrector, node, node.rhs)
           end
+        end
+
+        def autocorrect_operand(corrector, node, operand)
+          autocorrect(corrector, operand)
+          corrector.wrap(operand, '(', ')') if parenthesize_inverted_operand?(node, operand)
+        end
+
+        # When an `and` is nested in an `or`, inverting both operators turns the
+        # `and` into an `or` that now binds looser than its parent, so it must be
+        # parenthesized to keep the original grouping (`a && b || c` inverts to
+        # `(!a || !b) && !c`, not `!a || !b && !c`).
+        def parenthesize_inverted_operand?(node, operand)
+          node.or_type? && operand.and_type?
         end
 
         def autocorrect_send_node(corrector, node)

--- a/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
+++ b/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
@@ -130,6 +130,12 @@ RSpec.describe RuboCop::Cop::Style::InvertibleUnlessCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense when the condition is a multi-statement begin' do
+    expect_no_offenses(<<~RUBY)
+      foo unless (x != y; x.odd?)
+    RUBY
+  end
+
   it 'does not register an offense when using non invertible `unless`' do
     expect_no_offenses(<<~RUBY)
       foo unless x != y || x.awesome?

--- a/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
+++ b/spec/rubocop/cop/style/invertible_unless_condition_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe RuboCop::Cop::Style::InvertibleUnlessCondition, :config do
         foo if x == y || (((x.even?) && (((y < 5)))) && z.nonzero?)
       RUBY
     end
+
+    it 'registers an offense and corrects parenthesizing an `and` nested in an `or`' do
+      expect_offense(<<~RUBY)
+        foo unless x != y && y >= 5 || x.odd?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `if (x == y || y < 5) && x.even?` over `unless x != y && y >= 5 || x.odd?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo if (x == y || y < 5) && x.even?
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects methods without arguments called with implicit receivers' do


### PR DESCRIPTION
Two related correctness bugs found while auditing the Style department, one commit each:

**Multi-statement begin condition (false positive).** `invertible?` treated a `begin` as invertible based only on its *first* child, but a multi-statement begin evaluates to its *last* expression. So `foo unless (x != y; x.odd?)` was "corrected" to `foo if (x == y; x.odd?)`, negating the side-effect statement instead of the value. These are now skipped.

**Mixed `&&`/`||` lost parentheses.** The autocorrect swaps operators in place. Since `&&` binds tighter than `||`, swapping them changes the grouping unless parentheses are added:

```ruby
foo unless x != y && y >= 5 || x.odd?
# was corrected to (wrong grouping):
foo if x == y || y < 5 && x.even?
# now:
foo if (x == y || y < 5) && x.even?
```

An `and` nested in an `or` is now parenthesized when inverted.