### PR TITLE
[Fix #15321] Respect per-type styles in `Style/ClassAndModuleChildren`

### DIFF
--- a/changelog/change_use_the_project_index_in_style_class_and_module_children_autocorrection_20260715100516.md
+++ b/changelog/change_use_the_project_index_in_style_class_and_module_children_autocorrection_20260715100516.md
@@ -1,0 +1,1 @@
+* [#15463](https://github.com/rubocop/rubocop/pull/15463): Change `Style/ClassAndModuleChildren` autocorrection to consult the project index for the namespace kind and definition sites when `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/changelog/fix_make_style_class_and_module_children_respect_per_type_styles_20260715095753.md
+++ b/changelog/fix_make_style_class_and_module_children_respect_per_type_styles_20260715095753.md
@@ -1,0 +1,1 @@
+* [#15321](https://github.com/rubocop/rubocop/issues/15321): Fix `Style/ClassAndModuleChildren` ignoring `EnforcedStyleForClasses` and `EnforcedStyleForModules`, and skip autocorrection when mixed per-type styles make the result ambiguous. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3632,13 +3632,14 @@ Style/ClassAndModuleChildren:
   StyleGuide: '#namespace-definition'
   # Moving from compact to nested children requires knowledge of whether the
   # outer parent is a module or a class. Moving from nested to compact requires
-  # verification that the outer parent is defined elsewhere. RuboCop does not
-  # have the knowledge to perform either operation safely and thus requires
-  # manual oversight.
+  # verification that the outer parent is defined elsewhere. By default RuboCop
+  # does not have the knowledge to perform either operation safely and thus
+  # requires manual oversight. When `AllCops/UseProjectIndex` is enabled, the
+  # project-wide index is consulted for both operations.
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.19'
-  VersionChanged: '1.74'
+  VersionChanged: '<<next>>'
   #
   # Basically there are two different styles:
   #

--- a/docs/modules/ROOT/pages/cops_style.adoc
+++ b/docs/modules/ROOT/pages/cops_style.adoc
@@ -1848,7 +1848,7 @@ That's a good use case of a `?` literal so it doesn't count as an offense.
 | Yes
 | Always (Unsafe)
 | 0.19
-| 1.74
+| <<next>>
 |===
 
 Checks that namespaced classes and modules are defined with a consistent style.
@@ -1875,9 +1875,14 @@ Autocorrection is unsafe.
 
 Moving from `compact` to `nested` children requires knowledge of whether the
 outer parent is a module or a class. Moving from `nested` to `compact` requires
-verification that the outer parent is defined elsewhere. RuboCop does not
-have the knowledge to perform either operation safely and thus requires
+verification that the outer parent is defined elsewhere. By default RuboCop does
+not have the knowledge to perform either operation safely and thus requires
 manual oversight.
+
+When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+the project-wide index is consulted to resolve whether the outer parent is a
+class or a module, and compacting is skipped when the outer parent is not
+defined elsewhere.
 
 [#examples-styleclassandmodulechildren]
 === Examples

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -83,6 +83,11 @@ a parent class defined elsewhere in the project.
 `Style/StaticClass` does not report classes that are subclassed anywhere in the project.
 `Naming/PredicatePrefix` and `Naming/AccessorMethodName` do not suggest renaming methods
 that override a method defined by an ancestor elsewhere in the project.
+`Style/ClassAndModuleChildren` uses the index to make its (unsafe) autocorrection more reliable:
+when nesting a compact definition (`class Foo::Bar`), the namespace wrapper's keyword (`class` or
+`module`) is resolved from the actual definition of `Foo` instead of guessed, and compacting a
+nested definition is skipped when the outer namespace is not defined elsewhere (the compact form
+would raise `NameError` at load time).
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -23,9 +23,14 @@ module RuboCop
       #
       #   Moving from `compact` to `nested` children requires knowledge of whether the
       #   outer parent is a module or a class. Moving from `nested` to `compact` requires
-      #   verification that the outer parent is defined elsewhere. RuboCop does not
-      #   have the knowledge to perform either operation safely and thus requires
+      #   verification that the outer parent is defined elsewhere. By default RuboCop does
+      #   not have the knowledge to perform either operation safely and thus requires
       #   manual oversight.
+      #
+      #   When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+      #   the project-wide index is consulted to resolve whether the outer parent is a
+      #   class or a module, and compacting is skipped when the outer parent is not
+      #   defined elsewhere.
       #
       # @example EnforcedStyle: nested (default)
       #   # bad
@@ -53,6 +58,7 @@ module RuboCop
       class ClassAndModuleChildren < Base
         include Alignment
         include ConfigurableEnforcedStyle
+        include ProjectIndexHelp
         include RangeHelp
         extend AutoCorrector
 
@@ -96,6 +102,21 @@ module RuboCop
         end
 
         def namespace_keyword(node)
+          indexed_namespace_keyword(node) || heuristic_namespace_keyword(node)
+        end
+
+        def indexed_namespace_keyword(node)
+          return nil unless project_index
+
+          declaration = resolve_in_index(node.identifier.namespace.const_name, node)
+
+          case declaration
+          when Rubydex::Class then 'class'
+          when Rubydex::Module then 'module'
+          end
+        end
+
+        def heuristic_namespace_keyword(node)
           class_definition = node.left_sibling&.each_node(:class)&.find do |class_node|
             class_node.identifier == node.identifier.namespace
           end
@@ -121,10 +142,52 @@ module RuboCop
           # Compacting produces a definition whose type's style resolves to `nested`,
           # making autocorrection ping-pong between the two forms.
           return if style_for_kind(node.body.type) == :nested
+          return unless compactible_namespace?(node)
 
           compact_node(corrector, node)
           remove_end(corrector, node.body)
           unindent(corrector, node)
+        end
+
+        # Compacting removes this definition of the namespace, so the result raises
+        # `NameError` at load time unless the namespace is also defined somewhere else.
+        # With the project index this is verified before correcting; without it the
+        # correction is performed regardless (the cop's autocorrection is unsafe).
+        def compactible_namespace?(node)
+          return true unless project_index
+
+          declaration = resolve_in_index(node.identifier.const_name, node)
+          return false unless declaration.is_a?(Rubydex::Namespace)
+
+          declaration.definitions.any? { |definition| definition_elsewhere?(definition, node) }
+        end
+
+        def definition_elsewhere?(definition, node)
+          location = definition.location
+          return true unless location.uri.start_with?(FILE_URI_PREFIX)
+
+          !same_file?(location.to_file_path, processed_source.file_path) ||
+            location.to_display.start_line != node.first_line
+        rescue StandardError
+          # A path that cannot be converted or compared cannot prove the
+          # namespace is defined elsewhere; err on not correcting.
+          false
+        end
+
+        def same_file?(path, other)
+          return true if File.identical?(path, other)
+
+          normalized = [path, other].map { |p| File.expand_path(p).tr('\\', '/') }
+          normalized.uniq.one? || (Platform.windows? && normalized[0].casecmp?(normalized[1]))
+        end
+
+        def resolve_in_index(const_name, node)
+          project_index.resolve_constant(const_name, lexical_nesting(node))
+        end
+
+        def lexical_nesting(node)
+          node.each_ancestor(:class, :module).map { |ancestor| ancestor.identifier.const_name }
+                                             .reverse
         end
 
         def compact_node(corrector, node)

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -60,7 +60,7 @@ module RuboCop
         COMPACT_MSG = 'Use compact module/class definition instead of nested style.'
 
         def on_class(node)
-          return if node.parent_class && style != :nested
+          return if node.parent_class && style_for_classes != :nested
 
           check_style(node, node.body, style_for_classes)
         end
@@ -72,7 +72,7 @@ module RuboCop
         private
 
         def nest_or_compact(corrector, node)
-          style = node.class_type? ? style_for_classes : style_for_modules
+          style = style_for_kind(node.type)
 
           if style == :nested
             nest_definition(corrector, node)
@@ -82,21 +82,25 @@ module RuboCop
         end
 
         def nest_definition(corrector, node)
+          keyword = namespace_keyword(node)
+          # A namespace wrapper whose style resolves to `compact` would itself violate
+          # that style, making autocorrection ping-pong between the two forms.
+          return if style_for_kind(keyword.to_sym) == :compact
+
           padding = indentation(node) + leading_spaces(node)
           padding_for_trailing_end = padding.sub(' ' * node.loc.end.column, '')
 
-          replace_namespace_keyword(corrector, node)
+          corrector.replace(node.loc.keyword, keyword)
           split_on_double_colon(corrector, node, padding)
           add_trailing_end(corrector, node, padding_for_trailing_end)
         end
 
-        def replace_namespace_keyword(corrector, node)
+        def namespace_keyword(node)
           class_definition = node.left_sibling&.each_node(:class)&.find do |class_node|
             class_node.identifier == node.identifier.namespace
           end
-          namespace_keyword = class_definition ? 'class' : 'module'
 
-          corrector.replace(node.loc.keyword, namespace_keyword)
+          class_definition ? 'class' : 'module'
         end
 
         def split_on_double_colon(corrector, node, padding)
@@ -114,6 +118,10 @@ module RuboCop
         end
 
         def compact_definition(corrector, node)
+          # Compacting produces a definition whose type's style resolves to `nested`,
+          # making autocorrection ping-pong between the two forms.
+          return if style_for_kind(node.body.type) == :nested
+
           compact_node(corrector, node)
           remove_end(corrector, node.body)
           unindent(corrector, node)
@@ -219,7 +227,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, node)
-          return if node.class_type? && node.parent_class && style != :nested
+          return if node.class_type? && node.parent_class && style_for_classes != :nested
 
           nest_or_compact(corrector, node)
         end
@@ -232,12 +240,16 @@ module RuboCop
           node.identifier.source.include?('::')
         end
 
+        def style_for_kind(kind)
+          kind == :class ? style_for_classes : style_for_modules
+        end
+
         def style_for_classes
-          cop_config['EnforcedStyleForClasses'] || style
+          cop_config['EnforcedStyleForClasses']&.to_sym || style
         end
 
         def style_for_modules
-          cop_config['EnforcedStyleForModules'] || style
+          cop_config['EnforcedStyleForModules']&.to_sym || style
         end
       end
     end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -828,42 +828,6 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         expect_no_corrections
       end
     end
-
-    context 'EnforcedStyle: compact + EnforcedStyleForModules: nested' do
-      let(:cop_config) do
-        { 'EnforcedStyle' => 'compact', 'EnforcedStyleForModules' => 'nested' }
-      end
-
-      it 'registers an offense for a compact module and autocorrects it' do
-        expect_offense(<<~RUBY)
-          module FooModule::BarModule
-                 ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          module FooModule
-            module BarModule
-            end
-          end
-        RUBY
-      end
-
-      it 'registers an offense for classes with nested children' do
-        expect_offense(<<~RUBY)
-          class FooClass
-                ^^^^^^^^ Use compact module/class definition instead of nested style.
-            class BarClass
-            end
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          class FooClass::BarClass
-          end
-        RUBY
-      end
-    end
   end
 
   context 'when EnforcedStyleForModules is set' do
@@ -908,6 +872,225 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           module FooModule::BarModule
             def method_example
             end
+          end
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyle: compact + EnforcedStyleForModules: nested' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'compact', 'EnforcedStyleForModules' => 'nested' }
+      end
+
+      it 'registers an offense for a compact module and autocorrects it' do
+        expect_offense(<<~RUBY)
+          module FooModule::BarModule
+                 ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for classes with nested children' do
+        expect_offense(<<~RUBY)
+          class FooClass
+                ^^^^^^^^ Use compact module/class definition instead of nested style.
+            class BarClass
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass::BarClass
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    context 'EnforcedStyle: nested' do
+      let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
+
+      it 'nests with the `class` keyword when the index resolves the namespace to a class' do
+        cop.project_index = build_index('file:///lib/foo_class.rb' => "class FooClass\nend\n")
+
+        expect_offense(<<~RUBY)
+          class FooClass::BarClass
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass
+            class BarClass
+            end
+          end
+        RUBY
+      end
+
+      it 'nests with the `module` keyword when the index resolves the namespace to a module' do
+        cop.project_index = build_index('file:///lib/foo_mod.rb' => "module FooModule\nend\n")
+
+        expect_offense(<<~RUBY)
+          module FooModule::BarModule
+                 ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+      end
+
+      it 'resolves the namespace through the lexical nesting' do
+        cop.project_index = build_index(
+          'file:///lib/wrap.rb' => "module Wrap\n  class FooClass\n  end\nend\n"
+        )
+
+        expect_offense(<<~RUBY)
+          module Wrap
+            class Other
+            end
+            class FooClass::BarClass
+                  ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Wrap
+            class Other
+            end
+            class FooClass
+                class BarClass
+                end
+            end
+          end
+        RUBY
+      end
+
+      it 'falls back to the module keyword when the namespace is not in the index' do
+        cop.project_index = build_index('file:///lib/unrelated.rb' => "class Unrelated\nend\n")
+
+        expect_offense(<<~RUBY)
+          class FooClass::BarClass
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooClass
+            class BarClass
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'EnforcedStyle: compact' do
+      let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
+
+      # Platform-realistic paths: the cop compares indexed definition paths
+      # with the inspected file's path, and drive-less fake paths behave
+      # differently on Windows.
+      let(:current_path) { File.expand_path('current.rb') }
+      let(:other_path) { File.expand_path('other.rb') }
+
+      def file_uri(path)
+        path.start_with?('/') ? "file://#{path}" : "file:///#{path}"
+      end
+
+      it 'does not autocorrect when the namespace is not defined elsewhere' do
+        source = <<~RUBY
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+        cop.project_index = build_index(file_uri(current_path) => source)
+
+        expect_offense(<<~RUBY, current_path)
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            module BarModule
+            end
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'autocorrects when the namespace is defined in another file' do
+        source = <<~RUBY
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+        cop.project_index = build_index(
+          'file:///lib/current.rb' => source,
+          'file:///lib/other.rb' => "module FooModule\nend\n"
+        )
+
+        expect_offense(<<~RUBY, current_path)
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            module BarModule
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule::BarModule
+          end
+        RUBY
+      end
+
+      it 'autocorrects when the namespace is also defined elsewhere in the same file' do
+        source = <<~RUBY
+          module FooModule
+          end
+
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+        cop.project_index = build_index(file_uri(current_path) => source)
+
+        expect_offense(<<~RUBY, current_path)
+          module FooModule
+          end
+
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            module BarModule
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule
+          end
+
+          module FooModule::BarModule
           end
         RUBY
       end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -754,6 +754,116 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         RUBY
       end
     end
+
+    context 'EnforcedStyle: compact + EnforcedStyleForClasses: nested' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'compact', 'EnforcedStyleForClasses' => 'nested' }
+      end
+
+      it 'registers an offense for a compact class but does not autocorrect it when ' \
+         'the module style would immediately re-compact the namespace wrapper' do
+        expect_offense(<<~RUBY)
+          class FooClass::BarClass
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for a compact class with a superclass' do
+        expect_offense(<<~RUBY)
+          class FooClass::BarClass < Super
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'autocorrects a compact class when the namespace is known to be a class' do
+        expect_offense(<<~RUBY)
+          class FooClass
+          end
+          class FooClass::BarClass
+                ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass
+          end
+          class FooClass
+            class BarClass
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for modules with nested children' do
+        expect_offense(<<~RUBY)
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            module BarModule
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule::BarModule
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a module with a nested class but does not autocorrect it ' \
+         'when the class style would immediately re-nest the compacted definition' do
+        expect_offense(<<~RUBY)
+          module FooModule
+                 ^^^^^^^^^ Use compact module/class definition instead of nested style.
+            class BarClass
+            end
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+
+    context 'EnforcedStyle: compact + EnforcedStyleForModules: nested' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'compact', 'EnforcedStyleForModules' => 'nested' }
+      end
+
+      it 'registers an offense for a compact module and autocorrects it' do
+        expect_offense(<<~RUBY)
+          module FooModule::BarModule
+                 ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module FooModule
+            module BarModule
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for classes with nested children' do
+        expect_offense(<<~RUBY)
+          class FooClass
+                ^^^^^^^^ Use compact module/class definition instead of nested style.
+            class BarClass
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          class FooClass::BarClass
+          end
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyleForModules is set' do


### PR DESCRIPTION
Fixes #15321.

The per-type style options were silently ignored: `style_for_classes`/`style_for_modules` return the raw config string while all checks compare symbols, and the `on_class` guard reads the global style. Fixing detection surfaces the autocorrect ambiguity discussed in the issue - with mixed per-type styles, nesting a compact class invents a namespace wrapper that immediately violates the other type's style, so `rubocop -A` ping-pongs. I went with the option suggested there: the offense is still registered, but autocorrection is skipped when the corrected form would be unstable.

The second commit puts the project index (#15173) to work on the cop's two documented unsafety reasons: the namespace wrapper's keyword is resolved from the actual definition instead of the same-file sibling heuristic, and compacting is skipped when the outer namespace isn't defined anywhere else (the compact form would raise `NameError` at load time).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
