### PR TITLE
Verify `Layout/RedundantLineBreak` corrections by reparsing

### DIFF
--- a/changelog/change_verify_layout_redundant_line_break_corrections_by_reparsing_20260715182906.md
+++ b/changelog/change_verify_layout_redundant_line_break_corrections_by_reparsing_20260715182906.md
@@ -1,0 +1,1 @@
+* [#15476](https://github.com/rubocop/rubocop/pull/15476): Change `Layout/RedundantLineBreak` to verify each correction by reparsing before registering an offense. ([@bbatsov][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -82,10 +82,121 @@ module RuboCop
         end
 
         def register_offense(node)
+          return unless verified_correction?(node)
+
           add_offense(node) do |corrector|
             corrector.replace(node, to_single_line(node.source).strip)
           end
           ignore_node(node)
+        end
+
+        # The exact single-line correction is verified to parse to the same
+        # AST before the offense is registered, so a join that would change
+        # how the code parses is never reported or offered. When the node lies
+        # within a method definition or class/module body (which parse
+        # standalone), only that scope is reparsed.
+        def verified_correction?(node)
+          corrector = Corrector.new(processed_source)
+          corrector.replace(node, to_single_line(node.source).strip)
+          corrected = corrector.process
+          scope = reparse_scope(node)
+
+          if scope
+            parses_equivalently?(scope.source, scope, corrected_scope_fragment(scope, corrected))
+          else
+            parses_equivalently?(processed_source.raw_source, processed_source.ast, corrected)
+          end
+        end
+
+        def reparse_scope(node)
+          scope = node.each_ancestor(:any_def, :class, :module, :sclass).first
+          scope if scope&.source_range&.contains?(node.source_range)
+        end
+
+        def corrected_scope_fragment(scope, corrected)
+          delta = corrected.length - processed_source.raw_source.length
+          scope_range = scope.source_range
+
+          corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
+        end
+
+        # Both sides are parsed with the original path so that `__FILE__`
+        # resolves identically. When the fragment uses `__LINE__`, both sides
+        # are reparsed with the keyword neutralized: joining lines shifts the
+        # value of any later `__LINE__`, exactly as any other line-removing
+        # correction does, and that shift should not block the offense.
+        def parses_equivalently?(original, original_ast, corrected)
+          if original.include?('__LINE__')
+            original_ast = parse(neutralize_line_keyword(original), processed_source.path).ast
+            corrected = neutralize_line_keyword(corrected)
+          end
+
+          rewritten = parse(corrected, processed_source.path)
+          return false unless rewritten.valid_syntax? && original_ast
+
+          fold_string_concatenation(rewritten.ast) == fold_string_concatenation(original_ast)
+        end
+
+        def neutralize_line_keyword(source)
+          # The replacement must stay valid in every position `__LINE__` can
+          # appear in (expression, symbol, string content); an ordinary
+          # identifier parses symmetrically on both sides.
+          source.gsub(/\b__LINE__\b/, '__LINE0__')
+        end
+
+        # Joining lines merges split string literals (`"a" \<newline> "b"` into
+        # `"ab"`) and turns mixed-quote pairs into `+` concatenation, which
+        # changes the tree but not the resulting string. Normalize all string
+        # concatenation to a canonical form before comparing: nested
+        # concatenations are flattened and adjacent literal parts merged.
+        def fold_string_concatenation(node)
+          return node unless node.is_a?(::Parser::AST::Node)
+
+          children = node.children.map { |child| fold_string_concatenation(child) }
+          node = node.updated(nil, children)
+
+          parts = string_concatenation_parts(node)
+          return node unless parts
+
+          merged = merge_string_parts(parts)
+          if merged.one? && merged.first.str_type?
+            node.updated(:str, merged.first.children)
+          else
+            node.updated(:dstr, merged)
+          end
+        end
+
+        def string_concatenation_parts(node)
+          case node.type
+          when :dstr
+            node.children
+          when :send
+            parts = [node.receiver, *node.arguments]
+            parts if node.method?(:+) && parts.all? { |part| stringish?(part) }
+          end
+        end
+
+        def merge_string_parts(parts)
+          flattened = parts.flat_map do |part|
+            part.is_a?(::Parser::AST::Node) && part.dstr_type? ? part.children : [part]
+          end
+
+          flattened.chunk_while { |left, right| plain_string?(left) && plain_string?(right) }
+                   .map { |chunk| merge_plain_strings(chunk) }
+        end
+
+        def merge_plain_strings(chunk)
+          return chunk.first if chunk.one?
+
+          chunk.first.updated(:str, [chunk.map { |part| part.children.first }.join])
+        end
+
+        def stringish?(node)
+          node.is_a?(::Parser::AST::Node) && %i[str dstr].include?(node.type)
+        end
+
+        def plain_string?(node)
+          node.is_a?(::Parser::AST::Node) && node.str_type? && node.children.one?
         end
 
         def offense?(node)


### PR DESCRIPTION
Replaces #15473, which was auto-closed when the stack's base branch (#15471) merged; content unchanged, rebased onto master.

The regex-based line joining in `CheckSingleLineSuitability` has been a steady source of "autocorrect produced invalid code" bugs; the reparse gate suppresses that entire class instead of fixing it one report at a time.

Three equivalence subtleties surfaced and are handled in the comparison: joining merges split string literals (`"a" \<newline> "b"` becomes `"ab"`) and turns mixed-quote pairs into `+` concatenation, so string concatenation is normalized to a canonical form; the original path is passed to the reparse so `__FILE__` resolves identically; and `__LINE__` is neutralized on both sides, since joining lines shifts later `__LINE__` values exactly as any other line-removing correction does.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
