### PR TITLE
[Fix #15438] Fix false positives in `Style/ArrayIntersect`

### DIFF
--- a/changelog/fix_false_positives_for_style_array_intersect_20260710011035.md
+++ b/changelog/fix_false_positives_for_style_array_intersect_20260710011035.md
@@ -1,0 +1,1 @@
+* [#15438](https://github.com/rubocop/rubocop/issues/15438): Fix false positives in `Style/ArrayIntersect` when the receiver of `include?` in a block is not an array literal. ([@koic][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -30,6 +30,11 @@ module RuboCop
       # only cases where exactly one argument is provided can be replaced with
       # `Array#intersect?` and are handled by this cop.
       #
+      # NOTE: In the block form, `include?` is only detected when its receiver is
+      # an array literal, because `include?` is defined with different semantics
+      # on many non-array classes (e.g. `String#include?` checks for substrings).
+      # `member?` does not have this restriction.
+      #
       # @safety
       #   This cop cannot guarantee that `array1` and `array2` are
       #   actually arrays while method `intersect?` is for arrays only.
@@ -47,7 +52,7 @@ module RuboCop
       #
       #   # bad
       #   array1.any? { |elem| array2.member?(elem) }
-      #   array1.none? { |elem| array2.include?(elem) }
+      #   array1.none? { |elem| [1, 2].include?(elem) }
       #
       #   # good
       #   array1.intersect?(array2)
@@ -121,15 +126,15 @@ module RuboCop
             (block
               (call $_receiver ${:any? :none?})
               (args (arg _key))
-              (send $!nil? {:member? :include?} (lvar _key))
+              (send $!nil? ${:member? :include?} (lvar _key))
             )
             (numblock
               (call $_receiver ${:any? :none?}) 1
-              (send $!nil? {:member? :include?} (lvar :_1))
+              (send $!nil? ${:member? :include?} (lvar :_1))
             )
             (itblock
               (call $_receiver ${:any? :none?}) :it
-              (send $!nil? {:member? :include?} (lvar :it))
+              (send $!nil? ${:member? :include?} (lvar :it))
             )
           }
         PATTERN
@@ -156,7 +161,14 @@ module RuboCop
         alias on_csend on_send
 
         def on_block(node)
-          return unless (receiver, method_name, argument = any_none_block_intersection(node))
+          return unless (captures = any_none_block_intersection(node))
+
+          receiver, method_name, argument, block_method = captures
+
+          # `include?` is defined with different semantics on many non-array classes
+          # (e.g. `String#include?` checks for substrings), so it is only a reliable
+          # signal of an intersection check when the receiver is an array literal.
+          return if block_method == :include? && !argument.array_type?
 
           dot = node.send_node.loc.dot.source
           bang = method_name == :any? ? '' : '!'

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -349,25 +349,48 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         RUBY
       end
 
-      it 'registers an offense when using `array1.any? { |e| array2.include?(e) }`' do
+      it 'registers an offense when using `array1.any? { |e| [1, 2].include?(e) }`' do
         expect_offense(<<~RUBY)
-          array1.any? { |e| array2.include?(e) }
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1.intersect?(array2)` instead of `array1.any? { |e| array2.include?(e) }`.
+          array1.any? { |e| [1, 2].include?(e) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1.intersect?([1, 2])` instead of `array1.any? { |e| [1, 2].include?(e) }`.
         RUBY
 
         expect_correction(<<~RUBY)
-          array1.intersect?(array2)
+          array1.intersect?([1, 2])
         RUBY
       end
 
-      it 'registers an offense when using `array1.none? { |e| array2.include?(e) }`' do
+      it 'registers an offense when using `array1&.any? { |e| %w[foo bar].include?(e) }`' do
         expect_offense(<<~RUBY)
-          array1.none? { |e| array2.include?(e) }
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!array1.intersect?(array2)` instead of `array1.none? { |e| array2.include?(e) }`.
+          array1&.any? { |e| %w[foo bar].include?(e) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1&.intersect?(%w[foo bar])` instead of `array1&.any? { |e| %w[foo bar].include?(e) }`.
         RUBY
 
         expect_correction(<<~RUBY)
-          !array1.intersect?(array2)
+          array1&.intersect?(%w[foo bar])
+        RUBY
+      end
+
+      it 'registers an offense when using `array1.any? { [1, 2].include?(_1) }`' do
+        expect_offense(<<~RUBY)
+          array1.any? { [1, 2].include?(_1) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1.intersect?([1, 2])` instead of `array1.any? { [1, 2].include?(_1) }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array1.intersect?([1, 2])
+        RUBY
+      end
+
+      it 'does not register an offense when using `array1.any? { |e| array2.include?(e) }`' do
+        expect_no_offenses(<<~RUBY)
+          array1.any? { |e| array2.include?(e) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `array1.any? { |e| CONST.include?(e) }`' do
+        expect_no_offenses(<<~RUBY)
+          array1.any? { |e| CONST.include?(e) }
         RUBY
       end
 
@@ -405,6 +428,17 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
             array1.intersect?(array2)
           RUBY
         end
+
+        it 'registers an offense when using `array1.any? { [1, 2].include?(it) }`' do
+          expect_offense(<<~RUBY)
+            array1.any? { [1, 2].include?(it) }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `array1.intersect?([1, 2])` instead of `array1.any? { [1, 2].include?(it) }`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            array1.intersect?([1, 2])
+          RUBY
+        end
       end
 
       context '<= Ruby 3.3', :ruby33 do
@@ -417,6 +451,23 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
     end
 
     context 'with Array#none?' do
+      it 'registers an offense when using `array1.none? { |e| [1, 2].include?(e) }`' do
+        expect_offense(<<~RUBY)
+          array1.none? { |e| [1, 2].include?(e) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!array1.intersect?([1, 2])` instead of `array1.none? { |e| [1, 2].include?(e) }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          !array1.intersect?([1, 2])
+        RUBY
+      end
+
+      it 'does not register an offense when the receiver of `include?` may not be an array' do
+        expect_no_offenses(<<~RUBY)
+          substrings.none? { |substring| string.include?(substring) }
+        RUBY
+      end
+
       it 'registers an offense when using `array1.none? { |e| array2.member?(e) }`' do
         expect_offense(<<~RUBY)
           array1.none? { |e| array2.member?(e) }


### PR DESCRIPTION
This PR fixes false positives in `Style/ArrayIntersect` when the receiver of `include?` in a block is not an array literal.

Since #15421, the block form detection accepts `include?` in addition to `member?`. However, `include?` is defined with different semantics on many non-array classes; in particular, `String#include?` checks for substrings, and the following common idiom was registered as an offense:

```ruby
IGNORED_SUBSTRINGS.none? { |substring| relname.include?(substring) }
```

Autocorrecting it to `!IGNORED_SUBSTRINGS.intersect?(relname)` always raises a `TypeError` because `Array#intersect?` requires an `Array` argument.

Design decisions:

- The block form now registers an offense for `include?` only when its receiver is an array literal, so that the receiver is known to be an array. Constant receivers are also skipped because a constant is not necessarily an array (e.g. the `Doorkeeper::OAuth::Scopes` case in #15437) and cannot be resolved statically.
- `member?` keeps the unrestricted detection it has had since 1.66. `String#member?` does not exist, so this class of false positive cannot occur, and the duck-typed collection case is covered by `Safe: false` as settled in #11412 and #15437.

Fixes #15438.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
