### PR TITLE
Fix a crash for `Style/TrailingUnderscoreVariable`

### DIFF
--- a/changelog/fix_a_crash_for_style_trailing_underscore_variable_20260628170630.md
+++ b/changelog/fix_a_crash_for_style_trailing_underscore_variable_20260628170630.md
@@ -1,0 +1,1 @@
+* [#15379](https://github.com/rubocop/rubocop/pull/15379): Fix a crash for `Style/TrailingUnderscoreVariable` when a nested destructuring group consists only of underscore variables. ([@bbatsov][])

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -113,9 +113,7 @@ module RuboCop
 
           return unless first_offense
 
-          if unused_variables_only?(first_offense, variables)
-            return unused_range(node.type, mlhs_node, node.rhs)
-          end
+          return unused_range(node, mlhs_node) if unused_variables_only?(first_offense, variables)
 
           return range_for_parentheses(first_offense, mlhs_node) if Util.parentheses?(mlhs_node)
 
@@ -130,13 +128,14 @@ module RuboCop
           offense.source_range == variables.first.source_range
         end
 
-        def unused_range(node_type, mlhs_node, right)
+        def unused_range(node, mlhs_node)
           start_range = mlhs_node.source_range.begin_pos
 
-          end_range = case node_type
-                      when :masgn
-                        right.source_range.begin_pos
-                      when :mlhs
+          # `node` can be an `mlhs` when recursing into a nested destructuring
+          # group; only a `masgn` has a right-hand side to anchor against.
+          end_range = if node.masgn_type?
+                        node.rhs.source_range.begin_pos
+                      else
                         mlhs_node.source_range.end_pos
                       end
 

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -199,6 +199,30 @@ RSpec.describe RuboCop::Cop::Style::TrailingUnderscoreVariable, :config do
           RUBY
         end
       end
+
+      context 'with a nested destructuring group of only underscores' do
+        it 'does not crash and removes the group' do
+          expect_offense(<<~RUBY)
+            a, (_, _) = foo
+               ^^^^^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a,  = foo
+          RUBY
+        end
+
+        it 'does not crash and removes a deeply nested group' do
+          expect_offense(<<~RUBY)
+            a, (b, (_, _)) = foo
+                   ^^^^^^ Do not use trailing `_`s in parallel assignment. [...]
+          RUBY
+
+          expect_correction(<<~RUBY)
+            a, (b, ) = foo
+          RUBY
+        end
+      end
     end
   end
 


### PR DESCRIPTION
`Style/TrailingUnderscoreVariable` crashed with `NoMethodError: undefined method 'rhs' for an instance of RuboCop::AST::MlhsNode` on nested destructuring where a group is all underscores, e.g. `a, (_, _) = foo`. When recursing into a nested `mlhs` group, the code called `node.rhs` even though only the `masgn` branch needs the right-hand side. The `rhs` lookup now happens only for `masgn` nodes.