### PR TITLE
[Fix #15454] Fix an error for `Style/RedundantFormat`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_format_variable_width.md
+++ b/changelog/fix_an_error_for_style_redundant_format_variable_width.md
@@ -1,0 +1,1 @@
+* [#15454](https://github.com/rubocop/rubocop/issues/15454): Fix an error for `Style/RedundantFormat` when the argument for a positional variable width is missing. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -183,7 +183,7 @@ module RuboCop
           return false unless sequence.variable_width?
 
           argument = arguments[sequence.variable_width_argument_number - 1]
-          !numeric?(argument)
+          argument.nil? || !numeric?(argument)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -311,6 +311,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             RUBY
           end
 
+          it 'does not register an offense when the positional variable width argument is missing' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%*9$d', 1)
+            RUBY
+          end
+
           it 'does not register an offense when the star argument is not literal' do
             expect_no_offenses(<<~RUBY)
               #{method}('%*s', foo, 'bar')


### PR DESCRIPTION
This commit fixes the following error for `Style/RedundantFormat` when the argument for a positional variable width is missing:

```console
undefined method 'type?' for nil (NoMethodError)
```

For example, `sprintf("%*9$d", 1)` takes its width from the 9th argument, which does not exist. `unknown_variable_width?` indexed into the argument list and passed the resulting `nil` to `numeric?`, which calls `type?` on it.

A missing width argument means the width is unknown, so the sequence is now treated the same as a non-numeric width argument and no offense is registered. Such a call raises `ArgumentError` at runtime anyway, so the cop should leave it untouched.

Fixes #15454.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
