### PR TITLE
Fix false negatives in two method-definition Style cops

### DIFF
--- a/changelog/fix_a_false_negative_for_style_method_def_parentheses_20260629115933.md
+++ b/changelog/fix_a_false_negative_for_style_method_def_parentheses_20260629115933.md
@@ -1,0 +1,1 @@
+* [#15386](https://github.com/rubocop/rubocop/pull/15386): Fix a false negative for `Style/MethodDefParentheses` with named rest arguments under `EnforcedStyle: require_no_parentheses`. ([@bbatsov][])

--- a/changelog/fix_a_false_negative_for_style_optional_arguments_with_singleton_methods_20260629120001.md
+++ b/changelog/fix_a_false_negative_for_style_optional_arguments_with_singleton_methods_20260629120001.md
@@ -1,0 +1,1 @@
+* [#15386](https://github.com/rubocop/rubocop/pull/15386): Fix a false negative for `Style/OptionalArguments` with singleton methods. ([@bbatsov][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -166,7 +166,7 @@ module RuboCop
 
         def anonymous_arguments?(node)
           return true if node.arguments.any? do |arg|
-            arg.type?(:forward_arg, :restarg, :kwrestarg)
+            arg.forward_arg_type? || (arg.type?(:restarg, :kwrestarg) && arg.name.nil?)
           end
           return false unless (last_argument = node.last_argument)
 

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -27,6 +27,7 @@ module RuboCop
         def on_def(node)
           each_misplaced_optional_arg(node.arguments) { |argument| add_offense(argument) }
         end
+        alias on_defs on_def
 
         private
 

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -123,6 +123,32 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         end
       RUBY
     end
+
+    it 'removes the parens for named rest arguments' do
+      expect_offense(<<~RUBY)
+        def foo(*rest)
+               ^^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo *rest
+        end
+      RUBY
+    end
+
+    it 'removes the parens for named keyword rest arguments' do
+      expect_offense(<<~RUBY)
+        def foo(**opts)
+               ^^^^^^^^ Use def without parentheses.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo **opts
+        end
+      RUBY
+    end
   end
 
   shared_examples 'endless methods' do

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe RuboCop::Cop::Style::OptionalArguments, :config do
     RUBY
   end
 
+  it 'registers an offense for a singleton method when an optional argument is followed by a required argument' do
+    expect_offense(<<~RUBY)
+      def self.foo(a = 1, b)
+                   ^^^^^ Optional arguments should appear at the end of the argument list.
+      end
+    RUBY
+  end
+
   it 'allows methods without arguments' do
     expect_no_offenses(<<~RUBY)
       def foo


### PR DESCRIPTION
Two false-negative fixes for method-definition cops (one commit each):

- `Style/OptionalArguments` only defined `on_def`, so a misplaced optional argument in a singleton method (`def self.foo(a = 1, b)`) was never reported. It now also handles `on_defs`.
- `Style/MethodDefParentheses` under `EnforcedStyle: require_no_parentheses` treated *named* rest (`*rest`) and keyword-rest (`**opts`) arguments as anonymous and skipped them. Only genuinely anonymous rest arguments and argument forwarding (`...`) still require parentheses.