### PR TITLE
Fix a false negative for `Lint/UselessNumericOperation` with non-method-call receivers

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_useless_numeric_operation_with_non_method_call_20260701071313.md
+++ b/changelog/fix_a_false_negative_for_lint_useless_numeric_operation_with_non_method_call_20260701071313.md
@@ -1,0 +1,1 @@
+* [#15416](https://github.com/rubocop/rubocop/pull/15416): Fix a false negative for `Lint/UselessNumericOperation`, which only flagged bare method-call receivers and ignored local variables, instance/class/global variables, and constants (e.g. `@x + 0`, `CONST * 1`). ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_numeric_operation.rb
+++ b/lib/rubocop/cop/lint/useless_numeric_operation.rb
@@ -36,31 +36,31 @@ module RuboCop
         RESTRICT_ON_SEND = %i[+ - * / **].freeze
 
         # @!method useless_operation?(node)
-        def_node_matcher :useless_operation?, '(call (call nil? $_) $_ (int $_))'
+        def_node_matcher :useless_operation?, <<~PATTERN
+          (call ${lvar ivar cvar gvar const (send nil? _)} $_ (int $_))
+        PATTERN
 
         # @!method useless_abbreviated_assignment?(node)
-        def_node_matcher :useless_abbreviated_assignment?, '(op-asgn (lvasgn $_) $_ (int $_))'
+        def_node_matcher :useless_abbreviated_assignment?, <<~PATTERN
+          (op-asgn ${lvasgn ivasgn cvasgn gvasgn casgn} $_ (int $_))
+        PATTERN
 
         def on_send(node)
-          return unless useless_operation?(node)
-
-          variable, operation, number = useless_operation?(node)
+          return unless (receiver, operation, number = useless_operation?(node))
           return unless useless?(operation, number)
 
           add_offense(node) do |corrector|
-            corrector.replace(node, variable)
+            corrector.replace(node, receiver.source)
           end
         end
         alias on_csend on_send
 
         def on_op_asgn(node)
-          return unless useless_abbreviated_assignment?(node)
-
-          variable, operation, number = useless_abbreviated_assignment?(node)
+          return unless (variable, operation, number = useless_abbreviated_assignment?(node))
           return unless useless?(operation, number)
 
           add_offense(node) do |corrector|
-            corrector.replace(node, "#{variable} = #{variable}")
+            corrector.replace(node, "#{variable.source} = #{variable.source}")
           end
         end
 

--- a/spec/rubocop/cop/lint/useless_numeric_operation_spec.rb
+++ b/spec/rubocop/cop/lint/useless_numeric_operation_spec.rb
@@ -143,4 +143,83 @@ RSpec.describe RuboCop::Cop::Lint::UselessNumericOperation, :config do
       x.bar
     RUBY
   end
+
+  it 'registers an offense for a local variable receiver' do
+    expect_offense(<<~RUBY)
+      x = 1
+      x + 0
+      ^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x = 1
+      x
+    RUBY
+  end
+
+  it 'registers an offense for an instance variable receiver' do
+    expect_offense(<<~RUBY)
+      @x * 1
+      ^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      @x
+    RUBY
+  end
+
+  it 'registers an offense for a class variable receiver' do
+    expect_offense(<<~RUBY)
+      @@x / 1
+      ^^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      @@x
+    RUBY
+  end
+
+  it 'registers an offense for a global variable receiver' do
+    expect_offense(<<~RUBY)
+      $x - 0
+      ^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      $x
+    RUBY
+  end
+
+  it 'registers an offense for a constant receiver' do
+    expect_offense(<<~RUBY)
+      CONST ** 1
+      ^^^^^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      CONST
+    RUBY
+  end
+
+  it 'registers an offense for an instance variable abbreviated assignment' do
+    expect_offense(<<~RUBY)
+      @x += 0
+      ^^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      @x = @x
+    RUBY
+  end
+
+  it 'registers an offense for a constant abbreviated assignment' do
+    expect_offense(<<~RUBY)
+      CONST *= 1
+      ^^^^^^^^^^ Do not apply inconsequential numeric operations to variables.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      CONST = CONST
+    RUBY
+  end
 end


### PR DESCRIPTION
The cop's message says "Do not apply inconsequential numeric operations to variables", but its matcher only accepted a bare method-call receiver (`(call nil? ...)`). So it flagged `x + 0` only when `x` was an undeclared method call - an actual local variable, instance/class/global variable, or constant was silently ignored:

```ruby
x = 1
x + 0      # not flagged (x is a local variable)
@x * 1     # not flagged
@@x / 1    # not flagged
$x - 0     # not flagged
CONST ** 1 # not flagged
```

Broadened both matchers to cover those receivers (and the `@x += 0` / `CONST *= 1` abbreviated-assignment forms), autocorrecting via the receiver's source.