### PR TITLE
Fix an incorrect autocorrect for `Layout/SpaceAroundOperators`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_space_around_operators_20260629165623.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_space_around_operators_20260629165623.md
@@ -1,0 +1,1 @@
+* [#15401](https://github.com/rubocop/rubocop/pull/15401): Fix an incorrect autocorrect for `Layout/SpaceAroundOperators` that turned `**=` and `/=` compound assignments into `**`/`/`, dropping the assignment. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -204,10 +204,14 @@ module RuboCop
 
         def autocorrect(corrector, range, right_operand)
           range_source = range.source
+          # Match the operator exactly, not by substring, so compound assignments
+          # like `**=` and `/=` are not mistaken for `**` and `/` (which would drop
+          # the `=` and silently change the program's behavior).
+          operator = range_source.strip
 
-          if range_source.include?('**') && !space_around_exponent_operator?
+          if operator == '**' && !space_around_exponent_operator?
             corrector.replace(range, '**')
-          elsif range_source.include?('/') && !space_around_slash_operator?(right_operand)
+          elsif operator == '/' && !space_around_slash_operator?(right_operand)
             corrector.replace(range, '/')
           elsif range_source.end_with?("\n")
             corrector.replace(range, " #{range_source.strip}\n")

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -257,6 +257,28 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
     expect_no_offenses('x = a * b/42r')
   end
 
+  it 'registers an offense for an exponent-assignment operator without spaces and keeps the assignment' do
+    expect_offense(<<~RUBY)
+      base**=exp
+          ^^^ Surrounding space missing for operator `**=`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      base **= exp
+    RUBY
+  end
+
+  it 'registers an offense for a division-assignment operator without spaces and keeps the assignment' do
+    expect_offense(<<~RUBY)
+      val/=2r
+         ^^ Surrounding space missing for operator `/=`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      val /= 2r
+    RUBY
+  end
+
   it 'does not register an offense for slash in non rational literals without spaces' do
     expect_no_offenses(<<~RUBY)
       x = a * b / 42


### PR DESCRIPTION
The autocorrect matched the exponent and slash operators with a loose `include?` substring check, so a compound assignment like `base**=exp` or `val/=2r` was treated as `**`/`/` and rewritten to `base**exp`/`val/2r`, silently dropping the `=` and changing the program's behavior (the assignment result is discarded). The operator is now matched exactly, the same way `should_not_have_surrounding_space?` already does, so `**=`/`/=` correctly get `base **= exp` / `val /= 2r`.