### PR TITLE
Fix a crash for `Security/IoMethods` with a non-string-literal argument

### DIFF
--- a/changelog/fix_a_crash_for_security_io_methods_with_a_non_string_literal_argument_20260629174727.md
+++ b/changelog/fix_a_crash_for_security_io_methods_with_a_non_string_literal_argument_20260629174727.md
@@ -1,0 +1,1 @@
+* [#15405](https://github.com/rubocop/rubocop/pull/15405): Fix a crash for `Security/IoMethods` with a non-string-literal argument. ([@bbatsov][])

--- a/lib/rubocop/cop/security/io_methods.rb
+++ b/lib/rubocop/cop/security/io_methods.rb
@@ -37,7 +37,7 @@ module RuboCop
           return unless (receiver = node.receiver) && receiver.source == 'IO'
 
           argument = node.first_argument
-          return if argument.respond_to?(:value) && argument.value.strip.start_with?('|')
+          return if argument&.str_type? && argument.value.strip.start_with?('|')
 
           add_offense(node, message: format(MSG, method_name: node.method_name)) do |corrector|
             corrector.replace(receiver, 'File')

--- a/spec/rubocop/cop/security/io_methods_spec.rb
+++ b/spec/rubocop/cop/security/io_methods_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe RuboCop::Cop::Security::IoMethods, :config do
     end
   end
 
+  context 'when using `IO` receiver and a non-string-literal argument' do
+    it_behaves_like 'offense', 'IO.read(:some_path)', 'File.read(:some_path)', 'read'
+    it_behaves_like 'offense', 'IO.read(123)', 'File.read(123)', 'read'
+    it_behaves_like 'offense', 'IO.write(123, "hi")', 'File.write(123, "hi")', 'write'
+  end
+
   context 'when using `File` receiver' do
     it_behaves_like 'accepts', 'File.read(path)'
     it_behaves_like 'accepts', 'File.binread(path)'


### PR DESCRIPTION
`IO.read(:some_path)`, `IO.read(123)` and similar crashed the cop with `NoMethodError` - the pipe-prefix guard called `strip` on the argument's `value`, which is a Symbol/Integer/Float for non-string literals. The guard now only runs for string literals (`str_type?`), so other literal arguments are flagged and corrected to `File` without crashing.