### PR TITLE
Fix a false negative for `Style/CollectionCompact` with safe navigation `grep_v`

### DIFF
--- a/changelog/fix_a_false_negative_for_style_collection_compact_with_safe_navigation_grep_v_20260701082802.md
+++ b/changelog/fix_a_false_negative_for_style_collection_compact_with_safe_navigation_grep_v_20260701082802.md
@@ -1,0 +1,1 @@
+* [#15420](https://github.com/rubocop/rubocop/pull/15420): Fix a false negative for `Style/CollectionCompact`, which did not flag `grep_v(nil)`/`grep_v(NilClass)` on a safe-navigation call (e.g. `array&.grep_v(nil)`). ([@bbatsov][])

--- a/lib/rubocop/cop/style/collection_compact.rb
+++ b/lib/rubocop/cop/style/collection_compact.rb
@@ -96,7 +96,7 @@ module RuboCop
 
         # @!method grep_v_with_nil?(node)
         def_node_matcher :grep_v_with_nil?, <<~PATTERN
-          (send _ :grep_v {(nil) (const {nil? cbase} :NilClass)})
+          (call _ :grep_v {(nil) (const {nil? cbase} :NilClass)})
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/collection_compact_spec.rb
+++ b/spec/rubocop/cop/style/collection_compact_spec.rb
@@ -195,6 +195,17 @@ RSpec.describe RuboCop::Cop::Style::CollectionCompact, :config, :ruby24 do
     RUBY
   end
 
+  it 'registers an offense and corrects when using safe navigation `grep_v(nil)`' do
+    expect_offense(<<~RUBY)
+      array&.grep_v(nil)
+             ^^^^^^^^^^^ Use `compact` instead of `grep_v(nil)`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      array&.compact
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `grep_v(::NilClass)`' do
     expect_offense(<<~RUBY)
       array.grep_v(::NilClass)


### PR DESCRIPTION
`Style/CollectionCompact` already handles safe navigation for its `reject`/`select` matchers (all use `(call ...)`), but the `grep_v_with_nil?` matcher used `(send ...)`, so `array&.grep_v(nil)` was missed:

```ruby
array.grep_v(nil)   # flagged -> array.compact
array&.grep_v(nil)  # NOT flagged
```

Changed it to `(call ...)` for consistency; the cop already aliases `on_csend`, and the correction produces valid `array&.compact`.