### PR TITLE
[Fix #13786] Fix a false positive for `Lint/Void` with setter methods

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_void_with_setter_methods_20260711092150.md
+++ b/changelog/fix_a_false_positive_for_lint_void_with_setter_methods_20260711092150.md
@@ -1,0 +1,1 @@
+* [#13786](https://github.com/rubocop/rubocop/issues/13786): Fix a false positive for `Lint/Void` with setter methods. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -16,11 +16,10 @@ module RuboCop
       # enumerator.each { |item| item >= 2 } #=> [2, 3]
       # ----
       #
-      # NOTE: Return values in assignment method definitions such as `def foo=(arg)` are
-      # detected because they are in a void context. However, autocorrection does not remove
-      # the return value, as that would change behavior. In such cases, whether to remove
-      # the return value or rename the method to something more appropriate should be left to
-      # the user.
+      # NOTE: The last expression in an assignment method definition such as `def foo=(arg)`
+      # is not flagged. Ruby discards it (the method returns its argument), but the method can
+      # still be called directly and its return value relied upon, so flagging it would be a
+      # false positive for this lint.
       #
       # @example CheckForMethodsWithNoSideEffects: false (default)
       #   # bad
@@ -109,7 +108,7 @@ module RuboCop
         def check_begin(node)
           expressions = *node
           inside_each_block = node.each_ancestor(:any_block).first&.method?(:each)
-          expressions.pop if !in_void_context?(node) || inside_each_block
+          expressions.pop if !in_void_context?(node) || inside_each_block || setter_method?(node)
           expressions.each do |expr|
             check_void_op(expr) { inside_each_block }
             check_expression(expr)
@@ -242,6 +241,10 @@ module RuboCop
           return false unless parent && parent.children.last == node
 
           parent.respond_to?(:void_context?) && parent.void_context?
+        end
+
+        def setter_method?(node)
+          node.parent&.any_def_type? && node.parent.assignment_method?
         end
 
         def autocorrect_void_op(corrector, node)

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -878,30 +878,38 @@ RSpec.describe RuboCop::Cop::Lint::Void, :config do
     RUBY
   end
 
-  it 'registers two offenses for void literals in a setter method' do
+  it 'registers an offense only for the non-last void literal in a setter method' do
     expect_offense(<<~RUBY)
       def foo=(rhs)
         42
         ^^ Literal `42` used in void context.
         42
-        ^^ Literal `42` used in void context.
       end
     RUBY
 
     expect_no_corrections
   end
 
-  it 'registers two offenses for void literals in a class setter method' do
+  it 'registers an offense only for the non-last void literal in a class setter method' do
     expect_offense(<<~RUBY)
       def self.foo=(rhs)
         42
         ^^ Literal `42` used in void context.
         42
-        ^^ Literal `42` used in void context.
       end
     RUBY
 
     expect_no_corrections
+  end
+
+  it 'does not register an offense for the return value of a setter method' do
+    expect_no_offenses(<<~RUBY)
+      def name=(name)
+        @name = name
+        reset
+        name
+      end
+    RUBY
   end
 
   it 'registers an offense only for non-last void literal in a `#each` method' do


### PR DESCRIPTION
`Lint/Void` flagged the last expression of a setter method (`def foo=`) as used in a void context. Ruby discards a setter's return value, but the method can still be called directly (`obj.send(:foo=, x)`) and its value relied upon, so flagging it is a false positive for a Lint cop. This stops flagging the return position of assignment methods, while genuinely-void non-last expressions are still reported.

Fixes #13786.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
