### PR TITLE
Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name_20260629180441.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_naming_rescued_exceptions_variable_name_20260629180441.md
@@ -1,0 +1,1 @@
+* [#15411](https://github.com/rubocop/rubocop/pull/15411): Fix an incorrect autocorrect for `Naming/RescuedExceptionsVariableName`. ([@bbatsov][])

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -95,11 +95,14 @@ module RuboCop
 
         def autocorrect(corrector, node, range, offending_name, preferred_name)
           corrector.replace(range, preferred_name)
-          correct_node(corrector, node.body, offending_name, preferred_name)
+          # Once the exception variable is reassigned, later references point to a
+          # different value, so stop correcting after the reassignment - both in the
+          # body and in the code following the `begin`/`rescue`.
+          return if correct_node(corrector, node.body, offending_name, preferred_name)
           return unless (kwbegin_node = node.parent.each_ancestor(:kwbegin).first)
 
           kwbegin_node.right_siblings.each do |child_node|
-            correct_node(corrector, child_node, offending_name, preferred_name)
+            break if correct_node(corrector, child_node, offending_name, preferred_name)
           end
         end
 
@@ -113,6 +116,8 @@ module RuboCop
           end
         end
 
+        # Returns the reassignment node once the exception variable is reassigned (a truthy
+        # signal to stop correcting later references), or `nil` when no reassignment is found.
         # rubocop:disable Metrics/MethodLength
         def correct_node(corrector, node, offending_name, preferred_name)
           return unless node
@@ -131,9 +136,10 @@ module RuboCop
 
             if child_node.type?(:masgn, :lvasgn)
               correct_reassignment(corrector, child_node, offending_name, preferred_name)
-              break
+              return child_node
             end
           end
+          nil
         end
         # rubocop:enable Metrics/MethodLength
 

--- a/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb
@@ -413,6 +413,27 @@ RSpec.describe RuboCop::Cop::Naming::RescuedExceptionsVariableName, :config do
           end
         RUBY
       end
+
+      it 'corrects only up to the reassignment, leaving later references untouched' do
+        expect_offense(<<~RUBY)
+          begin
+            do_something
+          rescue StandardError => error
+                                  ^^^^^ Use `e` instead of `error`.
+            error = build_message(error)
+          end
+          puts error
+        RUBY
+
+        expect_correction(<<~RUBY)
+          begin
+            do_something
+          rescue StandardError => e
+            error = build_message(e)
+          end
+          puts error
+        RUBY
+      end
     end
 
     context 'when the variable is reassigned using multiple assignment' do


### PR DESCRIPTION
After the exception variable was reassigned inside the rescue body, a reference to it *after* the `begin`/`rescue` was still renamed:

```ruby
begin
  do_something
rescue StandardError => error
  error = build_message(error)
end
puts error
```

`puts error` became `puts e`, but `e` holds the raw exception while `error` holds the reassigned value - so the output changed. The cop already stopped correcting after a reassignment *within* the body; that behavior now extends to the code following the `begin`/`rescue` as well.