### PR TITLE
Fix a false negative for `Security/MarshalLoad` with a proc argument

### DIFF
--- a/changelog/fix_a_false_negative_for_security_marshal_load_with_a_proc_argument_20260629180703.md
+++ b/changelog/fix_a_false_negative_for_security_marshal_load_with_a_proc_argument_20260629180703.md
@@ -1,0 +1,1 @@
+* [#15412](https://github.com/rubocop/rubocop/pull/15412): Fix a false negative for `Security/MarshalLoad` with a proc argument. ([@bbatsov][])

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -25,7 +25,7 @@ module RuboCop
         # @!method marshal_load(node)
         def_node_matcher :marshal_load, <<~PATTERN
           (send (const {nil? cbase} :Marshal) ${:load :restore}
-          !(send (const {nil? cbase} :Marshal) :dump ...))
+          !(send (const {nil? cbase} :Marshal) :dump ...) _?)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/security/marshal_load_spec.rb
+++ b/spec/rubocop/cop/security/marshal_load_spec.rb
@@ -43,4 +43,19 @@ RSpec.describe RuboCop::Cop::Security::MarshalLoad, :config do
       Marshal.restore(Marshal.dump({}))
     RUBY
   end
+
+  it 'registers an offense for the two-argument form with a proc' do
+    expect_offense(<<~RUBY)
+      Marshal.load(data, proc)
+              ^^^^ Avoid using `Marshal.load`.
+      Marshal.restore(data, proc)
+              ^^^^^^^ Avoid using `Marshal.restore`.
+    RUBY
+  end
+
+  it 'allows deep cloning even when a proc is passed' do
+    expect_no_offenses(<<~RUBY)
+      Marshal.load(Marshal.dump({}), proc)
+    RUBY
+  end
 end


### PR DESCRIPTION
`Marshal.load` and `Marshal.restore` accept an optional second proc argument, but the node pattern only allowed a single argument, so `Marshal.load(data, proc)` was not flagged even though it is just as dangerous. Trailing arguments are now permitted in the matcher, while the deep-copy hack `Marshal.load(Marshal.dump(x))` (with or without a proc) stays allowed.