### PR TITLE
Fix a crash for `Gemspec/DevelopmentDependencies` when `AllowedGems` is nil

### DIFF
--- a/changelog/fix_a_crash_for_gemspec_development_dependencies_when_allowed_gems_is_nil_20260629180910.md
+++ b/changelog/fix_a_crash_for_gemspec_development_dependencies_when_allowed_gems_is_nil_20260629180910.md
@@ -1,0 +1,1 @@
+* [#15413](https://github.com/rubocop/rubocop/pull/15413): Fix a crash for `Gemspec/DevelopmentDependencies` when `AllowedGems` is nil. ([@bbatsov][])

--- a/lib/rubocop/cop/gemspec/development_dependencies.rb
+++ b/lib/rubocop/cop/gemspec/development_dependencies.rb
@@ -95,7 +95,7 @@ module RuboCop
         private
 
         def forbidden_gem?(gem_name)
-          !cop_config['AllowedGems'].include?(gem_name)
+          !Array(cop_config['AllowedGems']).include?(gem_name)
         end
 
         def message(_range)

--- a/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
+++ b/spec/rubocop/cop/gemspec/development_dependencies_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe RuboCop::Cop::Gemspec::DevelopmentDependencies, :config do
     end
   end
 
+  context 'when `AllowedGems` is nil' do
+    let(:cop_config) { { 'Enabled' => true, 'EnforcedStyle' => 'Gemfile', 'AllowedGems' => nil } }
+
+    it 'does not crash and registers an offense' do
+      expect_offense(<<~RUBY, 'example.gemspec')
+        Gem::Specification.new do |spec|
+          spec.add_development_dependency 'foo'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify development dependencies in Gemfile.
+        end
+      RUBY
+    end
+  end
+
   context 'with `EnforcedStyle: Gemfile`' do
     let(:enforced_style) { 'Gemfile' }
 


### PR DESCRIPTION
Setting `AllowedGems: ~` (nil) in the configuration made `forbidden_gem?` call `include?` on nil, raising `NoMethodError` and aborting the inspection. The value is now wrapped with `Array(...)` so a nil configuration is treated as an empty list.