### PR TITLE
Fix a false positive for `Gemspec/DuplicatedAssignment` with multiple specifications

### DIFF
--- a/changelog/fix_a_false_positive_for_gemspec_duplicated_assignment_with_multiple_20260629175739.md
+++ b/changelog/fix_a_false_positive_for_gemspec_duplicated_assignment_with_multiple_20260629175739.md
@@ -1,0 +1,1 @@
+* [#15409](https://github.com/rubocop/rubocop/pull/15409): Fix a false positive for `Gemspec/DuplicatedAssignment` with multiple specifications. ([@bbatsov][])

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -83,16 +83,26 @@ module RuboCop
         def duplicated_assignment_method_nodes
           assignment_method_declarations(processed_source.ast)
             .select(&:assignment_method?)
-            .group_by(&:method_name)
+            .group_by { |node| [enclosing_specification(node), node.method_name] }
             .values
             .select { |nodes| nodes.size > 1 }
         end
 
         def duplicated_indexed_assignment_method_nodes
           indexed_assignment_method_declarations(processed_source.ast)
-            .group_by { |node| [node.children.first.method_name, node.first_argument] }
+            .group_by { |node| indexed_assignment_key(node) }
             .values
             .select { |nodes| nodes.size > 1 }
+        end
+
+        def indexed_assignment_key(node)
+          [enclosing_specification(node), node.children.first.method_name, node.first_argument]
+        end
+
+        # Assignments in separate `Gem::Specification.new` blocks are not duplicates of
+        # one another, so the enclosing specification is part of the grouping key.
+        def enclosing_specification(node)
+          node.each_ancestor(:block).find { |block| gem_specification?(block) }
         end
 
         def register_offense(node, assignment, line_of_first_occurrence)

--- a/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
+++ b/spec/rubocop/cop/gemspec/duplicated_assignment_spec.rb
@@ -104,6 +104,30 @@ RSpec.describe RuboCop::Cop::Gemspec::DuplicatedAssignment, :config do
     RUBY
   end
 
+  it 'does not register an offense when the same attribute is assigned in separate specifications' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.name = 'gem1'
+      end
+
+      Gem::Specification.new do |spec|
+        spec.name = 'gem2'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the same indexed attribute is assigned in separate specifications' do
+    expect_no_offenses(<<~RUBY)
+      Gem::Specification.new do |spec|
+        spec.metadata['key'] = 'value1'
+      end
+
+      Gem::Specification.new do |spec|
+        spec.metadata['key'] = 'value2'
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `#[]=` with different keys' do
     expect_no_offenses(<<~RUBY)
       Gem::Specification.new do |spec|


### PR DESCRIPTION
Assignments were grouped by attribute name across the whole file, so the same attribute assigned once in each of two separate `Gem::Specification.new` blocks:

```ruby
Gem::Specification.new do |spec|
  spec.name = 'gem1'
end

Gem::Specification.new do |spec|
  spec.name = 'gem2'
end
```

was wrongly reported as a duplicate. The enclosing specification is now part of the grouping key, so duplicates are only detected within the same block.