### PR TITLE
Fix a false positive for `Style/OptionHash` with explicit `super`

### DIFF
--- a/changelog/fix_a_false_positive_for_style_option_hash_with_explicit_super_20260629121600.md
+++ b/changelog/fix_a_false_positive_for_style_option_hash_with_explicit_super_20260629121600.md
@@ -1,0 +1,1 @@
+* [#15389](https://github.com/rubocop/rubocop/pull/15389): Fix a false positive for `Style/OptionHash` when the options hash is forwarded with an explicit `super`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -46,7 +46,7 @@ module RuboCop
         end
 
         def super_used?(node)
-          node.parent.each_node(:zsuper).any?
+          node.parent.each_node(:zsuper, :super).any?
         end
       end
     end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe RuboCop::Cop::Style::OptionHash, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when the options hash is forwarded with an explicit super' do
+      expect_no_offenses(<<~RUBY)
+        def allowed(foo, options = {})
+          super(options)
+        end
+      RUBY
+    end
   end
 
   context 'permitted list' do


### PR DESCRIPTION
`super_used?` only matched bare `super` (`zsuper`), so a method that forwards its options hash with an explicit `super(options)` was still flagged even though changing its signature would break the `super` call. It now also recognizes explicit `super`.