### PR TITLE
Add new `Lint/UnusedPrivateMethod` cop

### DIFF
--- a/changelog/new_add_new_lint_unused_private_method_cop_20260715105300.md
+++ b/changelog/new_add_new_lint_unused_private_method_cop_20260715105300.md
@@ -1,0 +1,1 @@
+* [#15468](https://github.com/rubocop/rubocop/pull/15468): Add new `Lint/UnusedPrivateMethod` cop for project-wide dead-code detection via the project index (disabled by default). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2644,6 +2644,18 @@ Lint/UnusedMethodArgument:
   NotImplementedExceptions:
     - NotImplementedError
 
+Lint/UnusedPrivateMethod:
+  Description: >-
+                  Checks for private instance methods that are not referenced
+                  anywhere in the project. Requires `AllCops/UseProjectIndex`
+                  to be enabled.
+  # This cop is disabled by default because symbol-based references from other
+  # files (e.g. Rails callbacks declared in a concern) cannot be detected and
+  # would be reported as false positives. It is intended for occasional
+  # dead-code sweeps rather than permanent enforcement.
+  Enabled: false
+  VersionAdded: '<<next>>'
+
 Lint/UriEscapeUnescape:
   Description: >-
                  `URI.escape` method is obsolete and should not be used. Instead, use

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -72,6 +72,10 @@ referencing the definition in the other one. Redefining a method from another fi
 the redefinition), which also suppresses Ruby's method redefinition warning.
 `Lint/DeprecatedReference` (pending) is entirely powered by the index: it reports calls to methods
 and references to constants documented with a YARD `@deprecated` tag anywhere in the project.
+`Lint/UnusedPrivateMethod` (disabled by default) uses the index for project-wide dead-code
+detection: it reports private instance methods whose names are never referenced anywhere in
+the indexed project. Since symbol-based references from other files (e.g. Rails callbacks
+declared in a concern) cannot be detected, it is best suited for occasional dead-code sweeps.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -146,6 +146,7 @@ module RuboCop
       register_cop :UnreachablePatternBranch, "#{__dir__}/lint/unreachable_pattern_branch"
       register_cop :UnusedBlockArgument, "#{__dir__}/lint/unused_block_argument"
       register_cop :UnusedMethodArgument, "#{__dir__}/lint/unused_method_argument"
+      register_cop :UnusedPrivateMethod, "#{__dir__}/lint/unused_private_method"
       register_cop :UriEscapeUnescape, "#{__dir__}/lint/uri_escape_unescape"
       register_cop :UriRegexp, "#{__dir__}/lint/uri_regexp"
       register_cop :UselessAccessModifier, "#{__dir__}/lint/useless_access_modifier"

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for private instance methods that are not referenced anywhere
+      # in the project.
+      #
+      # The check is powered by the project-wide index, so it only runs when
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
+      # Without the index the cop does nothing.
+      #
+      # A method counts as referenced when a call with its name appears anywhere
+      # in the indexed project (regardless of the receiver), when it is the source
+      # of an `alias`, or when its name appears in the same file as a symbol or
+      # inside a string literal (covering `send(:name)` and declarative DSLs like
+      # `before_action :name`). Methods defined in classes or modules with
+      # descendants are not checked, since they may be invoked through `super`
+      # or inherited dispatch, and neither are methods whose names are built
+      # dynamically (e.g. `send("do_#{action}")`).
+      #
+      # The cop is disabled by default because symbol-based references from
+      # *other* files (e.g. a Rails callback declared in a concern) cannot be
+      # detected and would be reported as false positives. It is best suited
+      # for occasional dead-code sweeps rather than permanent enforcement.
+      #
+      # @example
+      #   # bad - `helper` is never referenced anywhere in the project
+      #   class Service
+      #     def call
+      #       do_something
+      #     end
+      #
+      #     private
+      #
+      #     def helper
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Service
+      #     def call
+      #       do_something(helper)
+      #     end
+      #
+      #     private
+      #
+      #     def helper
+      #     end
+      #   end
+      #
+      class UnusedPrivateMethod < Base
+        include ProjectIndexHelp
+
+        MSG = 'Private method `%<method>s` appears to be unused.'
+
+        IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!=]?/.freeze
+
+        # Methods invoked implicitly by the Ruby runtime.
+        IMPLICITLY_INVOKED_METHODS = %i[initialize initialize_copy initialize_clone
+                                        initialize_dup method_missing respond_to_missing?
+                                        marshal_dump marshal_load].to_set.freeze
+
+        class << self
+          # The reference-name set is derived once per index and shared by the
+          # per-file cop instances.
+          def reference_names_cache
+            @reference_names_cache ||= {}.compare_by_identity
+          end
+        end
+
+        def on_new_investigation
+          @literal_names = nil
+          super
+        end
+
+        def on_def(node)
+          return unless project_index
+
+          declaration = checkable_declaration(node)
+          return unless declaration
+          return if referenced?(node.method_name)
+          return if owner_with_descendants?(declaration) || override?(declaration, node.method_name)
+
+          message = format(MSG, method: node.method_name)
+          add_offense(node.loc.keyword.join(node.loc.name), message: message)
+        end
+
+        private
+
+        def checkable_declaration(node)
+          return nil if IMPLICITLY_INVOKED_METHODS.include?(node.method_name)
+          return nil if node.each_ancestor(:any_def, :any_block, :sclass).any?
+          return nil unless (namespace_node = node.each_ancestor(:class, :module).first)
+
+          declaration = method_declaration(node, namespace_node)
+          declaration if declaration&.private?
+        end
+
+        def method_declaration(node, namespace_node)
+          namespace = resolve_namespace(namespace_node)
+          return nil unless namespace.is_a?(Rubydex::Namespace)
+
+          namespace.member("#{node.method_name}()")
+        end
+
+        # Resolves the enclosing namespace segment by segment, since
+        # `resolve_constant` does not resolve qualified names against
+        # a lexical nesting.
+        def resolve_namespace(namespace_node)
+          identifier = namespace_node.identifier
+          segments = identifier.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(namespace_node, identifier)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(namespace_node, identifier)
+          return [] if identifier.absolute?
+
+          namespace_node.each_ancestor(:class, :module)
+                        .map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
+
+        def referenced?(method_name)
+          name = method_name.to_s
+
+          referenced_names.include?(name) || literal_names.include?(name)
+        end
+
+        def referenced_names
+          self.class.reference_names_cache[project_index] ||=
+            project_index.method_references
+                         .to_set { |reference| reference.name.delete_suffix('()') }
+        end
+
+        # Symbol literals and identifier-like tokens inside string literals in the
+        # current file, covering `send(:name)`, declarative DSLs like
+        # `before_action :name` and names embedded in strings (e.g. node-pattern
+        # `#helper` references).
+        def literal_names
+          @literal_names ||=
+            processed_source.ast.each_descendant(:sym, :str)
+                            .with_object(Set.new) do |literal, names|
+              if literal.sym_type?
+                names << literal.value.to_s
+              else
+                literal.value.scan(IDENTIFIER_PATTERN) { |token| names << token }
+              end
+            end
+        end
+
+        # A method defined in a class or module with descendants may be invoked
+        # through `super` or inherited dispatch, which the index does not track.
+        def owner_with_descendants?(declaration)
+          owner = declaration.owner
+          return false unless owner.is_a?(Rubydex::Namespace)
+
+          owner.descendants.any? { |descendant| descendant.name != owner.name }
+        end
+
+        # An override of an inherited method may be invoked polymorphically
+        # (e.g. a framework hook), even when no direct reference exists.
+        def override?(declaration, method_name)
+          owner = declaration.owner
+          return false unless owner.is_a?(Rubydex::Namespace)
+
+          owner.ancestors.any? do |ancestor|
+            ancestor.name != owner.name && ancestor.member("#{method_name}()")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
+  it 'does not register an offense without a project index' do
+    expect_no_offenses(<<~RUBY)
+      class Service
+        private
+
+        def helper
+        end
+      end
+    RUBY
+  end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(sources = {})
+      build_index(sources.merge('file:///lib/current.rb' => current_source))
+    end
+
+    let(:current_source) do
+      <<~RUBY
+        class Service
+          def call
+          end
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a private method never referenced in the project' do
+      cop.project_index = index_with_current
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Service
+          def call
+          end
+
+          private
+
+          def helper
+          ^^^^^^^^^^ Private method `helper` appears to be unused.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a public method' do
+      cop.project_index = index_with_current
+
+      expect_no_offenses(<<~RUBY, '/lib/current.rb')
+        class Service
+          def call
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the method is called in the same file' do
+      source = <<~RUBY
+        class Service
+          def call
+            helper
+          end
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when a call with the same name exists in another file' do
+      cop.project_index = index_with_current(
+        'file:///lib/other.rb' => "class Other\n  def go(service)\n    service.helper\n  end\nend\n"
+      )
+
+      expect_no_offenses(current_source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when the method name appears as a symbol in the same file' do
+      source = <<~RUBY
+        class Service
+          before_action :helper
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when the method is the source of an alias' do
+      source = <<~RUBY
+        class Service
+          alias_method :run, :helper
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when the class has descendants' do
+      cop.project_index = index_with_current(
+        'file:///lib/sub.rb' => "class SubService < Service\nend\n"
+      )
+
+      expect_no_offenses(current_source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense for implicitly invoked methods' do
+      source = <<~RUBY
+        class Service
+          private
+
+          def initialize
+          end
+
+          def respond_to_missing?(name, include_private = false)
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense for a singleton method' do
+      source = <<~RUBY
+        class Service
+          class << self
+            private
+
+            def helper
+            end
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense for an override of an inherited private method' do
+      source = <<~RUBY
+        class Child < Base
+          private
+
+          def hook
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///lib/current.rb' => source,
+        'file:///lib/base.rb' => "class Base\n  private\n\n  def hook\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when the method name appears inside a string literal' do
+      source = <<~RUBY
+        class Service
+          PATTERN = '(send nil? :require #helper)'
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    # Symbol-based references from other files cannot be detected; this is
+    # the documented reason the cop is disabled by default.
+    it 'registers an offense (known limitation) when the method is referenced only ' \
+       'by a symbol in another file' do
+      cop.project_index = index_with_current(
+        'file:///lib/config.rb' => "HOOKS = [:helper].freeze\n"
+      )
+
+      expect_offense(<<~RUBY, '/lib/current.rb')
+        class Service
+          def call
+          end
+
+          private
+
+          def helper
+          ^^^^^^^^^^ Private method `helper` appears to be unused.
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
A second index-native cop: `Lint/UnusedPrivateMethod` reports private instance methods whose names are never referenced anywhere in the indexed project. It does nothing without `UseProjectIndex`.

Rubydex tracks method calls by name (no type inference), so the cop is deliberately conservative: a call with a matching name anywhere counts as a reference, as do alias sources, symbols, and identifier-like tokens inside string literals in the same file (which covers `send(:name)`, `before_action :name` and node-pattern `#helper` references). Classes with descendants are skipped entirely (`super` and inherited dispatch aren't tracked), and so are overrides of inherited methods, since those may be invoked polymorphically as framework hooks.

What it can't see is symbol-based references from other files (a Rails callback declared in a concern, say), which is why the cop ships `Enabled: false` and is pitched as a dead-code sweep tool rather than permanent enforcement. A sweep over this repo found six genuinely unused private methods and five false positives, all from a single `send(:"format_#{type}")` dynamic-dispatch site. I'll send the removal of the dead methods separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
