### PR TITLE
Fix a false negative for `Style/DefWithParentheses` with single-line defs using a semicolon

### DIFF
--- a/changelog/fix_a_false_negative_for_style_def_with_parentheses_with_a_single_line_def_using_20260701105815.md
+++ b/changelog/fix_a_false_negative_for_style_def_with_parentheses_with_a_single_line_def_using_20260701105815.md
@@ -1,0 +1,1 @@
+* [#15422](https://github.com/rubocop/rubocop/pull/15422): Fix a false negative for `Style/DefWithParentheses` with a single-line definition whose body follows a semicolon (e.g. `def foo(); end`), where the parentheses can be safely omitted. ([@bbatsov][])

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -57,10 +57,14 @@ module RuboCop
         private
 
         def parentheses_required?(node, arguments_range)
-          return true if node.single_line? && !node.endless?
-
           end_pos = arguments_range.end.end_pos
           token_after_argument = range_between(end_pos, end_pos + 1).source
+
+          # A `;` after the parentheses (e.g. `def foo(); end`) already separates the
+          # signature from the body, so the parentheses can be removed (`def foo; end`).
+          return false if token_after_argument == ';'
+
+          return true if node.single_line? && !node.endless?
 
           token_after_argument == '='
         end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -82,4 +82,26 @@ RSpec.describe RuboCop::Cop::Style::DefWithParentheses, :config do
   it 'accepts empty parentheses in one liners' do
     expect_no_offenses("def to_s() join '/' end")
   end
+
+  it 'reports an offense for empty parens on a single line with a semicolon' do
+    expect_offense(<<~RUBY)
+      def foo(); end
+             ^^ Omit the parentheses in defs when the method doesn't accept any arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo; end
+    RUBY
+  end
+
+  it 'reports an offense for empty parens on a single line with a body after a semicolon' do
+    expect_offense(<<~RUBY)
+      def foo(); bar; end
+             ^^ Omit the parentheses in defs when the method doesn't accept any arguments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo; bar; end
+    RUBY
+  end
 end


### PR DESCRIPTION
`parentheses_required?` skipped every single-line non-endless def, treating the parentheses as a required statement separator. But when a `;` follows them, it already separates the signature from the body, so the parentheses are removable:

```ruby
def foo(); end        # was not flagged; def foo; end is valid
def foo(); bar; end   # was not flagged
def foo() bar end     # correctly still skipped (def foo bar end is a syntax error)
```

Now flagged when the token right after `)` is `;`.