### PR TITLE
Add new `Lint/DeprecatedReference` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,13 @@ Layout/RedundantLineBreak:
 Layout/TrailingWhitespace:
   AllowInHeredoc: false
 
+# The deprecated module itself is under test there; whether the reference
+# resolves depends on rubydex availability, so an inline disable would be
+# flagged as redundant in environments without the index.
+Lint/DeprecatedReference:
+  Exclude:
+    - 'spec/rubocop/cop/mixin/enforce_superclass_spec.rb'
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*.rb'

--- a/changelog/new_add_new_lint_deprecated_reference_cop_20260715102558.md
+++ b/changelog/new_add_new_lint_deprecated_reference_cop_20260715102558.md
@@ -1,0 +1,1 @@
+* [#15466](https://github.com/rubocop/rubocop/pull/15466): Add new `Lint/DeprecatedReference` cop to detect references to methods and constants documented as `@deprecated`, powered by the project index. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1831,6 +1831,14 @@ Lint/DeprecatedOpenSSLConstant:
   Enabled: true
   VersionAdded: '0.84'
 
+Lint/DeprecatedReference:
+  Description: >-
+                  Checks for references to methods and constants documented
+                  as deprecated with a YARD `@deprecated` tag.
+                  Requires `AllCops/UseProjectIndex` to be enabled.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Lint/DisjunctiveAssignmentInConstructor:
   Description: 'In constructor, plain assignment is preferred over disjunctive.'
   Enabled: true

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -70,6 +70,8 @@ With `UseProjectIndex: true`, RuboCop reports a `Lint/DuplicateMethods` offense 
 referencing the definition in the other one. Redefining a method from another file on purpose
 (e.g. a monkey patch) can be signaled with the self-alias trick (`alias bar bar` right before
 the redefinition), which also suppresses Ruby's method redefinition warning.
+`Lint/DeprecatedReference` (pending) is entirely powered by the index: it reports calls to methods
+and references to constants documented with a YARD `@deprecated` tag anywhere in the project.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -29,6 +29,7 @@ module RuboCop
       register_cop :DeprecatedClassMethods, "#{__dir__}/lint/deprecated_class_methods"
       register_cop :DeprecatedConstants, "#{__dir__}/lint/deprecated_constants"
       register_cop :DeprecatedOpenSSLConstant, "#{__dir__}/lint/deprecated_open_ssl_constant"
+      register_cop :DeprecatedReference, "#{__dir__}/lint/deprecated_reference"
       register_cop :DisjunctiveAssignmentInConstructor, "#{__dir__}/lint/disjunctive_assignment_in_constructor"
       register_cop :DuplicateBranch, "#{__dir__}/lint/duplicate_branch"
       register_cop :DuplicateCaseCondition, "#{__dir__}/lint/duplicate_case_condition"

--- a/lib/rubocop/cop/lint/deprecated_reference.rb
+++ b/lib/rubocop/cop/lint/deprecated_reference.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for calls to methods and references to constants that are documented
+      # as deprecated with a YARD `@deprecated` tag.
+      #
+      # The check is powered by the project-wide index, so it only runs when
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
+      # Without the index the cop does nothing.
+      #
+      # Only references that can be resolved without type inference are checked:
+      # constants, method calls without an explicit receiver (or with `self`),
+      # which are looked up in the enclosing class or module and its ancestry,
+      # and calls whose receiver is a constant, which are looked up in that
+      # namespace's singleton class. Calls on arbitrary objects are not checked.
+      #
+      # References made from a definition that is itself deprecated are allowed,
+      # so deprecated implementations can keep calling each other.
+      #
+      # @example
+      #   # Given a deprecated method and constant:
+      #   #
+      #   #   class Api
+      #   #     # @deprecated Use `#new_method` instead.
+      #   #     def old_method
+      #   #     end
+      #   #
+      #   #     # @deprecated
+      #   #     OLD_TIMEOUT = 10
+      #   #   end
+      #
+      #   # bad
+      #   class Client < Api
+      #     def call
+      #       old_method
+      #     end
+      #
+      #     def timeout
+      #       OLD_TIMEOUT
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Client < Api
+      #     def call
+      #       new_method
+      #     end
+      #
+      #     def timeout
+      #       NEW_TIMEOUT
+      #     end
+      #   end
+      #
+      class DeprecatedReference < Base
+        include ProjectIndexHelp
+
+        METHOD_MSG = 'Method `%<name>s` is deprecated%<detail>s'
+        CONSTANT_MSG = 'Constant `%<name>s` is deprecated%<detail>s'
+
+        DEPRECATED_TAG = '@deprecated'
+        DEPRECATION_DETAIL = /#{DEPRECATED_TAG}\s+(.+)/.freeze
+
+        def on_new_investigation
+          @namespace_cache = {}
+          super
+        end
+
+        def on_send(node)
+          return unless project_index
+
+          declaration = method_declaration_for(node)
+          return unless declaration && deprecated?(declaration)
+          return if within_deprecated_definition?(node)
+
+          message = format(METHOD_MSG, name: node.method_name, detail: detail_for(declaration))
+          add_offense(node.loc.selector, message: message)
+        end
+        alias on_csend on_send
+
+        def on_const(node)
+          return unless project_index
+          return if node.parent&.defined_module
+
+          declaration = resolve_constant_node(node)
+          return unless declaration && deprecated?(declaration)
+          return if within_deprecated_definition?(node)
+
+          message = format(CONSTANT_MSG, name: node.const_name, detail: detail_for(declaration))
+          add_offense(node, message: message)
+        end
+
+        private
+
+        def method_declaration_for(node)
+          receiver = node.receiver
+
+          if receiver.nil? || receiver.self_type?
+            implicit_receiver_declaration(node)
+          elsif receiver.const_type?
+            const_receiver_declaration(node, receiver)
+          end
+        end
+
+        def implicit_receiver_declaration(node)
+          namespace = enclosing_namespace(node)
+          return nil unless namespace.is_a?(Rubydex::Namespace)
+
+          if singleton_context?(node)
+            singleton_member(namespace, "#{node.method_name}()")
+          else
+            namespace.find_member("#{node.method_name}()")
+          end
+        end
+
+        def const_receiver_declaration(node, receiver)
+          namespace = resolve_constant_node(receiver)
+          return nil unless namespace.is_a?(Rubydex::Namespace)
+
+          singleton_member(namespace, "#{node.method_name}()")
+        end
+
+        def enclosing_namespace(node)
+          namespace_node = node.each_ancestor(:class, :module).first
+          return project_index['Object'] unless namespace_node
+
+          @namespace_cache.fetch(namespace_node) do
+            @namespace_cache[namespace_node] = resolve_constant_node(namespace_node.identifier)
+          end
+        end
+
+        # Resolves a constant the way Ruby does: the first segment through the
+        # lexical nesting and every following segment inside the previous one.
+        # (Qualified names cannot be passed to `resolve_constant` as a whole,
+        # since it only applies the nesting to the full name.)
+        def resolve_constant_node(const_node)
+          segments = const_node.const_name.split('::')
+          nesting = const_node.absolute? ? [] : lexical_nesting(const_node)
+
+          declaration = project_index.resolve_constant(segments.first, nesting)
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(node)
+          node.each_ancestor(:class, :module)
+              .map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
+
+        # A namespace without any singleton method has no singleton-class
+        # declaration of its own, so the lookup starts from the first ancestor
+        # that has one; its `find_member` covers the rest of the chain.
+        def singleton_member(namespace, member_name)
+          namespace.ancestors.each do |ancestor|
+            singleton = singleton_of(ancestor)
+            return singleton.find_member(member_name) if singleton
+          end
+
+          nil
+        end
+
+        def singleton_of(namespace)
+          project_index["#{namespace.name}::<#{namespace.name.split('::').last}>"]
+        end
+
+        # Whether an implicit-receiver call runs with the class or module itself
+        # as `self` (directly in a namespace body, in a singleton method, or
+        # inside `class << self`) rather than inside an instance method.
+        def singleton_context?(node)
+          instance_def_seen = false
+
+          node.each_ancestor do |ancestor|
+            case ancestor.type
+            when :defs, :sclass
+              return true
+            when :def
+              instance_def_seen = true
+            when :class, :module
+              return !instance_def_seen
+            end
+          end
+
+          false
+        end
+
+        def deprecated?(declaration)
+          definitions = declaration.definitions.to_a
+
+          definitions.any? && definitions.all?(&:deprecated?)
+        end
+
+        # References from a definition that is itself documented as deprecated
+        # are allowed.
+        def within_deprecated_definition?(node)
+          node.each_ancestor(:any_def, :class, :module).any? do |ancestor|
+            comments = processed_source.ast_with_comments[ancestor]
+            comments.any? { |comment| comment.text.include?(DEPRECATED_TAG) }
+          end
+        end
+
+        def detail_for(declaration)
+          text = deprecation_text(declaration)
+          return '.' if text.nil? || text.empty?
+
+          text.end_with?('.') ? ": #{text}" : ": #{text}."
+        end
+
+        def deprecation_text(declaration)
+          tag_comment = declaration.definitions.to_a.filter_map do |definition|
+            definition.comments.to_a.map(&:string).find { |string| string.include?(DEPRECATED_TAG) }
+          end.first
+
+          tag_comment && tag_comment[DEPRECATION_DETAIL, 1]&.strip
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/deprecated_reference_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_reference_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::DeprecatedReference, :config do
+  it 'does not register an offense without a project index' do
+    expect_no_offenses(<<~RUBY)
+      class Client
+        def call
+          old_method
+        end
+      end
+    RUBY
+  end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(sources = {})
+      build_index(sources.merge('file:///lib/current.rb' => current_source))
+    end
+
+    let(:api_source) do
+      <<~RUBY
+        class Api
+          # @deprecated Use `#new_method` instead.
+          def old_method
+          end
+
+          def new_method
+          end
+
+          # @deprecated
+          def bare_deprecation
+          end
+
+          # @deprecated Use `.modern_build` instead.
+          def self.legacy_build
+          end
+
+          # @deprecated Use `NEW_TIMEOUT` instead.
+          OLD_TIMEOUT = 10
+        end
+      RUBY
+    end
+
+    context 'for method calls' do
+      let(:current_source) do
+        <<~RUBY
+          class Client < Api
+            def call
+              old_method
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a call to an inherited deprecated method' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              old_method
+              ^^^^^^^^^^ Method `old_method` is deprecated: Use `#new_method` instead.
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a `self` call to a deprecated method' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              self.old_method
+                   ^^^^^^^^^^ Method `old_method` is deprecated: Use `#new_method` instead.
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense without extra detail for a bare `@deprecated` tag' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              bare_deprecation
+              ^^^^^^^^^^^^^^^^ Method `bare_deprecation` is deprecated.
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a call to a deprecated singleton method via constant' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          Api.legacy_build
+              ^^^^^^^^^^^^ Method `legacy_build` is deprecated: Use `.modern_build` instead.
+        RUBY
+      end
+
+      it 'registers an offense for a call to a deprecated singleton method from a class body' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            legacy_build
+            ^^^^^^^^^^^^ Method `legacy_build` is deprecated: Use `.modern_build` instead.
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a call to a regular method' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              new_method
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a call on an arbitrary receiver' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call(api)
+              api.old_method
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a call from a deprecated method' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            # @deprecated Use `#modern_call` instead.
+            def call
+              old_method
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'for constant references' do
+      let(:current_source) do
+        <<~RUBY
+          class Client < Api
+            def timeout
+              OLD_TIMEOUT
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a reference to a deprecated constant' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def timeout
+              Api::OLD_TIMEOUT
+              ^^^^^^^^^^^^^^^^ Constant `Api::OLD_TIMEOUT` is deprecated: Use `NEW_TIMEOUT` instead.
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for a reference to a deprecated class' do
+        cop.project_index = index_with_current(
+          'file:///lib/legacy.rb' => "# @deprecated Use `Modern` instead.\nclass Legacy\nend\n"
+        )
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          Legacy.new
+          ^^^^^^ Constant `Legacy` is deprecated: Use `Modern` instead.
+        RUBY
+      end
+
+      it 'does not register an offense when defining a deprecated class' do
+        cop.project_index = index_with_current(
+          'file:///lib/legacy.rb' => "# @deprecated\nclass Legacy\nend\n"
+        )
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          # @deprecated
+          class Legacy
+            def helper
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a regular constant' do
+        cop.project_index = index_with_current('file:///lib/api.rb' => api_source)
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def timeout
+              Api
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
First cop that exists because of the project index (#15173) rather than being enhanced by it: `Lint/DeprecatedReference` reports calls to methods and references to constants documented with a YARD `@deprecated` tag anywhere in the project, and includes the deprecation note in the offense message. Without `UseProjectIndex` the cop does nothing.

To avoid guessing types, only unambiguous references are checked: constants, receiverless/`self` calls (resolved through the enclosing namespace's ancestry) and calls with a constant receiver (resolved in that namespace's singleton class). Calls on arbitrary objects are ignored, and deprecated definitions may keep referencing each other. Fittingly, the cop found one genuine hit in this repo - the spec for the deprecated `EnforceSuperclass` module, which now carries a disable comment since the deprecated module is exactly what it tests.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
