### PR TITLE
Fix an incorrect autocorrect for `Naming/MemoizedInstanceVariableName`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_naming_memoized_instance_variable_name_20260629174923.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_naming_memoized_instance_variable_name_20260629174923.md
@@ -1,0 +1,1 @@
+* [#15406](https://github.com/rubocop/rubocop/pull/15406): Fix an incorrect autocorrect for `Naming/MemoizedInstanceVariableName`. ([@bbatsov][])

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -174,6 +174,7 @@ module RuboCop
 
           method_node, method_name = find_definition(node)
           return unless method_node
+          return unless nameable_method?(method_name)
 
           body = method_node.body
           return unless body == node || body.children.last == node
@@ -209,6 +210,7 @@ module RuboCop
 
           method_node, method_name = find_definition(node)
           return false unless method_node
+          return false unless nameable_method?(method_name)
 
           defined_memoized?(method_node.body, arg.name) do |defined_ivar, return_ivar, ivar_assign|
             return false if matches?(method_name, ivar_assign)
@@ -248,6 +250,13 @@ module RuboCop
           end
 
           nil
+        end
+
+        # Operator and other non-word method names (e.g. `[]`, `+`, `<=>`) cannot form a
+        # valid instance variable name, so there is no matching ivar to enforce and a
+        # suggested correction like `@[]` would be invalid Ruby.
+        def nameable_method?(method_name)
+          /\A[a-zA-Z_]\w*\z/.match?(method_name.to_s.delete('!?='))
         end
 
         def matches?(method_name, ivar_assign)

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -230,6 +230,24 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName, :config do
           end
         end
 
+        context 'method name is an operator that cannot form a valid ivar name' do
+          it 'does not register an offense (avoids suggesting an invalid `@[]`)' do
+            expect_no_offenses(<<~RUBY)
+              def []
+                @foo ||= 1
+              end
+            RUBY
+          end
+
+          it 'does not register an offense for a binary operator method' do
+            expect_no_offenses(<<~RUBY)
+              def +(other)
+                @foo ||= other
+              end
+            RUBY
+          end
+        end
+
         context 'code follows memoized variable assignment' do
           it 'does not register an offense' do
             expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
A memoized `||=` inside an operator or other non-word method:

```ruby
def []
  @foo ||= 1
end
```

was "corrected" to `@[] ||= 1`, which is invalid Ruby. Operator/symbolic method names (`[]`, `+`, `<=>`, ...) cannot form a valid instance variable name, so there is no matching ivar to enforce - the cop now skips them.