### PR TITLE
Fix an error for Style/ArrayIntersect cop

### DIFF
--- a/changelog/fix_an_error_for_style_array_intersect_cop_20260710134204.md
+++ b/changelog/fix_an_error_for_style_array_intersect_cop_20260710134204.md
@@ -1,0 +1,1 @@
+* [#15442](https://github.com/rubocop/rubocop/pull/15442): Fix an error for `Style/ArrayIntersect` cop when the block-based check calls `member?`/`include?` without an explicit receiver. ([@dduugg][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -121,15 +121,15 @@ module RuboCop
             (block
               (call $_receiver ${:any? :none?})
               (args (arg _key))
-              (send $_argument {:member? :include?} (lvar _key))
+              (send $!nil? {:member? :include?} (lvar _key))
             )
             (numblock
               (call $_receiver ${:any? :none?}) 1
-              (send $_argument {:member? :include?} (lvar :_1))
+              (send $!nil? {:member? :include?} (lvar :_1))
             )
             (itblock
               (call $_receiver ${:any? :none?}) :it
-              (send $_argument {:member? :include?} (lvar :it))
+              (send $!nil? {:member? :include?} (lvar :it))
             )
           }
         PATTERN

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -371,6 +371,18 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         RUBY
       end
 
+      it 'does not register an offense when using `array1.any? { |e| include?(e) }`' do
+        expect_no_offenses(<<~RUBY)
+          array1.any? { |e| include?(e) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `array1.any? { |e| member?(e) }`' do
+        expect_no_offenses(<<~RUBY)
+          array1.any? { |e| member?(e) }
+        RUBY
+      end
+
       it 'registers an offense when using `array1.any? { array2.member?(_1) }`' do
         expect_offense(<<~RUBY)
           array1.any? { array2.member?(_1) }
@@ -435,6 +447,12 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
 
         expect_correction(<<~RUBY)
           !array1.intersect?(array2)
+        RUBY
+      end
+
+      it 'does not register an offense when using `array1.none? { member?(_1) }`' do
+        expect_no_offenses(<<~RUBY)
+          array1.none? { member?(_1) }
         RUBY
       end
 


### PR DESCRIPTION
`Style/ArrayIntersect`'s `any_none_block_intersection` pattern matches `array1.any? { |e| array2.member?(e) }` and its `include?`/numblock/itblock variants, but it also matches when the inner `member?`/`include?` call has **no explicit receiver** — e.g. `array1.any? { |e| include?(e) }` (calling `include?` on `self`).

In that case the captured "argument" node is `nil` (there's no receiver to capture), and `on_block` unconditionally calls `argument.source` when building the replacement, raising `NoMethodError: undefined method 'source' for nil` and aborting analysis of the whole file.

Found this while updating a project's `rubocop-sorbet` dependency, which pulled in this cop's `include?` support and crashed on:

```ruby
def detect(locale_groups)
  locale_groups.find { |locales| locales.any? { |locale| eql?(locale) } } ||
    locale_groups.find { |locales| locales.any? { |locale| include?(locale) } }
end
```

This fixes it by requiring an explicit (non-nil) receiver on the inner `member?`/`include?` call, mirroring the existing `$!nil?` constraint already used for the `&`/`intersection` based check in this same cop.

-----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.
