### PR TITLE
Fix scope handling in `Style/MissingRespondToMissing`

### DIFF
--- a/changelog/fix_false_positive_and_false_negative_for_style_missing_respond_to_missing_20260629115550.md
+++ b/changelog/fix_false_positive_and_false_negative_for_style_missing_respond_to_missing_20260629115550.md
@@ -1,0 +1,1 @@
+* [#15384](https://github.com/rubocop/rubocop/pull/15384): Fix a false positive and a false negative for `Style/MissingRespondToMissing` when `method_missing` is defined at the top level or alongside sibling classes. ([@bbatsov][])

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -65,16 +65,19 @@ module RuboCop
         private
 
         def implements_respond_to_missing?(node)
-          return false unless (grand_parent = node.parent.parent)
+          scope = enclosing_scope(node)
+          search_root = scope || node.parent
+          return false unless search_root
 
-          grand_parent.each_descendant(node.type) do |descendant|
-            return true if descendant.method?(:respond_to_missing?)
-
-            child = descendant.children.first
-            return true if child.respond_to?(:method?) && child.method?(:respond_to_missing?)
+          search_root.each_descendant(node.type).any? do |descendant|
+            descendant.method?(:respond_to_missing?) && enclosing_scope(descendant).equal?(scope)
           end
+        end
 
-          false
+        # The class/module/`class << self` body that lexically contains `node`,
+        # or `nil` when `node` is defined at the top level.
+        def enclosing_scope(node)
+          node.each_ancestor(:class, :module, :sclass).first
         end
       end
     end

--- a/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
+++ b/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
@@ -97,4 +97,41 @@ RSpec.describe RuboCop::Cop::Style::MissingRespondToMissing, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when respond_to_missing? is defined only in a sibling class' do
+    expect_offense(<<~RUBY)
+      class Outer
+        class A
+          def method_missing(name)
+          ^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+          end
+        end
+
+        class B
+          def respond_to_missing?(name, include_private = false)
+            super
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'allows top-level method_missing and respond_to_missing?' do
+    expect_no_offenses(<<~RUBY)
+      def respond_to_missing?(name, include_private = false)
+        super
+      end
+
+      def method_missing(name)
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a top-level method_missing without respond_to_missing?' do
+    expect_offense(<<~RUBY)
+      def method_missing(name)
+      ^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
The check for an existing `respond_to_missing?` searched `node.parent.parent`, which was both too broad and sometimes `nil`:

- False negative: a `respond_to_missing?` defined in a *sibling* class under a common namespace suppressed the offense on an unrelated class's `method_missing`.
- False positive: at the top level, the grandparent was `nil`, so a top-level `method_missing` was flagged even when a top-level `respond_to_missing?` was present.

The search is now bounded to `method_missing`'s own lexical class/module scope.