### PR TITLE
Fix false negatives in several Style cops

### DIFF
--- a/changelog/fix_a_false_negative_for_style_mixin_usage.md
+++ b/changelog/fix_a_false_negative_for_style_mixin_usage.md
@@ -1,0 +1,1 @@
+* [#15388](https://github.com/rubocop/rubocop/pull/15388): Fix a false negative for `Style/MixinUsage` when including multiple modules in one statement. ([@bbatsov][])

--- a/changelog/fix_a_false_negative_for_style_module_function.md
+++ b/changelog/fix_a_false_negative_for_style_module_function.md
@@ -1,0 +1,1 @@
+* [#15388](https://github.com/rubocop/rubocop/pull/15388): Fix a false negative for `Style/ModuleFunction` when the module body is a single statement. ([@bbatsov][])

--- a/changelog/fix_a_false_negative_for_style_redundant_current_directory_in_path.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_current_directory_in_path.md
@@ -1,0 +1,1 @@
+* [#15388](https://github.com/rubocop/rubocop/pull/15388): Fix a false negative for `Style/RedundantCurrentDirectoryInPath` with double-quoted strings containing interpolation. ([@bbatsov][])

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -47,7 +47,7 @@ module RuboCop
         # @!method include_statement(node)
         def_node_matcher :include_statement, <<~PATTERN
           (send nil? ${:include :extend :prepend}
-            const)
+            const+)
         PATTERN
 
         # @!method in_top_level_scope?(node)

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -110,9 +110,11 @@ module RuboCop
         def_node_matcher :private_directive?, '(send nil? :private ...)'
 
         def on_module(node)
-          return unless node.body&.begin_type?
+          return unless node.body
 
-          each_wrong_style(node.body.children) do |child_node|
+          body_nodes = node.body.begin_type? ? node.body.children : [node.body]
+
+          each_wrong_style(body_nodes) do |child_node|
             add_offense(child_node) do |corrector|
               next if style == :forbidden
 

--- a/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
+++ b/lib/rubocop/cop/style/redundant_current_directory_in_path.rb
@@ -26,7 +26,9 @@ module RuboCop
         def on_send(node)
           return unless (first_argument = node.first_argument)
           return unless (index = first_argument.source.index(CURRENT_DIRECTORY_PREFIX))
-          return unless (redundant_length = redundant_path_length(first_argument.str_content))
+
+          content = leading_path_content(first_argument)
+          return unless (redundant_length = redundant_path_length(content))
 
           begin_pos = first_argument.source_range.begin.begin_pos + index
           end_pos = begin_pos + redundant_length
@@ -38,6 +40,16 @@ module RuboCop
         end
 
         private
+
+        # The literal text at the start of the path, which is the whole string
+        # for a plain string and the leading literal segment for an interpolated
+        # one (`nil` when it starts with interpolation).
+        def leading_path_content(node)
+          return node.str_content if node.str_type?
+          return unless node.dstr_type? && (first = node.children.first)&.str_type?
+
+          first.str_content
+        end
 
         def redundant_path_length(path)
           return unless (match = path&.match(REDUNDANT_CURRENT_DIRECTORY_PREFIX))

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe RuboCop::Cop::Style::MixinUsage, :config do
       RUBY
     end
 
+    it 'registers an offense when including multiple modules at the top level' do
+      expect_offense(<<~RUBY)
+        include Comparable, Enumerable
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
+      RUBY
+    end
+
     it 'registers an offense when using `include` in method definition outside class or module' do
       expect_offense(<<~RUBY)
         def foo

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
       RUBY
     end
 
+    it 'registers an offense for `extend self` as the only statement in a module' do
+      expect_offense(<<~RUBY)
+        module Test
+          extend self
+          ^^^^^^^^^^^ Use `module_function` instead of `extend self`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Test
+          module_function
+        end
+      RUBY
+    end
+
     it 'accepts for `extend self` in a module with private methods' do
       expect_no_offenses(<<~RUBY)
         module Test

--- a/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
+++ b/spec/rubocop/cop/style/redundant_current_directory_in_path_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::Style::RedundantCurrentDirectoryInPath, :config do
     RUBY
   end
 
+  it 'registers an offense when using a current directory path in a string with real interpolation' do
+    expect_offense(<<~'RUBY')
+      require_relative "./path/#{to}/feature"
+                        ^^ Remove the redundant current directory path.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      require_relative "path/#{to}/feature"
+    RUBY
+  end
+
   it "registers an offense when using a complex current directory path in `require_relative '...'`" do
     expect_offense(<<~RUBY)
       require_relative './//./../path/to/feature'


### PR DESCRIPTION
Three independent false-negative fixes, one commit each:

- `Style/MixinUsage`: `include Comparable, Enumerable` (multiple modules in one statement) at the top level was not flagged; the matcher only accepted a single constant argument.
- `Style/ModuleFunction`: a module whose body is a single statement (e.g. `module M; extend self; end`) was skipped because the body is not a `begin` node.
- `Style/RedundantCurrentDirectoryInPath`: a redundant `./` prefix in a double-quoted, interpolated path (`require_relative "./path/#{x}/feature"`) was missed because the cop only inspected plain-string content.