### PR TITLE
[Fix #15445] Fix false positives for `Style/MultilineIfThen`

### DIFF
--- a/changelog/fix_false_positives_for_style_multiline_if_then_20260711223143.md
+++ b/changelog/fix_false_positives_for_style_multiline_if_then_20260711223143.md
@@ -1,0 +1,1 @@
+* [#15445](https://github.com/rubocop/rubocop/issues/15445): Fix false positives in `Style/MultilineIfThen` when using the Prism parser engine and an `elsif` without `then` follows a branch using `then` with a body on the same line. ([@koic][])

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -36,7 +36,13 @@ module RuboCop
         private
 
         def non_modifier_then?(node)
-          node.multiline? && node.then? && node.loc.begin.line != node.if_branch&.loc&.line
+          node.multiline? && own_then?(node) && node.loc.begin.line != node.if_branch&.loc&.line
+        end
+
+        # Prism gives an `elsif` with no `then` of its own the previous branch's `then` location,
+        # which lies outside the node.
+        def own_then?(node)
+          node.then? && node.source_range.contains?(node.loc.begin)
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe RuboCop::Cop::Style::MultilineIfThen, :config do
     RUBY
   end
 
+  it 'accepts `then` with a body on the same line followed by an `elsif` without `then`' do
+    expect_no_offenses(<<~RUBY)
+      if cond1 then a
+      elsif cond2
+        b
+      end
+    RUBY
+  end
+
   it 'accepts table style if/then/elsif/ends' do
     expect_no_offenses(<<~RUBY)
       if    @io == $stdout then str << "$stdout"


### PR DESCRIPTION
This PR fixes false positives for `Style/MultilineIfThen` when using the Prism parser engine and an `elsif` without `then` follows a branch using `then` with a body on the same line:

```ruby
if cond1 then a
elsif cond2
  b
end
```

The root cause is a bug in Prism's `parse_conditional` (`src/prism.c`): the local `then_keyword` token is declared once and reused across the `elsif` loop, so an `elsif` without its own `then` inherits the previous branch's `then` location as its `then_keyword_loc`. Through the parser translation layer, the `elsif` node's `loc.begin` then points at the previous branch's `then`, making `then?` return true and registering an offense whose autocorrection removes that `then` and produces invalid Ruby (`if cond1 a`).

The proper fix belongs in Prism, but RuboCop supports already released Prism versions, so the cop now defensively ignores a `then` location that lies outside the node's own source range. Such a location can only come from a previous branch, and the guard stays harmless once Prism is fixed. The Parser (whitequark) engine is unaffected because it sets no `begin` location for an `elsif` without `then`.

Fixes #15445.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
