### PR TITLE
Fix an infinite loop for `Gemspec/RequireMFA` with multiple specifications

### DIFF
--- a/changelog/fix_an_infinite_loop_for_gemspec_require_mfa_with_multiple_specifications_20260629175251.md
+++ b/changelog/fix_an_infinite_loop_for_gemspec_require_mfa_with_multiple_specifications_20260629175251.md
@@ -1,0 +1,1 @@
+* [#15407](https://github.com/rubocop/rubocop/pull/15407): Fix an infinite loop for `Gemspec/RequireMFA` with multiple specifications. ([@bbatsov][])

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -143,7 +143,10 @@ module RuboCop
             #{block_var}.metadata['rubygems_mfa_required'] = 'true'
           RUBY
 
-          if (last_assignment = metadata_assignment(processed_source.ast).to_a.last)
+          # Scope the search to the current spec block. Searching the whole file
+          # would, for a second `Gem::Specification.new` block, insert the directive
+          # into the first block, leaving this block uncorrected and looping forever.
+          if (last_assignment = metadata_assignment(node).to_a.last)
             corrector.insert_after(last_assignment, "\n#{require_mfa_directive}")
           else
             corrector.insert_before(node.loc.end, "#{require_mfa_directive}\n")

--- a/spec/rubocop/cop/gemspec/require_mfa_spec.rb
+++ b/spec/rubocop/cop/gemspec/require_mfa_spec.rb
@@ -224,4 +224,26 @@ RSpec.describe RuboCop::Cop::Gemspec::RequireMFA, :config do
       RUBY
     end
   end
+
+  context 'when a second `Gem::Specification.new` block lacks the metadata' do
+    it 'corrects the offending block without looping into the first one' do
+      expect_offense(<<~RUBY, 'my.gemspec')
+        Gem::Specification.new do |spec|
+          spec.metadata = { 'rubygems_mfa_required' => 'true' }
+        end
+        Gem::Specification.new do |spec|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `metadata['rubygems_mfa_required']` must be set to `'true'`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.metadata = { 'rubygems_mfa_required' => 'true' }
+        end
+        Gem::Specification.new do |spec|
+        spec.metadata['rubygems_mfa_required'] = 'true'
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
When a gemspec file has more than one `Gem::Specification.new` block and a later block lacks the `rubygems_mfa_required` metadata, the autocorrect searched the whole file for the last metadata assignment and inserted the directive into the *first* block - leaving the offending block uncorrected. RuboCop then re-ran indefinitely, appending `spec.metadata['rubygems_mfa_required'] = 'true'` over and over until it aborted with an infinite-loop error and a corrupted file. The search is now scoped to the current specification block.