### PR TITLE
Fix a false negative for `Lint/Void` with safe navigation method calls

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_void_with_safe_navigation_method_calls_20260701082233.md
+++ b/changelog/fix_a_false_negative_for_lint_void_with_safe_navigation_method_calls_20260701082233.md
@@ -1,0 +1,1 @@
+* [#15419](https://github.com/rubocop/rubocop/pull/15419): Fix a false negative for `Lint/Void` where safe-navigation calls to nonmutating methods (e.g. `x&.sort`) were not flagged when `CheckForMethodsWithNoSideEffects` is enabled. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -212,7 +212,7 @@ module RuboCop
         end
 
         def check_nonmutating(node)
-          return unless node.type?(:send, :any_block)
+          return unless node.type?(:call, :any_block)
 
           method_name = node.method_name
           return unless NONMUTATING_METHODS.include?(method_name)
@@ -265,7 +265,7 @@ module RuboCop
         end
 
         def autocorrect_nonmutating_send(corrector, node, suggestion)
-          send_node = if node.send_type?
+          send_node = if node.call_type?
                         node
                       else
                         node.send_node

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -594,6 +594,19 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
       RUBY
     end
 
+    it 'registers an offense for a safe navigation call' do
+      expect_offense(<<~RUBY)
+        x&.sort
+        ^^^^^^^ Method `#sort` used in void context. Did you mean `#sort!`?
+        top(x)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x&.sort!
+        top(x)
+      RUBY
+    end
+
     it 'does not register an offense assigning variable' do
       expect_no_offenses(<<~RUBY)
         foo = bar


### PR DESCRIPTION
When `CheckForMethodsWithNoSideEffects` is enabled, `Lint/Void` flags nonmutating methods used in void context (`x.sort` -> did you mean `x.sort!`?), but safe-navigation calls were skipped because `check_nonmutating` only matched `:send`/`:any_block`, not `:csend`:

```ruby
def m
  x.sort   # flagged
  x&.sort  # NOT flagged, though equally void
  top(x)
end
```

Included `:csend` and routed it through the same autocorrect path (`x&.sort` -> `x&.sort!`).