### PR TITLE
Fix a `RangeError` for `Style/RedundantFormat`

### DIFF
--- a/changelog/fix_an_error_for_style_redundant_format_huge_argument_number.md
+++ b/changelog/fix_an_error_for_style_redundant_format_huge_argument_number.md
@@ -1,0 +1,1 @@
+* [#15469](https://github.com/rubocop/rubocop/pull/15469): Fix an error for `Style/RedundantFormat` when a format string uses a positional argument number beyond the 64-bit range. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -182,7 +182,7 @@ module RuboCop
         def unknown_variable_width?(sequence, arguments)
           return false unless sequence.variable_width?
 
-          argument = arguments[sequence.variable_width_argument_number - 1]
+          argument = positional_argument(arguments, sequence.variable_width_argument_number)
           argument.nil? || !numeric?(argument)
         end
 
@@ -195,7 +195,7 @@ module RuboCop
             arguments.delete_at(sequence.variable_width_argument_number - 1)
             arguments.shift
           elsif sequence.arg_number
-            arguments[sequence.arg_number.to_i - 1]
+            positional_argument(arguments, sequence.arg_number.to_i)
           else
             arguments.shift
           end
@@ -218,6 +218,15 @@ module RuboCop
           else
             false
           end
+        end
+
+        # `Array#[]` raises `RangeError` for an index beyond the 64-bit range
+        # (e.g. `format('%*9999999999999999999999$d', 1)`) instead of returning `nil`,
+        # so the index needs to be checked before accessing the array.
+        def positional_argument(arguments, number)
+          index = number - 1
+
+          arguments[index] if index < arguments.size
         end
 
         def numeric?(argument)

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -247,6 +247,12 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
               #{method}('%2$s %1$i', 'abcd', '5')
             RUBY
           end
+
+          it 'does not register an offense when the argument number is beyond the 64-bit range' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%999999999999999999999999999999999999999999999999999999999999$d', 1)
+            RUBY
+          end
         end
 
         context 'with `*` in specifier' do
@@ -314,6 +320,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
           it 'does not register an offense when the positional variable width argument is missing' do
             expect_no_offenses(<<~RUBY)
               #{method}('%*9$d', 1)
+            RUBY
+          end
+
+          it 'does not register an offense when the positional variable width argument number ' \
+             'is beyond the 64-bit range' do
+            expect_no_offenses(<<~RUBY)
+              #{method}('%*999999999999999999999999999999999999999999999999999999999999$d', 1)
             RUBY
           end
 


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/issues/15454#issuecomment-4976876085.

This is a follow-up to 2cb6b22e, which handled a missing width argument by checking the result of the array access for `nil`.
However, `Array#[]` raises `RangeError` instead of returning `nil` when the index is beyond the 64-bit range, so the cop still crashed for a positional argument number larger than `2**63 - 1`:

```console
bignum too big to convert into 'long' (RangeError)
```

There are two crash paths, both hit by `ruby/ruby`'s `test/ruby/test_sprintf.rb`:

- `sprintf("%*999999999999999999999999999999999999999999999999999999999999$d", 1)` crashed in `unknown_variable_width?`
- `sprintf("%999999999999999999999999999999999999999999999999999999999999$d", 1)` crashed in `find_argument`

Both array accesses now go through `positional_argument`, which checks the index against the argument count before accessing the array. Comparing a bignum index with the size raises nothing, and in-range behavior is unchanged. The `delete_at` call in `find_argument` needs no guard: it is only reached when `unknown_variable_width?` has found a numeric width argument, which implies the index is within range.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
