### PR TITLE
[Fix #15441] Add new `AllowYARDCommentBlockSeparator` option to `Layout/LeadingCommentSpace`

### DIFF
--- a/changelog/new_add_new_allow_yard_comment_block_separator_20260711003243.md
+++ b/changelog/new_add_new_allow_yard_comment_block_separator_20260711003243.md
@@ -1,0 +1,1 @@
+* [#15441](https://github.com/rubocop/rubocop/issues/15441): Add new `AllowYARDCommentBlockSeparator` option to `Layout/LeadingCommentSpace`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1069,6 +1069,7 @@ Layout/LeadingCommentSpace:
   AllowGemfileRubyComment: false
   AllowRBSInlineAnnotation: false
   AllowSteepAnnotation: false
+  AllowYARDCommentBlockSeparator: false
 
 Layout/LeadingEmptyLines:
   Description: Checks for unnecessary blank lines at the beginning of a file.

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -98,6 +98,24 @@ module RuboCop
       #
       #   name = 'John'      #: String
       #
+      # @example AllowYARDCommentBlockSeparator: false (default)
+      #
+      #   # bad
+      #
+      #   # Copyright (c) Example Corp
+      #   #-
+      #   class Client
+      #   end
+      #
+      # @example AllowYARDCommentBlockSeparator: true
+      #
+      #   # good
+      #
+      #   # Copyright (c) Example Corp
+      #   #-
+      #   class Client
+      #   end
+      #
       class LeadingCommentSpace < Base
         include RangeHelp
         extend AutoCorrector
@@ -113,6 +131,7 @@ module RuboCop
             next if gemfile_ruby_comment?(comment)
             next if rbs_inline_annotation?(comment)
             next if steep_annotation?(comment)
+            next if yard_comment_block_separator?(comment)
 
             add_offense(comment) do |corrector|
               expr = comment.source_range
@@ -196,6 +215,14 @@ module RuboCop
 
         def steep_annotation?(comment)
           allow_steep_annotation? && comment.text.start_with?(/#[$:]/)
+        end
+
+        def allow_yard_comment_block_separator?
+          cop_config['AllowYARDCommentBlockSeparator']
+        end
+
+        def yard_comment_block_separator?(comment)
+          allow_yard_comment_block_separator? && comment.text.match?(/\A#-\s*\z/)
         end
       end
     end

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -367,4 +367,85 @@ RSpec.describe RuboCop::Cop::Layout::LeadingCommentSpace, :config do
       end
     end
   end
+
+  describe 'YARD comment-block separator' do
+    context 'when config option is disabled' do
+      let(:cop_config) { { 'AllowYARDCommentBlockSeparator' => false } }
+
+      it 'registers an offense and corrects using `#-` comment-block separator' do
+        expect_offense(<<~RUBY)
+          # Some comment
+          #-
+          ^^ Missing space after `#`.
+          class Foo
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # Some comment
+          # -
+          class Foo
+          end
+        RUBY
+      end
+    end
+
+    context 'when config option is enabled' do
+      let(:cop_config) { { 'AllowYARDCommentBlockSeparator' => true } }
+
+      it 'does not register an offense when using `#-` comment-block separator' do
+        expect_no_offenses(<<~RUBY)
+          # Some comment
+          #-
+          class Foo
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using `#-` comment-block separator in consecutive comment blocks' do
+        expect_no_offenses(<<~RUBY)
+          # Some comment
+          #-
+
+          # Another comment
+          #-
+          class Foo
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when using indented `#-` comment-block separator' do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # Some comment
+            #-
+            def bar
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects when the comment has content after `#-`' do
+        expect_offense(<<~RUBY)
+          #-foo
+          ^^^^^ Missing space after `#`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # -foo
+        RUBY
+      end
+
+      it 'registers an offense and corrects when using `#+`' do
+        expect_offense(<<~RUBY)
+          #+
+          ^^ Missing space after `#`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # +
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
YARD 0.9.40 added support for `#-` as a comment-block separator that disconnects a comment block from the code that follows it.
Only a lone `#-` line works; `# -` with a space is treated as a normal comment line. This means the cop's autocorrect (`#-` to `# -`) silently destroys the separator semantics for YARD users.

The new option is disabled by default, following this cop's precedent of gating third-party tool syntax behind `Allow*` options
(`AllowDoxygenCommentStyle`, `AllowRBSInlineAnnotation`, `AllowSteepAnnotation`), unlike the RDoc `#--`/`#++` syntax, which is allowed unconditionally because RDoc is Ruby's built-in documentation tool. When enabled, the cop allows a comment whose text matches `/\A#-\s*\z/`, mirroring YARD's own separator regex (`/^\s*#-\s*$/`), without checking whether the line is the last one of its comment block, the same simplicity trade-off as the Doxygen and Steep checks.

Fixes #15441.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
