### PR TITLE
Fix a false negative for `Style/ArrayIntersect` with `include?` in a block

### DIFF
--- a/changelog/fix_a_false_negative_for_style_array_intersect_with_include_in_a_block_20260701105502.md
+++ b/changelog/fix_a_false_negative_for_style_array_intersect_with_include_in_a_block_20260701105502.md
@@ -1,0 +1,1 @@
+* [#15421](https://github.com/rubocop/rubocop/pull/15421): Fix a false negative for `Style/ArrayIntersect` with the block form using `include?` (e.g. `array1.any? { |e| array2.include?(e) }`), which was only detected for `member?`. ([@bbatsov][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -47,7 +47,7 @@ module RuboCop
       #
       #   # bad
       #   array1.any? { |elem| array2.member?(elem) }
-      #   array1.none? { |elem| array2.member?(elem) }
+      #   array1.none? { |elem| array2.include?(elem) }
       #
       #   # good
       #   array1.intersect?(array2)
@@ -121,15 +121,15 @@ module RuboCop
             (block
               (call $_receiver ${:any? :none?})
               (args (arg _key))
-              (send $_argument :member? (lvar _key))
+              (send $_argument {:member? :include?} (lvar _key))
             )
             (numblock
               (call $_receiver ${:any? :none?}) 1
-              (send $_argument :member? (lvar :_1))
+              (send $_argument {:member? :include?} (lvar :_1))
             )
             (itblock
               (call $_receiver ${:any? :none?}) :it
-              (send $_argument :member? (lvar :it))
+              (send $_argument {:member? :include?} (lvar :it))
             )
           }
         PATTERN

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -349,6 +349,28 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         RUBY
       end
 
+      it 'registers an offense when using `array1.any? { |e| array2.include?(e) }`' do
+        expect_offense(<<~RUBY)
+          array1.any? { |e| array2.include?(e) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1.intersect?(array2)` instead of `array1.any? { |e| array2.include?(e) }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array1.intersect?(array2)
+        RUBY
+      end
+
+      it 'registers an offense when using `array1.none? { |e| array2.include?(e) }`' do
+        expect_offense(<<~RUBY)
+          array1.none? { |e| array2.include?(e) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!array1.intersect?(array2)` instead of `array1.none? { |e| array2.include?(e) }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !array1.intersect?(array2)
+        RUBY
+      end
+
       it 'registers an offense when using `array1.any? { array2.member?(_1) }`' do
         expect_offense(<<~RUBY)
           array1.any? { array2.member?(_1) }


### PR DESCRIPTION
The block form was only detected when the membership check used `member?`:

```ruby
array1.any? { |e| array2.member?(e) }   # flagged
array1.any? { |e| array2.include?(e) }  # NOT flagged
```

`include?` is an alias of `member?` on `Array` and equally replaceable with `intersect?`, so the block/numblock/itblock matchers now accept both.