### PR TITLE
[Fix #15433] Mark `Lint/SafeNavigationChain` autocorrection as unsafe

### DIFF
--- a/changelog/change_mark_lint_safe_navigation_chain_as_unsafe_autocorrect.md
+++ b/changelog/change_mark_lint_safe_navigation_chain_as_unsafe_autocorrect.md
@@ -1,0 +1,1 @@
+* [#15433](https://github.com/rubocop/rubocop/issues/15433): Mark `Lint/SafeNavigationChain` autocorrection as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2409,8 +2409,9 @@ Lint/ReturnInVoidContext:
 Lint/SafeNavigationChain:
   Description: 'Do not chain ordinary method call after safe navigation operator.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.47'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   AllowedMethods:
     - present?
     - blank?

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -9,6 +9,13 @@ module RuboCop
       # safe navigation operator after a safe navigation operator.
       # This cop checks for the problem outlined above.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because it changes the behavior of
+      #   the code: `x&.foo.bar` raises `NoMethodError` when `x` or `x&.foo` is `nil`,
+      #   whereas the corrected `x&.foo&.bar` returns `nil` instead. The autocorrection
+      #   also assumes that extending safe navigation through the chain is intended,
+      #   while removing the first `&.` may be what was intended instead.
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -37,6 +37,16 @@ module RuboCop
       #   x&.foo      # raises NoMethodError
       #   ----
       #
+      #   Additionally, when a method chain is converted, a `NoMethodError` that
+      #   the original code raised for an intermediate `nil` value is suppressed:
+      #
+      #   [source,ruby]
+      #   ----
+      #   x = Struct.new(:foo).new(nil)
+      #   x && x.foo.bar  # raises NoMethodError
+      #   x&.foo&.bar     # returns nil
+      #   ----
+      #
       # @example
       #   # bad
       #   foo.bar if foo


### PR DESCRIPTION
Extending safe navigation through a method chain changes the behavior of the code when an intermediate value is `nil`: `x&.foo.bar` raises `NoMethodError` when `x` or `x&.foo` is `nil`, whereas the corrected `x&.foo&.bar` returns `nil`, masking an exception the author may have wanted. The autocorrection also assumes that extending safe navigation is intended, while removing the first `&.` may be what was intended instead.

Since the correction does not preserve intent, it should only be applied with `rubocop -A`, like the neighboring `Lint/SafeNavigationConsistency` whose autocorrection is already marked as unsafe.

`Style/SafeNavigation` performs the same chain-extending transformation and its autocorrection is already marked as unsafe, but its `@safety` section only documented the case where the receiver is `false`. This change also documents the masked `NoMethodError` hazard there, since it stems from the same transformation.

Fixes #15433.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
