### PR TITLE
Verify `Style/SoleNestedConditional` corrections parse before offering

### DIFF
--- a/changelog/change_verify_style_sole_nested_conditional_corrections_parse_before_offering_20260715184358.md
+++ b/changelog/change_verify_style_sole_nested_conditional_corrections_parse_before_offering_20260715184358.md
@@ -1,0 +1,1 @@
+* [#15478](https://github.com/rubocop/rubocop/pull/15478): Change `Style/SoleNestedConditional` to only register an offense when its correction is verified to parse. ([@bbatsov][])

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -57,11 +57,10 @@ module RuboCop
         end
 
         def on_if(node)
-          return if node.ternary? || node.else? || node.elsif?
+          return unless offending_conditional?(node)
 
           if_branch = node.if_branch
-          return if use_variable_assignment_in_condition?(node.condition, if_branch)
-          return unless offending_branch?(node, if_branch)
+          return unless correction_parses?(node, if_branch)
 
           message = format(MSG, conditional_type: node.keyword)
           add_offense(if_branch.loc.keyword, message: message) do |corrector|
@@ -73,6 +72,29 @@ module RuboCop
         end
 
         private
+
+        def offending_conditional?(node)
+          return false if node.ternary? || node.else? || node.elsif?
+
+          if_branch = node.if_branch
+          return false if use_variable_assignment_in_condition?(node.condition, if_branch)
+
+          offending_branch?(node, if_branch)
+        end
+
+        # Merging the conditionals intentionally produces a different AST, so
+        # full equivalence cannot be checked, but the corrected source must at
+        # least remain parseable: the exact correction is applied to a copy of
+        # the source and reparsed before the offense is registered, which
+        # suppresses the entire produces-invalid-code bug class.
+        def correction_parses?(node, if_branch)
+          corrector = Corrector.new(processed_source)
+          autocorrect(corrector, node, if_branch)
+
+          parse(corrector.process, processed_source.path).valid_syntax?
+        rescue ::Parser::ClobberingError
+          false
+        end
 
         def use_variable_assignment_in_condition?(condition, if_branch)
           assigned_variables = assigned_variables(condition)


### PR DESCRIPTION
A weaker gate than the other PRs in the series: it only requires that the corrected source still parses, applying the exact correction to a copy and reparsing before the offense is registered.

That still structurally suppresses this cop's dominant bug class: autocorrections producing invalid code through condition composition, comment handling, and modifier forms.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
