### PR TITLE
Fix a false positive for Layout/HashAlignment with table style and a multiline key

### DIFF
--- a/changelog/fix_a_false_positive_for_layout_hash_alignment.md
+++ b/changelog/fix_a_false_positive_for_layout_hash_alignment.md
@@ -1,0 +1,1 @@
+* [#15452](https://github.com/rubocop/rubocop/pull/15452): Fix a false positive for `Layout/HashAlignment` when using `EnforcedHashRocketStyle: table` and a hash key spans multiple lines. ([@dduugg][])

--- a/lib/rubocop/cop/mixin/hash_alignment_styles.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment_styles.rb
@@ -96,20 +96,37 @@ module RuboCop
         end
 
         def hash_rocket_delta(first_pair, current_pair)
-          first_pair.loc.column + max_key_width(first_pair.parent) + 1 -
-            current_pair.loc.operator.column
+          target_operator_column(first_pair) - current_pair.loc.operator.column
         end
 
         def value_delta(first_pair, current_pair)
-          correct_value_column = first_pair.key.loc.column +
-                                 max_key_width(first_pair.parent) +
-                                 max_delimiter_width(first_pair.parent)
+          correct_value_column = target_operator_column(first_pair) +
+                                 max_delimiter_width(first_pair.parent) - 1
 
           current_pair.value_omission? ? 0 : correct_value_column - current_pair.value.loc.column
         end
 
+        # The column the separator should land on: the shared key margin
+        # plus the widest single-line key, or, if larger, a multiline key's
+        # own last-line end column. The latter can't be measured from a
+        # multiline key's (newline-including) source length, so it's a
+        # separate candidate rather than folded into `max_key_width`.
+        def target_operator_column(first_pair)
+          hash_node = first_pair.parent
+          candidates = multiline_key_end_columns(hash_node)
+
+          key_width = max_key_width(hash_node)
+          candidates << (first_pair.loc.column + key_width + 1) if key_width.positive?
+
+          candidates.max
+        end
+
+        def multiline_key_end_columns(hash_node)
+          hash_node.keys.reject(&:single_line?).map { |key| key.source_range.end.column + 1 }
+        end
+
         def max_key_width(hash_node)
-          hash_node.keys.map { |key| key.source.length }.max
+          hash_node.keys.select(&:single_line?).map { |key| key.source.length }.max || 0
         end
 
         def max_delimiter_width(hash_node)

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -883,6 +883,103 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       RUBY
     end
 
+    it 'accepts a hash rocket pair whose key spans multiple lines' do
+      expect_no_offenses(<<~RUBY)
+        delegate [
+          :allow_network_access!,
+          :deny_network_access!,
+          :network_access_allowed?,
+        ] => :"self.class"
+      RUBY
+    end
+
+    it 'registers an offense and corrects a hash rocket pair whose key spans multiple ' \
+       'lines to align it with the other, single-line-keyed pairs' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'short' => 1,
+          [
+          ^ Align the keys and values of a hash literal if they span more than one line.
+            :a,
+            :b,
+          ] => :val,
+          'x' => 2,
+          ^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'short' => 1,
+          [
+            :a,
+            :b,
+          ]       => :val,
+          'x'     => 2,
+        }
+      RUBY
+    end
+
+    it 'aligns the other pairs to a multiline key instead of corrupting it, when the ' \
+       'multiline key\'s last line has content close to the operator' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'short' => 1,
+          ^^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+          [ :a,
+            :a_very_long_hash_key, ] => :val,
+          'x'     => 2,
+          ^^^^^^^^^^^^ Align the keys and values of a hash literal if they span more than one line.
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'short'                    => 1,
+          [ :a,
+            :a_very_long_hash_key, ] => :val,
+          'x'                        => 2,
+        }
+      RUBY
+    end
+
+    it 'registers an offense and corrects a multiline key\'s separator when it has ' \
+       'excess whitespace' do
+      expect_offense(<<~RUBY)
+        hash = {
+          'short' => 1,
+          [
+          ^ Align the keys and values of a hash literal if they span more than one line.
+            :a,
+          ]         => :val,
+          'x'     => 2,
+        }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash = {
+          'short' => 1,
+          [
+            :a,
+          ]       => :val,
+          'x'     => 2,
+        }
+      RUBY
+    end
+
+    it 'accepts a multiline hash with no single-line keys' do
+      expect_no_offenses(<<~RUBY)
+        hash = {
+          [
+            :a,
+          ] => 1,
+          [
+            :b,
+          ] => 2,
+        }
+      RUBY
+    end
+
     it 'accepts hashes that use different separators' do
       expect_no_offenses(<<~RUBY)
         hash = {


### PR DESCRIPTION
Fixes a false positive for `Layout/HashAlignment` when `EnforcedHashRocketStyle: table` (or `EnforcedColonStyle: table`) is configured and a hash pair's key spans multiple lines, e.g.:

```ruby
delegate [
  :allow_network_access!,
  :deny_network_access!,
  :network_access_allowed?,
] => :"self.class"
```

### The bug

`TableAlignment#max_key_width` computed a key's width via `key.source.length`. When the key itself is a multiline literal (like the array above), `.source` includes the embedded newlines and indentation, so `.length` returns a large, meaningless number. That bogus width got inserted as whitespace before the separator/value:

```ruby
delegate [
  :allow_network_access!,
  :deny_network_access!,
  :network_access_allowed?,
]                                                                                                   => :"self.class"
```

Since that bogus width is always *larger* than any real width, the master bug only ever inserts excess whitespace — it can't corrupt the key. That's worth calling out because it constrains what "the fix" can safely be: the natural instinct is to replace the single-line siblings' width with a target derived purely from a multiline key's own last-line end column, but if a multiline-keyed pair coexists with single-line-keyed siblings whose last line has real content close to the operator (e.g. `[ :a,\n  :a_very_long_hash_key, ] => :val,`), that naive replacement can compute a target column *smaller* than where the operator currently sits, and the correction — which repositions the operator by removing characters immediately before it — would end up deleting part of the key itself instead of just whitespace. (I caught this myself in review before it ever reached master, while iterating on this PR.)

### The fix

`max_key_width` itself is unchanged in spirit but now only considers single-line keys, so it no longer produces that bogus, newline-inflated number. Separately, the target column computation (`target_operator_column`) now takes the max across two *independent* candidate sources:
* `max_key_width`'s single-line-only result (the shared key margin plus the widest single-line key, as before), and
* for each multiline key, a brand new candidate: that key's own last-line **end column** (computed directly from its source range, not from `max_key_width`).

Using each multiline key's own end column as a lower-bound candidate guarantees the correction only ever inserts whitespace before a multiline key's separator, or removes whitespace that's actually there — never past the key itself. Because the two candidate sources are independent, single-line and multiline keys can coexist in the same table-aligned hash: whichever needs more room (the widest single-line key, or a multiline key's own natural end column) sets the column everything aligns to. A hash containing only multiline keys still gets a safe target derived purely from the multiline candidates (since `max_key_width` contributes nothing when there are no single-line keys), rather than skipping alignment altogether.

Covered by new specs for: a lone multiline-keyed pair (nothing to align to), a multiline pair aligned to wider single-line siblings, single-line siblings pushed out to match a wider multiline pair without corrupting it, excess whitespace trimmed off a multiline pair, and a hash with no single-line keys at all.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). (N/A — no separate issue was filed; this PR is the only tracking reference, linked from the changelog entry)
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code. (couldn't run this exact task locally since `bundle install` fails due to an unrelated `mcp` gem version mismatch in `Gemfile.lock`; instead ran the full spec suite and RuboCop-on-itself against the changed files directly, verified no corruption/idempotency by round-tripping several fixtures through the real CLI with `ruby -c` syntax checks, and CI's full matrix — including `internal_investigation` — is green)
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/



