### PR TITLE
[Fix #15458] Improve performance for large collection literals

### DIFF
--- a/changelog/change_fix_performance_for_layout_line_length.md
+++ b/changelog/change_fix_performance_for_layout_line_length.md
@@ -1,0 +1,1 @@
+* [#15458](https://github.com/rubocop/rubocop/issues/15458): Improve `Layout/LineLength` performance on files with large collection literals. ([@koic][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -61,11 +61,13 @@ module RuboCop
       # @api private
       def extract_breakable_node_from_elements(node, elements, max)
         return unless breakable_collection?(node, elements)
-        return if safe_to_ignore?(node)
 
+        # Check the cheap conditions first, `safe_to_ignore?` may traverse all elements of
+        # a containing collection.
         line = processed_source.lines[node.first_line - 1]
+        return if max && line.length <= max
         return if processed_source.line_with_comment?(node.loc.line)
-        return if line.length <= max
+        return if safe_to_ignore?(node)
 
         extract_first_element_over_column_limit(node, elements, max)
       end
@@ -173,20 +175,36 @@ module RuboCop
         node.each_ancestor.find do |ancestor|
           if ancestor.type?(:hash, :array) &&
              breakable_collection?(ancestor, ancestor.children)
-            return children_could_be_broken_up?(ancestor.children)
+            return children_could_be_broken_up?(ancestor, ancestor.children)
           end
 
           next unless ancestor.call_type?
 
           args = process_args(ancestor.arguments)
-          return children_could_be_broken_up?(args) if breakable_collection?(ancestor, args)
+          if breakable_collection?(ancestor, args)
+            return children_could_be_broken_up?(ancestor, args)
+          end
         end
 
         false
       end
 
       # @api private
-      def children_could_be_broken_up?(children)
+      # The result depends only on the given node, but the check may traverse all children of
+      # a large collection and is repeated for each contained element, so memoize it per node.
+      def children_could_be_broken_up?(node, children)
+        if @check_line_breakable_processed_source != processed_source
+          @check_line_breakable_processed_source = processed_source
+          @children_could_be_broken_up_cache = {}.compare_by_identity
+        end
+
+        @children_could_be_broken_up_cache.fetch(node) do
+          @children_could_be_broken_up_cache[node] = compute_children_could_be_broken_up?(children)
+        end
+      end
+
+      # @api private
+      def compute_children_could_be_broken_up?(children)
         return false if all_on_same_line?(children)
 
         last_seen_line = -1

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -664,6 +664,17 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
     end
   end
 
+  it 'checks a large collection literal with one element per line in a reasonable amount of time' do
+    # Should take under a second, but 5 seconds is plenty of margin.
+    Timeout.timeout(5) do
+      expect_no_offenses(<<~RUBY)
+        [
+          #{Array.new(10_000) { |n| format("['%04X', 0x%04X],", n, n) }.join("\n  ")}
+        ]
+      RUBY
+    end
+  end
+
   context 'affecting by IndentationWidth from Layout\Tab' do
     shared_examples 'with tabs indentation' do
       it "registers an offense for a line that's including 2 tab with size 2 " \


### PR DESCRIPTION
`Layout/LineLength` took quadratic time on files containing a large collection literal with one element per line, e.g. a 60k-element array table. Doubling the number of elements roughly quadrupled the inspection time (4000 elements: 4.0s, 8000 elements: 13.8s).

The cop calls `CheckLineBreakable#extract_breakable_node` for every element node of the collection, and for each of them `safe_to_ignore?` walked up to the containing collection and scanned all of its children in `children_could_be_broken_up?`. That is O(n) work per element, O(n^2) in total. When no line exceeds `Max`, all of this work is wasted because the element is discarded right after by the cheap line length guard.

This commit applies two changes to `CheckLineBreakable`:

- Check the cheap line length and comment guards before the expensive `safe_to_ignore?` in `extract_breakable_node_from_elements`. All guards are independent, so the reordering does not change the result. Since `max` was previously guarded only inside `safe_to_ignore?`, the line length check is skipped when `max` is `nil`.
- Memoize `children_could_be_broken_up?` per containing collection node, since it was recomputed with an identical result for each contained element. The cache is invalidated when `processed_source` changes, so it does not depend on the cop instance lifecycle.

With this change, the benchmark above becomes linear: 1.1s for 4000 elements and 1.5s for 8000 elements, most of which is startup time. Offense output is unchanged, including files whose collection lines exceed `Max`.

A `Timeout`-guarded regression spec inspects a 10,000-element collection literal, which takes about 0.3 seconds with this change and hits the 5-second timeout without it.

Fixes #15458.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
