### PR TITLE
Fix a false negative for `Style/MultilineMethodSignature`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_multiline_method_signature_20260629135118.md
+++ b/changelog/fix_a_false_negative_for_style_multiline_method_signature_20260629135118.md
@@ -1,0 +1,1 @@
+* [#15396](https://github.com/rubocop/rubocop/pull/15396): Fix a false negative for `Style/MultilineMethodSignature` where a signature that fits on one line was skipped because the multi-line source length was measured instead of the collapsed width. ([@bbatsov][])

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -87,7 +87,12 @@ module RuboCop
         end
 
         def definition_width(node)
-          node.source_range.begin.join(node.arguments.source_range.end).length
+          # Measure the collapsed single-line width the autocorrect would
+          # produce, not the multi-line source length, so a signature that
+          # would fit on one line is not skipped.
+          signature = node.source_range.begin.join(node.arguments.source_range.end).source
+
+          signature.gsub(/\s+/, ' ').length
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_method_signature_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_signature_spec.rb
@@ -259,6 +259,24 @@ RSpec.describe RuboCop::Cop::Style::MultilineMethodSignature, :config do
         RUBY
       end
     end
+
+    context 'when the collapsed signature fits but the multi-line source is longer than the maximum' do
+      let(:other_cops) { { 'Layout/LineLength' => { 'Max' => 20 } } }
+
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          def foo(bar,
+          ^^^^^^^^^^^^ Avoid multi-line method signatures.
+                  baz)
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(bar, baz)
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when `Layout/LineLength` is disabled' do


### PR DESCRIPTION
`definition_width` measured the multi-line source length (including the newline and indentation between arguments) rather than the collapsed single-line width the autocorrect produces. With a small `Layout/LineLength` Max, a signature that *would* fit on one line (e.g. `def foo(bar, baz)`) was wrongly skipped. It now measures the collapsed width.