### PR TITLE
[Fix #8565] Support `NewCops` in department configuration

### DIFF
--- a/changelog/new_support_new_cops_per_department_20260709172322.md
+++ b/changelog/new_support_new_cops_per_department_20260709172322.md
@@ -1,0 +1,1 @@
+* [#8565](https://github.com/rubocop/rubocop/pull/8565): Support `NewCops` in department configuration to enable pending cops per department, including cops added up to a specific version (e.g. `Style: NewCops: '1.19'`). ([@koic][])

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -104,6 +104,33 @@ AllCops:
 
 NOTE: The command-line option takes precedence over the `.rubocop.yml` file.
 
+=== Enabling/Disabling Pending Cops per Department
+
+A single version in `AllCops` cannot express which pending cops to enable, because extension gems follow their own version schemes.
+Instead, `NewCops` can be set for a department, in which case it takes precedence over the `AllCops` setting for the cops of that department.
+In addition to `enable`, `disable`, and `pending`, a department accepts a version, which enables all pending cops of the department
+that were added in the specified version or earlier:
+
+[source,yaml]
+----
+AllCops:
+  NewCops: disable # keywords only, as before
+
+Lint:
+  NewCops: enable  # a department overrides `AllCops`
+
+Style:
+  NewCops: '1.19'  # enables pending cops with `VersionAdded` <= 1.19
+
+Minitest:
+  NewCops: '0.10'  # an extension is pinned to its own version
+----
+
+Pending cops added in a later version keep emitting the warning, so you can review them and bump the version at your own pace.
+Since each department is pinned to its own version, this also works for extensions whose version schemes differ from RuboCop's.
+
+NOTE: Quote the version to avoid YAML interpreting it as a number (for example, an unquoted `1.20` is read as `1.2`).
+
 === Enabling/Disabling Individual Pending Cops
 
 Finally, you can enable/disable individual pending cops by setting their `Enabled` configuration to either `true` or `false` in your `.rubocop.yml` file:

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -209,6 +209,20 @@ module RuboCop
       for_all_cops['NewCops'] == 'enable'
     end
 
+    # Whether the given pending cop should be enabled, based on the `NewCops` setting of
+    # its department (if any) or of `AllCops`. A department may set `NewCops` to `enable`,
+    # `disable`, `pending`, or a version, in which case pending cops added in that version
+    # or earlier are enabled.
+    def enabled_new_cop?(qualified_cop_name)
+      setting = new_cops_setting_for(qualified_cop_name)
+
+      case setting.to_s
+      when 'enable' then true
+      when '', 'pending', 'disable' then false
+      else new_cops_version_covers?(setting, qualified_cop_name)
+      end
+    end
+
     def active_support_extensions_enabled?
       for_all_cops['ActiveSupportExtensionsEnabled']
     end
@@ -326,6 +340,7 @@ module RuboCop
 
         cop_metadata = self[qualified_cop_name]
         next unless cop_metadata['Enabled'] == 'pending'
+        next if new_cops_covered?(qualified_cop_name)
 
         pending_cops << CopConfig.new(qualified_cop_name, cop_metadata)
       end
@@ -398,6 +413,44 @@ module RuboCop
       return nil if cop_department.empty?
 
       self[cop_department.join('/')]
+    end
+
+    # The effective `NewCops` setting for the given cop: the department-level
+    # setting if present, otherwise the `AllCops` setting.
+    def new_cops_setting_for(qualified_cop_name)
+      department = department_of(qualified_cop_name)
+      setting = department['NewCops'] if department
+
+      setting || for_all_cops['NewCops']
+    end
+
+    # Whether the cop's pending status is resolved by a `NewCops` setting,
+    # so that it should not appear in the pending cops warning.
+    # Unlike `enabled_new_cop?`, `disable` counts as covered.
+    def new_cops_covered?(qualified_cop_name)
+      setting = new_cops_setting_for(qualified_cop_name)
+
+      case setting.to_s
+      when 'enable', 'disable' then true
+      when '', 'pending' then false
+      else new_cops_version_covers?(setting, qualified_cop_name)
+      end
+    end
+
+    def new_cops_version_covers?(new_cops_version, qualified_cop_name)
+      cop_metadata = self[qualified_cop_name]
+      version_added = comparable_version(cop_metadata['VersionAdded']) if cop_metadata
+      pinned_version = comparable_version(new_cops_version)
+      return false if version_added.nil? || pinned_version.nil?
+
+      version_added <= pinned_version
+    end
+
+    # Returns a `Gem::Version` for values like `'1.19'` or `1.19`, and `nil`
+    # for non-version values like `'N/A'` or `'<<next>>'`.
+    def comparable_version(value)
+      value = value.to_s
+      Gem::Version.new(value) if value.match?(/\A\d/) && Gem::Version.correct?(value)
     end
   end
 end

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -16,6 +16,8 @@ module RuboCop
                          Reference References Safe SafeAutoCorrect].freeze
     # @api private
     NEW_COPS_VALUES = %w[pending disable enable].freeze
+    # @api private
+    NEW_COPS_VERSION_PATTERN = /\A\d+(\.\d+)*\z/.freeze
 
     # @api private
     CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect References].to_set.freeze
@@ -164,14 +166,46 @@ module RuboCop
     end
 
     def validate_new_cops_parameter
+      validate_all_cops_new_cops_parameter
+      validate_department_new_cops_parameters
+    end
+
+    def validate_all_cops_new_cops_parameter
       new_cop_parameter = @config.for_all_cops['NewCops']
       return if new_cop_parameter.nil? || NEW_COPS_VALUES.include?(new_cop_parameter)
 
-      message = "invalid #{new_cop_parameter} for `NewCops` found in" \
+      message = "invalid #{new_cop_parameter} for `NewCops` found in " \
                 "#{smart_loaded_path}\n" \
                 "Valid choices are: #{NEW_COPS_VALUES.join(', ')}"
 
       raise ValidationError, message
+    end
+
+    def validate_department_new_cops_parameters
+      @config.each do |name, section|
+        value = new_cops_value_for_department(name, section)
+        next if value.nil? || NEW_COPS_VALUES.include?(value) || new_cops_version_value?(value)
+
+        raise ValidationError,
+              "invalid #{value} for `NewCops` found in #{smart_loaded_path}\n" \
+              "Valid choices for a department are: #{NEW_COPS_VALUES.join(', ')}, " \
+              "or a version string like '1.50'"
+      end
+    end
+
+    def new_cops_value_for_department(name, section)
+      return nil if name == 'AllCops' || !section.is_a?(Hash)
+      return nil unless Cop::Registry.global.department?(name)
+
+      section['NewCops']
+    end
+
+    def new_cops_version_value?(value)
+      case value
+      when Float, Integer then true
+      when String then NEW_COPS_VERSION_PATTERN.match?(value)
+      else false
+      end
     end
 
     def validate_parameter_shape(valid_cop_names)
@@ -207,6 +241,9 @@ module RuboCop
 
       @config[cop_name].each_key do |param|
         next if COMMON_PARAMS.include?(param) || default_config.key?(param)
+        # Departments shipped as top-level sections in an extension's default configuration accept
+        # `NewCops`, like any other department.
+        next if param == 'NewCops' && Cop::Registry.global.department?(cop_name)
 
         supported_params = default_config.keys - INTERNAL_PARAMS
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -205,7 +205,7 @@ module RuboCop
         # which expects cop names or cop classes as keys.
         cfg = config.for_cop(cop.cop_name)
 
-        cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config)
+        cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config, cop)
 
         if options.fetch(:safe, false)
           cop_enabled && cfg.fetch('Safe', true)
@@ -214,11 +214,12 @@ module RuboCop
         end
       end
 
-      def enabled_pending_cop?(cop_cfg, config)
+      def enabled_pending_cop?(cop_cfg, config, cop = nil)
         return false if @options[:disable_pending_cops]
+        return false unless cop_cfg.fetch('Enabled') == 'pending'
+        return true if @options[:enable_pending_cops]
 
-        cop_cfg.fetch('Enabled') == 'pending' &&
-          (@options[:enable_pending_cops] || config.enabled_new_cops?)
+        cop ? config.enabled_new_cop?(cop.cop_name) : config.enabled_new_cops?
       end
 
       def names

--- a/lib/rubocop/pending_cops_reporter.rb
+++ b/lib/rubocop/pending_cops_reporter.rb
@@ -20,7 +20,7 @@ module RuboCop
       attr_accessor :disable_pending_cops, :enable_pending_cops
 
       def warn_if_needed(config)
-        return if possible_new_cops?(config)
+        return if disable_pending_cops || enable_pending_cops
 
         pending_cops = pending_cops_only_qualified(config.pending_cops)
         warn_on_pending_cops(pending_cops) unless pending_cops.empty?
@@ -30,11 +30,6 @@ module RuboCop
 
       def pending_cops_only_qualified(pending_cops)
         pending_cops.select { |cop| Cop::Registry.qualified_cop?(cop.name) }
-      end
-
-      def possible_new_cops?(config)
-        disable_pending_cops || enable_pending_cops ||
-          config.disabled_new_cops? || config.enabled_new_cops?
       end
 
       def warn_on_pending_cops(pending_cops)

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -731,6 +731,86 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           end
         end
 
+        context 'when specifying `NewCops` for the Style department in .rubocop.yml' do
+          let(:output) { `ruby -I . "#{rubocop}" --require redirect.rb` }
+          let(:all_cops_config) { '' }
+          let(:cli_option) { '' }
+
+          before do
+            create_file('rubocop_ext.rb', <<~RUBY)
+              module RuboCop
+                module Cop
+                  module Style
+                    class SomeCop < Base
+                      def on_new_investigation
+                        add_global_offense('Some message')
+                      end
+                    end
+                  end
+                end
+              end
+            RUBY
+
+            create_file('.rubocop.yml', <<~YAML)
+              require: rubocop_ext
+
+              #{all_cops_config}
+
+              Style:
+                NewCops: #{new_cops_value}
+
+              Style/SomeCop:
+                Description: Something
+                Enabled: pending
+                VersionAdded: '0.80'
+            YAML
+          end
+
+          context 'when the cop was added after the specified version' do
+            let(:new_cops_value) { "'0.79'" }
+
+            it 'displays a pending cop warning and does not run the cop' do
+              expect(output).to start_with(pending_cop_warning)
+              expect(output).to include("Style/SomeCop: # new in 0.80\n  Enabled: true")
+              expect(output).not_to include('Some message')
+            end
+          end
+
+          context 'when the cop was added in the specified version' do
+            let(:new_cops_value) { "'0.80'" }
+
+            it 'does not include the cop in the pending cop warning and runs the cop' do
+              expect(output).not_to include('Style/SomeCop: # new in 0.80')
+              expect(output).to include('Some message')
+            end
+          end
+
+          context 'when `AllCops` has `NewCops: disable`' do
+            let(:new_cops_value) { "'0.80'" }
+            let(:all_cops_config) { <<~YAML }
+              AllCops:
+                NewCops: disable
+            YAML
+
+            it 'does not include the cop in the pending cop warning and runs the cop because ' \
+               'the department takes precedence over `AllCops`' do
+              expect(output).not_to include('Style/SomeCop: # new in 0.80')
+              expect(output).to include('Some message')
+            end
+          end
+
+          context 'when using `--disable-pending-cops` command-line option' do
+            let(:new_cops_value) { 'enable' }
+            let(:output) { `ruby -I . "#{rubocop}" --require redirect.rb --disable-pending-cops` }
+
+            it 'does not display a pending cop warning and does not run the cop because ' \
+               'the command-line option takes precedence over .rubocop.yml' do
+              expect(output).not_to start_with(pending_cop_warning)
+              expect(output).not_to include('Some message')
+            end
+          end
+        end
+
         context 'when Style department is disabled' do
           before do
             create_file('.rubocop.yml', <<~YAML)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -2101,6 +2101,99 @@ RSpec.describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'sets a version to `NewCops` for `AllCops`' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          AllCops:
+            NewCops: '1.19'
+        YAML
+      end
+
+      it 'raises an error because versions are only allowed for a department' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          /invalid 1\.19 for `NewCops` found in/
+        )
+      end
+    end
+
+    context 'sets `enable` to `NewCops` for a department' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint:
+            NewCops: enable
+        YAML
+      end
+
+      it 'loads the config without error' do
+        expect { load_file }.not_to raise_error
+      end
+    end
+
+    context 'sets a version string to `NewCops` for a department' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint:
+            NewCops: '1.19'
+        YAML
+      end
+
+      it 'loads the config without error' do
+        expect { load_file }.not_to raise_error
+      end
+    end
+
+    context 'sets an unquoted version to `NewCops` for a department' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint:
+            NewCops: 1.19
+        YAML
+      end
+
+      it 'loads the config without error' do
+        expect { load_file }.not_to raise_error
+      end
+    end
+
+    context 'sets an invalid value to `NewCops` for a department' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint:
+            NewCops: foo
+        YAML
+      end
+
+      it 'gets a validation error' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          /invalid foo for `NewCops` found in/
+        )
+      end
+    end
+
+    context 'sets a boolean to `NewCops` for a department' do
+      before do
+        create_file(configuration_path, <<~YAML)
+          Lint:
+            NewCops: true
+        YAML
+      end
+
+      it 'gets a validation error' do
+        expect do
+          load_file
+        end.to raise_error(
+          RuboCop::ValidationError,
+          /invalid true for `NewCops` found in/
+        )
+      end
+    end
+
     context 'when the file does not exist' do
       let(:configuration_path) { 'file_that_does_not_exist.yml' }
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -893,6 +893,171 @@ RSpec.describe RuboCop::Config do
     it { is_expected.to be_cop_enabled('Metrics/MethodLength') }
   end
 
+  describe '#pending_cops' do
+    subject(:pending_cops) { configuration.pending_cops.map(&:name) }
+
+    let(:hash) do
+      {
+        'Lint/Foo' => { 'Enabled' => 'pending', 'VersionAdded' => '1.18' },
+        'Lint/Bar' => { 'Enabled' => 'pending', 'VersionAdded' => '1.20' },
+        'Style/Baz' => { 'Enabled' => 'pending', 'VersionAdded' => '1.19' }
+      }.merge(new_cops_config)
+    end
+    let(:new_cops_config) { {} }
+
+    context 'when `NewCops` is not set' do
+      it 'returns all pending cops' do
+        expect(pending_cops).to eq(%w[Lint/Foo Lint/Bar Style/Baz])
+      end
+    end
+
+    context 'when `AllCops` has `NewCops: enable`' do
+      let(:new_cops_config) { { 'AllCops' => { 'NewCops' => 'enable' } } }
+
+      it 'returns no cops' do
+        expect(pending_cops).to be_empty
+      end
+    end
+
+    context 'when `AllCops` has `NewCops: disable`' do
+      let(:new_cops_config) { { 'AllCops' => { 'NewCops' => 'disable' } } }
+
+      it 'returns no cops' do
+        expect(pending_cops).to be_empty
+      end
+    end
+
+    context 'when a department has `NewCops: enable`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => 'enable' } } }
+
+      it 'returns only cops of other departments' do
+        expect(pending_cops).to eq(%w[Style/Baz])
+      end
+    end
+
+    context 'when a department has `NewCops: disable`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => 'disable' } } }
+
+      it 'returns only cops of other departments' do
+        expect(pending_cops).to eq(%w[Style/Baz])
+      end
+    end
+
+    context 'when a department has a version for `NewCops`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => '1.19' } } }
+
+      it 'returns cops of the department added after the version and cops of other departments' do
+        expect(pending_cops).to eq(%w[Lint/Bar Style/Baz])
+      end
+    end
+
+    context 'when a department has `NewCops: pending` and `AllCops` has `NewCops: enable`' do
+      let(:new_cops_config) do
+        { 'AllCops' => { 'NewCops' => 'enable' }, 'Lint' => { 'NewCops' => 'pending' } }
+      end
+
+      it 'returns only cops of the department' do
+        expect(pending_cops).to eq(%w[Lint/Foo Lint/Bar])
+      end
+    end
+
+    context 'when a department has `Enabled: false`' do
+      let(:new_cops_config) { { 'Lint' => { 'Enabled' => false } } }
+
+      it 'returns only cops of other departments' do
+        expect(pending_cops).to eq(%w[Style/Baz])
+      end
+    end
+  end
+
+  describe '#enabled_new_cop?' do
+    subject(:enabled_new_cop) { configuration.enabled_new_cop?('Lint/Foo') }
+
+    let(:hash) do
+      { 'Lint/Foo' => { 'Enabled' => 'pending', 'VersionAdded' => '1.19' } }.merge(new_cops_config)
+    end
+    let(:new_cops_config) { {} }
+
+    context 'when `NewCops` is not set' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `AllCops` has `NewCops: enable`' do
+      let(:new_cops_config) { { 'AllCops' => { 'NewCops' => 'enable' } } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when `AllCops` has `NewCops: disable`' do
+      let(:new_cops_config) { { 'AllCops' => { 'NewCops' => 'disable' } } }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when `AllCops` has `NewCops: pending`' do
+      let(:new_cops_config) { { 'AllCops' => { 'NewCops' => 'pending' } } }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the department has `NewCops: enable`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => 'enable' } } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the department has `NewCops: disable` and `AllCops` has `NewCops: enable`' do
+      let(:new_cops_config) do
+        { 'AllCops' => { 'NewCops' => 'enable' }, 'Lint' => { 'NewCops' => 'disable' } }
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the department has a version for `NewCops` equal to `VersionAdded`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => '1.19' } } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the department has a version for `NewCops` lower than `VersionAdded`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => '1.18' } } }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the department has a version for `NewCops` higher than `VersionAdded`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => '1.20' } } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the department has a Float version for `NewCops`' do
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => 1.19 } } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the department has a version for `NewCops` and the cop has `VersionAdded: N/A`' do
+      let(:hash) do
+        {
+          'Lint' => { 'NewCops' => '1.19' },
+          'Lint/Foo' => { 'Enabled' => 'pending', 'VersionAdded' => 'N/A' }
+        }
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the department has a version for `NewCops` and the cop is not configured' do
+      subject(:enabled_new_cop) { configuration.enabled_new_cop?('Lint/Undefined') }
+
+      let(:new_cops_config) { { 'Lint' => { 'NewCops' => '1.19' } } }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   context 'whether the cop is enabled' do
     def cop_enabled(cop_class)
       configuration.for_cop(cop_class).fetch('Enabled')

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -365,6 +365,193 @@ RSpec.describe RuboCop::Cop::Registry do
           expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
         end
       end
+
+      context 'when specifying `NewCops: enable` option for a department in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => 'enable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'includes them' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `NewCops: enable` option for another department in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Style' => { 'NewCops' => 'enable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'does not include them' do
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `NewCops: disable` option for a department and ' \
+              '`NewCops: enable` option for `AllCops` in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'AllCops' => { 'NewCops' => 'enable' },
+            'Lint' => { 'NewCops' => 'disable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'does not include them because the department takes precedence over `AllCops`' do
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `NewCops: enable` option for a department and `NewCops: disable` option for `AllCops` in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'AllCops' => { 'NewCops' => 'disable' },
+            'Lint' => { 'NewCops' => 'enable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'includes them because the department takes precedence over `AllCops`' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `NewCops: pending` option for a department and `NewCops: enable` option for `AllCops` in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'AllCops' => { 'NewCops' => 'enable' },
+            'Lint' => { 'NewCops' => 'pending' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'does not include them because the department takes precedence over `AllCops`' do
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying a version for `NewCops` option for a department in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => '0.90' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending', 'VersionAdded' => version_added }
+          )
+        end
+
+        context 'when the cop was added before the specified version' do
+          let(:version_added) { '0.89' }
+
+          it 'includes them' do
+            expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+
+        context 'when the cop was added in the specified version' do
+          let(:version_added) { '0.90' }
+
+          it 'includes them' do
+            expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+
+        context 'when the cop was added after the specified version' do
+          let(:version_added) { '0.91' }
+
+          it 'does not include them' do
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+
+        context 'when the cop has `VersionAdded: N/A`' do
+          let(:version_added) { 'N/A' }
+
+          it 'does not include them' do
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+
+        context 'when the cop has `VersionAdded: <<next>>`' do
+          let(:version_added) { '<<next>>' }
+
+          it 'does not include them' do
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+
+        context 'when the cop has no `VersionAdded`' do
+          let(:config) do
+            RuboCop::Config.new(
+              'Lint' => { 'NewCops' => '0.90' },
+              'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+            )
+          end
+
+          it 'does not include them' do
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+      end
+
+      context 'when specifying a version as an unquoted YAML value for `NewCops` option for a department in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => 1.19 },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending', 'VersionAdded' => '1.19' }
+          )
+        end
+
+        it 'includes them' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `--disable-pending-cops` command-line option and `NewCops: enable` option for a department in .rubocop.yml' do
+        let(:options) { { disable_pending_cops: true } }
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => 'enable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'does not include them because command-line option takes precedence over .rubocop.yml' do
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `--enable-pending-cops` command-line option and ' \
+              '`NewCops: disable` option for a department in .rubocop.yml' do
+        let(:options) { { enable_pending_cops: true } }
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'NewCops' => 'disable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'includes them because command-line option takes precedence over .rubocop.yml' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `Enabled: false` and `NewCops: enable` options ' \
+              'for a department in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'Lint' => { 'Enabled' => false, 'NewCops' => 'enable' },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'pending' }
+          )
+        end
+
+        it 'does not include them because `Enabled: false` takes precedence' do
+          expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
     end
   end
 
@@ -434,10 +621,10 @@ RSpec.describe RuboCop::Cop::Registry do
 
   describe '#unqualified_cop_names' do
     it 'returns a set of cop names without the department' do
-      expect(registry.unqualified_cop_names)
-        .to eq(Set['BooleanSymbol', 'DuplicateMethods',
-                   'FirstArrayElementIndentation', 'MethodLength',
-                   'Foo', 'RedundantCopDisableDirective'])
+      expect(registry.unqualified_cop_names).to eq(Set[
+        'BooleanSymbol', 'DuplicateMethods', 'FirstArrayElementIndentation', 'MethodLength',
+        'Foo', 'RedundantCopDisableDirective'
+     ])
     end
 
     context 'when there are lazy-loaded cops' do

--- a/spec/rubocop/pending_cops_reporter_spec.rb
+++ b/spec/rubocop/pending_cops_reporter_spec.rb
@@ -51,5 +51,39 @@ RSpec.describe RuboCop::PendingCopsReporter do
         end
       end
     end
+
+    context 'when a department sets a version for NewCops in a required file' do
+      let(:parent_config) do
+        {
+          'Lint' => { 'NewCops' => '0.90' },
+          'Lint/BooleanSymbol' => { 'Enabled' => 'pending', 'VersionAdded' => '0.90' },
+          'Lint/DuplicateBranch' => { 'Enabled' => 'pending', 'VersionAdded' => '1.3' }
+        }
+      end
+
+      it 'prints a warning only for cops added after the version' do
+        expect(described_class).to receive(:warn_on_pending_cops) do |pending_cops|
+          expect(pending_cops.map(&:name)).to eq(['Lint/DuplicateBranch'])
+        end
+        report_pending_cops
+      end
+    end
+
+    context 'when a department sets `NewCops: pending` and `AllCops` sets `NewCops: enable` in a required file' do
+      let(:parent_config) do
+        {
+          'AllCops' => { 'NewCops' => 'enable' },
+          'Lint' => { 'NewCops' => 'pending' },
+          'Lint/BooleanSymbol' => { 'Enabled' => 'pending', 'VersionAdded' => '0.90' }
+        }
+      end
+
+      it 'prints a warning for the cops of the department' do
+        expect(described_class).to receive(:warn_on_pending_cops) do |pending_cops|
+          expect(pending_cops.map(&:name)).to eq(['Lint/BooleanSymbol'])
+        end
+        report_pending_cops
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements the design agreed in #8565. The essence of the problem is that enabling pending cops in bulk cannot be expressed with a single version: extension gems such as rubocop-minitest follow their own version schemes, so `AllCops: EnableNewCopsUpTo: '0.89'` (the original proposal) was rejected. The discussion converged on setting `NewCops` per department instead, riding on the existing `NewCops` convention without introducing a new configuration option. A version pinned per department resolves the version differences between gems:

```yaml
AllCops:
  NewCops: disable # keywords only, as before

Lint:
  NewCops: enable  # a department overrides `AllCops`

Style:
  NewCops: '1.19'  # enables pending cops with `VersionAdded` <= 1.19

Minitest:
  NewCops: '0.10'  # an extension is pinned to its own version
```

Design decisions:

- A department's `NewCops` overrides the `AllCops` setting for the cops of that department. Since each department is pinned to its own version, extensions with version schemes that differ from RuboCop's can be controlled independently, which resolves the reason the original proposal was rejected.
- A department accepts `enable`, `disable`, `pending`, or a version. The keywords are normalized into the same decision path as the version form: `disable` enables nothing and `enable` enables everything, so they are the two endpoints of the version spectrum rather than a separate concept.
- A version pin enables pending cops whose `VersionAdded` is at or below the pin. Cops added later stay pending and keep emitting the pending cops warning, so users can review them and bump the pin at their own pace. Cops without a comparable `VersionAdded` (missing, `N/A`, or `<<next>>`) are treated as newer than any pin.
- `AllCops: NewCops` still accepts only the keywords. A global version would reintroduce the cross-gem ambiguity described above.
- The `--enable-pending-cops` and `--disable-pending-cops` command-line options keep taking precedence over the configuration file.
- Config-level suppression of the pending cops warning moved from `PendingCopsReporter`  into `Config#pending_cops`, which now excludes cops covered by an effective `NewCops` setting per cop. The reporter previously suppressed the entire warning whenever `AllCops` set `enable` or `disable`, which would hide departments that opt back in with `NewCops: pending` and the newer-than-pin cops of a pinned department.

Fixes #8565.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
