### PR TITLE
Build the project index over the whole project

### DIFF
--- a/changelog/fix_index_the_whole_project_regardless_of_inspected_files_20260716095205.md
+++ b/changelog/fix_index_the_whole_project_regardless_of_inspected_files_20260716095205.md
@@ -1,0 +1,1 @@
+* [#15481](https://github.com/rubocop/rubocop/pull/15481): Fix cross-file offenses depending on which files are inspected: the project index now always covers the whole project (`UseProjectIndex`). ([@bbatsov][])

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -56,4 +56,10 @@ Index-aware cops automatically pick up the index whenever it is built; no per-co
 - `rubydex` requires Ruby 3.2 or newer and ships native (Rust) extensions.
 - Parallel inspection is currently disabled on Windows when `UseProjectIndex` is on;
   use serial inspection (omit `--parallel`).
-- The index is rebuilt once per `rubocop` invocation; no on-disk index is shared between runs.
+- The index always covers the whole project (rooted at the directory containing `Gemfile`
+  or `gems.rb`, falling back to the current directory), regardless of which files a
+  particular run inspects. Inspecting a single file therefore reports the same cross-file
+  offenses as a full run.
+- The index is rebuilt once per `rubocop` invocation; no on-disk index is shared between
+  runs. Indexing is fast (roughly 100ms for a couple thousand files), but very large
+  monorepos will notice the per-run cost on single-file runs.

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -72,7 +72,7 @@ module RuboCop
       ResultCache.source_checksum
 
       target_files = find_target_files(paths)
-      @project_index = ProjectIndexLoader.build_index(target_files) if project_index_enabled?
+      build_project_index(target_files)
 
       if @options[:list_target_files]
         list_files(target_files)
@@ -102,6 +102,24 @@ module RuboCop
              end
       target_files = target_finder.find(paths, mode)
       target_files.each(&:freeze).freeze
+    end
+
+    def build_project_index(target_files)
+      return unless project_index_enabled?
+
+      @project_index = ProjectIndexLoader.build_index(project_index_files(target_files))
+    end
+
+    # The index always covers the whole project, not just the files being
+    # inspected: cross-file offenses must not depend on which files a
+    # particular run happens to include, or single-file runs (editors, CI
+    # sharding) would see different offenses than full runs. The project is
+    # rooted at the directory of the configuration that enabled the index.
+    def project_index_files(target_files)
+      root = @config_store.for_pwd.base_dir_for_path_parameters
+      (find_target_files([root]) | target_files).sort
+    rescue Errno::ENOENT
+      target_files
     end
 
     def project_index_enabled?

--- a/spec/rubocop/cop/lint/constant_reassignment_spec.rb
+++ b/spec/rubocop/cop/lint/constant_reassignment_spec.rb
@@ -633,6 +633,25 @@ RSpec.describe RuboCop::Cop::Lint::ConstantReassignment, :config do
       expect(offenses.map { |o| o['message'] }).to all(include('already assigned in'))
     end
 
+    it 'reports a cross-file collision when only one file is inspected' do
+      Dir.mktmpdir do |tmpdir|
+        stage_fixture(tmpdir)
+        write_rubocop_config(
+          tmpdir,
+          'AllCops' => { 'UseProjectIndex' => true },
+          'Lint/ConstantReassignment' => { 'Enabled' => true }
+        )
+
+        # The index covers the whole project even when a single file is
+        # inspected, so the offense set does not depend on the run's scope.
+        offenses = project_index_offenses(tmpdir, paths: [File.join(tmpdir, 'a.rb')])
+                   .select { |offense| offense['cop_name'] == 'Lint/ConstantReassignment' }
+
+        expect(offenses).not_to be_empty
+        expect(offenses.map { |o| o['message'] }).to all(include('already assigned in'))
+      end
+    end
+
     it 'does not report any offense when UseProjectIndex is disabled' do
       offenses = run_with_config(
         'AllCops' => { 'UseProjectIndex' => false },

--- a/spec/support/project_index_metadata.rb
+++ b/spec/support/project_index_metadata.rb
@@ -19,13 +19,13 @@ module ProjectIndexSpecHelpers
     File.write(File.join(tmpdir, '.rubocop.yml'), YAML.dump(merged))
   end
 
-  def project_index_offenses(tmpdir, cache_root: nil)
+  def project_index_offenses(tmpdir, cache_root: nil, paths: nil)
     output_path = File.join(tmpdir, 'offenses.json')
     Dir.chdir(tmpdir) do
       config_store = RuboCop::ConfigStore.new
       config_store.options_config = File.join(tmpdir, '.rubocop.yml')
       options = project_index_runner_options(output_path, cache_root)
-      RuboCop::Runner.new(options, config_store).run([tmpdir])
+      RuboCop::Runner.new(options, config_store).run(paths || [tmpdir])
     end
     JSON.load_file(output_path).fetch('files').flat_map { |f| f['offenses'] }
   end


### PR DESCRIPTION
With `UseProjectIndex` enabled, the index was built over the run's target files, so cross-file offenses depended on which files a particular run happened to include: inspecting a single file (editor integrations, CI sharding, `rubocop path/to/file.rb`) silently missed collisions with files outside the run, and `Lint/RedundantCopDisableDirective` judgments about index-dependent disables flip-flopped between partial and full runs.

The index is now built over the whole project - rooted at the directory containing `Gemfile`/`gems.rb` (falling back to the current directory) and honoring the configuration's excludes - regardless of the run's scope. A single-file run reports the same cross-file offenses as a full run. Indexing rubocop's own 1.7k files costs about 80ms, so even editor-style runs stay cheap; the docs note that very large monorepos will notice it, which a future persistent index in server mode can address. Result-cache invalidation already hashes every indexed file, so cached single-file results correctly invalidate when any project file changes.

This was the main correctness prerequisite for taking `UseProjectIndex` beyond its experimental status.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
