### PR TITLE
Fix an incorrect autocorrect for `Naming/BinaryOperatorParameterName`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_naming_binary_operator_parameter_name_20260629180058.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_naming_binary_operator_parameter_name_20260629180058.md
@@ -1,0 +1,1 @@
+* [#15410](https://github.com/rubocop/rubocop/pull/15410): Fix an incorrect autocorrect for `Naming/BinaryOperatorParameterName`. ([@bbatsov][])

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -43,6 +43,12 @@ module RuboCop
 
         private
 
+        def op_method?(name)
+          return false if EXCLUDED.include?(name)
+
+          !/\A[[:word:]]/.match?(name) || OP_LIKE_METHODS.include?(name)
+        end
+
         # A reference is shadowed when an enclosing block within the method redeclares the
         # parameter name (as a block parameter or block-local). Such a reference points to
         # the block's variable, not the operator's parameter, so it must not be renamed.
@@ -56,12 +62,6 @@ module RuboCop
           block.arguments.any? do |argument|
             argument.respond_to?(:name) && argument.name.to_s == name
           end
-        end
-
-        def op_method?(name)
-          return false if EXCLUDED.include?(name)
-
-          !/\A[[:word:]]/.match?(name) || OP_LIKE_METHODS.include?(name)
         end
       end
     end

--- a/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
+++ b/lib/rubocop/cop/naming/binary_operator_parameter_name.rb
@@ -33,6 +33,7 @@ module RuboCop
               node.each_descendant(:lvar, :lvasgn) do |lvar|
                 lvar_location = lvar.loc.name
                 next unless lvar_location.source == arg.source
+                next if shadowed?(lvar, arg.source, node)
 
                 corrector.replace(lvar_location, 'other')
               end
@@ -41,6 +42,21 @@ module RuboCop
         end
 
         private
+
+        # A reference is shadowed when an enclosing block within the method redeclares the
+        # parameter name (as a block parameter or block-local). Such a reference points to
+        # the block's variable, not the operator's parameter, so it must not be renamed.
+        def shadowed?(node, name, def_node)
+          node.each_ancestor(:block).any? do |block|
+            def_node.source_range.contains?(block.source_range) && redeclares?(block, name)
+          end
+        end
+
+        def redeclares?(block, name)
+          block.arguments.any? do |argument|
+            argument.respond_to?(:name) && argument.name.to_s == name
+          end
+        end
 
         def op_method?(name)
           return false if EXCLUDED.include?(name)

--- a/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
+++ b/spec/rubocop/cop/naming/binary_operator_parameter_name_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe RuboCop::Cop::Naming::BinaryOperatorParameterName, :config do
     RUBY
   end
 
+  it 'does not rename a reference to a block parameter that shadows the operator argument' do
+    expect_offense(<<~RUBY)
+      def +(foo)
+            ^^^ When defining the `+` operator, name its argument `other`.
+        result = foo
+        [1, 2, 3].each do |foo|
+          result += foo
+        end
+        result
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def +(other)
+        result = other
+        [1, 2, 3].each do |foo|
+          result += foo
+        end
+        result
+      end
+    RUBY
+  end
+
   it 'registers an offense and corrects when assigned to argument in method body' do
     expect_offense(<<~RUBY)
       def +(arg)


### PR DESCRIPTION
The autocorrect renamed every reference to the operator's parameter name in the method body, including references to a block parameter that shadowed it:

```ruby
def +(foo)
  result = foo
  [1, 2, 3].each do |foo|
    result += foo   # refers to the block parameter, not the method parameter
  end
  result
end
```

The inner `result += foo` was rewritten to `result += other`, so it suddenly referenced the method argument instead of the block variable - silently changing behavior. References shadowed by an enclosing block parameter (or block-local) are now left untouched.