### PR TITLE
Fix an incorrect autocorrect for `Layout/EmptyLineBetweenDefs`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_empty_line_between_defs_20260629154320.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_empty_line_between_defs_20260629154320.md
@@ -1,0 +1,1 @@
+* [#15400](https://github.com/rubocop/rubocop/pull/15400): Fix an incorrect autocorrect for `Layout/EmptyLineBetweenDefs` that inserted a blank line inside a heredoc body when an endless method's body was a heredoc. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -274,7 +274,20 @@ module RuboCop
         end
 
         def end_loc(node)
-          node.source_range.end
+          end_location = node.source_range.end
+          trailing_heredoc_end(node, end_location) || end_location
+        end
+
+        # For an endless method whose body is a heredoc (e.g. `def a = <<~TEXT`), the
+        # node's source range ends at the heredoc opening line, before the heredoc body.
+        # Use the heredoc's closing delimiter so the def's real end is located after the
+        # heredoc and blank-line insertion does not land inside the heredoc body.
+        def trailing_heredoc_end(node, end_location)
+          heredocs = node.each_descendant(:any_str).select(&:heredoc?)
+          return if heredocs.empty?
+
+          heredoc_end = heredocs.map { |heredoc| heredoc.loc.heredoc_end }.max_by(&:end_pos)
+          heredoc_end if heredoc_end.end_pos > end_location.end_pos
         end
 
         def autocorrect_remove_lines(corrector, newline_pos, count)

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -606,6 +606,30 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
     end
 
+    context 'when the endless method body is a heredoc' do
+      it 'registers an offense and corrects after the heredoc, preserving its body' do
+        expect_offense(<<~RUBY)
+          def foo = <<~TEXT
+            hello
+          TEXT
+          def bar
+          ^^^^^^^ Expected 1 empty line between method definitions; found 0.
+            y
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo = <<~TEXT
+            hello
+          TEXT
+
+          def bar
+            y
+          end
+        RUBY
+      end
+    end
+
     context 'between regular and endless methods' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
When an endless method's body is a heredoc:

```ruby
def foo = <<~TEXT
  hello
TEXT
def bar
  y
end
```

the def node's source range ends at the heredoc opening line, so autocorrect inserted the required blank line right after `<<~TEXT`, landing inside the heredoc body and silently changing the string from `"hello\n"` to `"\nhello\n"`. The def's end is now located at the heredoc's closing delimiter, so the blank line is inserted after the heredoc.