### PR TITLE
Fix --fail-fast reporting for first offending file

### DIFF
--- a/changelog/fix_fail_fast_reports_offenses.md
+++ b/changelog/fix_fail_fast_reports_offenses.md
@@ -1,0 +1,1 @@
+* [#15318](https://github.com/rubocop/rubocop/issues/15318): Fix `--fail-fast` to report offenses and return a failing exit status when the first inspected file has offenses. ([@minhluuquang][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -120,7 +120,6 @@ module RuboCop
       file_iterator(files) do |file|
         offenses = process_file(file)
         succeeded = offenses.none? { |o| considered_failure?(o) && offense_displayed?(o) }
-        raise Parallel::Break if @options[:fail_fast] && !succeeded
 
         [offenses, succeeded]
       end
@@ -142,6 +141,7 @@ module RuboCop
       on_finish = lambda do |file, index, (offenses, passed)|
         all_passed &&= passed
         finished_report(file, index, offenses)
+        raise Parallel::Break if @options[:fail_fast] && !passed
       end
 
       if run_in_parallel?(files)

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -121,6 +121,31 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       end
     end
 
+    context 'when fail-fast is enabled and there is an offense in the inspected file' do
+      let(:options) { { fail_fast: true, formatters: [['progress', formatter_output_path]] } }
+      let(:source) { <<~RUBY }
+        # frozen_string_literal: true
+
+        def INVALID_CODE; end
+      RUBY
+
+      it 'reports the offense and returns false' do
+        expect(runner.run([])).to be false
+        expect(formatter_output).to eq <<~RESULT
+          Inspecting 1 file
+          C
+
+          Offenses:
+
+          example.rb:3:5: C: Naming/MethodName: Use snake_case for method names.
+          def INVALID_CODE; end
+              ^^^^^^^^^^^^
+
+          1 file inspected, 1 offense detected
+        RESULT
+      end
+    end
+
     context 'custom ruby extractors' do
       around do |example|
         described_class.ruby_extractors.unshift(custom_ruby_extractor)


### PR DESCRIPTION
Fixes #15318.

This updates `--fail-fast` so RuboCop reports the first file with offenses and records the failing result before stopping. Previously, fail-fast raised before the formatter completion callback ran, which could produce `0 files inspected, no offenses detected` and exit successfully even though offenses were found.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. Targeted tests and RuboCop checks were run locally.
* [x] Added an entry file to the changelog folder.

Verification performed locally:

* `mise exec ruby@4.0.1 -- bundle exec rspec spec/rubocop/runner_spec.rb`
* `mise exec ruby@4.0.1 -- bundle exec rubocop --cache false --disable-pending-cops lib/rubocop/runner.rb spec/rubocop/runner_spec.rb`
* CLI smoke test for `--fail-fast` reporting and failing exit status.