### PR TITLE
Fix numbered-parameter block handling in two Style cops

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_filter_chain_20260629115101.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_filter_chain_20260629115101.md
@@ -1,0 +1,1 @@
+* [#15383](https://github.com/rubocop/rubocop/pull/15383): Fix a false negative for `Style/RedundantFilterChain` with numbered-parameter blocks. ([@bbatsov][])

--- a/changelog/fix_a_false_positive_for_style_numeric_predicate_20260629115102.md
+++ b/changelog/fix_a_false_positive_for_style_numeric_predicate_20260629115102.md
@@ -1,0 +1,1 @@
+* [#15383](https://github.com/rubocop/rubocop/pull/15383): Fix a false positive for `Style/NumericPredicate` when an allowed method encloses a numbered-parameter or `it` block. ([@bbatsov][])

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -92,7 +92,7 @@ module RuboCop
           return unless numeric
 
           return if allowed_method_name?(node.method_name) ||
-                    node.each_ancestor(:send, :block).any? do |ancestor|
+                    node.each_ancestor(:send, :any_block).any? do |ancestor|
                       allowed_method_name?(ancestor.method_name)
                     end
 

--- a/lib/rubocop/cop/style/redundant_filter_chain.rb
+++ b/lib/rubocop/cop/style/redundant_filter_chain.rb
@@ -62,7 +62,7 @@ module RuboCop
         def_node_matcher :select_predicate?, <<~PATTERN
           (call
             {
-              (block $(call _ {:select :filter :find_all}) ...)
+              (any_block $(call _ {:select :filter :find_all}) ...)
               $(call _ {:select :filter :find_all} block_pass_type?)
             }
             ${:#{RESTRICT_ON_SEND.join(' :')}})

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -328,6 +328,12 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             expect_no_offenses('where { _1 > 0 }')
           end
         end
+
+        context 'with an `it`-parameter block', :ruby34 do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('where { it > 0 }')
+          end
+        end
       end
 
       context 'not ignored method' do

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -322,6 +322,12 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
             expect_no_offenses('order(Sequel[:number] < 0)')
           end
         end
+
+        context 'with a numbered-parameter block' do
+          it 'allows checking if a number is positive' do
+            expect_no_offenses('where { _1 > 0 }')
+          end
+        end
       end
 
       context 'not ignored method' do

--- a/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
+++ b/spec/rubocop/cop/style/redundant_filter_chain_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantFilterChain, :config do
       RUBY
     end
 
+    it "registers an offense when using `##{method}` with a numbered-parameter block followed by `#any?`" do
+      expect_offense(<<~RUBY, method: method)
+        arr.%{method} { _1 > 1 }.any?
+            ^{method}^^^^^^^^^^^^^^^^ Use `any?` instead of `#{method}.any?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        arr.any? { _1 > 1 }
+      RUBY
+    end
+
+    it "registers an offense when using `##{method}` with an `it`-parameter block followed by `#any?`", :ruby34 do
+      expect_offense(<<~RUBY, method: method)
+        arr.%{method} { it > 1 }.any?
+            ^{method}^^^^^^^^^^^^^^^^ Use `any?` instead of `#{method}.any?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        arr.any? { it > 1 }
+      RUBY
+    end
+
     it "does not register an offense when using `##{method}` followed by `#many?`" do
       expect_no_offenses(<<~RUBY)
         arr.#{method} { |x| x > 1 }.many?


### PR DESCRIPTION
Two cops that already handle regular and `it` blocks were missing the numbered-parameter (`_1`) block form (one commit each):

- `Style/NumericPredicate`: `AllowedMethods`/`AllowedPatterns` were ignored when the comparison sat inside a numbered-parameter (or `it`) block, e.g. `where { _1 > 0 }` was flagged even with `where` allowed. The ancestor scan now includes `:any_block`.
- `Style/RedundantFilterChain`: `arr.select { _1 > 1 }.any?` was never flagged, unlike the equivalent named-block form. The matcher now uses `any_block`.