### PR TITLE
Fix a crash for `Naming/InclusiveLanguage` with nil or empty `FlaggedTerms`

### DIFF
--- a/changelog/fix_a_crash_for_naming_inclusive_language_with_nil_or_empty_flagged_terms_20260629181212.md
+++ b/changelog/fix_a_crash_for_naming_inclusive_language_with_nil_or_empty_flagged_terms_20260629181212.md
@@ -1,0 +1,1 @@
+* [#15414](https://github.com/rubocop/rubocop/pull/15414): Fix a crash for `Naming/InclusiveLanguage` with nil or empty `FlaggedTerms`. ([@bbatsov][])

--- a/lib/rubocop/cop/naming/inclusive_language.rb
+++ b/lib/rubocop/cop/naming/inclusive_language.rb
@@ -91,6 +91,8 @@ module RuboCop
         end
 
         def on_new_investigation
+          return unless @flagged_terms_regex
+
           investigate_filepath if cop_config['CheckFilepaths']
           investigate_tokens
         end
@@ -144,7 +146,7 @@ module RuboCop
         def preprocess_flagged_terms
           allowed_strings = []
           flagged_term_strings = []
-          cop_config['FlaggedTerms'].each do |term, term_definition|
+          (cop_config['FlaggedTerms'] || {}).each do |term, term_definition|
             next if term_definition.nil?
 
             allowed_strings.concat(process_allowed_regex(term_definition['AllowedRegex']))
@@ -181,7 +183,11 @@ module RuboCop
         end
 
         def set_regexes(flagged_term_strings, allowed_strings)
-          @flagged_terms_regex = array_to_ignorecase_regex(flagged_term_strings)
+          # With no flagged terms an empty regex would match everything, so leave the
+          # regex nil and let `on_new_investigation` treat the cop as a no-op.
+          unless flagged_term_strings.empty?
+            @flagged_terms_regex = array_to_ignorecase_regex(flagged_term_strings)
+          end
           @allowed_regex = array_to_ignorecase_regex(allowed_strings) unless allowed_strings.empty?
         end
 

--- a/spec/rubocop/cop/naming/inclusive_language_spec.rb
+++ b/spec/rubocop/cop/naming/inclusive_language_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Naming::InclusiveLanguage, :config do
+  context 'when `FlaggedTerms` is nil' do
+    let(:cop_config) { { 'FlaggedTerms' => nil } }
+
+    it 'does not crash and registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        whitelist = 1
+      RUBY
+    end
+  end
+
+  context 'when `FlaggedTerms` is empty' do
+    let(:cop_config) { { 'FlaggedTerms' => {} } }
+
+    it 'does not crash and registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        whitelist = 1
+      RUBY
+    end
+  end
+
   context 'flagged term matching' do
     let(:cop_config) do
       { 'FlaggedTerms' => { 'whitelist' => {} } }


### PR DESCRIPTION
Setting `FlaggedTerms: ~` made `preprocess_flagged_terms` call `each` on nil (crashing during cop construction), and an empty `FlaggedTerms` built an empty regex that matched every position and crashed in `create_message`. A nil configuration is now treated as empty, and with no flagged terms the cop is a no-op.