### PR TITLE
Add `AllowedMethods` option to `Style/MutableConstant`

### DIFF
--- a/changelog/new_add_allowed_methods_option_to_style_mutable_constant_20260709180701.md
+++ b/changelog/new_add_allowed_methods_option_to_style_mutable_constant_20260709180701.md
@@ -1,0 +1,1 @@
+* [#15440](https://github.com/rubocop/rubocop/pull/15440): Add `AllowedMethods` option to `Style/MutableConstant` to exempt method calls (e.g. Sorbet's `type_template`) from strict mode. ([@dduugg][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4886,7 +4886,7 @@ Style/MutableConstant:
   Description: 'Do not assign mutable objects to constants.'
   Enabled: true
   VersionAdded: '0.34'
-  VersionChanged: '1.88'
+  VersionChanged: '<<next>>'
   SafeAutoCorrect: false
   EnforcedStyle: literals
   SupportedStyles:
@@ -4898,6 +4898,9 @@ Style/MutableConstant:
     # no harm in freezing an already frozen object.
     - literals
     - strict
+  # Method calls (with or without a block) whose return values are treated as
+  # immutable, e.g. Sorbet's `type_template`. Only relevant in strict mode.
+  AllowedMethods: []
   # When `true`, recursively check and freeze mutable literals nested inside
   # arrays and hashes (e.g. `[{a: []}]` becomes `[{a: [].freeze}.freeze].freeze`).
   Recursive: false

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -36,6 +36,12 @@ module RuboCop
       # NOTE: From Ruby 3.0, this cop allows explicit freezing of constants when
       # the `shareable_constant_value` directive is used.
       #
+      # The `AllowedMethods` option can be used to exempt method calls (with or
+      # without a block) whose return values should be treated as immutable,
+      # such as Sorbet's `type_template` and `type_member`. This option only
+      # has an effect with `EnforcedStyle: strict`, since method calls are
+      # never flagged with `EnforcedStyle: literals`.
+      #
       # @safety
       #   This cop's autocorrection is unsafe since any mutations on objects that
       #   are made frozen will change from being accepted to raising `FrozenError`,
@@ -92,6 +98,10 @@ module RuboCop
       #   # good - `Data.define` declares an immutable value type
       #   CONST = Data.define(:foo, :bar)
       #
+      # @example AllowedMethods: ['type_template'] (with EnforcedStyle: strict)
+      #   # good
+      #   CONST = type_template { { fixed: T::Hash[String, T.untyped] } }
+      #
       # @example
       #   # Magic comment - shareable_constant_value: literal
       #
@@ -140,6 +150,7 @@ module RuboCop
         private_constant :ShareableConstantValue
 
         include ShareableConstantValue
+        include AllowedMethods
         include FrozenStringLiteral
         include ConfigurableEnforcedStyle
         extend AutoCorrector
@@ -190,6 +201,7 @@ module RuboCop
         def strict_check(value)
           return if immutable_literal?(value)
           return if operation_produces_immutable_object?(value)
+          return if allowed_method_call?(value)
           return if frozen_string_literal?(value)
           return if shareable_constant_value?(value)
 
@@ -202,6 +214,11 @@ module RuboCop
           return if shareable_constant_value?(value)
 
           true
+        end
+
+        def allowed_method_call?(value)
+          call = value.any_block_type? ? value.send_node : value
+          call.call_type? && allowed_method?(call.method_name)
         end
 
         def mutable_or_unfrozen_range?(value)

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -497,6 +497,53 @@ RSpec.describe RuboCop::Cop::Style::MutableConstant, :config do
       RUBY
     end
 
+    context 'with AllowedMethods' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'strict', 'AllowedMethods' => ['type_template'] }
+      end
+
+      it 'allows an allowed method call with a block' do
+        expect_no_offenses(<<~RUBY)
+          CONST = type_template { { fixed: T::Hash[String, T.untyped] } }
+        RUBY
+      end
+
+      it 'allows an allowed method call without a block' do
+        expect_no_offenses(<<~RUBY)
+          CONST = type_template
+        RUBY
+      end
+
+      it 'allows an allowed method call with a receiver' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.type_template
+        RUBY
+      end
+
+      it 'allows an allowed method call with `||=`' do
+        expect_no_offenses(<<~RUBY)
+          CONST ||= type_template { { fixed: T::Hash[String, T.untyped] } }
+        RUBY
+      end
+
+      it 'allows an allowed method call with safe navigation' do
+        expect_no_offenses(<<~RUBY)
+          CONST = foo&.type_template
+        RUBY
+      end
+
+      it 'registers an offense for method calls that are not allowed' do
+        expect_offense(<<~RUBY)
+          CONST = type_member { { fixed: T::Hash[String, T.untyped] } }
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          CONST = type_member { { fixed: T::Hash[String, T.untyped] } }.freeze
+        RUBY
+      end
+    end
+
     context 'splat expansion' do
       context 'expansion of a range' do
         it 'registers an offense and corrects to use to_a.freeze' do


### PR DESCRIPTION
## Summary

Adds an `AllowedMethods` option to `Style/MutableConstant` that exempts method calls (with or without a block) from strict mode.

With `EnforcedStyle: strict`, the cop flags any method call it cannot prove returns an immutable object. This produces false positives for DSLs whose return values should be treated as immutable — most notably Sorbet's generics, which cannot be frozen:

```ruby
# Homebrew currently needs a disable comment for every one of these
# rubocop:disable Style/MutableConstant
Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
# rubocop:enable Style/MutableConstant

Key = type_member # rubocop:disable Style/MutableConstant
```

With this change, such projects can configure:

```yaml
Style/MutableConstant:
  EnforcedStyle: strict
  AllowedMethods:
    - type_template
    - type_member
```

In Homebrew alone this would remove 30 of the 34 `rubocop:disable Style/MutableConstant` comments (plus their paired `rubocop:enable` lines).

The option has no effect with the default `EnforcedStyle: literals`, since that style never flags method calls; this is noted in the cop's documentation.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://docs.rubocop.org/rubocop/contributing.html#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/