### PR TITLE
Fix `Style/StructInheritance` autocorrect not preserving indentation

### DIFF
--- a/changelog/fix_struct_inheritance_preserve_indentation_20260701165026.md
+++ b/changelog/fix_struct_inheritance_preserve_indentation_20260701165026.md
@@ -1,0 +1,1 @@
+* [#15424](https://github.com/rubocop/rubocop/pull/15424): Fix `Style/StructInheritance` autocorrect dropping leading indentation when class is inside a module or namespace. ([@amckinnie][])

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -41,7 +41,9 @@ module RuboCop
           return unless struct_constructor?(node.parent_class)
 
           add_offense(node.parent_class) do |corrector|
-            corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
+            corrector.remove(
+              range_with_surrounding_space(node.loc.keyword, side: :right, newlines: false)
+            )
             corrector.replace(node.loc.operator, '=')
 
             correct_parent(node.parent_class, corrector)

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -111,6 +111,25 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance, :config do
     RUBY
   end
 
+  it 'registers an offense and preserves indentation when class is inside a module' do
+    expect_offense(<<~RUBY)
+      module MyModule
+        class Person < Struct.new(:first_name, :last_name)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`. Use a block to customize the struct.
+          def foo; end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module MyModule
+        Person = Struct.new(:first_name, :last_name) do
+          def foo; end
+        end
+      end
+    RUBY
+  end
+
   it 'accepts plain class' do
     expect_no_offenses(<<~RUBY)
       class Person


### PR DESCRIPTION
## Summary

- `Style/StructInheritance` autocorrect was using `range_with_surrounding_space` with the default `side: :both` when removing the `class` keyword, which consumed leading whitespace (indentation) in addition to the trailing space.
- This caused the corrected assignment to lose its indentation when the class was nested inside a module or other namespace.
- Fixed by passing `side: :right` so only the space after `class` is consumed.

## Test plan

- [x] Added a failing spec reproducing the indented case before the fix
- [x] All 14 `Style/StructInheritance` specs pass after the fix
- [x] `bundle exec rake` passes (pending changelog number update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)