### PR TITLE
[Fix #12269] Fix a false positive for `Lint/UselessAssignment` with modifier conditions

### DIFF
--- a/changelog/fix_a_false_positive_for_lint_useless_assignment_with_modifier_conditions_20260711093028.md
+++ b/changelog/fix_a_false_positive_for_lint_useless_assignment_with_modifier_conditions_20260711093028.md
@@ -1,0 +1,1 @@
+* [#12269](https://github.com/rubocop/rubocop/issues/12269): Fix a false positive for `Lint/UselessAssignment` with modifier conditions. ([@bbatsov][])

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -63,7 +63,7 @@ module RuboCop
             # if/unless keyword. A preceding assignment is needed to put the
             # variable in scope. For this reason we skip to the next assignment
             # here.
-            next if in_modifier_conditional?(assignment)
+            next if in_modifier_conditional?(assignment, node)
 
             break if !assignment.branch || assignment.branch == reference.branch
 
@@ -74,12 +74,24 @@ module RuboCop
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-        def in_modifier_conditional?(assignment)
-          parent = assignment.node.parent
-          parent = parent.parent if parent&.begin_type?
-          return false if parent.nil?
+        def in_modifier_conditional?(assignment, reference_node)
+          conditional = modifier_conditional_of(assignment.node)
+          return false unless conditional
 
-          parent.basic_conditional? && parent.modifier_form?
+          # The out-of-scope problem only affects a reference in the modifier body (to the
+          # left of the keyword); a reference after the modifier is put in scope by the
+          # condition's assignment, so an earlier assignment there is genuinely useless.
+          covers?(conditional, reference_node) && !covers?(conditional.condition, reference_node)
+        end
+
+        def modifier_conditional_of(node)
+          node.each_ancestor(:if, :while, :until).find do |conditional|
+            conditional.modifier_form? && covers?(conditional.condition, node)
+          end
+        end
+
+        def covers?(container, node)
+          container.equal?(node) || container.source_range.contains?(node.source_range)
         end
 
         def capture_with_block!

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -15,6 +15,58 @@ RSpec.describe RuboCop::Cop::Lint::UselessAssignment, :config do
         puts a unless a = 123
       RUBY
     end
+
+    it 'accepts when the reassignment is nested in the condition expression' do
+      expect_no_offenses(<<~RUBY)
+        a = nil
+        puts a if (a = 123) != 0
+      RUBY
+    end
+
+    it 'accepts when the reference is inside string interpolation' do
+      expect_no_offenses(<<~'RUBY')
+        nerrs = 0
+        raise "there were #{nerrs}" if (nerrs = get_nerrs) != 0
+      RUBY
+    end
+
+    it 'still registers a useless assignment that follows the modifier' do
+      expect_offense(<<~'RUBY')
+        a = 0
+        puts "x #{a}" if (a = 1) != 0
+        a = 2
+        ^ Useless assignment to variable - `a`.
+      RUBY
+    end
+
+    it 'still registers an earlier assignment shadowed before the modifier' do
+      expect_offense(<<~'RUBY')
+        a = nil
+        ^ Useless assignment to variable - `a`.
+        a = 5
+        puts "x #{a}" if (a = 123) != 0
+      RUBY
+    end
+
+    it 'does not suppress a same-named variable in a different scope' do
+      expect_offense(<<~'RUBY')
+        a = nil
+        ^ Useless assignment to variable - `a`.
+        def foo
+          a = 10
+          puts "x #{a}" if (a = 1) != 0
+        end
+      RUBY
+    end
+
+    it 'still registers an earlier assignment when the reference follows the modifier' do
+      expect_offense(<<~RUBY)
+        x = 0
+        ^ Useless assignment to variable - `x`.
+        y = 1 if (x = 2) > 0
+        puts x, y
+      RUBY
+    end
   end
 
   context 'when a variable is assigned and assigned again in a modifier loop condition' do


### PR DESCRIPTION
In `body if (var = ...)`, Ruby parses the body before the modifier's condition, so a reference to `var` in the body needs `var` to already be declared. VariableForce already accounted for this, but only when the assignment sat directly in the condition, not when it was nested in a larger expression such as `(nerrs = get_nerrs) != 0`. In that case the preceding declaration was reported as a useless assignment, even though removing it raises a `NameError`.

The fix teaches `in_modifier_conditional?` to recognize an assignment anywhere in a modifier condition, and to only treat it as out-of-scope for a reference that sits in the modifier body (a reference after the modifier is genuinely put in scope by the condition's assignment, so an earlier assignment there stays useless).

Fixes #12269.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
