### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantRegexpEscape` with interpolation sigils

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_escape_with_20260628124738.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_regexp_escape_with_20260628124738.md
@@ -1,0 +1,1 @@
+* [#15373](https://github.com/rubocop/rubocop/pull/15373): Fix an incorrect autocorrect for `Style/RedundantRegexpEscape` that stripped a necessary `\@`/`\$` escape after `#` in `%r{}`/`%r//` literals, enabling unintended interpolation. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_regexp_escape.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_escape.rb
@@ -65,7 +65,7 @@ module RuboCop
           # different versions of Ruby so that e.g. /\i/ != /i/
           return true if /[[:alnum:]]/.match?(char)
           return true if ALLOWED_ALWAYS_ESCAPES.include?(char) || delimiter?(node, char)
-          return true if requires_escape_to_avoid_interpolation?(node.source[index], char)
+          return true if requires_escape_to_avoid_interpolation?(node, index, char)
 
           if within_character_class
             ALLOWED_WITHIN_CHAR_CLASS_METACHAR_ESCAPES.include?(char) &&
@@ -97,10 +97,14 @@ module RuboCop
           delimiters.include?(char)
         end
 
-        def requires_escape_to_avoid_interpolation?(char_before_escape, escaped_char)
+        def requires_escape_to_avoid_interpolation?(node, index, escaped_char)
           # Preserve escapes after '#' that would otherwise trigger interpolation:
-          # '#@ivar', '#@@cvar', and '#$gvar'.
-          char_before_escape == '#' && INTERPOLATION_SIGILS.include?(escaped_char)
+          # '#@ivar', '#@@cvar', and '#$gvar'. `index` is relative to the regexp
+          # contents, so index into those rather than `node.source` (which also
+          # includes the opening delimiter, e.g. `%r{`).
+          return false unless index.positive? && INTERPOLATION_SIGILS.include?(escaped_char)
+
+          contents_range(node).source[index - 1] == '#'
         end
 
         def each_escape(node)

--- a/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_regexp_escape_spec.rb
@@ -281,6 +281,20 @@ RSpec.describe RuboCop::Cop::Style::RedundantRegexpEscape, :config do
       end
     end
 
+    context 'with an escaped interpolation sigil after `#` in a `%r{}` literal' do
+      it 'does not register an offense for an instance variable' do
+        expect_no_offenses('foo = %r{#\@not_ivar}')
+      end
+
+      it 'does not register an offense for a global variable' do
+        expect_no_offenses('foo = %r{#\$not_gvar}')
+      end
+
+      it 'does not register an offense for an instance variable in a `%r//` literal' do
+        expect_no_offenses('foo = %r/#\@not_ivar/')
+      end
+    end
+
     context 'with an escape inside an interpolated string' do
       it 'does not register an offense' do
         expect_no_offenses('foo = /#{"\""}/')


### PR DESCRIPTION
In a `%r{}` or `%r//` literal, the cop stripped a `\@` or `\$` escape that follows `#`, silently turning a literal into an interpolation:

```ruby
%r{#\@foo}  # matches the literal text "#@foo"
# autocorrected to:
%r{#@foo}   # now interpolates @foo
```

The interpolation guard indexed `node.source[index]`, but `index` is relative to the regexp *contents* while `node.source` includes the opening delimiter. For single-char delimiters (`/.../`) the off-by-one happened to cancel out, so only multi-char delimiters (`%r{`, `%r/`) were affected. The fix indexes into the contents range instead.

Found while auditing the Style department.