### PR TITLE
Fix a crash for `Bundler/GemComment` with a non-literal gem option key

### DIFF
--- a/changelog/fix_a_crash_for_bundler_gem_comment_with_a_non_literal_gem_option_key_20260629175505.md
+++ b/changelog/fix_a_crash_for_bundler_gem_comment_with_a_non_literal_gem_option_key_20260629175505.md
@@ -1,0 +1,1 @@
+* [#15408](https://github.com/rubocop/rubocop/pull/15408): Fix a crash for `Bundler/GemComment` with a non-literal gem option key. ([@bbatsov][])

--- a/lib/rubocop/cop/bundler/gem_comment.rb
+++ b/lib/rubocop/cop/bundler/gem_comment.rb
@@ -163,7 +163,9 @@ module RuboCop
         def gem_options(node)
           return [] unless node.last_argument&.hash_type?
 
-          node.last_argument.keys.map(&:value)
+          # Only literal keys carry an option name to check; a non-literal key
+          # (e.g. a variable or method call) has no `value` and must be skipped.
+          node.last_argument.keys.filter_map { |key| key.value if key.type?(:sym, :str) }
         end
       end
     end

--- a/spec/rubocop/cop/bundler/gem_comment_spec.rb
+++ b/spec/rubocop/cop/bundler/gem_comment_spec.rb
@@ -248,6 +248,14 @@ RSpec.describe RuboCop::Cop::Bundler::GemComment, :config do
             RUBY
           end
         end
+
+        context 'when a gem option uses a non-literal key' do
+          it 'does not crash and does not register an offense' do
+            expect_no_offenses(<<~RUBY, 'Gemfile')
+              gem 'rubocop', key => 'value'
+            RUBY
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
A `gem` call whose option hash used a non-literal key, e.g.

```ruby
gem 'foo', key => 'value'
```

crashed the cop with `NoMethodError: undefined method 'value' for ... SendNode` - `gem_options` mapped `value` over every hash key, including `send`/`lvar` nodes. Only literal symbol/string keys are now read.