### PR TITLE
Fix indentation in `Style/IdenticalConditionalBranches` autocorrect

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_identical_conditional_branches_20260629142922.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_identical_conditional_branches_20260629142922.md
@@ -1,0 +1,1 @@
+* [#15397](https://github.com/rubocop/rubocop/pull/15397): Fix an incorrect autocorrect for `Style/IdenticalConditionalBranches` that hoisted the moved expression to column zero instead of matching the surrounding indentation. ([@bbatsov][])

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -216,21 +216,32 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def correct_assignment(corrector, node, expression, insert_position)
+          indentation = indentation_of(node.parent)
+
           if insert_position == :after_condition
             assignment = node.parent.source_range.with(end_pos: node.source_range.begin_pos)
             corrector.remove(assignment)
-            corrector.insert_after(node, "\n#{assignment.source}#{expression.source}")
+            corrector.insert_after(node, "\n#{indentation}#{assignment.source}#{expression.source}")
           else
-            corrector.insert_before(node.parent, "#{expression.source}\n")
+            corrector.insert_before(node.parent, "#{expression.source}\n#{indentation}")
           end
         end
 
         def correct_no_assignment(corrector, node, expression, insert_position)
+          indentation = indentation_of(node)
+
           if insert_position == :after_condition
-            corrector.insert_after(node, "\n#{expression.source}")
+            corrector.insert_after(node, "\n#{indentation}#{expression.source}")
           else
-            corrector.insert_before(node, "#{expression.source}\n")
+            corrector.insert_before(node, "#{expression.source}\n#{indentation}")
           end
+        end
+
+        # The leading indentation of the line the conditional starts on, so a
+        # hoisted expression keeps the surrounding nesting instead of landing
+        # at column zero.
+        def indentation_of(node)
+          ' ' * node.source_range.column
         end
 
         def last_child_of_parent?(node)

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -22,6 +22,35 @@ RSpec.describe RuboCop::Cop::Style::IdenticalConditionalBranches, :config do
     end
   end
 
+  context 'when the conditional is nested inside a method' do
+    it 'hoists the trailing expression with the surrounding indentation' do
+      expect_offense(<<~RUBY)
+        def foo
+          if something
+            bar
+            do_x
+            ^^^^ Move `do_x` out of the conditional.
+          else
+            baz
+            do_x
+            ^^^^ Move `do_x` out of the conditional.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          if something
+            bar
+          else
+            baz
+          end
+          do_x
+        end
+      RUBY
+    end
+  end
+
   context 'on if..else with identical trailing lines' do
     it 'registers and corrects an offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
When an identical expression is hoisted out of a nested conditional (e.g. inside a method), the cop inserts it at column zero rather than at the conditional's indentation. A full `rubocop -A` run repairs this via the Layout cops, but the cop should emit correctly-indented code on its own (Layout cops may be disabled, and column-zero output is surprising when running this cop alone). The hoisted expression now keeps the surrounding indentation.