### PR TITLE
Mark `Lint/NumericOperationWithConstantResult` autocorrect as unsafe

### DIFF
--- a/changelog/change_mark_lint_numeric_operation_with_constant_result_autocorrect_as_unsafe_20260630234934.md
+++ b/changelog/change_mark_lint_numeric_operation_with_constant_result_autocorrect_as_unsafe_20260630234934.md
@@ -1,0 +1,1 @@
+* [#15415](https://github.com/rubocop/rubocop/pull/15415): Mark `Lint/NumericOperationWithConstantResult` autocorrect as unsafe because it drops the operands, discarding their side effects and silencing cases where the result is not actually constant (e.g. `x / x` raises when `x` is `0`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2213,7 +2213,9 @@ Lint/NumberedParameterAssignment:
 Lint/NumericOperationWithConstantResult:
   Description: 'Checks for numeric operations with constant results.'
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '1.69'
+  VersionChanged: '<<next>>'
 
 Lint/OrAssignmentToConstant:
   Description: 'Checks unintended or-assignment to constant.'

--- a/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
+++ b/lib/rubocop/cop/lint/numeric_operation_with_constant_result.rb
@@ -15,6 +15,13 @@ module RuboCop
       # can't determine the type of `x`. If `x` is an `Array` or `String`, it doesn't perform
       # a numeric operation.
       #
+      # @safety
+      #   This cop is unsafe because the autocorrection drops the operands, which
+      #   discards any side effects of evaluating them and can change behavior when
+      #   the result is not actually constant. For example, `x / x` raises
+      #   `ZeroDivisionError` when `x` is `0`, and returns `Float::NAN` (not `1`)
+      #   when `x` is `0.0`; replacing it with `1` silences that.
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
The cop's autocorrect replaces operations like `x * 0`, `x ** 0`, and `x / x` with their constant result (`0` or `1`), but that drops the operands entirely. This discards any side effects of evaluating them, and the result isn't always constant: `x / x` raises `ZeroDivisionError` when `x` is `0`, and `0.0 / 0.0` is `Float::NAN`, not `1`. So the correction can silence exceptions or change the value. Marking it `SafeAutoCorrect: false` (with a `@safety` note), consistent with similar cops.