### PR TITLE
Fix an incorrect autocorrect for `Layout/EmptyComment`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_empty_comment_20260629154017.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_empty_comment_20260629154017.md
@@ -1,0 +1,1 @@
+* [#15399](https://github.com/rubocop/rubocop/pull/15399): Fix an incorrect autocorrect for `Layout/EmptyComment` that deleted a heredoc when removing an empty comment trailing its opener. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -95,8 +95,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, node)
-          previous_token = previous_token(node)
-          range = if previous_token && same_line?(node, previous_token)
+          range = if inline_comment?(node)
                     range_with_surrounding_space(node.source_range, newlines: false)
                   else
                     range_by_whole_lines(node.source_range, include_final_newline: true)
@@ -138,14 +137,13 @@ module RuboCop
           cop_config['AllowMarginComment']
         end
 
-        def current_token(comment)
-          processed_source.tokens.find { |token| token.pos == comment.source_range }
-        end
-
-        def previous_token(node)
-          current_token = current_token(node)
-          index = processed_source.tokens.index(current_token)
-          index.zero? ? nil : processed_source.tokens[index - 1]
+        # A comment is inline when code precedes it on the same line. Detecting this
+        # from the source (rather than the token stream) is required because, for a
+        # comment trailing a heredoc opener, the preceding token is the heredoc end on
+        # a later line, which would wrongly trigger whole-line removal of the opener.
+        def inline_comment?(comment)
+          preceding_source = processed_source.lines[comment.loc.line - 1][0...comment.loc.column]
+          !preceding_source.strip.empty?
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects an empty comment trailing a heredoc opener' do
+    expect_offense(<<~RUBY)
+      x = <<~HEREDOC #
+                     ^ Source code comment is empty.
+        hello
+      HEREDOC
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = <<~HEREDOC
+        hello
+      HEREDOC
+    RUBY
+  end
+
   it 'registers an offense and corrects when using an empty comment next to code after comment line' do
     expect_offense(<<~RUBY)
       # comment


### PR DESCRIPTION
An empty comment trailing a heredoc opener:

```ruby
x = <<~HEREDOC #
  hello
HEREDOC
```

was treated as a standalone comment, because the token preceding it is the heredoc end on a later line. Autocorrect then removed the whole opener line, deleting the assignment and the heredoc body. Inline comments are now detected from the source that precedes the comment rather than from the token stream.