### PR TITLE
Fix an infinite loop for `Layout/LineLength` with `SplitStrings`

### DIFF
--- a/changelog/fix_an_infinite_loop_for_layout_line_length_with_split_strings_20260629170145.md
+++ b/changelog/fix_an_infinite_loop_for_layout_line_length_with_split_strings_20260629170145.md
@@ -1,0 +1,1 @@
+* [#15402](https://github.com/rubocop/rubocop/pull/15402): Fix an infinite loop and file corruption for `Layout/LineLength` with `SplitStrings` when an over-long string is indented under a multi-line parent. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -420,11 +420,16 @@ module RuboCop
           # The maximum allowed length of a string value is:
           # `Max` - end delimiter (quote) - continuation characters (space and slash)
           max_length = max - 3
-          # If the string is on the same line as its parent, offset by the column difference
-          # (Only apply when on same line to avoid negative offsets for multi-line dstr)
-          if same_line?(node, node.parent)
-            max_length -= column_offset_between(node.loc, node.parent.loc)
-          end
+          # Offset by the string's starting column so the broken line actually fits
+          # within `Max`. When on the same line as its parent, use the column difference;
+          # otherwise the string is indented on its own line, so subtract that indentation.
+          # (Without this, an indented string under a multi-line parent never shortens
+          # below `Max` and the autocorrect loops, inserting empty `"" \` fragments.)
+          max_length -= if same_line?(node, node.parent)
+                          column_offset_between(node.loc, node.parent.loc)
+                        else
+                          node.loc.column
+                        end
           node.source[0...(max_length)]
         end
       end

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -785,6 +785,22 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             RUBY
           end
 
+          it 'breaks an indented string under a multi-line parent without looping' do
+            expect_offense(<<~RUBY)
+              foo(
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbb'
+                                                      ^^^^^^ Line is too long. [46/40]
+              )
+            RUBY
+
+            expect_correction(<<~'RUBY')
+              foo(
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ' \
+              'bbbbbbbbbbb'
+              )
+            RUBY
+          end
+
           context 'when AllowHeredoc: false' do
             let(:cop_config) { super().merge('AllowHeredoc' => false) }
 


### PR DESCRIPTION
When `SplitStrings` is enabled and a too-long string literal is indented under a multi-line parent:

```ruby
foo(
  "very long string that exceeds limit here"
)
```

the break-point calculation ignored the string's indentation, so each correction left the line still over `Max`. The autocorrect never converged - it kept inserting empty `"" \` fragments until RuboCop aborted with "Infinite loop detected ... caused by Layout/LineLength", leaving a corrupted file. The string's starting column is now subtracted from the available width in this case too, so the break actually shortens the line.