### PR TITLE
Fix an incorrect autocorrect for `Style/NilLambda`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_nil_lambda_20260629132041.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_nil_lambda_20260629132041.md
@@ -1,0 +1,1 @@
+* [#15394](https://github.com/rubocop/rubocop/pull/15394): Fix an incorrect autocorrect for `Style/NilLambda` when a non-lambda proc returns `nil` with `return`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -6,6 +6,11 @@ module RuboCop
       # Checks for lambdas and procs that always return nil,
       # which can be replaced with an empty lambda or proc instead.
       #
+      # NOTE: A `proc` that returns nil via an explicit `return` is allowed,
+      # because in a `proc` `return` exits the enclosing method, so removing it
+      # would change behavior. A lambda is still reported, since there `return`
+      # only exits the lambda itself.
+      #
       # @example
       #   # bad
       #   -> { nil }
@@ -46,6 +51,9 @@ module RuboCop
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless node.lambda_or_proc?
           return unless nil_return?(node.body)
+          # `return` inside a non-lambda proc returns from the enclosing method,
+          # so dropping it changes behavior; only a lambda can omit it safely.
+          return if node.body.return_type? && !node.lambda?
 
           message = format(MSG, type: node.lambda? ? 'lambda' : 'proc')
           add_offense(node, message: message) do |corrector|

--- a/spec/rubocop/cop/style/nil_lambda_spec.rb
+++ b/spec/rubocop/cop/style/nil_lambda_spec.rb
@@ -187,16 +187,12 @@ RSpec.describe RuboCop::Cop::Style::NilLambda, :config do
       RUBY
     end
 
-    it 'registers an offense when returning nil with `return`' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense when returning nil with `return`' do
+      # `return` in a proc returns from the enclosing method, so it cannot be
+      # safely removed.
+      expect_no_offenses(<<~RUBY)
         proc do
-        ^^^^^^^ Use an empty proc instead of always returning nil.
           return nil
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        proc do
         end
       RUBY
     end
@@ -286,16 +282,12 @@ RSpec.describe RuboCop::Cop::Style::NilLambda, :config do
       RUBY
     end
 
-    it 'registers an offense when returning nil with `return`' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense when returning nil with `return`' do
+      # `return` in a proc returns from the enclosing method, so it cannot be
+      # safely removed.
+      expect_no_offenses(<<~RUBY)
         Proc.new do
-        ^^^^^^^^^^^ Use an empty proc instead of always returning nil.
           return nil
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        Proc.new do
         end
       RUBY
     end


### PR DESCRIPTION
`proc { return nil }` (and `Proc.new { return nil }`) was autocorrected to an empty `proc {}`, but `return` inside a non-lambda proc returns from the *enclosing method*, so removing it changes behavior. The cop no longer flags a `return` body for procs. Lambdas (where `return` is local) and `next`/`break`/bare-`nil` bodies are still handled.