### PR TITLE
[Fix #15432] Fix false positives in Layout/ElseAlignment

### DIFF
--- a/changelog/fix_false_positives_in_layout_else_alignment_20260706190908.md
+++ b/changelog/fix_false_positives_in_layout_else_alignment_20260706190908.md
@@ -1,0 +1,1 @@
+* [#15432](https://github.com/rubocop/rubocop/issues/15432): Fix false positives in `Layout/ElseAlignment` when using `else` within a block that is part of a larger expression. ([@koic][])

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -92,13 +92,7 @@ module RuboCop
           case parent.type
           when :def, :defs then base_for_method_definition(parent)
           when :kwbegin then parent.loc.begin
-          when :block, :numblock, :itblock
-            assignment_node = assignment_node(parent)
-            if same_line?(parent, assignment_node)
-              assignment_node.source_range
-            else
-              parent.send_node.source_range
-            end
+          when :block, :numblock, :itblock then start_line_range(parent)
           else node.loc.keyword
           end
         end
@@ -142,13 +136,6 @@ module RuboCop
           add_offense(else_range, message: message) do |corrector|
             autocorrect(corrector, else_range)
           end
-        end
-
-        def assignment_node(node)
-          assignment_node = node.ancestors.first
-          return unless assignment_node&.assignment?
-
-          assignment_node
         end
       end
     end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -796,6 +796,65 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
       RUBY
     end
 
+    it 'accepts a correctly aligned else when the block is within an operator method call' do
+      expect_no_offenses(<<~RUBY)
+        foo << array_like.map do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
+    it 'accepts a correctly aligned else when the block is a method argument' do
+      expect_no_offenses(<<~RUBY)
+        foo(array_like.map do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end)
+      RUBY
+    end
+
+    it 'accepts a correctly aligned else with an assignment and an operator method call' do
+      expect_no_offenses(<<~RUBY)
+        result = foo << array_like.map do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for misaligned else when the block is within an operator method call' do
+      expect_offense(<<~RUBY)
+        foo << array_like.map do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+          else
+          ^^^^ Align `else` with `foo`.
+          puts 'normal handling'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo << array_like.map do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
     it 'registers an offense for misaligned else' do
       expect_offense(<<~RUBY)
         array_like.each do |n|


### PR DESCRIPTION
This PR fixes false positives in `Layout/ElseAlignment` when using `else` within a block that is part of a larger expression.

`Layout/RescueEnsureAlignment` aligns `rescue` in a block to the start of the line where the block begins (with the default `Layout/BeginEndAlignment: EnforcedStyleAlignWith: start_of_line`), but `Layout/ElseAlignment` required `else` to be aligned with the block's send node unless the block was directly assigned on the same line. For code such as `foo << bar.each do ... rescue ... else ... end`, the two cops demanded different columns and could not be satisfied at the same time.

As a design decision, `else` in a block now uses the same start of line base that `Layout/RescueEnsureAlignment` uses for `rescue`, so both keywords always align to the same column. This replaces the previous special case that only handled a same line assignment.

Fixes #15432.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
