### PR TITLE
Fix an incorrect autocorrect for `Style/StringHashKeys`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_string_hash_keys_20260628163129.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_string_hash_keys_20260628163129.md
@@ -1,0 +1,1 @@
+* [#15378](https://github.com/rubocop/rubocop/pull/15378): Fix an incorrect autocorrect for `Style/StringHashKeys` when the hash key is a heredoc. ([@bbatsov][])

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -41,6 +41,7 @@ module RuboCop
 
         def on_pair(node)
           return unless string_hash_key?(node)
+          return if node.key.heredoc?
 
           key_content = node.key.str_content
           return unless key_content.valid_encoding?

--- a/spec/rubocop/cop/style/string_hash_keys_spec.rb
+++ b/spec/rubocop/cop/style/string_hash_keys_spec.rb
@@ -75,4 +75,14 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys, :config do
       "The sky is green.".gsub!(/green/, "green" => "blue")
     RUBY
   end
+
+  it 'does not register an offense when the string key is a heredoc' do
+    expect_no_offenses(<<~RUBY)
+      {
+        <<~KEY => 1
+          text
+        KEY
+      }
+    RUBY
+  end
 end


### PR DESCRIPTION
When a hash key is a heredoc, the autocorrect replaced just the `<<~KEY` opener with a symbol, leaving the heredoc body orphaned on the following lines and producing broken (and sometimes syntactically invalid) Ruby. The cop now skips heredoc keys, since a heredoc can't be meaningfully rewritten as a symbol key.