### PR TITLE
Use the project index to verify ancestry in `Lint/MissingSuper`

### DIFF
--- a/changelog/change_use_the_project_index_to_verify_ancestry_in_lint_missing_super_20260715101214.md
+++ b/changelog/change_use_the_project_index_to_verify_ancestry_in_lint_missing_super_20260715101214.md
@@ -1,0 +1,1 @@
+* [#15464](https://github.com/rubocop/rubocop/pull/15464): Change `Lint/MissingSuper` to skip the constructor offense when the project index shows no ancestor defines `initialize` (`UseProjectIndex`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2141,7 +2141,7 @@ Lint/MissingSuper:
                   without calls to `super`.
   Enabled: true
   VersionAdded: '0.89'
-  VersionChanged: '1.4'
+  VersionChanged: '<<next>>'
   AllowedParentClasses: []
 
 Lint/MixedCaseRange:

--- a/docs/modules/ROOT/pages/cops_lint.adoc
+++ b/docs/modules/ROOT/pages/cops_lint.adoc
@@ -3955,7 +3955,7 @@ x += 1
 | Yes
 | No
 | 0.89
-| 1.4
+| <<next>>
 |===
 
 Checks for the presence of constructors and lifecycle callbacks
@@ -3975,6 +3975,13 @@ classes from this cop, for example in the case of an abstract class that is
 not meant to be called with `super`. In those cases, you can use the
 `AllowedParentClasses` option to specify which classes should be allowed
 *in addition to* `Object` and `BasicObject`.
+
+When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+the constructor check additionally consults the project-wide index: if the
+class' entire ancestry is resolvable and no ancestor defines `initialize`,
+no offense is registered, since `super` would only reach the no-op
+`Object#initialize`. Classes whose ancestry contains an unresolvable
+superclass or mixin (e.g. one defined in a gem) are still reported.
 
 [#examples-lintmissingsuper]
 === Examples

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -88,6 +88,10 @@ when nesting a compact definition (`class Foo::Bar`), the namespace wrapper's ke
 `module`) is resolved from the actual definition of `Foo` instead of guessed, and compacting a
 nested definition is skipped when the outer namespace is not defined elsewhere (the compact form
 would raise `NameError` at load time).
+`Lint/MissingSuper` skips the constructor offense when the class' entire ancestry is resolvable
+in the index and no ancestor defines `initialize` - in that case `super` would only reach the
+no-op `Object#initialize`. This removes the need to list project-local abstract base classes in
+`AllowedParentClasses`.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -21,6 +21,13 @@ module RuboCop
       # `AllowedParentClasses` option to specify which classes should be allowed
       # *in addition to* `Object` and `BasicObject`.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+      # the constructor check additionally consults the project-wide index: if the
+      # class' entire ancestry is resolvable and no ancestor defines `initialize`,
+      # no offense is registered, since `super` would only reach the no-op
+      # `Object#initialize`. Classes whose ancestry contains an unresolvable
+      # superclass or mixin (e.g. one defined in a gem) are still reported.
+      #
       # @example
       #   # bad
       #   class Employee < Person
@@ -83,6 +90,8 @@ module RuboCop
       #   end
       #
       class MissingSuper < Base
+        include ProjectIndexHelp
+
         CONSTRUCTOR_MSG = 'Call `super` to initialize state of the parent class.'
         CALLBACK_MSG    = 'Call `super` to invoke callback defined in the parent class.'
 
@@ -140,7 +149,8 @@ module RuboCop
 
             !allowed_class?(super_class)
           elsif (class_node = node.each_ancestor(:class).first)
-            class_node.parent_class && !allowed_class?(class_node.parent_class)
+            class_node.parent_class && !allowed_class?(class_node.parent_class) &&
+              !index_verified_stateless_ancestry?(class_node)
           else
             false
           end
@@ -152,6 +162,60 @@ module RuboCop
 
         def allowed_classes
           @allowed_classes ||= STATELESS_CLASSES + cop_config.fetch('AllowedParentClasses', [])
+        end
+
+        # With the project index, the offense is skipped when the class' whole ancestry
+        # is resolvable and none of the inherited ancestors defines `initialize` —
+        # `super` would only reach the no-op `Object#initialize`. An unresolvable
+        # superclass or mixin anywhere in the chain (e.g. a class from a gem) means
+        # the ancestry cannot be verified and the offense is kept.
+        def index_verified_stateless_ancestry?(class_node)
+          return false unless project_index
+
+          declaration = resolve_in_index(class_node)
+          return false unless declaration.is_a?(Rubydex::Class)
+
+          ancestors = declaration.ancestors.to_a
+          inherited = ancestors.reject { |ancestor| ancestor.name == declaration.name }
+          return false if inherited.any? { |ancestor| ancestor.member('initialize()') }
+
+          ancestors.all? { |ancestor| resolved_ancestry_definitions?(ancestor) }
+        end
+
+        def resolve_in_index(class_node)
+          identifier = class_node.identifier
+          nesting = if identifier.absolute?
+                      []
+                    else
+                      class_node.each_ancestor(:class, :module)
+                                .map { |ancestor| ancestor.identifier.const_name }.reverse
+                    end
+
+          project_index.resolve_constant(identifier.const_name, nesting)
+        end
+
+        def resolved_ancestry_definitions?(declaration)
+          declaration.definitions.all? do |definition|
+            superclass_reference_resolved?(definition) && mixin_references_resolved?(definition)
+          end
+        end
+
+        def superclass_reference_resolved?(definition)
+          return true unless definition.is_a?(Rubydex::ClassDefinition)
+
+          !definition.superclass.is_a?(Rubydex::UnresolvedConstantReference)
+        end
+
+        def mixin_references_resolved?(definition)
+          return true unless definition.respond_to?(:mixins)
+
+          definition.mixins.none? do |mixin|
+            # `extend` affects the singleton class and cannot introduce an
+            # inherited `initialize`.
+            next false if mixin.is_a?(Rubydex::Extend)
+
+            mixin.constant_reference.is_a?(Rubydex::UnresolvedConstantReference)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -258,4 +258,149 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
       RUBY
     end
   end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(sources = {})
+      build_index(sources.merge('file:///lib/current.rb' => current_source))
+    end
+
+    let(:current_source) do
+      <<~RUBY
+        class Child < Parent
+          def initialize
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when no ancestor defines `initialize`' do
+      cop.project_index = index_with_current('file:///lib/parent.rb' => "class Parent\nend\n")
+
+      expect_no_offenses(current_source, '/lib/current.rb')
+    end
+
+    it 'registers an offense when the parent defines `initialize`' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent\n  def initialize\n  end\nend\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when a grandparent defines `initialize`' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent < GrandParent\nend\n",
+        'file:///lib/grand_parent.rb' => "class GrandParent\n  def initialize\n  end\nend\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when an included module defines `initialize`' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent\n  include Initializable\nend\n",
+        'file:///lib/initializable.rb' => "module Initializable\n  def initialize\n  end\nend\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the parent is not in the index' do
+      cop.project_index = index_with_current
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the ancestry contains an unresolvable superclass' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent < SomeGemClass\nend\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the ancestry contains an unresolvable include' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent\n  include SomeGemModule\nend\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Child < Parent
+          def initialize
+          ^^^^^^^^^^^^^^ Call `super` to initialize state of the parent class.
+            @foo = 1
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the ancestry contains only an unresolvable `extend`' do
+      cop.project_index = index_with_current(
+        'file:///lib/parent.rb' => "class Parent\n  extend SomeGemModule\nend\n"
+      )
+
+      expect_no_offenses(current_source, '/lib/current.rb')
+    end
+
+    it 'resolves the parent through the lexical nesting' do
+      source = <<~RUBY
+        module Wrap
+          class Child < Parent
+            def initialize
+              @foo = 1
+            end
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///lib/current.rb' => source,
+        'file:///lib/parent.rb' => "module Wrap\n  class Parent\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+  end
 end


### PR DESCRIPTION
Another cop that benefits from the project index (#15173). `Lint/MissingSuper` flags `initialize` without `super` whenever the parent class isn't `Object`/`BasicObject` or allowlisted, even when nothing in the ancestry actually defines `initialize`, so project-local abstract base classes have to be added to `AllowedParentClasses` by hand.

With `UseProjectIndex` enabled the cop now resolves the class through the index and skips the offense when the entire ancestry is resolvable and no ancestor defines `initialize` (in that case `super` would only reach the no-op `Object#initialize`). It stays conservative about what the index can't see: rubydex marks unresolvable superclasses and mixins (e.g. `ActiveRecord::Base` from a gem) with `UnresolvedConstantReference`, and any such link in the chain keeps the offense, so `class User < ApplicationRecord` doesn't become a false negative.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
