### PR TITLE
Fix false negative and incorrect autocorrect for `Lint/ToJSON`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_to_json_with_singleton_method_definitions_20260701071739.md
+++ b/changelog/fix_a_false_negative_for_lint_to_json_with_singleton_method_definitions_20260701071739.md
@@ -1,0 +1,1 @@
+* [#15417](https://github.com/rubocop/rubocop/pull/15417): Fix a false negative for `Lint/ToJSON`, which did not flag singleton `def self.to_json` definitions. ([@bbatsov][])

--- a/changelog/fix_an_incorrect_autocorrect_for_lint_to_json_with_explicit_empty_parentheses_20260701071714.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_to_json_with_explicit_empty_parentheses_20260701071714.md
@@ -1,0 +1,1 @@
+* [#15417](https://github.com/rubocop/rubocop/pull/15417): Fix an incorrect autocorrect for `Lint/ToJSON` that produced invalid Ruby (`def to_json(*_args)()`) when the method had explicit empty parentheses. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/to_json.rb
+++ b/lib/rubocop/cop/lint/to_json.rb
@@ -45,6 +45,7 @@ module RuboCop
             end
           end
         end
+        alias on_defs on_def
       end
     end
   end

--- a/lib/rubocop/cop/lint/to_json.rb
+++ b/lib/rubocop/cop/lint/to_json.rb
@@ -36,7 +36,13 @@ module RuboCop
             # The following used `*_args` because `to_json(*args)` has
             # an offense of `Lint/UnusedMethodArgument` cop if `*args`
             # is not used.
-            corrector.insert_after(node.loc.name, '(*_args)')
+            if (opening_parenthesis = node.each_child_node(:args).first.loc.begin)
+              # Explicit empty parentheses (`def to_json()`) are already present,
+              # so insert the argument inside them to avoid producing `to_json(*_args)()`.
+              corrector.insert_after(opening_parenthesis, '*_args')
+            else
+              corrector.insert_after(node.loc.name, '(*_args)')
+            end
           end
         end
       end

--- a/spec/rubocop/cop/lint/to_json_spec.rb
+++ b/spec/rubocop/cop/lint/to_json_spec.rb
@@ -27,9 +27,29 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects a singleton `#to_json` without arguments' do
+    expect_offense(<<~RUBY)
+      def self.to_json
+      ^^^^^^^^^^^^^^^^ `#to_json` requires an optional argument to be parsable via JSON.generate(obj).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.to_json(*_args)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `#to_json` with arguments' do
     expect_no_offenses(<<~RUBY)
       def to_json(*_args)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using a singleton `#to_json` with arguments' do
+    expect_no_offenses(<<~RUBY)
+      def self.to_json(*_args)
       end
     RUBY
   end

--- a/spec/rubocop/cop/lint/to_json_spec.rb
+++ b/spec/rubocop/cop/lint/to_json_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe RuboCop::Cop::Lint::ToJSON, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects `#to_json` with explicit empty parentheses' do
+    expect_offense(<<~RUBY)
+      def to_json()
+      ^^^^^^^^^^^^^ `#to_json` requires an optional argument to be parsable via JSON.generate(obj).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def to_json(*_args)
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `#to_json` with arguments' do
     expect_no_offenses(<<~RUBY)
       def to_json(*_args)


### PR DESCRIPTION
Two small fixes for `Lint/ToJSON` (separate commits):

1. **Incorrect autocorrect** - a method with explicit empty parentheses (`def to_json()`) was corrected to `def to_json(*_args)()`, which is invalid Ruby. The argument is now inserted inside the existing parentheses.
2. **False negative** - singleton definitions (`def self.to_json`) were never flagged, since only `on_def` was handled. Added `on_defs`.