### PR TITLE
Consolidate reparse verification into `ReparsedEquivalence`

### DIFF
--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -49,6 +49,7 @@ module RuboCop
       class RedundantLineBreak < Base
         include CheckAssignment
         include CheckSingleLineSuitability
+        include ReparsedEquivalence
         extend AutoCorrector
 
         MSG = 'Redundant line break detected.'
@@ -82,7 +83,10 @@ module RuboCop
         end
 
         def register_offense(node)
-          return unless verified_correction?(node)
+          # The exact single-line correction is verified to parse equivalently
+          # before the offense is registered, so a join that would change how
+          # the code parses is never reported or offered.
+          return if verified_by_reparse([node], oversized: :verify).empty?
 
           add_offense(node) do |corrector|
             corrector.replace(node, to_single_line(node.source).strip)
@@ -90,58 +94,20 @@ module RuboCop
           ignore_node(node)
         end
 
-        # The exact single-line correction is verified to parse to the same
-        # AST before the offense is registered, so a join that would change
-        # how the code parses is never reported or offered. When the node lies
-        # within a method definition or class/module body (which parse
-        # standalone), only that scope is reparsed.
-        def verified_correction?(node)
-          corrector = Corrector.new(processed_source)
+        def apply_reparse_correction(corrector, node)
           corrector.replace(node, to_single_line(node.source).strip)
-          corrected = corrector.process
-          scope = reparse_scope(node)
-
-          if scope
-            parses_equivalently?(scope.source, scope, corrected_scope_fragment(scope, corrected))
-          else
-            parses_equivalently?(processed_source.raw_source, processed_source.ast, corrected)
-          end
         end
 
-        def reparse_scope(node)
-          scope = node.each_ancestor(:any_def, :class, :module, :sclass).first
-          scope if scope&.source_range&.contains?(node.source_range)
-        end
-
-        def corrected_scope_fragment(scope, corrected)
-          delta = corrected.length - processed_source.raw_source.length
-          scope_range = scope.source_range
-
-          corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
-        end
-
-        # Both sides are parsed with the original path so that `__FILE__`
-        # resolves identically. When the fragment uses `__LINE__`, both sides
-        # are reparsed with the keyword neutralized: joining lines shifts the
-        # value of any later `__LINE__`, exactly as any other line-removing
-        # correction does, and that shift should not block the offense.
-        def parses_equivalently?(original, original_ast, corrected)
-          if original.include?('__LINE__')
-            original_ast = parse(neutralize_line_keyword(original), processed_source.path).ast
-            corrected = neutralize_line_keyword(corrected)
-          end
-
-          rewritten = parse(corrected, processed_source.path)
-          return false unless rewritten.valid_syntax? && original_ast
-
-          fold_string_concatenation(rewritten.ast) == fold_string_concatenation(original_ast)
-        end
-
-        def neutralize_line_keyword(source)
-          # The replacement must stay valid in every position `__LINE__` can
-          # appear in (expression, symbol, string content); an ordinary
-          # identifier parses symmetrically on both sides.
+        # Joining lines shifts the value of any later `__LINE__`, exactly as
+        # any other line-removing correction does; neutralize it on both sides
+        # with an identifier, which stays valid in every position the keyword
+        # can appear in.
+        def preprocess_reparsed_source(source)
           source.gsub(/\b__LINE__\b/, '__LINE0__')
+        end
+
+        def normalize_reparsed_ast(node)
+          fold_string_concatenation(node)
         end
 
         # Joining lines merges split string literals (`"a" \<newline> "b"` into

--- a/lib/rubocop/cop/mixin/reparsed_equivalence.rb
+++ b/lib/rubocop/cop/mixin/reparsed_equivalence.rb
@@ -2,84 +2,168 @@
 
 module RuboCop
   module Cop
-    # Verifies that a candidate rewrite of the inspected source is a syntactic
-    # no-op: the rewritten source must parse successfully and produce the same
-    # AST as the original.
+    # Verifies that a candidate correction of the inspected source is a
+    # syntactic no-op: the corrected source must parse successfully and produce
+    # the same AST as the original.
     #
     # This turns "is this piece of syntax redundant?" questions into a
     # parser-backed check instead of a hand-maintained enumeration of grammar
     # rules: instead of modeling which constructs make (for example) a line
     # continuation or a pair of parentheses significant, a cop can apply the
-    # removal and let the parser answer.
+    # correction and let the parser answer.
     #
-    # Note that comments are invisible to the AST, so rewrites that may touch
-    # comment text must be guarded separately by the caller.
+    # Cops implement `#apply_reparse_correction(corrector, item)` and call
+    # `verified_by_reparse(items)`, which returns the items whose corrections
+    # are verified. Items sharing a reparse scope (the innermost method
+    # definition or class/module body, which parse standalone and cannot
+    # capture outer local variables) are verified together with a single
+    # reparse, falling back to per-item verification when the batch does not
+    # hold. Scope groups are keyed by node identity, since structurally
+    # identical definitions in different places must not share a group.
+    #
+    # Two hooks customize the comparison:
+    #
+    # * `normalize_reparsed_ast(node)` - loosen strict tree equality where a
+    #   cop's correction is equivalence-preserving beyond parse identity (such
+    #   laws must be justified per cop; the default compares trees as-is).
+    # * `preprocess_reparsed_source(source)` - rewrite both sides before
+    #   parsing (e.g. to neutralize `__LINE__` when a correction legitimately
+    #   shifts line numbers).
+    #
+    # `__FILE__` is handled by parsing with the original path, and fragments
+    # containing `__LINE__` are verified by reparsing both sides so that
+    # fragment line offsets cancel out.
+    #
+    # Note that comments are invisible to the AST, so corrections that may
+    # touch comment text must be guarded separately by the caller.
     module ReparsedEquivalence
+      # Above this size, verification does not reparse. What happens to such
+      # items depends on `oversized`; in practice only machine-generated files
+      # come near the limit.
+      MAX_VERIFICATION_FRAGMENT_SIZE = 64 * 1024
+
       private
 
-      # Whether `rewritten_source` parses to the same AST as the source under
-      # inspection.
-      def parses_identically?(rewritten_source)
-        rewritten = parse(rewritten_source)
-
-        rewritten.valid_syntax? && rewritten.ast == processed_source.ast
-      end
-
-      # Whether `rewritten_fragment` parses to the same AST as `scope_node`, a
-      # node whose source parses standalone (e.g. a method definition).
-      # Reparsing just the scope enclosing an edit is much cheaper than
-      # reparsing the whole file.
-      def parses_identically_to_node?(scope_node, rewritten_fragment)
-        rewritten = parse(rewritten_fragment)
-
-        rewritten.valid_syntax? && rewritten.ast == scope_node
-      end
-
-      # Like `parses_identically?`, but treats grouping parentheses as
-      # transparent: single-child `begin` nodes are collapsed on both sides
-      # before comparison, so removing a pair of grouping parentheses that
-      # does not affect how the code parses counts as identical.
-      def parses_identically_ignoring_grouping?(rewritten_source)
-        rewritten = parse(rewritten_source)
-        return false unless rewritten.valid_syntax?
-
-        collapse_groupings(rewritten.ast) == collapsed_scope(processed_source.ast)
-      end
-
-      # The scoped counterpart of `parses_identically_ignoring_grouping?`:
-      # compares `rewritten_fragment` against `scope_node` (a node whose
-      # source parses standalone, e.g. a method definition), so only the
-      # scope enclosing an edit needs to be reparsed.
-      def parses_fragment_identically_ignoring_grouping?(scope_node, rewritten_fragment)
-        rewritten = parse(rewritten_fragment)
-        return false unless rewritten.valid_syntax?
-
-        collapse_groupings(rewritten.ast) == collapsed_scope(scope_node)
-      end
-
-      def collapsed_scope(scope_node)
-        @collapsed_scopes ||= {}.compare_by_identity
-        @collapsed_scopes[scope_node] ||= collapse_groupings(scope_node)
-      end
-
-      def collapse_groupings(node)
-        return node unless node.is_a?(::Parser::AST::Node)
-
-        children = node.children.map { |child| collapse_groupings(child) }
-        children = splice_nested_sequences(children) if %i[begin kwbegin].include?(node.type)
-
-        if node.begin_type? && children.one? && children.first.is_a?(::Parser::AST::Node)
-          children.first
-        else
-          node.updated(nil, children)
+      # Returns the items whose corrections are verified. `oversized` controls
+      # items whose reparse scope exceeds `MAX_VERIFICATION_FRAGMENT_SIZE`:
+      # `:report` accepts them unverified (for cops whose offense logic stands
+      # on its own and uses verification as a safety gate), `:verify` reparses
+      # regardless of size (for cops where verification is the offense logic).
+      def verified_by_reparse(items, oversized: :report)
+        scope_groups(items).flat_map do |scope, group|
+          if (oversized == :report && verification_too_large?(scope)) ||
+             (group.size > 1 && corrections_verify?(scope, group))
+            group
+          else
+            group.select { |item| corrections_verify?(scope, [item]) }
+          end
         end
       end
 
-      # A parenthesized statement sequence inside another sequence is
-      # equivalent to its statements spliced in place.
-      def splice_nested_sequences(children)
-        children.flat_map do |child|
-          child.is_a?(::Parser::AST::Node) && child.begin_type? ? child.children : [child]
+      # Whether the exact correction for `item` produces source that still
+      # parses, without requiring an equivalent AST. For corrections that
+      # intentionally change the tree.
+      def correction_parses?(item)
+        corrector = Corrector.new(processed_source)
+        apply_reparse_correction(corrector, item)
+
+        parse(corrector.process, processed_source.path).valid_syntax?
+      rescue ::Parser::ClobberingError
+        false
+      end
+
+      # Hook: loosen strict tree equality for corrections that are
+      # equivalence-preserving beyond parse identity.
+      def normalize_reparsed_ast(node)
+        node
+      end
+
+      # Hook: rewrite both sides before parsing.
+      def preprocess_reparsed_source(source)
+        source
+      end
+
+      def scope_groups(items)
+        groups = {}.compare_by_identity
+        items.each { |item| (groups[reparse_scope(item_range(item))] ||= []) << item }
+
+        groups
+      end
+
+      def item_range(item)
+        item.respond_to?(:source_range) ? item.source_range : item
+      end
+
+      # The innermost scope that both contains `range` and parses standalone.
+      # Method definitions and class/module bodies neither capture outer local
+      # variables nor continue an outer expression; blocks and single
+      # statements do not qualify, since an outer local would reparse as a
+      # method call.
+      def reparse_scope(range)
+        node = processed_source.ast
+        scope = nil
+
+        while node.is_a?(::Parser::AST::Node)
+          scope = node if node.type?(:any_def, :class, :module, :sclass)
+          node = node.children.find do |child|
+            child.is_a?(::Parser::AST::Node) && child.source_range&.contains?(range)
+          end
+        end
+
+        scope
+      end
+
+      def verification_too_large?(scope)
+        (scope ? scope.source_range.size : processed_source.raw_source.size) >
+          MAX_VERIFICATION_FRAGMENT_SIZE
+      end
+
+      def corrections_verify?(scope, items)
+        corrector = Corrector.new(processed_source)
+        items.each { |item| apply_reparse_correction(corrector, item) }
+        corrected = corrector.process
+
+        if scope
+          fragment = corrected_scope_fragment(scope, corrected)
+          parses_equivalently?(scope.source, scope, fragment)
+        else
+          parses_equivalently?(processed_source.raw_source, processed_source.ast, corrected)
+        end
+      rescue ::Parser::ClobberingError
+        false
+      end
+
+      # The corrections' edits are all contained within the scope, so the
+      # corrected fragment can be cut out of the corrected source by adjusting
+      # for the edits' length delta.
+      def corrected_scope_fragment(scope, corrected)
+        delta = corrected.length - processed_source.raw_source.length
+        scope_range = scope.source_range
+
+        corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
+      end
+
+      # Both sides are parsed with the original path so that `__FILE__`
+      # resolves identically. The original side is reparsed (instead of using
+      # the already parsed node) when preprocessing altered it or it contains
+      # `__LINE__`, whose values would otherwise differ from a fragment parsed
+      # at a different line offset.
+      def parses_equivalently?(original_source, original_ast, corrected_source)
+        original_normalized = normalized_original(original_source, original_ast)
+        return false unless original_normalized
+
+        rewritten = parse(preprocess_reparsed_source(corrected_source), processed_source.path)
+        rewritten.valid_syntax? && normalize_reparsed_ast(rewritten.ast) == original_normalized
+      end
+
+      def normalized_original(original_source, original_ast)
+        original = preprocess_reparsed_source(original_source)
+        if original != original_source || original_source.include?('__LINE__')
+          reparsed = parse(original, processed_source.path).ast
+          reparsed && normalize_reparsed_ast(reparsed)
+        else
+          @normalized_originals ||= {}.compare_by_identity
+          @normalized_originals[original_ast] ||= normalize_reparsed_ast(original_ast)
         end
       end
     end

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -8,23 +8,22 @@ module RuboCop
         # rubocop:disable Metrics/ModuleLength, Metrics/CyclomaticComplexity
         module OmitParentheses
           include RangeHelp
+          include ReparsedEquivalence
 
           TRAILING_WHITESPACE_REGEX = /\s+\Z/.freeze
           OMIT_MSG = 'Omit parentheses for method calls with arguments.'
           private_constant :OMIT_MSG
 
-          # Above this size, an unverifiable candidate is reported based on
-          # the style logic alone instead of reparsing a huge fragment; in
-          # practice only machine-generated files come near it.
-          MAX_VERIFICATION_FRAGMENT_SIZE = 64 * 1024
-          private_constant :MAX_VERIFICATION_FRAGMENT_SIZE
-
           def on_investigation_end
-            verified_omit_offenses.each do |node|
+            # Each candidate's exact correction is verified by reparsing before
+            # the offense is registered, so an omission that would change how
+            # the code parses is never reported or offered.
+            verified_by_reparse(@pending_omit_offenses || []).each do |node|
               add_offense(offense_range(node), message: OMIT_MSG) do |corrector|
                 autocorrect(corrector, node)
               end
             end
+            @pending_omit_offenses = []
 
             super
           end
@@ -45,83 +44,8 @@ module RuboCop
             (@pending_omit_offenses ||= []) << node
           end
 
-          # Each candidate's exact correction is applied to a copy of the
-          # source and verified to parse to the same AST before the offense is
-          # registered, so an omission that would change how the code parses
-          # is never reported or offered. Candidates sharing a reparse scope
-          # are verified together with a single reparse first, falling back to
-          # per-candidate verification only when the batch does not hold.
-          def verified_omit_offenses
-            pending = @pending_omit_offenses || []
-            @pending_omit_offenses = []
-
-            # Group by scope identity: structurally identical definitions in
-            # different places must not share a group.
-            groups = {}.compare_by_identity
-            pending.each { |node| (groups[omission_reparse_scope(node)] ||= []) << node }
-
-            groups.flat_map { |scope, nodes| verified_group(scope, nodes) }
-          end
-
-          def verified_group(scope, nodes)
-            return nodes if verification_too_large?(scope)
-
-            if nodes.one? || !verified_omission?(scope, nodes)
-              nodes.select { |node| verified_omission?(scope, [node]) }
-            else
-              nodes
-            end
-          end
-
-          def verification_too_large?(scope)
-            (scope ? scope.source_range.size : processed_source.raw_source.size) >
-              MAX_VERIFICATION_FRAGMENT_SIZE
-          end
-
-          def verified_omission?(scope, nodes)
-            corrector = Corrector.new(processed_source)
-            nodes.each { |node| autocorrect(corrector, node) }
-            corrected = corrector.process
-
-            if scope
-              fragment = corrected_scope_fragment(scope, corrected)
-              omission_parses_equivalently?(scope.source, scope, fragment)
-            else
-              omission_parses_equivalently?(
-                processed_source.raw_source, processed_source.ast, corrected
-              )
-            end
-          rescue ::Parser::ClobberingError
-            false
-          end
-
-          # The corrections' edits are all contained within the scope, so the
-          # corrected fragment can be cut out of the corrected source by
-          # adjusting for the edits' length delta.
-          def corrected_scope_fragment(scope, corrected)
-            delta = corrected.length - processed_source.raw_source.length
-            scope_range = scope.source_range
-
-            corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
-          end
-
-          def omission_reparse_scope(node)
-            scope = node.each_ancestor(:any_def, :class, :module, :sclass).first
-            scope if scope&.source_range&.contains?(node.source_range)
-          end
-
-          # Both sides are parsed with the original path so that `__FILE__`
-          # resolves identically. When the fragment uses `__LINE__`, both
-          # sides are reparsed so that fragment line offsets do not produce
-          # spurious differences.
-          def omission_parses_equivalently?(original, original_ast, corrected)
-            if original.include?('__LINE__')
-              original_ast = parse(original, processed_source.path).ast
-            end
-
-            rewritten = parse(corrected, processed_source.path)
-
-            rewritten.valid_syntax? && original_ast && rewritten.ast == original_ast
+          def apply_reparse_correction(corrector, node)
+            autocorrect(corrector, node)
           end
 
           def autocorrect(corrector, node)

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -80,7 +80,10 @@ module RuboCop
         def on_new_investigation
           return unless processed_source.ast
 
-          redundant_ranges(line_continuation_candidates).each do |range|
+          # A backslash is redundant if the source parses to the same AST
+          # without it; verification is the offense logic itself, so oversized
+          # scopes are reparsed regardless of size.
+          verified_by_reparse(line_continuation_candidates, oversized: :verify).each do |range|
             add_offense(range) do |corrector|
               corrector.remove_leading(range, 1)
             end
@@ -90,6 +93,10 @@ module RuboCop
         end
 
         private
+
+        def apply_reparse_correction(corrector, range)
+          corrector.remove_leading(range, 1)
+        end
 
         def line_continuation_candidates
           candidates = []
@@ -102,48 +109,6 @@ module RuboCop
           end
 
           candidates
-        end
-
-        # All candidates are first verified together with a single reparse: in
-        # the common case a file's continuations are either all redundant or
-        # all significant, so most files need at most one reparse regardless of
-        # how many continuations they contain.
-        def redundant_ranges(candidates)
-          return [] if candidates.empty?
-          return candidates if candidates.size > 1 && removable_backslashes?(candidates)
-
-          candidates.select { |range| removable_backslashes?([range]) }
-        end
-
-        # A backslash is redundant if the source parses to the same AST without
-        # it. Comments are not part of the AST, so backslashes in comments are
-        # excluded up front. When all backslashes lie within a method
-        # definition, only that definition is reparsed instead of the whole
-        # file.
-        def removable_backslashes?(ranges)
-          if (scope = enclosing_def_node(ranges))
-            parses_identically_to_node?(scope, without_backslashes(scope.source, ranges,
-                                                                   scope.source_range.begin_pos))
-          else
-            parses_identically?(without_backslashes(processed_source.raw_source, ranges, 0))
-          end
-        end
-
-        def without_backslashes(source, ranges, base)
-          source = source.dup
-          ranges.reverse_each { |range| source.slice!(range.begin_pos - base) }
-          source
-        end
-
-        # A method definition parses standalone, so it can serve as the
-        # reparse scope for the backslashes it contains.
-        def enclosing_def_node(ranges)
-          processed_source.ast.each_node(:any_def) do |node|
-            source_range = node.source_range
-            return node if ranges.all? { |range| source_range.contains?(range) }
-          end
-
-          nil
         end
 
         def within_comment?(range)
@@ -180,7 +145,7 @@ module RuboCop
 
           range = trailing_line_continuation_range(last_line_number)
           return if within_comment?(range)
-          return unless removable_backslashes?([range])
+          return if verified_by_reparse([range], oversized: :verify).empty?
 
           add_offense(range) do |corrector|
             corrector.remove_trailing(range, 1)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -31,14 +31,8 @@ module RuboCop
         # @!method allowed_pin_operator?(node)
         def_node_matcher :allowed_pin_operator?, '^(pin (begin !{lvar ivar cvar gvar}))'
 
-        # Above this size, an unverifiable candidate is reported based on the
-        # message logic alone (the pre-verification behavior) instead of
-        # reparsing a huge fragment per candidate; in practice only
-        # machine-generated files come near it.
-        MAX_VERIFICATION_FRAGMENT_SIZE = 64 * 1024
-
         def on_new_investigation
-          @pending_offenses = []
+          @pending_offenses = {}.compare_by_identity
           super
         end
 
@@ -49,8 +43,11 @@ module RuboCop
         end
 
         def on_investigation_end
-          verified_offenses.each do |node, message|
-            add_offense(node, message: message) do |corrector|
+          # Each candidate's exact correction is verified by reparsing before
+          # the offense is registered, so redundancy never depends on
+          # hand-maintained knowledge of Ruby's grammar.
+          verified_by_reparse(@pending_offenses.keys).each do |node|
+            add_offense(node, message: @pending_offenses[node]) do |corrector|
               ParenthesesCorrector.correct(corrector, node)
             end
           end
@@ -249,93 +246,48 @@ module RuboCop
         end
 
         def offense(node, msg)
-          @pending_offenses << [node, "Don't use parentheses around #{msg}."]
+          @pending_offenses[node] = "Don't use parentheses around #{msg}."
         end
 
-        # Each candidate's exact correction is applied to a copy of the source
-        # and verified to parse to the same AST (modulo the removed grouping)
-        # before the offense is registered, so redundancy never depends on
-        # hand-maintained knowledge of Ruby's grammar. Candidates sharing a
-        # reparse scope are verified together with a single reparse first,
-        # falling back to per-candidate verification only when the batch does
-        # not hold.
-        def verified_offenses
-          # Group by scope identity: structurally identical definitions in
-          # different places must not share a group.
-          groups = {}.compare_by_identity
-          @pending_offenses.each do |offense|
-            (groups[reparse_scope(offense.first)] ||= []) << offense
-          end
-
-          groups.flat_map do |scope, offenses|
-            if offenses.one? || !batch_verified?(scope, offenses)
-              offenses.select { |node, _| verified_correction?(scope, node) }
-            else
-              offenses
-            end
-          end
-        end
-
-        # Method definitions and class/module bodies neither capture outer
-        # local variables nor continue an outer expression, so they parse
-        # standalone. Blocks and single statements do not qualify: an outer
-        # local would reparse as a method call.
-        def reparse_scope(node)
-          scope = node.each_ancestor(:any_def, :class, :module, :sclass).first
-          scope if scope&.source_range&.contains?(node.source_range)
-        end
-
-        def batch_verified?(scope, offenses)
-          corrector = Corrector.new(processed_source)
-          offenses.map(&:first).each { |node| ParenthesesCorrector.correct(corrector, node) }
-
-          corrected_source_verified?(scope, corrector.process)
-        rescue ::Parser::ClobberingError
-          false
-        end
-
-        def verified_correction?(scope, node)
-          return true if scope && scope.source_range.size > MAX_VERIFICATION_FRAGMENT_SIZE
-
-          corrector = Corrector.new(processed_source)
+        def apply_reparse_correction(corrector, node)
           ParenthesesCorrector.correct(corrector, node)
-
-          corrected_source_verified?(scope, corrector.process)
         end
 
-        # The correction's edits are all contained within the scope, so the
-        # corrected fragment can be cut out of the corrected source by
-        # adjusting for the edits' length delta.
-        def corrected_source_verified?(scope, corrected)
-          if scope
-            delta = corrected.length - processed_source.raw_source.length
-            scope_range = scope.source_range
-            fragment = corrected[scope_range.begin_pos...(scope_range.end_pos + delta)]
+        # Grouping parentheses are transparent to the comparison: single-child
+        # `begin` nodes are collapsed, a parenthesized statement sequence
+        # inside another sequence is spliced in place, and chains of the same
+        # `&&`/`||` operator are normalized to left association (`x && (y &&
+        # z)` and `x && y && z` differ as trees but `&&` and `||` cannot be
+        # redefined, so same-operator regrouping is semantically transparent).
+        def normalize_reparsed_ast(node)
+          return node unless node.is_a?(::Parser::AST::Node)
 
-            parses_fragment_identically_ignoring_grouping?(scope, fragment)
+          children = node.children.map { |child| normalize_reparsed_ast(child) }
+          children = splice_nested_sequences(children) if %i[begin kwbegin].include?(node.type)
+
+          node = node.updated(nil, children)
+          if node.begin_type? && children.one? && children.first.is_a?(::Parser::AST::Node)
+            children.first
           else
-            parses_identically_ignoring_grouping?(corrected)
+            rotate_same_operator(node)
           end
         end
 
-        # `&&` and `||` cannot be redefined, so regrouping a chain of the same
-        # operator (`x && (y && z)` to `x && y && z`) is semantically
-        # transparent even though the trees differ; normalize both to left
-        # association before comparing.
-        def collapse_groupings(node)
-          collapsed = super
-          return collapsed unless collapsed.is_a?(::Parser::AST::Node)
-
-          left, right = collapsed.children
-          if collapsed.type?(:and, :or) &&
-             right.is_a?(::Parser::AST::Node) && right.type == collapsed.type
-            inner_left, inner_right = right.children
-            collapsed = collapse_groupings(
-              collapsed.updated(nil, [collapsed.updated(nil, [left, inner_left]), inner_right])
-            )
+        def splice_nested_sequences(children)
+          children.flat_map do |child|
+            child.is_a?(::Parser::AST::Node) && child.begin_type? ? child.children : [child]
           end
+        end
 
-          collapsed
+        def rotate_same_operator(node)
+          return node unless node.type?(:and, :or)
+
+          right = node.rhs
+          return node unless right.is_a?(::Parser::AST::Node) && right.type == node.type
+
+          rotated_left = rotate_same_operator(node.updated(nil, [node.lhs, right.lhs]))
+
+          rotate_same_operator(node.updated(nil, [rotated_left, right.rhs]))
         end
 
         def suspect_unary?(node)

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -48,6 +48,7 @@ module RuboCop
       #   end if condition_a
       class SoleNestedConditional < Base
         include RangeHelp
+        include ReparsedEquivalence
         extend AutoCorrector
 
         MSG = 'Consider merging nested conditions into outer `%<conditional_type>s` conditions.'
@@ -60,7 +61,7 @@ module RuboCop
           return unless offending_conditional?(node)
 
           if_branch = node.if_branch
-          return unless correction_parses?(node, if_branch)
+          return unless correction_parses?(node)
 
           message = format(MSG, conditional_type: node.keyword)
           add_offense(if_branch.loc.keyword, message: message) do |corrector|
@@ -84,16 +85,10 @@ module RuboCop
 
         # Merging the conditionals intentionally produces a different AST, so
         # full equivalence cannot be checked, but the corrected source must at
-        # least remain parseable: the exact correction is applied to a copy of
-        # the source and reparsed before the offense is registered, which
-        # suppresses the entire produces-invalid-code bug class.
-        def correction_parses?(node, if_branch)
-          corrector = Corrector.new(processed_source)
-          autocorrect(corrector, node, if_branch)
-
-          parse(corrector.process, processed_source.path).valid_syntax?
-        rescue ::Parser::ClobberingError
-          false
+        # least remain parseable (see `ReparsedEquivalence#correction_parses?`),
+        # which suppresses the entire produces-invalid-code bug class.
+        def apply_reparse_correction(corrector, node)
+          autocorrect(corrector, node, node.if_branch)
         end
 
         def use_variable_assignment_in_condition?(condition, if_branch)

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -1092,6 +1092,19 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'registers an offense when `__FILE__` appears in the surrounding scope' do
+    expect_offense(<<~'RUBY')
+      class A
+        ROOT = __FILE__
+        def same
+          foo(bar, \
+                   ^ Redundant line continuation.
+              baz)
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense for a line continuation after the last string of a concatenation' do
     expect_offense(<<~'RUBY')
       def foo

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -865,6 +865,39 @@ RSpec.describe RuboCop::Cop::Style::RedundantParentheses, :config do
     RUBY
   end
 
+  it 'registers an offense when `__FILE__` appears in the surrounding scope' do
+    expect_offense(<<~RUBY)
+      class A
+        ROOT = __FILE__
+        def same
+          (foo)
+          ^^^^^ Don't use parentheses around a method call.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class A
+        ROOT = __FILE__
+        def same
+          foo
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `__LINE__` appears in the surrounding scope' do
+    expect_offense(<<~RUBY)
+      class A
+        def same
+          (foo)
+          ^^^^^ Don't use parentheses around a method call.
+        end
+        LINE = __LINE__
+      end
+    RUBY
+  end
+
   it 'registers offenses in structurally identical definitions in different classes' do
     expect_offense(<<~RUBY)
       class A


### PR DESCRIPTION
Follow-up to the reparse-verification series (#15471-#15478): the five verified cops each carried a deliberately duplicated copy of the verification plumbing while their PRs were in flight. This gives the machinery one audited home in `ReparsedEquivalence`: scope selection, corrected-fragment extraction, identity-keyed scope grouping with batch-first verification, the oversized-scope policy, and the `__FILE__`/`__LINE__` handling.

Cops implement `#apply_reparse_correction` and call `verified_by_reparse` (or `correction_parses?` for corrections that intentionally change the tree), with two documented hooks for the per-cop equivalence laws: `normalize_reparsed_ast` and `preprocess_reparsed_source`.

Net -68 lines, and consolidation spreads the sharpest implementation to every cop: `Style/RedundantLineContinuation` and `Style/RedundantParentheses` now resolve `__FILE__` against the original path and handle `__LINE__` instead of suppressing offenses in scopes containing those keywords (covered by new specs), and the continuation cop gains class/module reparse scopes and identity-keyed grouping.

No changelog entry: the behavior it refines only exists in unreleased changes (#15471-#15478).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
