### PR TITLE
Fix incorrect autocorrects for `Style/ItBlockParameter`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_it_block_parameter_20260629114622.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_it_block_parameter_20260629114622.md
@@ -1,0 +1,1 @@
+* [#15382](https://github.com/rubocop/rubocop/pull/15382): Fix incorrect autocorrects for `Style/ItBlockParameter` when a block argument is only referenced inside a nested block, and when a multi-line numbered parameter block is used with `EnforcedStyle: allow_single_line`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -112,8 +112,16 @@ module RuboCop
           return [] unless node.body
 
           node.body.each_descendant(:lvar).select do |descendant|
-            descendant.source == block_argument_name
+            descendant.source == block_argument_name && !nested_in_inner_block?(descendant, node)
           end
+        end
+
+        # A reference nested inside another block cannot be rewritten to `it`,
+        # because `it` would resolve to that inner block instead of this one.
+        def nested_in_inner_block?(descendant, node)
+          inner_block = descendant.each_ancestor(:any_block).first
+
+          inner_block && !inner_block.equal?(node)
         end
       end
     end

--- a/lib/rubocop/cop/style/it_block_parameter.rb
+++ b/lib/rubocop/cop/style/it_block_parameter.rb
@@ -80,6 +80,9 @@ module RuboCop
 
         def on_numblock(node)
           return if style == :disallow
+          # Under `allow_single_line`, a multi-line block must not use `it`, so
+          # converting a multi-line `_1` would only create an uncorrectable offense.
+          return if style == :allow_single_line && node.multiline?
           return unless node.children[1] == 1
 
           variables = find_block_variables(node, '_1')

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -188,6 +188,13 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         RUBY
       end
 
+      it 'does not register an offense when the block argument is only referenced inside a nested block' do
+        # Rewriting `arg` to `it` would bind `it` to the inner block, not the outer one.
+        expect_no_offenses(<<~RUBY)
+          block { |arg| foo.bar { arg.something } }
+        RUBY
+      end
+
       it 'registers an offense when using twice a single named parameters' do
         expect_offense(<<~RUBY)
           block do |arg|

--- a/spec/rubocop/cop/style/it_block_parameter_spec.rb
+++ b/spec/rubocop/cop/style/it_block_parameter_spec.rb
@@ -34,20 +34,13 @@ RSpec.describe RuboCop::Cop::Style::ItBlockParameter, :config do
         RUBY
       end
 
-      it 'registers an offense when using twice a single numbered parameters' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense for a multi-line numbered parameter block' do
+        # Converting `_1` to `it` here would only create an uncorrectable
+        # "Avoid using `it` block parameter for multi-line blocks" offense.
+        expect_no_offenses(<<~RUBY)
           block do
             foo(_1)
-                ^^ Use `it` block parameter.
             bar(_1)
-                ^^ Use `it` block parameter.
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          block do
-            foo(it)
-            bar(it)
           end
         RUBY
       end


### PR DESCRIPTION
Two autocorrect fixes for this cop (one commit each):

1. When a block argument is only referenced inside a nested block (e.g. `block { |arg| foo.bar { arg.something } }`), the cop rewrote it to `it`, but `it` then resolves to the *inner* block, silently changing behavior. Such references are no longer converted.

2. Under `EnforcedStyle: allow_single_line`, a multi-line numbered-parameter block (`block do foo(_1) end`) was converted to `it`, which immediately produces an uncorrectable "Avoid using `it` block parameter for multi-line blocks" offense. Multi-line numbered blocks are now left alone for that style.