### PR TITLE
Accept cross-definition documentation in `Style/Documentation`

### DIFF
--- a/changelog/change_accept_cross_definition_documentation_in_style_documentation_20260716145739.md
+++ b/changelog/change_accept_cross_definition_documentation_in_style_documentation_20260716145739.md
@@ -1,0 +1,1 @@
+* [#15482](https://github.com/rubocop/rubocop/pull/15482): Change `Style/Documentation` to accept a reopened class or module documented at another definition site when `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3968,6 +3968,7 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '<<next>>'
   AllowedConstants: []
   Exclude:
     - 'spec/**/*'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -97,6 +97,8 @@ constant provably resolves identically without it.
 `Lint/ConstantResolution` reports only genuinely ambiguous constants - those that resolve to a
 different declaration through the surrounding nesting than they would fully qualified - which
 makes the cop practical to enable without `Only`/`Ignore` lists.
+`Style/Documentation` accepts a reopened class or module when any of its other definition
+sites carries a documentation comment, instead of requiring a comment at every reopening.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -13,6 +13,11 @@ module RuboCop
       # a `#:nodoc:` comment next to it. Likewise, `#:nodoc: all` does the
       # same for all its children.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, a reopened class or module is not reported when any of its
+      # other definition sites (in the same or another file) carries a
+      # documentation comment.
+      #
       # @example
       #   # bad
       #   class Person
@@ -71,9 +76,14 @@ module RuboCop
       #
       class Documentation < Base
         include DocumentationComment
+        include ProjectIndexHelp
         include RangeHelp
 
         MSG = 'Missing top-level documentation comment for `%<type>s %<identifier>s`.'
+
+        # Comments that configure tooling rather than document the code.
+        DIRECTIVE_COMMENT_REGEXP = /\A\#\s*(rubocop:|frozen_string_literal:|encoding:|
+                                            shareable_constant_value:|typed:|-\*-)/x.freeze
 
         # @!method constant_definition?(node)
         def_node_matcher :constant_definition?, '{class module casgn}'
@@ -109,10 +119,74 @@ module RuboCop
           return if constant_allowed?(node)
           return if nodoc_self_or_outer_module?(node)
           return if include_statement_only?(body)
+          return if documented_elsewhere?(node)
 
+          add_documentation_offense(node)
+        end
+
+        def add_documentation_offense(node)
           range = range_between(node.source_range.begin_pos, node.loc.name.end_pos)
           message = format(MSG, type: node.type, identifier: identifier(node))
           add_offense(range, message: message)
+        end
+
+        # A reopened class or module is typically documented at a single
+        # definition site. When `AllCops/UseProjectIndex` is enabled, the
+        # documentation requirement is satisfied by a comment on any other
+        # definition of the same class or module.
+        def documented_elsewhere?(node)
+          return false unless project_index
+
+          declaration = resolve_in_index(node)
+          return false unless declaration.is_a?(Rubydex::Namespace)
+
+          declaration.definitions.any? do |definition|
+            other_definition?(definition, node) && documenting_comments?(definition)
+          end
+        rescue StandardError
+          false
+        end
+
+        def resolve_in_index(node)
+          identifier = node.identifier
+          segments = identifier.const_name.split('::')
+          nesting = identifier.absolute? ? [] : lexical_nesting(node)
+
+          declaration = project_index.resolve_constant(segments.first, nesting)
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(node)
+          node.each_ancestor(:class, :module)
+              .map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
+
+        def other_definition?(definition, node)
+          location = definition.location
+          return false unless location.uri.start_with?(FILE_URI_PREFIX)
+
+          !same_file?(location.to_file_path, processed_source.file_path) ||
+            location.to_display.start_line != node.first_line
+        end
+
+        def same_file?(path, other)
+          return true if File.identical?(path, other)
+
+          normalized = [path, other].map { |p| File.expand_path(p).tr('\\', '/') }
+          normalized.uniq.one? || (Platform.windows? && normalized[0].casecmp?(normalized[1]))
+        end
+
+        def documenting_comments?(definition)
+          definition.comments.to_a.any? do |comment|
+            text = comment.string.strip
+            !text.empty? && !DIRECTIVE_COMMENT_REGEXP.match?(text)
+          end
         end
 
         def nodoc_self_or_outer_module?(node)

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -561,4 +561,130 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       end
     end
   end
+
+  context 'with a project index', :project_index do
+    # Platform-realistic paths: the cop compares indexed definition paths
+    # with the inspected file's path.
+    let(:current_path) { File.expand_path('current.rb') }
+    let(:other_path) { File.expand_path('other.rb') }
+
+    def file_uri(path)
+      path.start_with?('/') ? "file://#{path}" : "file:///#{path}"
+    end
+
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge(file_uri(current_path) => source))
+    end
+
+    it 'does not register an offense when the class is documented at another definition site' do
+      source = <<~RUBY
+        class Person
+          def foo; end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, file_uri(other_path) => "# Description of Person.\nclass Person\nend\n"
+      )
+
+      expect_no_offenses(source, current_path)
+    end
+
+    it 'does not register an offense when an earlier definition in the same file is documented' do
+      source = <<~RUBY
+        # Description of Person.
+        class Person
+        end
+
+        class Person
+          def foo; end
+        end
+      RUBY
+      cop.project_index = index_with_current(source)
+
+      expect_no_offenses(source, current_path)
+    end
+
+    it 'registers an offense when no definition site is documented' do
+      source = <<~RUBY
+        class Person
+          def foo; end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, file_uri(other_path) => "class Person\nend\n"
+      )
+
+      expect_offense(<<~RUBY, current_path)
+        class Person
+        ^^^^^^^^^^^^ Missing top-level documentation comment for `class Person`.
+          def foo; end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the other definition only has directive comments' do
+      source = <<~RUBY
+        class Person
+          def foo; end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        file_uri(other_path) => "# rubocop:disable Style/ClassVars\nclass Person\nend\n" \
+                                "# rubocop:enable Style/ClassVars\n"
+      )
+
+      expect_offense(<<~RUBY, current_path)
+        class Person
+        ^^^^^^^^^^^^ Missing top-level documentation comment for `class Person`.
+          def foo; end
+        end
+      RUBY
+    end
+
+    it 'resolves nested namespaces to the right declaration' do
+      source = <<~RUBY
+        module Outer
+          class Person
+            def foo; end
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        file_uri(other_path) => "module Outer\n  # Documented here.\n  class Person\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, current_path)
+    end
+
+    it 'registers an offense when only a different class with the same name is documented' do
+      source = <<~RUBY
+        module Outer
+          class Person
+            def foo; end
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, file_uri(other_path) => "# Top-level Person.\nclass Person\nend\n"
+      )
+
+      expect_offense(<<~RUBY, current_path)
+        module Outer
+          class Person
+          ^^^^^^^^^^^^ Missing top-level documentation comment for `class Outer::Person`.
+            def foo; end
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Another cop picking up the project index (#15173): `Style/Documentation` demanded a documentation comment at every definition of a class or module, which made it noisy for the common pattern of documenting a class once and reopening it elsewhere (monkey patches, concerns split across files, `class << self` extensions in separate files).

With `UseProjectIndex` enabled, the requirement is now satisfied by a comment on any other definition site of the same class or module, in the same file or another one. Resolution goes through the index's declaration model, so a top-level `Person` doesn't vouch for `Outer::Person`. Directive-only comments (`# rubocop:...`, magic comments) don't count. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
