### PR TITLE
Remove unused private methods

### DIFF
--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -313,10 +313,6 @@ module RuboCop
         end
         alias max_line_length max
 
-        def allow_heredoc?
-          allowed_heredoc
-        end
-
         def allowed_heredoc
           cop_config['AllowHeredoc']
         end
@@ -342,10 +338,6 @@ module RuboCop
             range.cover?(line_number) &&
               (allowed_heredoc == true || allowed_heredoc.include?(delimiter))
           end
-        end
-
-        def line_in_heredoc?(line_number)
-          heredocs.any? { |range, _delimiter| range.cover?(line_number) }
         end
 
         def receiver_contains_heredoc?(node)

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -201,12 +201,6 @@ module RuboCop
           end
         end
 
-        def next_to_bracket?(token, side: :right)
-          line_index, col = line_and_column_for(token)
-          line = processed_source.lines[line_index]
-          side == :right ? line[col] == ']' : line[col + 2] == '['
-        end
-
         def compact_offense(node, token, side: :right)
           if side == :right
             space_offense(node, token, :left, MSG, NO_SPACE_COMMAND)

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -119,10 +119,6 @@ module RuboCop
         def regexp_receiver?(send_node)
           send_node.receiver&.regexp_type?
         end
-
-        def nth_ref_receiver?(send_node)
-          send_node.receiver&.nth_ref_type?
-        end
       end
     end
   end

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -50,10 +50,6 @@ module RuboCop
 
         private
 
-        def disable_comment_offset
-          Regexp.last_match(1).length
-        end
-
         def check_cop_name(name, comment, offset)
           start = comment.source_range.begin_pos + offset
           range = range_between(start, start + name.length)

--- a/lib/rubocop/feature_loader.rb
+++ b/lib/rubocop/feature_loader.rb
@@ -76,12 +76,6 @@ module RuboCop
       @feature.start_with?('.')
     end
 
-    # @param [LoadError] error
-    # @return [Boolean]
-    def seems_cannot_load_such_file_error?(error)
-      error.path == target
-    end
-
     # @return [String]
     def target
       if relative?


### PR DESCRIPTION
Follow-up to #15468: the new `Lint/UnusedPrivateMethod` cop flagged six private methods with no references anywhere in the project. Pure deletion, no behavior change, no changelog entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
