### PR TITLE
Fix a false positive for `Style/Semicolon` with a semicolon inside a string literal

### DIFF
--- a/changelog/fix_a_false_positive_for_style_semicolon_with_a_semicolon_inside_a_string_20260628162538.md
+++ b/changelog/fix_a_false_positive_for_style_semicolon_with_a_semicolon_inside_a_string_20260628162538.md
@@ -1,0 +1,1 @@
+* [#15376](https://github.com/rubocop/rubocop/pull/15376): Fix a false positive for `Style/Semicolon` with a semicolon inside a string literal. ([@bbatsov][])

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -170,10 +170,10 @@ module RuboCop
         end
 
         def find_semicolon_positions(line)
-          # Scan for all the semicolons on the line
-          semicolons = processed_source[line - 1].enum_for(:scan, ';')
-          semicolons.each do
-            yield Regexp.last_match.begin(0)
+          # Scan for all the semicolon tokens on the line. Iterating tokens rather
+          # than the raw source skips `;` characters inside string/regexp literals.
+          processed_source.tokens.each do |token|
+            yield token.column if token.line == line && token.semicolon?
           end
         end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -26,6 +26,30 @@ RSpec.describe RuboCop::Cop::Style::Semicolon, :config do
     RUBY
   end
 
+  it 'registers an offense for the separator but not a semicolon inside a string literal' do
+    expect_offense(<<~RUBY)
+      x = "foo;bar"; y = 2
+                   ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = "foo;bar"
+       y = 2
+    RUBY
+  end
+
+  it 'registers an offense for the separator but not a semicolon inside a regexp literal' do
+    expect_offense(<<~RUBY)
+      x = /a;b/; y = 2
+               ^ Do not use semicolons to terminate expressions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = /a;b/
+       y = 2
+    RUBY
+  end
+
   it 'registers an offense without autocorrect when a heredoc is opened before the semicolon' do
     expect_offense(<<~RUBY)
       x = <<~TEXT; y = 2


### PR DESCRIPTION
When a line held more than one expression, the cop scanned the raw source text for `;`, so a semicolon inside a string or regexp literal was flagged and the autocorrect replaced it with a newline, corrupting the literal:

```ruby
x = "foo;bar"; y = 2
# autocorrected to:
x = "foo
bar"
 y = 2
```

`find_semicolon_positions` now iterates the semicolon tokens on the line instead of raw-scanning, so only real expression separators are considered. Found while auditing the Style department.