### PR TITLE
Fix a false negative for `Lint/UnreachableCode` with multiple unreachable statements

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_unreachable_code_with_multiple_unreachable_20260701072047.md
+++ b/changelog/fix_a_false_negative_for_lint_unreachable_code_with_multiple_unreachable_20260701072047.md
@@ -1,0 +1,1 @@
+* [#15418](https://github.com/rubocop/rubocop/pull/15418): Fix a false negative for `Lint/UnreachableCode`, which only flagged the first statement after a flow-of-control statement instead of every unreachable statement that followed it. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -52,10 +52,15 @@ module RuboCop
         def on_begin(node)
           expressions = *node
 
-          expressions.each_cons(2) do |expression1, expression2|
-            next unless flow_expression?(expression1)
-
-            add_offense(expression2)
+          # Once a flow-of-control statement is reached, every following statement
+          # in the block is unreachable, not just the one immediately after it.
+          flow_reached = false
+          expressions.each_with_index do |expression, index|
+            if flow_reached
+              add_offense(expression)
+            elsif index < expressions.size - 1 && flow_expression?(expression)
+              flow_reached = true
+            end
           end
         end
 

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe RuboCop::Cop::Lint::UnreachableCode, :config do
     head + body + tail
   end
 
+  it 'registers an offense for every statement following a flow-of-control statement' do
+    expect_offense(wrap(<<~RUBY))
+      return
+      bar
+      ^^^ Unreachable code detected.
+      baz
+      ^^^ Unreachable code detected.
+    RUBY
+  end
+
   %w[return next break retry redo throw raise fail exit exit! abort].each do |t|
     # The syntax using `retry` is not supported in Ruby 3.3 and later.
     next if t == 'retry' && ENV['PARSER_ENGINE'] == 'parser_prism'


### PR DESCRIPTION
When a flow-of-control statement (`return`, `raise`, `next`, etc.) is followed by more than one statement, the cop only flagged the first one - the `each_cons(2)` pairing checked each statement against its immediate predecessor:

```ruby
def foo
  raise
  bar   # flagged
  baz   # NOT flagged, though equally unreachable
end
```

Once a flow statement is reached, every statement after it in the block is unreachable, so they're all flagged now (one offense per statement, consistent with how other cops report).