### PR TITLE
Speed up the investigation hot path

### DIFF
--- a/changelog/change_avoid_allocating_a_range_per_offense_in_the_common_case_20260703090823.md
+++ b/changelog/change_avoid_allocating_a_range_per_offense_in_the_common_case_20260703090823.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve performance of offense reporting by not allocating a new source range per offense outside of embedded sources. ([@bbatsov][])

--- a/changelog/change_dispatch_investigation_callbacks_only_to_cops_that_refine_them_20260703091305.md
+++ b/changelog/change_dispatch_investigation_callbacks_only_to_cops_that_refine_them_20260703091305.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve investigation performance by dispatching `on_new_investigation`, `on_investigation_end`, and `on_other_file` only to cops that refine them, and by skipping `after_*` dispatch when no cop needs it. ([@bbatsov][])

--- a/changelog/change_fast_path_the_gem_requirements_check_in_cop_relevancy_20260703090755.md
+++ b/changelog/change_fast_path_the_gem_requirements_check_in_cop_relevancy_20260703090755.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve performance of the per-file cop relevancy check by skipping gem requirement evaluation for cops without gem requirements. ([@bbatsov][])

--- a/changelog/change_improve_lint_debugger_performance_on_non_debugger_code_20260703090300.md
+++ b/changelog/change_improve_lint_debugger_performance_on_non_debugger_code_20260703090300.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve `Lint/Debugger` performance on code without debugger calls. ([@bbatsov][])

--- a/changelog/change_keep_autocorrections_in_memory_during_the_inspection_loop_20260703092305.md
+++ b/changelog/change_keep_autocorrections_in_memory_during_the_inspection_loop_20260703092305.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve autocorrection performance by keeping corrections in memory across inspection iterations and writing each corrected file only once. ([@bbatsov][])

--- a/changelog/change_memoize_compiled_regexps_in_pattern_mixins_20260703090517.md
+++ b/changelog/change_memoize_compiled_regexps_in_pattern_mixins_20260703090517.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve performance of cops using `AllowedPatterns`, `ForbiddenPatterns`, and `AllowedMethods` by compiling the configured patterns only once. ([@bbatsov][])

--- a/changelog/change_speed_up_style_if_unless_modifier_eligibility_checks_20260703091511.md
+++ b/changelog/change_speed_up_style_if_unless_modifier_eligibility_checks_20260703091511.md
@@ -1,0 +1,1 @@
+* [#15430](https://github.com/rubocop/rubocop/pull/15430): Improve performance of `Style/IfUnlessModifier` and other modifier cops on files with many comments or conditionals. ([@bbatsov][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -553,7 +553,10 @@ module RuboCop
       end
 
       def target_satisfies_all_gem_version_requirements?
-        self.class.gem_requirements.all? do |gem_name, version_req|
+        gem_requirements = self.class.gem_requirements
+        return true if gem_requirements.empty?
+
+        gem_requirements.all? do |gem_name, version_req|
           all_gem_versions_in_target = @config.gem_versions_in_target
           next false unless all_gem_versions_in_target
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -545,8 +545,11 @@ module RuboCop
       end
 
       def range_for_original(range)
+        buffer = @current_original.buffer
+        return range if @current_offset.zero? && range.source_buffer.equal?(buffer)
+
         ::Parser::Source::Range.new(
-          @current_original.buffer,
+          buffer,
           range.begin_pos + @current_offset,
           range.end_pos + @current_offset
         )

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -331,12 +331,11 @@ module RuboCop
       # @api private
       def self.callbacks_needed
         @callbacks_needed ||= public_instance_methods.select do |m|
-          # OPTIMIZE: Check method existence first to make fewer `start_with?` calls.
-          # At the time of writing this comment, this excludes 98 of ~104 methods.
-          # `start_with?` with two string arguments instead of a regex is faster
-          # in this specific case as well.
-          !Base.method_defined?(m) && # exclude standard "callbacks" like 'on_begin_investigation'
-            m.start_with?('on_', 'after_')
+          # OPTIMIZE: `start_with?` with two string arguments instead of a regex
+          # is faster in this specific case.
+          m.start_with?('on_', 'after_') &&
+            # exclude standard "callbacks" like 'on_new_investigation' unless refined
+            instance_method(m).owner != Base
         end
       end
       # rubocop:enable Layout/ClassStructure

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -64,14 +64,16 @@ module RuboCop
         r = '#' unless RESTRICTED_CALLBACKS.include?(method_name) # has Restricted?
         c = '#' if NO_CHILD_NODES.include?(node_type) # has Children?
 
+        # The `after_` calls are guarded because barely any cop defines an `after_`
+        # callback, and the guard is cheaper than the method call it avoids.
         class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-                  def on_#{node_type}(node)                               # def on_send(node)
-                    trigger_responding_cops(:on_#{node_type}, node)       #   trigger_responding_cops(:on_send, node)
-              #{r}  trigger_restricted_cops(:on_#{node_type}, node)       #   trigger_restricted_cops(:on_send, node)
-          #{c}      super(node)                                           #   super(node)
-          #{c}      trigger_responding_cops(:after_#{node_type}, node)    #   trigger_responding_cops(:after_send, node)
-          #{c}#{r}  trigger_restricted_cops(:after_#{node_type}, node)    #   trigger_restricted_cops(:after_send, node)
-                  end                                                     # end
+                  def on_#{node_type}(node)                                                                                # def on_send(node)
+                    trigger_responding_cops(:on_#{node_type}, node)                                                        #   trigger_responding_cops(:on_send, node)
+              #{r}  trigger_restricted_cops(:on_#{node_type}, node)                                                        #   trigger_restricted_cops(:on_send, node)
+          #{c}      super(node)                                                                                            #   super(node)
+          #{c}      trigger_responding_cops(:after_#{node_type}, node) if @callbacks[:after_#{node_type}]                  #   trigger_responding_cops(:after_send, node) if @callbacks[:after_send]
+          #{c}#{r}  trigger_restricted_cops(:after_#{node_type}, node) unless @restricted_map[:after_#{node_type}].empty?  #   trigger_restricted_cops(:after_send, node) unless @restricted_map[:after_send].empty?
+                  end                                                                                                      # end
         RUBY
       end
 
@@ -81,13 +83,13 @@ module RuboCop
 
         begin_investigation(processed_source, offset: offset, original: original)
         if processed_source.valid_syntax?
-          invoke(:on_new_investigation, @cops)
+          invoke(:on_new_investigation, @callbacks[:on_new_investigation])
           invoke_with_argument(:investigate, @forces, processed_source)
 
           walk(processed_source.ast) unless @cops.empty?
-          invoke(:on_investigation_end, @cops)
+          invoke(:on_investigation_end, @callbacks[:on_investigation_end])
         else
-          invoke(:on_other_file, @cops)
+          invoke(:on_other_file, @callbacks[:on_other_file])
         end
         reports = @cops.map { |cop| cop.send(:complete_investigation) }
         InvestigationReport.new(processed_source, reports, @errors)
@@ -157,7 +159,7 @@ module RuboCop
       end
 
       def invoke(callback, cops)
-        cops.each { |cop| with_cop_error_handling(cop) { cop.send(callback) } }
+        cops&.each { |cop| with_cop_error_handling(cop) { cop.send(callback) } }
       end
 
       def invoke_with_argument(callback, cops, arg)

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -75,9 +75,10 @@ module RuboCop
         MSG = 'Remove debugger entry point `%<source>s`.'
 
         def on_send(node)
+          return unless debugger_method?(node) || debugger_require?(node)
           return if assumed_usage_context?(node)
 
-          add_offense(node) if debugger_method?(node) || debugger_require?(node)
+          add_offense(node)
         end
 
         private
@@ -101,7 +102,18 @@ module RuboCop
         end
 
         def debugger_method?(send_node)
+          return false unless debugger_method_names.include?(send_node.method_name)
+
           debugger_methods.include?(chained_method_name(send_node))
+        end
+
+        # The last segment of each configured debugger method, used to cheaply
+        # rule out the vast majority of `send` nodes before building the
+        # chained method name.
+        def debugger_method_names
+          @debugger_method_names ||= debugger_methods.to_set do |method|
+            method.to_s.split('.').last&.to_sym
+          end
         end
 
         def debugger_require?(send_node)

--- a/lib/rubocop/cop/mixin/allowed_methods.rb
+++ b/lib/rubocop/cop/mixin/allowed_methods.rb
@@ -25,11 +25,11 @@ module RuboCop
 
       # @api public
       def allowed_methods
-        if cop_config_deprecated_values.any?(Regexp)
-          cop_config_allowed_methods
-        else
-          cop_config_allowed_methods + cop_config_deprecated_values
-        end
+        @allowed_methods ||= if cop_config_deprecated_values.any?(Regexp)
+                               cop_config_allowed_methods
+                             else
+                               cop_config_allowed_methods + cop_config_deprecated_values
+                             end
       end
 
       def cop_config_allowed_methods

--- a/lib/rubocop/cop/mixin/allowed_pattern.rb
+++ b/lib/rubocop/cop/mixin/allowed_pattern.rb
@@ -27,7 +27,7 @@ module RuboCop
       end
 
       def matches_allowed_pattern?(line)
-        allowed_patterns.any? { |pattern| Regexp.new(pattern).match?(line) }
+        allowed_pattern_regexps.any? { |pattern| pattern.match?(line) }
       end
 
       # @deprecated Use matches_allowed_pattern? instead
@@ -47,6 +47,10 @@ module RuboCop
         else
           cop_config_patterns_values
         end
+      end
+
+      def allowed_pattern_regexps
+        @allowed_pattern_regexps ||= allowed_patterns.map { |pattern| Regexp.new(pattern) }
       end
 
       def cop_config_patterns_values

--- a/lib/rubocop/cop/mixin/forbidden_pattern.rb
+++ b/lib/rubocop/cop/mixin/forbidden_pattern.rb
@@ -5,11 +5,15 @@ module RuboCop
     # This module encapsulates the ability to forbid certain patterns in a cop.
     module ForbiddenPattern
       def forbidden_pattern?(name)
-        forbidden_patterns.any? { |pattern| Regexp.new(pattern).match?(name) }
+        forbidden_pattern_regexps.any? { |pattern| pattern.match?(name) }
       end
 
       def forbidden_patterns
         cop_config.fetch('ForbiddenPatterns', [])
+      end
+
+      def forbidden_pattern_regexps
+        @forbidden_pattern_regexps ||= forbidden_patterns.map { |pattern| Regexp.new(pattern) }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -75,7 +75,7 @@ module RuboCop
       end
 
       def first_line_comment(node)
-        comment = processed_source.comments.find { |c| same_line?(c, node) }
+        comment = processed_source.comment_at_line(node.first_line)
         return unless comment
 
         comment_source = comment.source

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -91,7 +91,7 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
-          return if endless_method?(node.body) || node.ancestors.any?(&:dstr_type?)
+          return if endless_method?(node.body) || node.each_ancestor(:dstr).any?
 
           condition = node.condition
           return if defined_nodes(condition).any? { |n| defined_argument_is_undefined?(node, n) } ||
@@ -119,7 +119,7 @@ module RuboCop
           if condition.defined_type?
             [condition]
           else
-            condition.each_descendant.select(&:defined_type?)
+            condition.each_descendant(:defined?)
           end
         end
 
@@ -137,7 +137,7 @@ module RuboCop
           if condition.any_match_pattern_type?
             [condition]
           else
-            condition.each_descendant.select(&:any_match_pattern_type?)
+            condition.each_descendant(:any_match_pattern)
           end
         end
 
@@ -350,7 +350,7 @@ module RuboCop
         end
 
         def comment_on_node_line(node)
-          processed_source.comments.find { |c| same_line?(c, node) }
+          processed_source.comment_at_line(node.first_line)
         end
 
         def remove_comment(corrector, _node, comment)

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -59,6 +59,16 @@ module RuboCop
 
       attr_reader :errors, :warnings, :updated_source_file, :cops
 
+      # When set to true, the corrected source is not written back to the
+      # inspected file; it is exposed through `#updated_source` instead.
+      # @api private
+      attr_accessor :defer_corrections
+
+      # The corrected source of the last investigation, if corrections were
+      # made with `#defer_corrections` enabled.
+      # @api private
+      attr_reader :updated_source
+
       alias updated_source_file? updated_source_file
 
       def initialize(cops, config = nil, options = {})
@@ -135,20 +145,24 @@ module RuboCop
 
       def autocorrect(processed_source, corrector)
         @updated_source_file = false
+        @updated_source = nil
         return unless autocorrect?
         return unless corrector
         return if corrector.empty?
 
-        new_source = corrector.rewrite
+        apply_correction(processed_source, corrector.rewrite)
+        @updated_source_file = true
+      end
 
+      def apply_correction(processed_source, new_source)
         if @options[:stdin]
           # holds source read in from stdin, when --stdin option is used
           @options[:stdin] = new_source
+        elsif defer_corrections
+          @updated_source = new_source
         else
-          filename = processed_source.file_path
-          File.write(filename, new_source)
+          File.write(processed_source.file_path, new_source)
         end
-        @updated_source_file = true
       end
 
       def be_ready

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -346,16 +346,18 @@ module RuboCop
       # inspection iteration. This is used to output meaningful infinite loop
       # error message.
       offenses_by_iteration = []
+      corrected_source = nil
 
-      # When running with --autocorrect, we need to inspect the file (which
-      # includes writing a corrected version of it) until no more corrections
-      # are made. This is because automatic corrections can introduce new
-      # offenses. In the normal case the loop is only executed once.
+      # When running with --autocorrect, we need to inspect the file until no
+      # more corrections are made. This is because automatic corrections can
+      # introduce new offenses. In the normal case the loop is only executed
+      # once. The corrections are kept in memory while iterating and written
+      # back to the file when the loop is done.
       iterate_until_no_changes(processed_source, offenses_by_iteration) do
         # The offenses that couldn't be corrected will be found again so we
         # only keep the corrected ones in order to avoid duplicate reporting.
         !offenses_by_iteration.empty? && offenses_by_iteration.last.select!(&:corrected?)
-        new_offenses, updated_source_file = inspect_file(processed_source)
+        team, new_offenses, updated_source_file = inspect_iteration(processed_source)
         offenses_by_iteration.push(new_offenses)
 
         # We have to reprocess the source to pickup the changes. Since the
@@ -364,12 +366,43 @@ module RuboCop
         break unless updated_source_file
 
         # Autocorrect has happened, don't use the prism result since it is stale.
-        processed_source = get_processed_source(file, nil)
+        # With --stdin the corrected source is kept in @options[:stdin] instead.
+        corrected_source = team.updated_source
+        processed_source = get_processed_source(file, nil, source: corrected_source)
       end
 
       # Return summary of corrected offenses after all iterations
-      offenses = offenses_by_iteration.flatten.uniq
-      [processed_source, offenses]
+      [processed_source, offenses_by_iteration.flatten.uniq]
+    ensure
+      # Write the file once, even when the loop was left through an exception
+      # (e.g. an infinite correction loop), like the per-iteration writes
+      # used to be.
+      File.write(file, corrected_source) if corrected_source
+    end
+
+    def inspect_iteration(processed_source)
+      team = mobilize_team(processed_source)
+      team.defer_corrections = in_memory_corrections_possible?
+      offenses, updated_source_file = inspect_file(processed_source, team)
+      [team, offenses, updated_source_file]
+    end
+
+    # When corrections were written to disk and read back between iterations,
+    # the text-mode write converted LF to CRLF on Windows, and cops like
+    # `Layout/EndOfLine` rely on seeing the source as it would be on disk.
+    # Apply the same conversion to the in-memory source. The final `File.write`
+    # still performs it for the file itself.
+    def emulate_write_read_cycle(source)
+      return source unless Platform.windows?
+
+      source.encode(source.encoding, crlf_newline: true)
+    end
+
+    # Custom ruby extractors may derive their fragments from the file on
+    # disk rather than from the passed processed source, so corrections can
+    # only be kept in memory when the default extractor is used.
+    def in_memory_corrections_possible?
+      self.class.ruby_extractors.one?
     end
 
     def iterate_until_no_changes(source, offenses_by_iteration)
@@ -552,12 +585,19 @@ module RuboCop
     end
 
     # rubocop:disable Metrics/MethodLength
-    def get_processed_source(file, prism_result)
+    def get_processed_source(file, prism_result, source: nil)
       config = @config_store.for_file(file)
       ruby_version = config.target_ruby_version
       parser_engine = config.parser_engine
 
-      processed_source = if @options[:stdin]
+      processed_source = if source
+                           ProcessedSource.new(
+                             emulate_write_read_cycle(source),
+                             ruby_version,
+                             file,
+                             parser_engine: parser_engine
+                           )
+                         elsif @options[:stdin]
                            ProcessedSource.new(
                              @options[:stdin],
                              ruby_version,

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -4362,4 +4362,18 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       end
     end
   end
+
+  context 'when a correction inserts new lines and `Layout/EndOfLine` expects CRLF' do
+    before { allow(RuboCop::Platform).to receive(:windows?).and_return(true) }
+
+    it 'treats the corrected source as if it had been written to disk and read back' do
+      File.binwrite('example.rb', "puts 1\r\n")
+
+      expect(cli.run(%w[--autocorrect-all
+                        --only Style/FrozenStringLiteralComment,Layout/EndOfLine])).to eq(0)
+      expect($stderr.string).to eq('')
+      expect($stdout.string).not_to include('Layout/EndOfLine')
+      expect(File.binread('example.rb')).to start_with('# frozen_string_literal: true')
+    end
+  end
 end

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe RuboCop::Cop::Commissioner do
     let(:report) { commissioner.investigate(processed_source) }
     let(:cop_class) do
       stub_const('Fake::FakeCop', Class.new(RuboCop::Cop::Base) do
+                                    # The investigation callbacks are only dispatched
+                                    # to cops that refine them.
+                                    # rubocop:disable Lint/UselessMethodDefinition
+                                    def on_new_investigation
+                                      super
+                                    end
+
+                                    def on_other_file
+                                      super
+                                    end
+                                    # rubocop:enable Lint/UselessMethodDefinition
+
                                     def on_int(node); end
                                     alias_method :on_def, :on_int
                                     alias_method :on_send, :on_int


### PR DESCRIPTION
A batch of performance improvements to the investigation hot path, based on profiling RuboCop linting its own codebase (stackprof, wall and object modes). Each fix is a separate commit with its own changelog entry:

* `Lint/Debugger` now checks the method name (via a memoized set of the configured methods' last segments) before doing ancestor walks, so non-debugger sends exit on a single symbol lookup.
* `AllowedPattern`/`ForbiddenPattern` compile their regexps once per cop instance instead of on every call; previously `Layout/LineLength` recompiled every configured pattern for each long line. `AllowedMethods` memoizes its merged list.
* The gem requirements check in `Base#relevant_file?` bails out when a cop declares no gem requirements. It runs for every cop on every file and was the single largest allocation source in the profile (6.7% of all allocations).
* `range_for_original` no longer allocates a new `Parser::Source::Range` per offense outside embedded sources.
* The Commissioner dispatches `on_new_investigation`, `on_investigation_end` and `on_other_file` only to cops that actually refine them (detected via `Method#owner`, so mixin-provided callbacks still count), instead of invoking no-ops on all ~500 cops per file. The generated `after_*` dispatch is guarded, since barely any cop defines an `after_` callback.
* `Style/IfUnlessModifier` uses the O(1) `comment_at_line` lookup instead of scanning all comments per candidate node, and lazy type-filtered traversals instead of materializing ancestor/descendant arrays.
* The autocorrection loop keeps corrections in memory across iterations and writes each corrected file once, instead of writing to disk and re-reading it on every iteration. Corrections are only deferred when the default ruby extractor is in use, since custom extractors may re-read the inspected file from disk between iterations. `Team`'s default behavior is unchanged for other callers.

Measured on this machine (Ruby 3.4, cache disabled, single process):

* Linting `lib/rubocop/cop/style` + `lib/rubocop/cop/lint`: ~4-5% faster (median 8.39s vs 8.78s user time).
* `-A` on 200 generated files with multi-iteration correction cascades: ~10% faster (median 3.34s vs 3.72s).
* Object allocations on the profiled workload: down ~7%.

`bundle exec rake default` and `rake prism_spec` pass (the only failures before filling in the PR number were the changelog placeholder checks).
