### PR TITLE
Fix an incorrect autocorrect for `Layout/ConditionPosition`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_condition_position_20260629153747.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_condition_position_20260629153747.md
@@ -1,0 +1,1 @@
+* [#15398](https://github.com/rubocop/rubocop/pull/15398): Fix an incorrect autocorrect for `Layout/ConditionPosition` that dropped a body statement sharing the condition's line via a semicolon. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/condition_position.rb
+++ b/lib/rubocop/cop/layout/condition_position.rb
@@ -44,15 +44,25 @@ module RuboCop
           message = message(condition)
 
           add_offense(condition, message: message) do |corrector|
-            range = range_by_whole_lines(condition.source_range, include_final_newline: true)
-
             corrector.insert_after(condition.parent.loc.keyword, " #{condition.source}")
-            corrector.remove(range)
+            corrector.remove(removal_range(node, condition))
           end
         end
 
         def message(condition)
           format(MSG, keyword: condition.parent.keyword)
+        end
+
+        # When a body statement shares the condition's line (e.g. `while\n cond; body\nend`),
+        # removing the whole line would delete the body too. In that case only remove the
+        # condition and its trailing separator, preserving the body statement.
+        def removal_range(node, condition)
+          body = node.body
+          if body && body.source_range.line == condition.source_range.last_line
+            range_between(condition.source_range.begin_pos, body.source_range.begin_pos)
+          else
+            range_by_whole_lines(condition.source_range, include_final_newline: true)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/layout/condition_position_spec.rb
+++ b/spec/rubocop/cop/layout/condition_position_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe RuboCop::Cop::Layout::ConditionPosition, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects while preserving a body statement on the condition line' do
+      expect_offense(<<~RUBY)
+        #{keyword}
+          x == 10; do_something
+          ^^^^^^^ Place the condition on the same line as `#{keyword}`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{keyword} x == 10
+          do_something
+        end
+      RUBY
+    end
+
     it 'accepts condition on the same line' do
       expect_no_offenses(<<~RUBY)
         #{keyword} x == 10


### PR DESCRIPTION
When a body statement shared the condition's line via a semicolon, e.g.

```ruby
while
  i < 3; i += 1
end
```

the autocorrect removed the entire condition line, silently dropping `i += 1`. For loops that turned the code into an infinite loop. Now only the condition and its trailing separator are removed, so the body is preserved.