### PR TITLE
Fix a false positive for `Style/RedundantSelf` with a rescue exception variable

### DIFF
--- a/changelog/fix_a_false_positive_for_style_redundant_self_with_a_rescue_exception_variable_20260628125113.md
+++ b/changelog/fix_a_false_positive_for_style_redundant_self_with_a_rescue_exception_variable_20260628125113.md
@@ -1,0 +1,1 @@
+* [#15374](https://github.com/rubocop/rubocop/pull/15374): Fix a false positive for `Style/RedundantSelf` with a rescue exception variable. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -100,6 +100,15 @@ module RuboCop
           add_lhs_to_local_variables_scopes(node.rhs, node.lhs)
         end
 
+        # Register the exception variable of `rescue => e` so that `self.e` in the
+        # body is not treated as redundant (it disambiguates the local variable).
+        def on_resbody(node)
+          exception_variable = node.exception_variable
+          return unless exception_variable&.lvasgn_type?
+
+          @local_variables_scopes[node] << exception_variable.name
+        end
+
         def on_in_pattern(node)
           add_match_var_scopes(node)
         end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -283,6 +283,26 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf, :config do
       RUBY
     end
 
+    it 'accepts a self receiver used to distinguish from a rescue exception variable' do
+      expect_no_offenses(<<~RUBY)
+        def foo
+          do_something
+        rescue => e
+          self.e
+        end
+      RUBY
+    end
+
+    it 'accepts a self receiver used to distinguish from a rescue exception variable at the top level' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          do_something
+        rescue => e
+          self.e
+        end
+      RUBY
+    end
+
     it 'accepts a self receiver used to distinguish from an argument' do
       expect_no_offenses(<<~RUBY)
         def foo(bar)


### PR DESCRIPTION
`self.e` inside a `rescue => e` body was treated as redundant and autocorrected to `e`, which changes meaning: `self.e` calls the method `e`, while `e` is the bound exception. The cop never registered the rescue exception variable as a local in scope (the `lvasgn` for `=> e` has a nil rhs and was filed under a `nil` scope key that's never consulted).

Added an `on_resbody` handler that registers the exception variable name in the rescue body's scope, so `self.e` is correctly preserved (both inside a method and at the top level). Found while auditing the Style department.