### PR TITLE
Fix spurious blank line in `Style/KeywordParametersOrder` autocorrect

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_keyword_parameters_order_20260629120600.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_keyword_parameters_order_20260629120600.md
@@ -1,0 +1,1 @@
+* [#15387](https://github.com/rubocop/rubocop/pull/15387): Fix an incorrect autocorrect for `Style/KeywordParametersOrder` that inserted a spurious blank line when a keyword optional parameter already trailed the parameters list. ([@bbatsov][])

--- a/lib/rubocop/cop/style/keyword_parameters_order.rb
+++ b/lib/rubocop/cop/style/keyword_parameters_order.rb
@@ -62,11 +62,15 @@ module RuboCop
         end
 
         def append_newline_to_last_kwoptarg(arguments, corrector)
-          last_argument = arguments.last
-          return if last_argument.type?(:kwrestarg, :blockarg)
+          # The newline only needs restoring when the moved keyword argument was
+          # the last parameter, so removing it also consumes the line break before
+          # the body. When a `kwoptarg` already trails the list, the body stays
+          # separated and inserting a newline would leave a spurious blank line.
+          return unless arguments.last.kwarg_type?
+          return if arguments.parent.block_type?
 
           last_kwoptarg = arguments.reverse.find(&:kwoptarg_type?)
-          corrector.insert_after(last_kwoptarg, "\n") unless arguments.parent.block_type?
+          corrector.insert_after(last_kwoptarg, "\n")
         end
 
         def remove_kwargs(kwarg_nodes, corrector)

--- a/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
+++ b/spec/rubocop/cop/style/keyword_parameters_order_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe RuboCop::Cop::Style::KeywordParametersOrder, :config do
     RUBY
   end
 
+  it 'does not insert a blank line when a `kwoptarg` already trails the parameters list' do
+    expect_offense(<<~RUBY)
+      def m optional: 1, required:, other_optional: 2
+            ^^^^^^^^^^^ Place optional keyword parameters at the end of the parameters list.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def m required:, optional: 1, other_optional: 2
+        do_something
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when multiple `kwoptarg`s are interleaved with `kwarg`s' do
     expect_offense(<<~RUBY)
       def m(arg, optional1: 1, required1:, optional2: 2, required2:, **rest, &block)


### PR DESCRIPTION
When reordering keyword parameters in a parens-less `def`, the cop unconditionally re-added a newline after the last keyword optional parameter. That newline is only needed to restore the line break that removing a trailing keyword *argument* consumes; when a keyword optional parameter already trails the list (e.g. `def m optional: 1, required:, other_optional: 2`), the body is still separated and the insertion just left a blank line between the signature and the body.