### PR TITLE
Bump SimpleCov to 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,9 @@ gem 'ruby-lsp', '~> 0.24', platform: :mri if RUBY_VERSION >= '3.0'
 # native binaries for MRI on supported platforms, so we gate by `RUBY_ENGINE` to
 # keep JRuby and other engines unaffected.
 gem 'rubydex', require: false if RUBY_VERSION >= '3.2' && RUBY_ENGINE == 'ruby'
-gem 'simplecov', '~> 0.20'
+# SimpleCov 1.0 requires Ruby 3.2+. Coverage measurement is opt-in (`COVERAGE=1`)
+# and unnecessary on the older Rubies in the CI matrix.
+gem 'simplecov', '~> 1.0' if RUBY_VERSION >= '3.2'
 gem 'stackprof', platform: :mri
 gem 'test-queue'
 gem 'yard', '~> 0.9'


### PR DESCRIPTION
SimpleCov 1.0 requires Ruby 3.2+, while the CI matrix still runs Ruby 2.7 through 3.1. There is likely no need to run coverage on older Ruby versions.

Since coverage is opt-in via `COVERAGE=1` and never runs on CI, there is no need to support older Rubies with the 0.x series.

Coverage is therefore enabled only on Ruby 3.2+, omitting the gem entirely on older versions instead of pinning them to SimpleCov 0.x.

All SimpleCov APIs used by this repository (the `SimpleCov.start` block in `.simplecov`, and `command_name` / `result` / `at_exit` in `tasks/spec_runner.rake`) are unchanged in 1.0, and `COVERAGE=1 bundle exec rake spec` generates the merged parallel coverage report as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
