### PR TITLE
Fix an incorrect autocorrect for `Style/RedundantStructKeywordInit` when `keyword_init` is not last

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_struct_keyword_init_when_20260628125554.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_struct_keyword_init_when_20260628125554.md
@@ -1,0 +1,1 @@
+* [#15375](https://github.com/rubocop/rubocop/pull/15375): Fix an incorrect autocorrect for `Style/RedundantStructKeywordInit` when `keyword_init` is not the last pair. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_struct_keyword_init.rb
+++ b/lib/rubocop/cop/style/redundant_struct_keyword_init.rb
@@ -100,12 +100,31 @@ module RuboCop
         end
 
         def range(redundant_keyword_init)
-          if redundant_keyword_init.parent.left_siblings.last.is_a?(AST::Node)
-            beginning_of_range = redundant_keyword_init.parent.left_siblings.last.source_range.end
-
-            beginning_of_range.join(redundant_keyword_init.source_range.end)
+          if redundant_keyword_init.parent.pairs.all? { |pair| keyword_init?(pair) }
+            # The hash holds only `keyword_init` pairs, so it is emptied; anchor the
+            # removal before the hash to also drop the comma that precedes it.
+            range_emptying_hash(redundant_keyword_init)
           else
-            redundant_keyword_init
+            # Other pairs remain, so just drop this pair and one adjacent comma.
+            range_within_hash(redundant_keyword_init)
+          end
+        end
+
+        def range_within_hash(pair)
+          if (left = pair.left_sibling)
+            left.source_range.end.join(pair.source_range.end)
+          elsif (right = pair.right_sibling)
+            pair.source_range.begin.join(right.source_range.begin)
+          else
+            pair.source_range
+          end
+        end
+
+        def range_emptying_hash(pair)
+          if (preceding = pair.parent.left_sibling).is_a?(AST::Node)
+            preceding.source_range.end.join(pair.source_range.end)
+          else
+            pair.source_range
           end
         end
       end

--- a/spec/rubocop/cop/style/redundant_struct_keyword_init_spec.rb
+++ b/spec/rubocop/cop/style/redundant_struct_keyword_init_spec.rb
@@ -24,6 +24,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantStructKeywordInit, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when `keyword_init` is followed by other keyword arguments' do
+      expect_offense(<<~RUBY)
+        Struct.new(a: 1, keyword_init: nil, b: 2)
+                         ^^^^^^^^^^^^^^^^^ Remove the redundant `keyword_init: nil`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Struct.new(a: 1, b: 2)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `keyword_init` is the first of several keyword arguments' do
+      expect_offense(<<~RUBY)
+        Struct.new(keyword_init: true, a: 1)
+                   ^^^^^^^^^^^^^^^^^^ Remove the redundant `keyword_init: true`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Struct.new(a: 1)
+      RUBY
+    end
+
     it 'registers an offense when using only `keyword_init: true` in `Struct.new`' do
       expect_offense(<<~RUBY)
         Struct.new(keyword_init: true)


### PR DESCRIPTION
When `keyword_init` was not the last pair in the hash, the removal range was computed from the *hash's* siblings in the `send` rather than the pair's own siblings within the hash, so it removed only the pair and left dangling commas (invalid Ruby) or dropped unrelated pairs:

```ruby
Struct.new(a: 1, keyword_init: nil, b: 2)  # -> Struct.new(a: 1, , b: 2)  (SyntaxError)
Struct.new(keyword_init: true, a: 1)       # -> Struct.new(, a: 1)        (SyntaxError)
```

The removal now consumes the pair plus one adjacent comma within the hash, and still drops the comma before the hash when removing the pair empties it.

Found while auditing the Style department.