### PR TITLE
Fix a false negative for `Style/RedundantHeredocDelimiterQuotes` with double quotes

### DIFF
--- a/changelog/fix_a_false_negative_for_style_redundant_heredoc_delimiter_quotes_with_double_20260629134750.md
+++ b/changelog/fix_a_false_negative_for_style_redundant_heredoc_delimiter_quotes_with_double_20260629134750.md
@@ -1,0 +1,1 @@
+* [#15395](https://github.com/rubocop/rubocop/pull/15395): Fix a false negative for `Style/RedundantHeredocDelimiterQuotes` with double-quoted delimiters whose body contains interpolation or escapes. ([@bbatsov][])

--- a/lib/rubocop/cop/style/redundant_heredoc_delimiter_quotes.rb
+++ b/lib/rubocop/cop/style/redundant_heredoc_delimiter_quotes.rb
@@ -48,8 +48,13 @@ module RuboCop
         def need_heredoc_delimiter_quotes?(node)
           heredoc_delimiter = node.source.delete(heredoc_type(node))
           return true unless heredoc_delimiter.start_with?("'", '"')
+          return true if node.loc.heredoc_end.source.strip.match?(/\W/)
 
-          node.loc.heredoc_end.source.strip.match?(/\W/) ||
+          # A double-quoted delimiter interpolates exactly like an unquoted one,
+          # so its quotes are always redundant. A single-quoted delimiter is
+          # required when the body contains interpolation or escapes that would
+          # otherwise be evaluated.
+          heredoc_delimiter.start_with?("'") &&
             node.loc.heredoc_body.source.match?(STRING_INTERPOLATION_OR_ESCAPED_CHARACTER_PATTERN)
         end
       end

--- a/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
+++ b/spec/rubocop/cop/style/redundant_heredoc_delimiter_quotes_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantHeredocDelimiterQuotes, :config do
     RUBY
   end
 
+  it 'registers an offense when using double quotes around a body with interpolation' do
+    expect_offense(<<~'RUBY')
+      do_something(<<~"EOS")
+                   ^^^^^^^^ Remove the redundant heredoc delimiter quotes, use `<<~EOS` instead.
+        #{string} #{interpolation}
+      EOS
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      do_something(<<~EOS)
+        #{string} #{interpolation}
+      EOS
+    RUBY
+  end
+
   it 'does not register an offense when using the redundant heredoc delimiter backquotes' do
     expect_no_offenses(<<~RUBY)
       do_something(<<~`EOS`)


### PR DESCRIPTION
A double-quoted heredoc delimiter (`<<~"EOS"`) interpolates exactly like an unquoted one, so its quotes are always redundant. The cop skipped it whenever the body contained interpolation or escapes - logic that is only correct for *single*-quoted delimiters (where removing the quotes would enable interpolation). Double-quoted delimiters are now flagged regardless of body content; single-quoted handling is unchanged.