### PR TITLE
Change `Lint/DuplicateMethods` to detect duplicates across files

### DIFF
--- a/changelog/change_lint_duplicate_methods_to_detect_duplicates_across_files_20260715092531.md
+++ b/changelog/change_lint_duplicate_methods_to_detect_duplicates_across_files_20260715092531.md
@@ -1,0 +1,1 @@
+* [#15462](https://github.com/rubocop/rubocop/pull/15462): Change `Lint/DuplicateMethods` to detect duplicates across files when `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/changelog/fix_lint_constant_reassignment_error_on_built_in_constant_names_20260715091419.md
+++ b/changelog/fix_lint_constant_reassignment_error_on_built_in_constant_names_20260715091419.md
@@ -1,0 +1,1 @@
+* [#15462](https://github.com/rubocop/rubocop/pull/15462): Fix an error for `Lint/ConstantReassignment` when a built-in constant name is assigned and `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1877,6 +1877,7 @@ Lint/DuplicateMethods:
   Description: 'Checks for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
+  VersionChanged: '<<next>>'
 
 Lint/DuplicateRegexpCharacterClassElement:
   Description: 'Checks for duplicate elements in Regexp character classes.'

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -1818,7 +1818,7 @@ end
 | Yes
 | No
 | 0.29
-| -
+| <<next>>
 |===
 
 Checks for duplicated instance (or singleton) method
@@ -1827,6 +1827,17 @@ definitions.
 NOTE: Aliasing a method to itself is allowed, as it indicates that
 the developer intends to suppress Ruby's method redefinition warnings.
 See https://bugs.ruby-lang.org/issues/13574.
+
+By default the cop can only detect duplicates within a single file.
+When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+the cop additionally consults the project-wide index and reports methods
+whose duplicate definition lives in another file.
+
+NOTE: The project index does not record whether a definition in another
+file is wrapped in a conditional, so a platform-specific redefinition in
+another file may still be reported. Aliasing the method to itself (see above)
+before redefining marks the redefinition as intentional and is respected
+across files.
 
 [#examples-lintduplicatemethods]
 === Examples

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -49,6 +49,28 @@ CROSS_FILE_CONST = :second
 ----
 
 With `UseProjectIndex: true`, RuboCop reports a `Lint/ConstantReassignment` offense referencing the other file.
+
+`Lint/DuplicateMethods` reports methods whose duplicate definition lives in another file.
+For example:
+
+[source,ruby]
+----
+# a.rb
+class Foo
+  def bar; end
+end
+
+# b.rb
+class Foo
+  def bar; end
+end
+----
+
+With `UseProjectIndex: true`, RuboCop reports a `Lint/DuplicateMethods` offense in each file,
+referencing the definition in the other one. Redefining a method from another file on purpose
+(e.g. a monkey patch) can be signaled with the self-alias trick (`alias bar bar` right before
+the redefinition), which also suppresses Ruby's method redefinition warning.
+
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 
 == Notes

--- a/lib/rubocop/cop/lint/constant_reassignment.rb
+++ b/lib/rubocop/cop/lint/constant_reassignment.rb
@@ -209,20 +209,11 @@ module RuboCop
         def report_cross_file_collision(node, fully_qualified_name, display_name)
           return unless project_index
           return unless (declaration = project_index[fully_qualified_name.delete_prefix('::')])
-          return unless (prior = prior_definition_in_other_file(declaration))
+          return unless (prior = prior_definition_in_other_file(declaration.definitions))
 
           msg = format(CROSS_FILE_MSG, constant: display_name, path: prior.location.to_file_path)
 
           add_offense(node, message: msg)
-        end
-
-        def prior_definition_in_other_file(declaration)
-          current = processed_source.file_path
-
-          declaration.definitions.find do |definition|
-            other = definition.location.to_file_path
-            !File.identical?(other, current)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -10,6 +10,17 @@ module RuboCop
       # the developer intends to suppress Ruby's method redefinition warnings.
       # See https://bugs.ruby-lang.org/issues/13574.
       #
+      # By default the cop can only detect duplicates within a single file.
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+      # the cop additionally consults the project-wide index and reports methods
+      # whose duplicate definition lives in another file.
+      #
+      # NOTE: The project index does not record whether a definition in another
+      # file is wrapped in a conditional, so a platform-specific redefinition in
+      # another file may still be reported. Aliasing the method to itself (see above)
+      # before redefining marks the redefinition as intentional and is respected
+      # across files.
+      #
       # @example
       #
       #   # bad
@@ -119,7 +130,15 @@ module RuboCop
       #   end
       #
       class DuplicateMethods < Base # rubocop:disable Metrics/ClassLength
+        include ProjectIndexHelp
+
         MSG = 'Method `%<method>s` is defined at both %<defined>s and %<current>s.'
+
+        # Method names the cop registers that can be looked up in the project index:
+        # a fully qualified namespace followed by `#` (instance) or `.` (singleton)
+        # and the method name.
+        INDEXABLE_METHOD_NAME =
+          /\A(?<owner>[A-Z]\w*(?:::[A-Z]\w*)*)(?<separator>[#.])(?<name>[^#.]+)\z/.freeze
         RESTRICT_ON_SEND = %i[alias_method attr_reader attr_writer attr_accessor attr
                               delegate def_delegator def_instance_delegator def_delegators
                               def_instance_delegators].freeze
@@ -128,6 +147,14 @@ module RuboCop
           super
           @definitions = {}
           @scopes = Hash.new { |hash, key| hash[key] = [] }
+          @self_aliased = Set.new
+        end
+
+        def on_new_investigation
+          # The self-alias trick declares an intentional redefinition only within
+          # the file that uses it, so the tracked names do not carry over.
+          @self_aliased = Set.new
+          super
         end
 
         def on_def(node)
@@ -157,7 +184,11 @@ module RuboCop
         def on_alias(node)
           name, original_name = method_alias?(node)
           return unless name && original_name
-          return if name == original_name
+
+          if name == original_name
+            track_self_alias(node, name)
+            return
+          end
           return if node.ancestors.any?(&:if_type?)
 
           found_instance_method(node, name)
@@ -208,7 +239,10 @@ module RuboCop
           name, original_name = alias_method?(node)
 
           if name && original_name
-            return if name == original_name
+            if name == original_name
+              track_self_alias(node, name)
+              return
+            end
             return if inside_condition?(node)
 
             found_instance_method(node, name)
@@ -340,27 +374,45 @@ module RuboCop
           found_method(node, "#{singleton_receiver_node.method_name}.#{name}")
         end
 
-        # rubocop:disable Metrics/AbcSize
         def found_method(node, method_name, scope_id: nil)
           key = method_key(node, method_name)
           key = "#{key}@#{scope_id}" if scope_id
           scope = node.each_ancestor(:rescue, :ensure).first&.type
 
           if @definitions.key?(key)
-            if scope && !@scopes[scope].include?(key)
-              @definitions[key] = node
-              @scopes[scope] << key
-              return
-            end
-
-            message = message_for_dup(node, method_name, key)
-
-            add_offense(location(node), message: message)
+            found_redefinition(node, method_name, key, scope)
           else
             @definitions[key] = node
+            check_cross_file_duplicate(node, method_name) if scope_id.nil? && scope.nil?
           end
         end
-        # rubocop:enable Metrics/AbcSize
+
+        def found_redefinition(node, method_name, key, scope)
+          if scope && !@scopes[scope].include?(key)
+            @definitions[key] = node
+            @scopes[scope] << key
+          elsif intentional_cross_file_redefinition?(node, method_name, key)
+            @definitions[key] = node
+          else
+            add_offense(location(node), message: message_for_dup(node, method_name, key))
+          end
+        end
+
+        # The self-alias trick (`alias foo foo` or `alias_method :foo, :foo` right before
+        # a `def`) suppresses Ruby's method redefinition warning, signaling an intentional
+        # redefinition of a method defined in another file.
+        def intentional_cross_file_redefinition?(node, method_name, key)
+          @self_aliased.include?(method_name) &&
+            @definitions[key].source_range.source_buffer.name !=
+              node.source_range.source_buffer.name
+        end
+
+        def track_self_alias(node, name)
+          scope = node.parent_module_name
+          return unless scope
+
+          @self_aliased << "#{humanize_scope(scope)}#{name}"
+        end
 
         def method_key(node, method_name)
           if (ancestor_def = node.each_ancestor(:any_def).first)
@@ -438,6 +490,74 @@ module RuboCop
           range = node.source_range
           path = smart_path(range.source_buffer.name)
           "#{path}:#{range.line}"
+        end
+
+        def check_cross_file_duplicate(node, method_name)
+          return unless project_index
+          return if @self_aliased.include?(method_name)
+          return if node.each_ancestor(:any_def).any?
+          return unless (prior = cross_file_prior_definition(method_name))
+
+          message = format(MSG, method: method_name,
+                                defined: index_source_location(prior),
+                                current: source_location(node))
+          add_offense(location(node), message: message)
+        end
+
+        def cross_file_prior_definition(method_name)
+          return unless (match = INDEXABLE_METHOD_NAME.match(method_name))
+
+          definitions = definitions_in_other_files(
+            indexed_definitions(match[:owner], match[:separator], match[:name])
+          )
+          return if definitions.empty? || cross_file_self_alias_trick?(definitions)
+
+          first_indexed_definition(definitions)
+        end
+
+        def indexed_definitions(owner, separator, name)
+          namespace = separator == '.' ? "#{owner}::<#{owner.split('::').last}>" : owner
+
+          if name.match?(/\A\w+=\z/)
+            # Rubydex indexes `attr_writer :foo` under `foo` rather than `foo=`, so
+            # writer definitions come from both the `foo=` and the `foo` declarations.
+            indexed_declaration_definitions(namespace, name) +
+              indexed_declaration_definitions(namespace, name.delete_suffix('='))
+              .select { |definition| writer_attr_definition?(definition) }
+          else
+            indexed_declaration_definitions(namespace, name).grep_v(Rubydex::AttrWriterDefinition)
+          end
+        end
+
+        def indexed_declaration_definitions(namespace, name)
+          project_index["#{namespace}##{name}()"]&.definitions.to_a
+        end
+
+        def writer_attr_definition?(definition)
+          definition.is_a?(Rubydex::AttrWriterDefinition) ||
+            definition.is_a?(Rubydex::AttrAccessorDefinition)
+        end
+
+        # An alias of the method alongside one of its definitions in another file may be
+        # the self-alias trick marking an intentional redefinition there, so no offense
+        # is registered. A genuine `alias` duplicate is still reported when the alias
+        # itself is inspected.
+        def cross_file_self_alias_trick?(definitions)
+          aliases, others = definitions.partition do |definition|
+            definition.is_a?(Rubydex::MethodAliasDefinition)
+          end
+          alias_paths = aliases.map { |definition| definition.location.to_file_path }
+
+          others.any? { |definition| alias_paths.include?(definition.location.to_file_path) }
+        end
+
+        def first_indexed_definition(definitions)
+          definitions.find { |definition| !definition.is_a?(Rubydex::MethodAliasDefinition) }
+        end
+
+        def index_source_location(definition)
+          location = definition.location
+          "#{smart_path(location.to_file_path)}:#{location.to_display.start_line}"
         end
       end
     end

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -27,6 +27,25 @@ module RuboCop
 
       private
 
+      # Returns the definitions among `definitions` that live in a file other than the
+      # one being inspected, ordered by path and line. Definitions without a `file://`
+      # URI (e.g. Rubydex's built-in declarations) are ignored.
+      def definitions_in_other_files(definitions)
+        current = processed_source.file_path
+
+        definitions
+          .select { |definition| definition.location.uri.start_with?(FILE_URI_PREFIX) }
+          .reject { |definition| File.identical?(definition.location.to_file_path, current) }
+          .sort_by do |definition|
+          [definition.location.to_file_path,
+           definition.location.start_line]
+        end
+      end
+
+      def prior_definition_in_other_file(definitions)
+        definitions_in_other_files(definitions).first
+      end
+
       def project_index_signature
         project_index.documents.filter_map do |doc|
           uri = doc.uri

--- a/spec/fixtures/cross_file_duplicate_methods/a.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/a.rb
@@ -1,0 +1,4 @@
+class A
+  def some_method
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/b.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/b.rb
@@ -1,0 +1,4 @@
+class A
+  def some_method
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/c.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/c.rb
@@ -1,0 +1,3 @@
+class B
+  attr_reader :shared_attr
+end

--- a/spec/fixtures/cross_file_duplicate_methods/d.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/d.rb
@@ -1,0 +1,3 @@
+class B
+  attr_writer :shared_attr
+end

--- a/spec/fixtures/cross_file_duplicate_methods/e.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/e.rb
@@ -1,0 +1,3 @@
+class C
+  attr_writer :val
+end

--- a/spec/fixtures/cross_file_duplicate_methods/f.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/f.rb
@@ -1,0 +1,4 @@
+class C
+  def val=(value)
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/g.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/g.rb
@@ -1,0 +1,4 @@
+class D
+  def self.build
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/h.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/h.rb
@@ -1,0 +1,4 @@
+class D
+  def self.build
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/i.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/i.rb
@@ -1,0 +1,4 @@
+class E
+  def unique_method
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/j.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/j.rb
@@ -1,0 +1,4 @@
+class F
+  def patched
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods/k.rb
+++ b/spec/fixtures/cross_file_duplicate_methods/k.rb
@@ -1,0 +1,5 @@
+class F
+  alias_method :patched, :patched
+  def patched
+  end
+end

--- a/spec/rubocop/cop/lint/constant_reassignment_spec.rb
+++ b/spec/rubocop/cop/lint/constant_reassignment_spec.rb
@@ -661,6 +661,24 @@ RSpec.describe RuboCop::Cop::Lint::ConstantReassignment, :config do
       expect(offenses).to be_empty
     end
 
+    it 'does not error when a built-in constant name is assigned' do
+      Dir.mktmpdir do |tmpdir|
+        # `Module` has a built-in (non-file) definition in the index; scanning
+        # for a prior definition must not trip over its `rubydex:built-in` URI.
+        File.write(File.join(tmpdir, 'built_in.rb'), "Module = 1\n")
+        write_rubocop_config(
+          tmpdir,
+          'AllCops' => { 'UseProjectIndex' => true },
+          'Lint/ConstantReassignment' => { 'Enabled' => true }
+        )
+
+        offenses = nil
+        expect { offenses = cop_offenses(tmpdir) }.not_to output(/An error occurred/).to_stderr
+
+        expect(offenses).to be_empty
+      end
+    end
+
     it 'invalidates the cache when an indexed file changes' do
       Dir.mktmpdir do |tmpdir|
         Dir.mktmpdir do |cache_dir|

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -818,6 +818,86 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     end
   end
 
+  it 'does not register an offense when the self-alias trick is used to redefine ' \
+     'a method from another file' do
+    expect_no_offenses(<<~RUBY, 'first.rb')
+      class A
+        def some_method
+          implement 1
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY, 'second.rb')
+      class A
+        alias_method :some_method, :some_method
+        def some_method
+          implement 2
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the `alias` self-alias trick is used to redefine ' \
+     'a method from another file' do
+    expect_no_offenses(<<~RUBY, 'first.rb')
+      class A
+        def some_method
+          implement 1
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY, 'second.rb')
+      class A
+        alias some_method some_method
+        def some_method
+          implement 2
+        end
+      end
+    RUBY
+  end
+
+  # rubocop:disable InternalAffairs/ExampleDescription -- `expect_no_offenses` is only the
+  # cross-file setup; the example asserts the offense in the second file.
+  it 'registers an offense when the self-alias trick from a previous file is used ' \
+     'without a redefinition in its own file' do
+    expect_no_offenses(<<~RUBY, 'first.rb')
+      class A
+        alias_method :some_method, :some_method
+        def some_method
+          implement 1
+        end
+      end
+    RUBY
+
+    expect_offense(<<~RUBY, 'second.rb')
+      class A
+        def some_method
+        ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both first.rb:3 and second.rb:2.
+          implement 2
+        end
+      end
+    RUBY
+  end
+  # rubocop:enable InternalAffairs/ExampleDescription
+
+  it 'registers an offense for a same-file duplicate even when the self-alias trick ' \
+     'is used for the same method' do
+    expect_offense(<<~RUBY, 'test.rb')
+      class A
+        alias_method :some_method, :some_method
+        def some_method
+          implement 1
+        end
+        def some_method
+        ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both test.rb:3 and test.rb:6.
+          implement 2
+        end
+      end
+    RUBY
+  end
+
   it_behaves_like('in scope', 'class', 'class A')
   it_behaves_like('in scope', 'module', 'module A')
   it_behaves_like('in scope', 'dynamic class', 'A = Class.new do')
@@ -1681,6 +1761,59 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
         ^^^^^^^^^^^^^ Method `Object#something` is defined at both /no/project/root/foo.rb:1 and /no/project/root/foo.rb:3.
         end
       RUBY
+    end
+  end
+
+  context 'cross-file detection', :project_index do
+    let(:fixture_dir) do
+      File.expand_path('../../../fixtures/cross_file_duplicate_methods', __dir__)
+    end
+
+    def stage_fixture(tmpdir)
+      Dir.glob(File.join(fixture_dir, '*.rb')).each do |file|
+        FileUtils.cp(file, tmpdir)
+      end
+    end
+
+    def cop_offenses(tmpdir)
+      offenses = project_index_offenses(tmpdir)
+
+      offenses.select { |offense| offense['cop_name'] == 'Lint/DuplicateMethods' }
+    end
+
+    def run_with_config(body)
+      Dir.mktmpdir do |tmpdir|
+        stage_fixture(tmpdir)
+        write_rubocop_config(tmpdir, body)
+        cop_offenses(tmpdir)
+      end
+    end
+
+    # The fixture contains:
+    # * `a.rb`/`b.rb` - `A#some_method` defined with `def` in both files
+    # * `c.rb`/`d.rb` - `attr_reader :shared_attr` and `attr_writer :shared_attr` on `B`
+    # * `e.rb`/`f.rb` - `attr_writer :val` and `def val=` on `C`
+    # * `g.rb`/`h.rb` - `def self.build` on `D` in both files
+    # * `i.rb`       - a unique method
+    # * `j.rb`/`k.rb` - `F#patched` redefined in `k.rb` using the self-alias trick
+    it 'reports duplicates defined in another file when UseProjectIndex is enabled' do
+      offenses = run_with_config('AllCops' => { 'UseProjectIndex' => true })
+      messages = offenses.to_h { |o| [File.basename(o['path']), o['message']] }
+
+      expect(offenses.size).to eq(6)
+      expect(messages.keys.sort).to eq(%w[a.rb b.rb e.rb f.rb g.rb h.rb])
+      expect(messages['a.rb']).to include('`A#some_method`', 'a.rb:2', 'b.rb:2')
+      expect(messages['b.rb']).to include('`A#some_method`', 'a.rb:2', 'b.rb:2')
+      expect(messages['e.rb']).to include('`C#val=`', 'e.rb:2', 'f.rb:2')
+      expect(messages['f.rb']).to include('`C#val=`', 'e.rb:2', 'f.rb:2')
+      expect(messages['g.rb']).to include('`D.build`', 'g.rb:2', 'h.rb:2')
+      expect(messages['h.rb']).to include('`D.build`', 'g.rb:2', 'h.rb:2')
+    end
+
+    it 'does not report cross-file duplicates when UseProjectIndex is disabled' do
+      offenses = run_with_config('AllCops' => { 'UseProjectIndex' => false })
+
+      expect(offenses).to be_empty
     end
   end
 end

--- a/spec/support/project_index_metadata.rb
+++ b/spec/support/project_index_metadata.rb
@@ -27,7 +27,9 @@ module ProjectIndexSpecHelpers
       options = project_index_runner_options(output_path, cache_root)
       RuboCop::Runner.new(options, config_store).run(paths || [tmpdir])
     end
-    JSON.load_file(output_path).fetch('files').flat_map { |f| f['offenses'] }
+    JSON.load_file(output_path).fetch('files').flat_map do |file|
+      file['offenses'].map { |offense| offense.merge('path' => file['path']) }
+    end
   end
 
   private

--- a/spec/support/suppress_pending_warning.rb
+++ b/spec/support/suppress_pending_warning.rb
@@ -8,7 +8,9 @@
 module RuboCop
   class PendingCopsReporter
     class << self
-      remove_method :warn_on_pending_cops
+      # The self-alias suppresses Ruby's method redefinition warning and marks
+      # the redefinition as intentional for `Lint/DuplicateMethods`.
+      alias warn_on_pending_cops warn_on_pending_cops
       def warn_on_pending_cops(config)
         # noop
       end


### PR DESCRIPTION
Builds on the Rubydex integration from #15173 and teaches `Lint/DuplicateMethods` to report methods whose duplicate definition lives in another file when `AllCops/UseProjectIndex` is enabled. Rubydex has a few modeling quirks the lookup accounts for (`attr_writer :foo` is indexed under `foo`, not `foo=`, and singleton methods live under the singleton-class declaration), and the self-alias trick the cop already respects within a file now marks an intentional redefinition across files too, on both sides of the duplicate.

`Lint/ConstantReassignment` also crashes when a built-in constant name (say `Module`) is assigned with the index enabled, since built-in declarations have no file URI. That fix is the first commit, and the shared helper it introduces is reused by the new detection.

Related: #15317 takes a different approach to the same idea.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
