### PR TITLE
Verify `Layout/RedundantLineBreak` corrections by reparsing

### DIFF
--- a/changelog/change_verify_layout_redundant_line_break_corrections_by_reparsing_20260715182906.md
+++ b/changelog/change_verify_layout_redundant_line_break_corrections_by_reparsing_20260715182906.md
@@ -1,0 +1,1 @@
+* [#15473](https://github.com/rubocop/rubocop/pull/15473): Change `Layout/RedundantLineBreak` to verify each correction by reparsing before registering an offense. ([@bbatsov][])

--- a/changelog/fix_reimplement_style_redundant_line_continuation_on_a_reparse_oracle_20260715161336.md
+++ b/changelog/fix_reimplement_style_redundant_line_continuation_on_a_reparse_oracle_20260715161336.md
@@ -1,0 +1,1 @@
+* [#15471](https://github.com/rubocop/rubocop/pull/15471): Fix false negatives for `Style/RedundantLineContinuation` by verifying backslash removal against a reparse of the source instead of hand-written grammar rules. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -172,7 +172,7 @@ module RuboCop
             'Indent the right bracket the same as the first position ' \
             'after the preceding left parenthesis.'
           when :parent_hash_key
-            'Indent the right bracket the same as the parent hash key.' \
+            'Indent the right bracket the same as the parent hash key.'
           else
             'Indent the right bracket the same as the start of the line ' \
             'where the left bracket is.'

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -82,10 +82,121 @@ module RuboCop
         end
 
         def register_offense(node)
+          return unless verified_correction?(node)
+
           add_offense(node) do |corrector|
             corrector.replace(node, to_single_line(node.source).strip)
           end
           ignore_node(node)
+        end
+
+        # The exact single-line correction is verified to parse to the same
+        # AST before the offense is registered, so a join that would change
+        # how the code parses is never reported or offered. When the node lies
+        # within a method definition or class/module body (which parse
+        # standalone), only that scope is reparsed.
+        def verified_correction?(node)
+          corrector = Corrector.new(processed_source)
+          corrector.replace(node, to_single_line(node.source).strip)
+          corrected = corrector.process
+          scope = reparse_scope(node)
+
+          if scope
+            parses_equivalently?(scope.source, scope, corrected_scope_fragment(scope, corrected))
+          else
+            parses_equivalently?(processed_source.raw_source, processed_source.ast, corrected)
+          end
+        end
+
+        def reparse_scope(node)
+          scope = node.each_ancestor(:any_def, :class, :module, :sclass).first
+          scope if scope&.source_range&.contains?(node.source_range)
+        end
+
+        def corrected_scope_fragment(scope, corrected)
+          delta = corrected.length - processed_source.raw_source.length
+          scope_range = scope.source_range
+
+          corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
+        end
+
+        # Both sides are parsed with the original path so that `__FILE__`
+        # resolves identically. When the fragment uses `__LINE__`, both sides
+        # are reparsed with the keyword neutralized: joining lines shifts the
+        # value of any later `__LINE__`, exactly as any other line-removing
+        # correction does, and that shift should not block the offense.
+        def parses_equivalently?(original, original_ast, corrected)
+          if original.include?('__LINE__')
+            original_ast = parse(neutralize_line_keyword(original), processed_source.path).ast
+            corrected = neutralize_line_keyword(corrected)
+          end
+
+          rewritten = parse(corrected, processed_source.path)
+          return false unless rewritten.valid_syntax? && original_ast
+
+          fold_string_concatenation(rewritten.ast) == fold_string_concatenation(original_ast)
+        end
+
+        def neutralize_line_keyword(source)
+          # The replacement must stay valid in every position `__LINE__` can
+          # appear in (expression, symbol, string content); an ordinary
+          # identifier parses symmetrically on both sides.
+          source.gsub(/\b__LINE__\b/, '__LINE0__')
+        end
+
+        # Joining lines merges split string literals (`"a" \<newline> "b"` into
+        # `"ab"`) and turns mixed-quote pairs into `+` concatenation, which
+        # changes the tree but not the resulting string. Normalize all string
+        # concatenation to a canonical form before comparing: nested
+        # concatenations are flattened and adjacent literal parts merged.
+        def fold_string_concatenation(node)
+          return node unless node.is_a?(::Parser::AST::Node)
+
+          children = node.children.map { |child| fold_string_concatenation(child) }
+          node = node.updated(nil, children)
+
+          parts = string_concatenation_parts(node)
+          return node unless parts
+
+          merged = merge_string_parts(parts)
+          if merged.one? && merged.first.str_type?
+            node.updated(:str, merged.first.children)
+          else
+            node.updated(:dstr, merged)
+          end
+        end
+
+        def string_concatenation_parts(node)
+          case node.type
+          when :dstr
+            node.children
+          when :send
+            parts = [node.receiver, *node.arguments]
+            parts if node.method?(:+) && parts.all? { |part| stringish?(part) }
+          end
+        end
+
+        def merge_string_parts(parts)
+          flattened = parts.flat_map do |part|
+            part.is_a?(::Parser::AST::Node) && part.dstr_type? ? part.children : [part]
+          end
+
+          flattened.chunk_while { |left, right| plain_string?(left) && plain_string?(right) }
+                   .map { |chunk| merge_plain_strings(chunk) }
+        end
+
+        def merge_plain_strings(chunk)
+          return chunk.first if chunk.one?
+
+          chunk.first.updated(:str, [chunk.map { |part| part.children.first }.join])
+        end
+
+        def stringish?(node)
+          node.is_a?(::Parser::AST::Node) && %i[str dstr].include?(node.type)
+        end
+
+        def plain_string?(node)
+          node.is_a?(::Parser::AST::Node) && node.str_type? && node.children.one?
         end
 
         def offense?(node)

--- a/lib/rubocop/cop/mixin.rb
+++ b/lib/rubocop/cop/mixin.rb
@@ -65,6 +65,7 @@ module RuboCop
     autoload :PrecedingFollowingAlignment, "#{__dir__}/mixin/preceding_following_alignment"
     autoload :PreferredDelimiters, "#{__dir__}/mixin/preferred_delimiters"
     autoload :RationalLiteral, "#{__dir__}/mixin/rational_literal"
+    autoload :ReparsedEquivalence, "#{__dir__}/mixin/reparsed_equivalence"
     autoload :RequireLibrary, "#{__dir__}/mixin/require_library"
     autoload :RescueNode, "#{__dir__}/mixin/rescue_node"
     autoload :SafeAssignment, "#{__dir__}/mixin/safe_assignment"

--- a/lib/rubocop/cop/mixin/reparsed_equivalence.rb
+++ b/lib/rubocop/cop/mixin/reparsed_equivalence.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Verifies that a candidate rewrite of the inspected source is a syntactic
+    # no-op: the rewritten source must parse successfully and produce the same
+    # AST as the original.
+    #
+    # This turns "is this piece of syntax redundant?" questions into a
+    # parser-backed check instead of a hand-maintained enumeration of grammar
+    # rules: instead of modeling which constructs make (for example) a line
+    # continuation or a pair of parentheses significant, a cop can apply the
+    # removal and let the parser answer.
+    #
+    # Note that comments are invisible to the AST, so rewrites that may touch
+    # comment text must be guarded separately by the caller.
+    module ReparsedEquivalence
+      private
+
+      # Whether `rewritten_source` parses to the same AST as the source under
+      # inspection.
+      def parses_identically?(rewritten_source)
+        rewritten = parse(rewritten_source)
+
+        rewritten.valid_syntax? && rewritten.ast == processed_source.ast
+      end
+
+      # Whether `rewritten_fragment` parses to the same AST as `scope_node`, a
+      # node whose source parses standalone (e.g. a method definition).
+      # Reparsing just the scope enclosing an edit is much cheaper than
+      # reparsing the whole file.
+      def parses_identically_to_node?(scope_node, rewritten_fragment)
+        rewritten = parse(rewritten_fragment)
+
+        rewritten.valid_syntax? && rewritten.ast == scope_node
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -5,10 +5,13 @@ module RuboCop
     module Style
       # Checks for redundant line continuation.
       #
-      # This cop marks a line continuation as redundant if removing the backslash
-      # does not result in a syntax error.
-      # However, a backslash at the end of a comment or
-      # for string concatenation is not redundant and is not considered an offense.
+      # A line continuation is redundant when removing the backslash does not
+      # change how the program parses: the source is reparsed without the
+      # backslash and the resulting AST is compared to the original. Only
+      # backslashes that are pure noise are reported; backslashes that are
+      # significant — inside strings, for string concatenation, before an
+      # operator or argument that would otherwise start a new statement, and
+      # so on — are left alone, as are backslashes in comments.
       #
       # @example
       #   # bad
@@ -66,31 +69,18 @@ module RuboCop
       #
       class RedundantLineContinuation < Base
         include MatchRange
+        include ReparsedEquivalence
         extend AutoCorrector
 
         MSG = 'Redundant line continuation.'
         LINE_CONTINUATION = '\\'
         LINE_CONTINUATION_PATTERN = /(\\\n)/.freeze
-        ALLOWED_STRING_TOKENS = %i[tSTRING tSTRING_CONTENT].freeze
-        ARGUMENT_TYPES = %i[
-          kDEF kDEFINED kFALSE kNIL kSELF kTRUE tAMPER tBANG tCARET tCHARACTER tCOLON3 tCONSTANT
-          tCVAR tDOT2 tDOT3 tFLOAT tGVAR tIDENTIFIER tINTEGER tIVAR tLAMBDA tLBRACK tLCURLY
-          tLPAREN_ARG tPIPE tQSYMBOLS_BEG tQWORDS_BEG tREGEXP_BEG tSTAR tSTRING tSTRING_BEG tSYMBEG
-          tSYMBOL tSYMBOLS_BEG tTILDE tUMINUS tUNARY_NUM tUPLUS tWORDS_BEG tXSTRING_BEG
-        ].freeze
-        ARGUMENT_TAKING_FLOW_TOKEN_TYPES = %i[
-          tIDENTIFIER kBREAK kNEXT kRETURN kSUPER kYIELD
-        ].freeze
-        ARITHMETIC_OPERATOR_TOKENS = %i[tDIVIDE tDSTAR tMINUS tPERCENT tPLUS tSTAR2].freeze
-        STRING_LITERAL_BEGIN_TOKENS = %i[tSTRING_BEG tXSTRING_BEG tREGEXP_BEG tSYMBEG].freeze
+        STRING_TOKEN_TYPES = %i[tSTRING tSTRING_CONTENT].freeze
 
         def on_new_investigation
           return unless processed_source.ast
 
-          each_match_range(processed_source.ast.source_range, LINE_CONTINUATION_PATTERN) do |range|
-            next if require_line_continuation?(range)
-            next unless redundant_line_continuation?(range)
-
+          redundant_ranges(line_continuation_candidates).each do |range|
             add_offense(range) do |corrector|
               corrector.remove_leading(range, 1)
             end
@@ -101,85 +91,100 @@ module RuboCop
 
         private
 
-        def require_line_continuation?(range)
-          !ends_with_uncommented_backslash?(range) ||
-            string_concatenation?(range.source_line) ||
-            start_with_arithmetic_operator?(range) ||
-            inside_string_literal_or_method_with_argument?(range) ||
-            inside_string_literal_with_interpolation?(range) ||
-            leading_dot_method_chain_with_blank_line?(range)
+        def line_continuation_candidates
+          candidates = []
+
+          each_match_range(processed_source.ast.source_range, LINE_CONTINUATION_PATTERN) do |range|
+            next if within_comment?(range) || within_string_content?(range)
+            next if leading_dot_method_chain_with_blank_line?(range)
+
+            candidates << range
+          end
+
+          candidates
         end
 
-        def ends_with_uncommented_backslash?(range)
-          # A line continuation always needs to be the last character on the line, which
-          # means that it is impossible to have a comment following a continuation.
-          # Therefore, if the line contains a comment, it cannot end with a continuation.
-          return false if processed_source.line_with_comment?(range.line)
+        # All candidates are first verified together with a single reparse: in
+        # the common case a file's continuations are either all redundant or
+        # all significant, so most files need at most one reparse regardless of
+        # how many continuations they contain.
+        def redundant_ranges(candidates)
+          return [] if candidates.empty?
+          return candidates if candidates.size > 1 && removable_backslashes?(candidates)
 
-          range.source_line.end_with?(LINE_CONTINUATION)
+          candidates.select { |range| removable_backslashes?([range]) }
         end
 
-        def string_concatenation?(source_line)
-          /["']\s*\\\z/.match?(source_line)
-        end
-
-        def inside_string_literal_or_method_with_argument?(range)
-          line_range = range_by_whole_lines(range)
-
-          processed_source.tokens.each_cons(2).any? do |token, next_token|
-            next if token.line == next_token.line
-
-            inside_string_literal?(range, token) ||
-              method_with_argument?(line_range, token, next_token)
+        # A backslash is redundant if the source parses to the same AST without
+        # it. Comments are not part of the AST, so backslashes in comments are
+        # excluded up front. When all backslashes lie within a method
+        # definition, only that definition is reparsed instead of the whole
+        # file.
+        def removable_backslashes?(ranges)
+          if (scope = enclosing_def_node(ranges))
+            parses_identically_to_node?(scope, without_backslashes(scope.source, ranges,
+                                                                   scope.source_range.begin_pos))
+          else
+            parses_identically?(without_backslashes(processed_source.raw_source, ranges, 0))
           end
         end
 
-        def inside_string_literal_with_interpolation?(range)
-          string_depth = 0
-          processed_source.tokens.each do |token|
-            break if token.pos.begin_pos >= range.begin_pos
-
-            if STRING_LITERAL_BEGIN_TOKENS.include?(token.type)
-              string_depth += 1
-            elsif token.type == :tSTRING_END
-              string_depth -= 1
-            end
-          end
-          string_depth.positive?
+        def without_backslashes(source, ranges, base)
+          source = source.dup
+          ranges.reverse_each { |range| source.slice!(range.begin_pos - base) }
+          source
         end
 
+        # A method definition parses standalone, so it can serve as the
+        # reparse scope for the backslashes it contains.
+        def enclosing_def_node(ranges)
+          processed_source.ast.each_node(:any_def) do |node|
+            source_range = node.source_range
+            return node if ranges.all? { |range| source_range.contains?(range) }
+          end
+
+          nil
+        end
+
+        def within_comment?(range)
+          processed_source.comments.any? do |comment|
+            comment.source_range.overlaps?(range)
+          end
+        end
+
+        # A backslash in string content is never a redundant line continuation
+        # (removing it changes the string's value, which the reparse check would
+        # detect); skipping it up front just avoids a useless reparse.
+        def within_string_content?(range)
+          @string_content_ranges ||= processed_source.tokens.filter_map do |token|
+            token.pos if STRING_TOKEN_TYPES.include?(token.type)
+          end
+
+          @string_content_ranges.any? { |pos| pos.overlaps?(range) }
+        end
+
+        # The `parser` gem, unlike Ruby itself, accepts a leading-dot method
+        # chain continued across a blank line, so the reparse check alone would
+        # deem the backslash redundant even though removing it breaks the code
+        # on MRI. Prism matches Ruby here and does not need this guard.
         def leading_dot_method_chain_with_blank_line?(range)
           return false unless range.source_line.strip.start_with?('.', '&.')
 
           processed_source[range.line].strip.empty?
         end
 
-        def redundant_line_continuation?(range)
-          return true unless (node = find_node_for_line(range.last_line))
-          return false if argument_newline?(node)
-
-          # Check if source is still valid without the continuation
-          source = processed_source.raw_source.dup
-          source[range.begin_pos, range.length] = "\n"
-          parse(source).valid_syntax?
-        end
-
         def inspect_end_of_ruby_code_line_continuation
           last_line_number = processed_source.ast.last_line
           last_line = processed_source.lines[last_line_number - 1]
-          return unless code_ends_with_continuation?(last_line)
+          return unless last_line&.end_with?(LINE_CONTINUATION)
 
-          line_continuation_range = trailing_line_continuation_range(last_line_number)
+          range = trailing_line_continuation_range(last_line_number)
+          return if within_comment?(range)
+          return unless removable_backslashes?([range])
 
-          add_offense(line_continuation_range) do |corrector|
-            corrector.remove_trailing(line_continuation_range, 1)
+          add_offense(range) do |corrector|
+            corrector.remove_trailing(range, 1)
           end
-        end
-
-        def code_ends_with_continuation?(last_line)
-          return false if processed_source.line_with_comment?(processed_source.ast.last_line)
-
-          last_line.end_with?(LINE_CONTINUATION)
         end
 
         # The backslash is the last character of the line; locate it by the line's
@@ -188,71 +193,6 @@ module RuboCop
         def trailing_line_continuation_range(line_number)
           line_range = processed_source.buffer.line_range(line_number)
           range_between(line_range.end_pos - 1, line_range.end_pos)
-        end
-
-        def inside_string_literal?(range, token)
-          ALLOWED_STRING_TOKENS.include?(token.type) && token.pos.overlaps?(range)
-        end
-
-        # A method call without parentheses such as the following cannot remove `\`:
-        #
-        #   do_something \
-        #     argument
-        def method_with_argument?(line_range, current_token, next_token)
-          return false unless ARGUMENT_TAKING_FLOW_TOKEN_TYPES.include?(current_token.type)
-          return false unless current_token.pos.overlaps?(line_range)
-
-          ARGUMENT_TYPES.include?(next_token.type)
-        end
-
-        def argument_newline?(node)
-          return false if node.parenthesized_call?
-
-          node = node.children.first if node.root? && node.begin_type?
-
-          if argument_is_method?(node)
-            argument_newline?(node.first_argument)
-          else
-            return false unless method_call_with_arguments?(node)
-
-            node.loc.selector.line != node.first_argument.loc.line
-          end
-        end
-
-        def find_node_for_line(last_line)
-          processed_source.ast.each_node do |node|
-            return node if same_line?(node, last_line)
-          end
-        end
-
-        def same_line?(node, line)
-          return false unless (source_range = node.source_range)
-
-          if node.is_a?(AST::StrNode)
-            if node.heredoc?
-              (node.loc.heredoc_body.line..node.loc.heredoc_body.last_line).cover?(line)
-            else
-              (source_range.line..source_range.last_line).cover?(line)
-            end
-          else
-            source_range.line == line
-          end
-        end
-
-        def argument_is_method?(node)
-          return false unless node.send_type?
-          return false unless (first_argument = node.first_argument)
-
-          method_call_with_arguments?(first_argument)
-        end
-
-        def method_call_with_arguments?(node)
-          node.call_type? && !node.arguments.empty?
-        end
-
-        def start_with_arithmetic_operator?(range)
-          line_range = processed_source.buffer.line_range(range.line + 1)
-          ARITHMETIC_OPERATOR_TOKENS.include?(processed_source.first_token_of(line_range).type)
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -1091,4 +1091,28 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
         c = [1, 2, 3]
     RUBY
   end
+
+  it 'registers an offense for a line continuation after the last string of a concatenation' do
+    expect_offense(<<~'RUBY')
+      def foo
+        'first' \
+          'second' \
+                   ^ Redundant line continuation.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def foo
+        'first' \\
+          'second'#{trailing_whitespace}
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a line continuation in an endless method definition', :ruby30 do
+    expect_no_offenses(<<~'RUBY')
+      def foo = 1 \
+        + 2
+    RUBY
+  end
 end


### PR DESCRIPTION
Stacked on #15471; same recipe as #15472, applied to `Layout/RedundantLineBreak`: the exact single-line correction is applied to a copy of the source, reparsed, and required to produce the same AST before the offense is registered. The regex-based line joining in `CheckSingleLineSuitability` has been a steady source of "autocorrect produced invalid code" bugs over the years - the gate suppresses that entire class instead of fixing it one report at a time.

Three equivalence subtleties surfaced and are handled in the comparison: joining merges split string literals (`"a" \<newline> "b"` becomes `"ab"`) and turns mixed-quote pairs into `+` concatenation, so string concatenation is normalized to a canonical form; the original path is passed to the reparse so `__FILE__` resolves identically; and `__LINE__` is neutralized on both sides, since joining lines shifts later `__LINE__` values exactly as any other line-removing correction rubocop performs does.

Corrections over a 400-file corpus are byte-identical to the previous implementation (the verification fires only where the cop already intends to flag, and it reparses only the enclosing method definition or class/module body where possible). Full spec suite passes under both parser engines.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
