### PR TITLE
Add AllowTrailingComment to DisableCopsWithinSourceCodeDirective

### DIFF
--- a/changelog/add_allow_trailing_comment_to_disable_cops_directive.md
+++ b/changelog/add_allow_trailing_comment_to_disable_cops_directive.md
@@ -1,0 +1,1 @@
+* [#15073](https://github.com/rubocop/rubocop/issues/15073): Add `AllowTrailingComment` to `Style/DisableCopsWithinSourceCodeDirective`. ([@minhluuquang][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3925,6 +3925,7 @@ Style/DisableCopsWithinSourceCodeDirective:
   VersionAdded: '0.82'
   VersionChanged: '1.9'
   AllowedCops: []
+  AllowTrailingComment: false
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -3780,6 +3780,10 @@ and not quickly disabled with a comment.
 Specific cops can be allowed with the `AllowedCops` configuration. Note that
 if this configuration is set, `rubocop:disable all` is still disallowed.
 
+Directives with trailing comments can be allowed with the
+`AllowTrailingComment` configuration. The trailing comment must start with
+`--` and include explanatory text.
+
 [#examples-styledisablecopswithinsourcecodedirective]
 === Examples
 
@@ -3808,6 +3812,18 @@ end
 # rubocop:enable Metrics/AbcSize
 ----
 
+[#allowtrailingcomment_-_true_-styledisablecopswithinsourcecodedirective]
+==== AllowTrailingComment: true
+
+[source,ruby]
+----
+# good
+# rubocop:disable Metrics/AbcSize -- Reason for disabling.
+def foo
+end
+# rubocop:enable Metrics/AbcSize
+----
+
 [#configurable-attributes-styledisablecopswithinsourcecodedirective]
 === Configurable attributes
 
@@ -3817,6 +3833,10 @@ end
 | AllowedCops
 | `[]`
 | Array
+
+| AllowTrailingComment
+| `false`
+| Boolean
 |===
 
 [#styledocumentdynamicevaldefinition]

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -12,6 +12,10 @@ module RuboCop
       # Specific cops can be allowed with the `AllowedCops` configuration. Note that
       # if this configuration is set, `rubocop:disable all` is still disallowed.
       #
+      # Directives with trailing comments can be allowed with the
+      # `AllowTrailingComment` configuration. The trailing comment must start with
+      # `--` and include explanatory text.
+      #
       # @example
       #   # bad
       #   # rubocop:disable Metrics/AbcSize
@@ -30,6 +34,13 @@ module RuboCop
       #   end
       #   # rubocop:enable Metrics/AbcSize
       #
+      # @example AllowTrailingComment: true
+      #   # good
+      #   # rubocop:disable Metrics/AbcSize -- Reason for disabling.
+      #   def foo
+      #   end
+      #   # rubocop:enable Metrics/AbcSize
+      #
       class DisableCopsWithinSourceCodeDirective < Base
         extend AutoCorrector
 
@@ -38,11 +49,19 @@ module RuboCop
         MSG_FOR_COPS = 'RuboCop disable/enable directives for %<cops>s are not permitted.'
 
         def on_new_investigation
+          documented_cops = []
+
           processed_source.comments.each do |comment|
-            directive_cops = directive_cops(comment)
+            directive_comment = DirectiveComment.new(comment)
+            directive_cops = directive_cops(directive_comment)
             disallowed_cops = directive_cops - allowed_cops
 
             next unless disallowed_cops.any?
+
+            if trailing_comment_allowed?(directive_comment, directive_cops, documented_cops)
+              documented_cops |= directive_cops if directive_comment.disabled?
+              next
+            end
 
             register_offense(comment, directive_cops, disallowed_cops)
           end
@@ -69,13 +88,36 @@ module RuboCop
           end
         end
 
-        def directive_cops(comment)
-          match_captures = DirectiveComment.new(comment).match_captures
+        def directive_cops(directive_comment)
+          match_captures = directive_comment.match_captures
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
         end
 
         def allowed_cops
           Array(cop_config['AllowedCops'])
+        end
+
+        def trailing_comment_allowed?(directive_comment, directive_cops, documented_cops)
+          return false unless cop_config['AllowTrailingComment']
+
+          if directive_comment.disabled?
+            trailing_comment?(directive_comment)
+          elsif directive_comment.enabled?
+            (directive_cops - documented_cops).empty?
+          else
+            false
+          end
+        end
+
+        def trailing_comment?(directive_comment)
+          trailing_comment_text(directive_comment).match?(/\A\s*#{DirectiveComment::TRAILING_COMMENT_MARKER}\s+\S/)
+        end
+
+        def trailing_comment_text(directive_comment)
+          comment = directive_comment.comment
+          directive_end = directive_comment.range.end_pos - comment.source_range.begin_pos
+
+          comment.text[directive_end..].to_s
         end
 
         def any_cops_allowed?

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -93,4 +93,48 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       end
     end
   end
+
+  context 'with AllowTrailingComment' do
+    let(:cop_config) { { 'AllowTrailingComment' => true } }
+
+    it 'does not register an offense for a disable directive with a trailing comment' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Metrics/AbcSize -- This method has domain-specific branching.
+        def foo
+        end
+        # rubocop:enable Metrics/AbcSize
+      RUBY
+    end
+
+    it 'registers an offense for a disable directive with only a trailing comment marker' do
+      expect_offense(<<~RUBY)
+        def foo # rubocop:disable Metrics/AbcSize --
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo#{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    context 'with AllowedCops' do
+      let(:cop_config) do
+        {
+          'AllowedCops' => ['Metrics/AbcSize'],
+          'AllowTrailingComment' => true
+        }
+      end
+
+      it 'does not register an offense for a non-allowed cop with a trailing comment' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity -- Temporary workaround.
+          def foo
+          end
+          # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #15073.

This adds an `AllowTrailingComment` option to `Style/DisableCopsWithinSourceCodeDirective`. When enabled, documented disable/todo directives using `-- explanation` are allowed, and the matching later enable directive is allowed for the same cops. A bare `--` marker still registers an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
  * I ran the focused checks for this change:
    * `bundle exec rspec spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb`
    * `bundle exec rubocop --cache false --disable-pending-cops lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb`
    * `git diff --check`
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
