### PR TITLE
Fix an incorrect autocorrect for `Style/TernaryParentheses`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_ternary_parentheses_20260628170922.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_ternary_parentheses_20260628170922.md
@@ -1,0 +1,1 @@
+* [#15380](https://github.com/rubocop/rubocop/pull/15380): Fix an incorrect autocorrect for `Style/TernaryParentheses` when the condition is a modifier `if`/`unless` expression. ([@bbatsov][])

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -113,6 +113,10 @@ module RuboCop
         def offense?(node)
           condition = node.condition
 
+          # A modifier `if`/`unless` requires the parentheses, e.g. `(a if b) ? x : y`,
+          # so removing them would change the meaning. Don't flag it.
+          return false if parenthesized_modifier_condition?(condition)
+
           if safe_assignment?(condition)
             !safe_assignment_allowed?
           else
@@ -172,6 +176,13 @@ module RuboCop
 
         def unsafe_autocorrect?(condition)
           condition.children.any? { |child| below_ternary_precedence?(child) }
+        end
+
+        def parenthesized_modifier_condition?(condition)
+          return false unless condition.begin_type?
+
+          inner = condition.children.first
+          inner&.if_type? && inner.modifier_form?
         end
 
         def unparenthesized_method_call?(child)

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -359,6 +359,18 @@ RSpec.describe RuboCop::Cop::Style::TernaryParentheses, :config do
         expect_no_corrections
       end
 
+      it 'does not register an offense for a modifier `if` condition' do
+        expect_no_offenses(<<~RUBY)
+          foo = (a if b) ? a : b
+        RUBY
+      end
+
+      it 'does not register an offense for a modifier `unless` condition' do
+        expect_no_offenses(<<~RUBY)
+          foo = (a unless b) ? a : b
+        RUBY
+      end
+
       it 'registers an offense for defined with variable in condition' do
         expect_offense(<<~RUBY)
           foo = (defined? bar) ? a : b


### PR DESCRIPTION
With `EnforcedStyle: require_no_parentheses` (the default), `foo = (a if b) ? x : y` was autocorrected to `foo = a if b ? x : y`, which is still valid Ruby but means something entirely different (a modifier-`if` statement instead of a ternary). A modifier `if`/`unless` binds looser than `?:`, so its parentheses are load-bearing. `below_ternary_precedence?` already guarded keyword `and`/`or`/`not`; it now also treats modifier `if`/`unless` conditions as unsafe to autocorrect.