### PR TITLE
[Fix #15423] Fix false positives in `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/changelog/fix_false_positives_in_layout_multiline_method_call_indentation.md
+++ b/changelog/fix_false_positives_in_layout_multiline_method_call_indentation.md
@@ -1,0 +1,1 @@
+* [#15423](https://github.com/rubocop/rubocop/issues/15423): Fix false positives in `Layout/MultilineMethodCallIndentation` when a method chain is nested inside a parenthesized argument list or a grouped expression within a hash pair value. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -73,7 +73,12 @@ module RuboCop
         end
 
         def find_pair_ancestor(node)
-          node.each_ancestor.find(&:pair_type?)
+          node.each_ancestor do |ancestor|
+            return ancestor if ancestor.pair_type?
+            break if grouped_expression?(ancestor) || inside_arg_list_parentheses?(node, ancestor)
+          end
+
+          nil
         end
 
         def unwrap_block_node(node)

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -153,6 +153,28 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
           .bar
       RUBY
     end
+
+    it 'accepts a method chain nested inside a parenthesized argument list within a hash pair value' do
+      expect_no_offenses(<<~RUBY)
+        foo(
+          key => Model.joins(
+            Other
+              .arel_table
+              .join_sources
+          )
+        )
+      RUBY
+    end
+
+    it 'accepts a method chain nested inside a grouped expression within a hash pair value' do
+      expect_no_offenses(<<~RUBY)
+        foo(
+          key => (Other
+                    .arel_table
+                    .join_sources)
+        )
+      RUBY
+    end
   end
 
   shared_examples 'common for aligned and indented' do


### PR DESCRIPTION
This cop registered offenses for a method chain whose receiver sits on its own line when the chain is nested inside a parenthesized argument list, or a grouped expression, within a hash pair value:

```ruby
foo(
  key => Model.joins(
    Other
      .arel_table
      .join_sources
  )
)
```

The chain is correctly indented relative to its own receiver `Other`, but the cop anchored it to the hash pair key line under both the `indented` and `aligned` styles, and autocorrection outdented the chain to the same column as its receiver.

This is a regression introduced in 1.84.1 by the fix for #11513, which started checking chains that are hash pair values even inside the outer call's argument parentheses. That bypass fired for any node with a pair ancestor, including chains that are re-anchored by parentheses inside the pair value and were previously skipped.

A pair ancestor is now only honored when nothing between the node and the pair re-anchors indentation, restoring the pre-1.84.1 behavior for these shapes while keeping the fixes for #11513, #14916, and #15054.

Fixes #15423.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
