### PR TITLE
Mark `Style/MapCompactWithConditionalBlock` autocorrect as unsafe

### DIFF
--- a/changelog/change_mark_style_map_compact_with_conditional_block_autocorrect_as_unsafe_20260629121819.md
+++ b/changelog/change_mark_style_map_compact_with_conditional_block_autocorrect_as_unsafe_20260629121819.md
@@ -1,0 +1,1 @@
+* [#15390](https://github.com/rubocop/rubocop/pull/15390): Mark `Style/MapCompactWithConditionalBlock` autocorrect as unsafe because `compact` also removes `nil` elements already present in the collection. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4658,7 +4658,9 @@ Style/MagicCommentFormat:
 Style/MapCompactWithConditionalBlock:
   Description: 'Prefer `select` or `reject` over `map { ... }.compact`.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.30'
+  VersionChanged: '<<next>>'
 
 Style/MapIntoArray:
   Description: 'Checks for usages of `each` with `<<`, `push`, or `append` which can be replaced by `map`.'

--- a/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
+++ b/lib/rubocop/cop/style/map_compact_with_conditional_block.rb
@@ -6,6 +6,17 @@ module RuboCop
       # Prefer `select` or `reject` over `map { ... }.compact`.
       # This cop also handles `filter_map { ... }`, similar to `map { ... }.compact`.
       #
+      # @safety
+      #   This cop is unsafe because `compact` also removes `nil` elements that
+      #   were already present in the receiver, whereas `select`/`reject` keep
+      #   them. The result therefore differs when the collection contains `nil`:
+      #
+      #   [source,ruby]
+      #   ----
+      #   [nil, 1].map { |e| e if e }.compact # => [1]
+      #   [nil, 1].select { |e| e }           # => [nil, 1]
+      #   ----
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
The autocorrect rewrites `map { |e| e if cond }.compact` to `select { |e| cond }`, but `compact` also strips `nil` elements that were already in the receiver, which `select` keeps. For a collection containing `nil`, the corrected code returns a different result (e.g. `[nil, 1].map { |e| e if e }.compact` => `[1]` vs `select` => `[nil, 1]`). Added a `@safety` note and `SafeAutoCorrect: false`; the offense is still reported.