### PR TITLE
[Fix #15453] Fix an error for `Metrics/MethodLength`

### DIFF
--- a/changelog/fix_an_error_for_metrics_method_length_cop.md
+++ b/changelog/fix_an_error_for_metrics_method_length_cop.md
@@ -1,0 +1,1 @@
+* [#15453](https://github.com/rubocop/rubocop/issues/15453): Fix an error for `Metrics/MethodLength` when a method contains a heredoc and `__ENCODING__`. ([@koic][])

--- a/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
+++ b/lib/rubocop/cop/metrics/utils/code_length_calculator.rb
@@ -189,7 +189,7 @@ module RuboCop
           def source_from_node_with_heredoc(node)
             last_line = -1
             node.each_descendant do |descendant|
-              next unless descendant.source
+              next if descendant.loc.nil? || descendant.source_range.nil?
 
               descendant_last_line =
                 if heredoc_node?(descendant)

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -283,6 +283,20 @@ RSpec.describe RuboCop::Cop::Metrics::MethodLength, :config do
     RUBY
   end
 
+  it 'registers an offense when a method contains a heredoc and `__ENCODING__`' do
+    expect_offense(<<~RUBY)
+      def m
+      ^^^^^ Method has too many lines. [6/5]
+        a = 1
+        a = 2
+        a = <<~TEXT
+          text
+        TEXT
+        __ENCODING__
+      end
+    RUBY
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 


### PR DESCRIPTION
This commit fixes the following error for `Metrics/MethodLength` when a method contains a heredoc and `__ENCODING__`:

```console
undefined method 'expression' for nil (NoMethodError)
```

`__ENCODING__` is desugared by the modern AST builder into `s(:const, s(:const, nil, :Encoding), :UTF_8)`, where the inner `const` node is synthesized and its `loc` is `nil`. This happens with both the parser and prism engines.

`CodeLengthCalculator#source_from_node_with_heredoc` guards descendants with `descendant.source`, but `Node#source` is implemented as `loc.expression&.source`, so it raises `NoMethodError` when `loc` itself is `nil`.

The guard originally checked `descendant.loc`, which was safe for this case, but fa8c74edf changed it to `descendant.source` to skip nodes whose location has no expression (e.g. an empty `args` node in a block without block arguments). That change regressed the `nil` location case. The new guard checks both conditions explicitly, keeping the fa8c74edf behavior while restoring safety for synthesized nodes without a location.

Fixes #15453.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
