### PR TITLE
[Fix #15426] Fix an incorrect autocorrect for `Style/MethodCallWithoutArgsParentheses`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_method_call_without_args_parentheses_multiline_20260702230807.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_method_call_without_args_parentheses_multiline_20260702230807.md
@@ -1,0 +1,1 @@
+* [#15426](https://github.com/rubocop/rubocop/issues/15426): Fix an incorrect autocorrect for `Style/MethodCallWithoutArgsParentheses` when empty parentheses span multiple lines and the method call has a block. ([@koic][])

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -50,9 +50,11 @@ module RuboCop
         private
 
         def register_offense(node)
-          add_offense(offense_range(node)) do |corrector|
-            corrector.remove(node.loc.begin)
-            corrector.remove(node.loc.end)
+          range = offense_range(node)
+          return if processed_source.contains_comment?(range)
+
+          add_offense(range) do |corrector|
+            corrector.remove(range)
           end
         end
 

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -12,6 +12,49 @@ RSpec.describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense for multiline parens in method call without args' do
+    expect_offense(<<~RUBY)
+      obj.do_something(
+                      ^ Do not use parentheses for method calls with no arguments.
+      )
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.do_something
+    RUBY
+  end
+
+  it 'registers an offense for multiline parens in method call without args with a block' do
+    expect_offense(<<~RUBY)
+      obj.do_something(
+                      ^ Do not use parentheses for method calls with no arguments.
+      ) do
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      obj.do_something do
+      end
+    RUBY
+  end
+
+  it 'accepts parens containing a comment' do
+    expect_no_offenses(<<~RUBY)
+      obj.do_something(
+        # comment
+      )
+    RUBY
+  end
+
+  it 'accepts parens containing a comment in method call with a block' do
+    expect_no_offenses(<<~RUBY)
+      obj.do_something(
+        # comment
+      ) do
+      end
+    RUBY
+  end
+
   it 'accepts parentheses for methods starting with an upcase letter' do
     expect_no_offenses('Test()')
   end


### PR DESCRIPTION
This cop's autocorrect removes only the `(` and `)` tokens, so anything between them is left behind. When the method call has a `do`...`end` block, the leftover content separates the block from its method call and the corrected code no longer parses:

```ruby
x = Foo.new(
  # just a comment
) do |c|
  c.bar
end
```

The same breakage occurs without a comment when empty parentheses span multiple lines, because the leftover newline also detaches the block.

Remove the entire parenthesized range instead, so that only whitespace disappears with the parentheses. When the parentheses contain a comment they cannot be removed without relocating the comment, so do not report an offense at all in that case; an offense the user can only resolve by moving a comment elsewhere would not be actionable as written.

Fixes #15426.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
