### PR TITLE
Allow right-aligned numeric operands in SpaceAroundOperators

### DIFF
--- a/changelog/fix_space_around_operators_right_aligned_numeric_operands.md
+++ b/changelog/fix_space_around_operators_right_aligned_numeric_operands.md
@@ -1,0 +1,1 @@
+* [#15286](https://github.com/rubocop/rubocop/issues/15286): Fix a false positive for `Layout/SpaceAroundOperators` when numeric operands are right-aligned. ([@minhluuquang][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -72,6 +72,7 @@ module RuboCop
 
         IRREGULAR_METHODS = %i[[] ! []=].freeze
         EXCESSIVE_SPACE = '  '
+        NUMERIC_TOKEN_TYPES = %i[tINTEGER tFLOAT tRATIONAL tIMAGINARY].freeze
 
         def self.autocorrect_incompatible_with
           [Style::SelfAssignment]
@@ -237,7 +238,7 @@ module RuboCop
           elsif !/^\s.*\s$/.match?(with_space.source)
             "Surrounding space missing for operator `#{operator.source}`."
           elsif excess_leading_space?(type, operator, with_space) ||
-                excess_trailing_space?(right_operand.source_range, with_space)
+                excess_trailing_space?(right_operand, with_space)
             "Operator `#{operator.source}` should be surrounded " \
               'by a single space.'
           end
@@ -259,8 +260,34 @@ module RuboCop
         end
 
         def excess_trailing_space?(right_operand, with_space)
+          right_operand_range = right_operand.source_range
+
           with_space.source.end_with?(EXCESSIVE_SPACE) &&
-            (!allow_for_alignment? || !aligned_with_something?(right_operand))
+            (!allow_for_alignment? ||
+              !(aligned_with_something?(right_operand_range) ||
+                right_aligned_numeric_literal?(right_operand_range)))
+        end
+
+        def right_aligned_numeric_literal?(right_operand_range)
+          numeric_token = leading_numeric_token(right_operand_range)
+          return false unless numeric_token
+
+          aligned_with_adjacent_line?(numeric_token.pos, method(:right_aligned_numeric_token?))
+        end
+
+        def leading_numeric_token(range)
+          processed_source.tokens_within(range).find do |token|
+            token.pos.begin_pos == range.begin_pos && NUMERIC_TOKEN_TYPES.include?(token.type)
+          end
+        end
+
+        def right_aligned_numeric_token?(range, _line, lineno)
+          line_range = processed_source.buffer.line_range(lineno)
+          return false unless line_range
+
+          processed_source.tokens_within(line_range).any? do |token|
+            NUMERIC_TOKEN_TYPES.include?(token.type) && token.pos.last_column == range.last_column
+          end
         end
 
         def align_hash_cop_config

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -880,6 +880,39 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
       RUBY
     end
 
+    it 'accepts right-aligned numeric operands' do
+      expect_no_offenses(<<~RUBY)
+        if    a <  1 then 2
+        elsif a <  3 then a <  4 + 20
+        elsif a < 10 then a < 10 +  5
+        end
+      RUBY
+    end
+
+    context 'with AllowForAlignment disabled' do
+      let(:allow_for_alignment) { false }
+
+      it 'registers an offense and corrects right-aligned numeric operands' do
+        expect_offense(<<~RUBY)
+          if    a <  1 then 2
+                  ^ Operator `<` should be surrounded by a single space.
+          elsif a <  3 then a <  4 + 20
+                  ^ Operator `<` should be surrounded by a single space.
+                              ^ Operator `<` should be surrounded by a single space.
+          elsif a < 10 then a < 10 +  5
+                                   ^ Operator `+` should be surrounded by a single space.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if    a < 1 then 2
+          elsif a < 3 then a < 4 + 20
+          elsif a < 10 then a < 10 + 5
+          end
+        RUBY
+      end
+    end
+
     it 'registers an offense and corrects arguments to a method' do
       expect_offense(<<~RUBY)
         puts 1 +  2


### PR DESCRIPTION
Fixes #15286.

This updates `Layout/SpaceAroundOperators` so it accepts right-aligned numeric operands when `AllowForAlignment` is enabled. This keeps the existing behavior for normal operands and still reports/corrects the spacing when `AllowForAlignment` is disabled.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
  * I ran the focused checks for this change:
    * `bundle exec rspec spec/rubocop/cop/layout/space_around_operators_spec.rb`
    * `bundle exec rubocop --cache false --disable-pending-cops lib/rubocop/cop/layout/space_around_operators.rb spec/rubocop/cop/layout/space_around_operators_spec.rb`
    * `git diff --check`
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
