### PR TITLE
[Fix #15261] Mention required parentheses in Style/IfUnlessModifier message

### DIFF
--- a/changelog/change_if_unless_modifier_message_to_mention_parentheses_20260709000000.md
+++ b/changelog/change_if_unless_modifier_message_to_mention_parentheses_20260709000000.md
@@ -1,0 +1,1 @@
+* [#15261](https://github.com/rubocop/rubocop/issues/15261): Mention the required parentheses in the `Style/IfUnlessModifier` offense message when the condition is part of a larger expression. ([@rafa-el-souza][])

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -83,6 +83,10 @@ module RuboCop
         MSG_USE_MODIFIER = 'Favor modifier `%<keyword>s` usage when having a ' \
                            'single-line body. Another good alternative is ' \
                            'the usage of control flow `&&`/`||`.'
+        MSG_USE_MODIFIER_PARENS = 'Favor modifier `%<keyword>s` usage when having a ' \
+                                  'single-line body. Wrap the expression in parentheses ' \
+                                  'to keep the current behavior, as it is part of a ' \
+                                  'larger expression.'
         MSG_USE_NORMAL = 'Modifier form of `%<keyword>s` makes the line too long.'
 
         def self.autocorrect_incompatible_with
@@ -143,7 +147,7 @@ module RuboCop
 
         def message(node)
           if single_line_as_modifier?(node) && !named_capture_in_condition?(node)
-            MSG_USE_MODIFIER
+            parenthesize?(node) ? MSG_USE_MODIFIER_PARENS : MSG_USE_MODIFIER
           elsif too_long_due_to_modifier?(node)
             MSG_USE_NORMAL
           end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -18,8 +18,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   let(:other_cops) { { 'Layout/LineLength' => line_length_config } }
 
   extra = ' Another good alternative is the usage of control flow `&&`/`||`.'
-  it_behaves_like 'condition modifier cop', :if, extra
-  it_behaves_like 'condition modifier cop', :unless, extra
+  parens_message = 'Favor modifier `%s` usage when having a single-line body. ' \
+                   'Wrap the expression in parentheses to keep the current behavior, ' \
+                   'as it is part of a larger expression.'
+  it_behaves_like 'condition modifier cop', :if, extra, format(parens_message, 'if')
+  it_behaves_like 'condition modifier cop', :unless, extra, format(parens_message, 'unless')
 
   context 'modifier if that does not fit on one line' do
     let(:spaces) { ' ' * 59 }
@@ -654,7 +657,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   it 'adds parens in autocorrect when if-end used with `||` operator' do
     expect_offense(<<~RUBY)
       a || if b
-           ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+           ^^ Favor modifier `if` usage when having a single-line body. Wrap the expression in parentheses to keep the current behavior, as it is part of a larger expression.
         1
       end
     RUBY
@@ -667,13 +670,26 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   it 'adds parens in autocorrect when if-end used with `&&` operator' do
     expect_offense(<<~RUBY)
       a && if b
-           ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+           ^^ Favor modifier `if` usage when having a single-line body. Wrap the expression in parentheses to keep the current behavior, as it is part of a larger expression.
         1
       end
     RUBY
 
     expect_correction(<<~RUBY)
       a && (1 if b)
+    RUBY
+  end
+
+  it 'adds parens in autocorrect when if-end is LHS of `||` operator' do
+    expect_offense(<<~RUBY)
+      if b
+      ^^ Favor modifier `if` usage when having a single-line body. Wrap the expression in parentheses to keep the current behavior, as it is part of a larger expression.
+        1
+      end || a
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (1 if b) || a
     RUBY
   end
 
@@ -1228,7 +1244,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         expect_offense(<<~RUBY)
           {
             first_key: if first_cond
-                       ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+                       ^^ Favor modifier `if` usage when having a single-line body. Wrap the expression in parentheses to keep the current behavior, as it is part of a larger expression.
                             first_expr
                           end,
             second_key: (second_expr if second_cond)
@@ -1249,7 +1265,7 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
         expect_offense(<<~RUBY)
           {
             first_key: if first_cond
-                       ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+                       ^^ Favor modifier `if` usage when having a single-line body. Wrap the expression in parentheses to keep the current behavior, as it is part of a larger expression.
                          first_expr
                        end,
             second_key: second_cond ? second_then : second_else

--- a/spec/support/condition_modifier_cop.rb
+++ b/spec/support/condition_modifier_cop.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
+RSpec.shared_examples 'condition modifier cop' do |keyword, extra = nil, parens_message = nil|
+  base_message = "Favor modifier `#{keyword}` usage when having a single-line body."
+  parenthesized_message = parens_message || "#{base_message}#{extra}"
+
   let(:other_cops) { { 'Layout/LineLength' => { 'Max' => 80 } } }
 
   context "for a multiline '#{keyword}'" do
@@ -36,7 +39,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
       it 'registers an offense even for a long modifier statement' do
         expect_offense(<<~RUBY, keyword: keyword)
           %{keyword} foo
-          ^{keyword} Favor modifier `#{keyword}` usage when having a single-line body.#{extra_message}
+          ^{keyword} Favor modifier `#{keyword}` usage when having a single-line body.#{extra}
             "This string would make the line longer than eighty characters if combined with the statement."
           end
         RUBY
@@ -55,7 +58,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it 'corrects it if result fits in one line' do
       expect_offense(<<~RUBY, keyword: keyword)
         %{keyword} condition
-        ^{keyword} Favor modifier `#{keyword}` usage when having a single-line body.#{extra_message}
+        ^{keyword} Favor modifier `#{keyword}` usage when having a single-line body.#{extra}
           do_something
         end
       RUBY
@@ -83,7 +86,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it 'corrects it when assignment is in body' do
       expect_offense(<<~RUBY, keyword: keyword)
         %{keyword} true
-        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra}
           x = 0
         end
       RUBY
@@ -96,7 +99,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it "doesn't break when used as RHS of local var assignment" do
       expect_offense(<<~RUBY, keyword: keyword)
         a = %{keyword} b
-            ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+            ^{keyword} #{parenthesized_message}
           1
         end
       RUBY
@@ -109,7 +112,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it "doesn't break when used as RHS of instance var assignment" do
       expect_offense(<<~RUBY, keyword: keyword)
         @a = %{keyword} b
-             ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+             ^{keyword} #{parenthesized_message}
           1
         end
       RUBY
@@ -122,7 +125,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it "doesn't break when used as RHS of class var assignment" do
       expect_offense(<<~RUBY, keyword: keyword)
         @@a = %{keyword} b
-              ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+              ^{keyword} #{parenthesized_message}
           1
         end
       RUBY
@@ -135,7 +138,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it "doesn't break when used as RHS of constant assignment" do
       expect_offense(<<~RUBY, keyword: keyword)
         A = %{keyword} b
-            ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+            ^{keyword} #{parenthesized_message}
           1
         end
       RUBY
@@ -148,7 +151,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it "doesn't break when used as RHS of binary arithmetic" do
       expect_offense(<<~RUBY, keyword: keyword)
         a + %{keyword} b
-            ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+            ^{keyword} #{parenthesized_message}
           1
         end
       RUBY
@@ -161,7 +164,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it 'handles inline comments during autocorrection' do
       expect_offense(<<~RUBY, keyword: keyword)
         %{keyword} bar # important comment not to be nuked
-        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra}
           baz
         end
       RUBY
@@ -174,7 +177,7 @@ RSpec.shared_examples 'condition modifier cop' do |keyword, extra_message = nil|
     it 'handles one-line usage' do
       expect_offense(<<~RUBY, keyword: keyword)
         %{keyword} foo; bar; end
-        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra_message}
+        ^{keyword} Favor modifier `%{keyword}` usage when having a single-line body.#{extra}
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
Fixes #15261, following the direction confirmed in
https://github.com/rubocop/rubocop/issues/15261#issuecomment-4950295633.

**Problem**

`Style/IfUnlessModifier` also flags `if`/`end` blocks that are part of a
larger expression:

```ruby
if $need
  $load
end || $file
```

Autocorrect handles this correctly — `parenthesize?` wraps the replacement,
producing `($load if $need) || $file`. But the offense message ("Favor
modifier `if` usage when having a single-line body...") never mentions the
parentheses, so fixing the offense *manually* naturally yields:

```ruby
$load || $file if $need
```

which changes behavior: modifier `if` has lower precedence than `||`, so with
`$need = false` the original expression evaluates to `$file` while the manual
rewrite evaluates to `nil`.

**Fix**

Message-only change: when `parenthesize?` applies, use a message variant that
calls out the required parentheses:

> Favor modifier `if` usage when having a single-line body. Wrap the
> expression in parentheses to keep the current behavior, as it is part of a
> larger expression.

Detection and autocorrection are unchanged.

Notes:

- `Style/WhileUntilModifier` shares `StatementModifier` and has the same
  messaging gap; left unchanged on purpose to keep this PR focused on the
  reported issue — happy to follow up separately.
- The shared examples in `spec/support/condition_modifier_cop.rb` gained a
  `parens_message` parameter so each cop can declare its expected message in
  the parenthesized context.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/