### PR TITLE
[Fix #15428] Fix an incorrect autocorrect for `Style/TrivialAccessors`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_trivial_accessors_20260703021530.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_trivial_accessors_20260703021530.md
@@ -1,0 +1,1 @@
+* [#15428](https://github.com/rubocop/rubocop/issues/15428): Fix an incorrect autocorrect for `Style/TrivialAccessors` when `AllowPredicates: false` is set and a trivial reader is defined as a predicate class method. ([@koic][])

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -234,7 +234,7 @@ module RuboCop
         def autocorrect_class(corrector, node)
           kind = trivial_accessor_kind(node)
 
-          return unless names_match?(node) && kind
+          return unless names_match?(node) && !node.predicate_method? && kind
 
           indent = ' ' * node.loc.column
           corrector.replace(

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -412,6 +412,19 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
       expect_no_corrections
     end
+
+    it 'does not accept predicate-like reader defined as a class method' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def self.foo?
+          ^^^ Use `attr_reader` to define trivial reader methods.
+            @foo
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
   end
 
   context 'allow predicates' do


### PR DESCRIPTION
When `AllowPredicates: false` is set, `def self.foo?` with a trivial ivar body was autocorrected into:

```ruby
class << self
  attr_reader :foo?
end
```

This passes a syntax check but raises `NameError: invalid attribute name 'foo?'` as soon as the file is loaded, because `attr_reader` rejects method names ending in `?`.

No safe autocorrection exists for predicate readers. Ruby has no way to define a `?`-suffixed attribute via `attr_*`, and the documented good code (`attr_reader :foo`) requires renaming the method, which changes the public API and would break callers the cop cannot see.

For that reason, instance predicate readers under `AllowPredicates: false` are already reported without autocorrection, leaving the rename to the user. This commit applies the same design decision to the class method path so that `def self.foo?` is reported but left untouched as well.

Fixes #15428.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
