### PR TITLE
Fix a crash for `Metrics/MethodLength` with an anonymous `define_method`

### DIFF
--- a/changelog/fix_a_crash_for_metrics_method_length_with_an_anonymous_define_method_20260629174410.md
+++ b/changelog/fix_a_crash_for_metrics_method_length_with_an_anonymous_define_method_20260629174410.md
@@ -1,0 +1,1 @@
+* [#15404](https://github.com/rubocop/rubocop/pull/15404): Fix a crash for `Metrics/MethodLength` with an anonymous `define_method`. ([@bbatsov][])

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -58,7 +58,7 @@ module RuboCop
           return unless node.method?(:define_method)
 
           method_name = node.send_node.first_argument
-          return if method_name.basic_literal? && allowed?(method_name.value)
+          return if method_name&.basic_literal? && allowed?(method_name.value)
 
           check_code_length(node)
         end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
         end
       RUBY
     end
+
+    it 'does not crash when `define_method` is called without a name argument' do
+      expect_offense(<<~RUBY)
+        define_method do
+        ^^^^^^^^^^^^^^^^ Method has too many lines. [6/5]
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
   end
 
   context 'when using numbered parameter', :ruby27 do


### PR DESCRIPTION
`define_method` called without a name argument (`define_method do ... end`) made `on_block` call `basic_literal?` on a nil `first_argument`, raising `NoMethodError` and aborting the inspection. The nil is now guarded with safe navigation, so the block is still measured.