### PR TITLE
Fix a false positive for `Layout/CommentIndentation` with inline access modifiers

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_comment_indentation_with_an_inline_access_modifier_20260629160930.md
+++ b/changelog/fix_a_false_positive_for_layout_comment_indentation_with_an_inline_access_modifier_20260629160930.md
@@ -1,0 +1,1 @@
+* [#15403](https://github.com/rubocop/rubocop/pull/15403): Fix a false positive for `Layout/CommentIndentation` with a comment above an inline access modifier (e.g. `private def foo`) when `Layout/AccessModifierIndentation` is configured with `EnforcedStyle: outdent`. ([@grk][])

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -155,8 +155,15 @@ module RuboCop
 
         def less_indented?(line)
           rule = config.for_cop('Layout/AccessModifierIndentation')['EnforcedStyle'] == 'outdent'
-          access_modifier = 'private|protected|public'
-          /\A\s*(end\b|[)}\]])/.match?(line) || (rule && /\A\s*(#{access_modifier})\b/.match?(line))
+          /\A\s*(end\b|[)}\]])/.match?(line) || (rule && bare_access_modifier?(line))
+        end
+
+        # Only a bare access modifier (the keyword alone on its line) is outdented by
+        # `Layout/AccessModifierIndentation`. An inline modifier such as `private def foo`
+        # keeps the regular method indentation, so a comment above it must not be pushed
+        # one level deeper.
+        def bare_access_modifier?(line)
+          /\A\s*(private|protected|public)\s*(#.*)?\z/.match?(line)
         end
 
         def two_alternatives?(line)

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -415,6 +415,29 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense for a comment above an inline access modifier' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          # Explains what bar does.
+          private def bar
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a comment above a bare access modifier aligned with the keyword' do
+      expect_offense(<<~RUBY)
+        class A
+        # Explains what bar does.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Incorrect indentation detected (column 0 instead of 2).
+        private
+
+          def bar
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when the cop is configured with `IndentationWidth`' do


### PR DESCRIPTION
When `Layout/AccessModifierIndentation` is configured with `EnforcedStyle: outdent`, `Layout/CommentIndentation` pushed a comment one indent level deeper whenever the next line of code began with `private`, `protected`, or `public`. The detection matched an inline modifier such as `private def foo` the same as a bare, outdented `private`, even though an inline modifier keeps the regular method indentation — so a comment correctly aligned with `private def foo` was flagged and autocorrected one column too deep.

```ruby
# EnforcedStyle: outdent
class Foo
  # Explains what bar does.
  private def bar          # comment above is flagged: "column 2 instead of 4"
  end
end
```

The fix restricts the outdent detection to a *bare* access modifier (the keyword alone on its line) — the only form `Layout/AccessModifierIndentation` actually outdents. A comment above a bare `private` still aligns with the wrapped method body, as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/