### PR TITLE
Fix an incorrect autocorrect for `Style/SingleLineDoEndBlock`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_single_line_do_end_block_20260628162936.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_single_line_do_end_block_20260628162936.md
@@ -1,0 +1,1 @@
+* [#15377](https://github.com/rubocop/rubocop/pull/15377): Fix an incorrect autocorrect for `Style/SingleLineDoEndBlock` when the block body contains a heredoc. ([@bbatsov][])

--- a/lib/rubocop/cop/style/single_line_do_end_block.rb
+++ b/lib/rubocop/cop/style/single_line_do_end_block.rb
@@ -44,11 +44,12 @@ module RuboCop
           add_offense(node) do |corrector|
             corrector.insert_after(do_line(node), "\n")
 
-            node_body = node.body
-
-            if node_body.respond_to?(:heredoc?) && node_body.heredoc?
+            if (heredoc = trailing_heredoc(node.body))
+              # The heredoc body extends past the `end` on the source, so the
+              # `end` has to be moved after it rather than before, which would
+              # otherwise move it into the heredoc body and break the syntax.
               corrector.remove(node.loc.end)
-              corrector.insert_after(node_body.loc.heredoc_end, "\nend")
+              corrector.insert_after(heredoc.loc.heredoc_end, "\nend")
             else
               corrector.insert_before(node.loc.end, "\n")
             end
@@ -59,6 +60,18 @@ module RuboCop
         alias on_itblock on_block
 
         private
+
+        # Returns the heredoc opened on the block's line whose body extends the
+        # furthest down, whether it is the block body itself or nested within it.
+        def trailing_heredoc(node_body)
+          return unless node_body
+
+          heredocs = [node_body, *node_body.each_descendant].select do |node|
+            node.respond_to?(:heredoc?) && node.heredoc?
+          end
+
+          heredocs.max_by { |heredoc| heredoc.loc.heredoc_end.line }
+        end
 
         def do_line(node)
           if node.type?(:numblock, :itblock) ||

--- a/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/single_line_do_end_block_spec.rb
@@ -83,6 +83,44 @@ RSpec.describe RuboCop::Cop::Style::SingleLineDoEndBlock, :config do
     RUBY
   end
 
+  it 'registers an offense when using single line `do`...`end` with a heredoc nested in the body' do
+    expect_offense(<<~RUBY)
+      foo do bar(<<~EOS) end
+      ^^^^^^^^^^^^^^^^^^^^^^ Prefer multiline `do`...`end` block.
+        text
+      EOS
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+       bar(<<~EOS)#{' '}
+        text
+      EOS
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using single line `do`...`end` with multiple heredocs in the body' do
+    expect_offense(<<~RUBY)
+      foo do bar(<<~ONE, <<~TWO) end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer multiline `do`...`end` block.
+        one
+      ONE
+        two
+      TWO
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo do
+       bar(<<~ONE, <<~TWO)#{' '}
+        one
+      ONE
+        two
+      TWO
+      end
+    RUBY
+  end
+
   it 'registers an offense when using single line `do`...`end` with `->` block' do
     expect_offense(<<~RUBY)
       ->(arg) do foo arg end


### PR DESCRIPTION
When a single-line `do`...`end` block has a heredoc nested inside its body (e.g. as a method argument), the autocorrect moved the `end` keyword before the heredoc body, producing invalid Ruby. The cop only handled the case where the heredoc *was* the block body directly. It now relocates the `end` after the trailing heredoc terminator in either case.