### PR TITLE
Accept cross-file `respond_to_missing?` in `Style/MissingRespondToMissing`

### DIFF
--- a/changelog/fix_accept_cross_file_respond_to_missing_in_style_missing_respond_to_missing_20260716150109.md
+++ b/changelog/fix_accept_cross_file_respond_to_missing_in_style_missing_respond_to_missing_20260716150109.md
@@ -1,0 +1,1 @@
+* [#15483](https://github.com/rubocop/rubocop/pull/15483): Fix a false positive for `Style/MissingRespondToMissing` when `respond_to_missing?` is defined in a reopening of the class and `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4802,6 +4802,7 @@ Style/MissingRespondToMissing:
   StyleGuide: '#no-method-missing'
   Enabled: true
   VersionAdded: '0.56'
+  VersionChanged: '<<next>>'
 
 Style/MixinGrouping:
   Description: 'Checks for grouping of mixins in `class` and `module` bodies.'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -76,6 +76,8 @@ and references to constants documented with a YARD `@deprecated` tag anywhere in
 detection: it reports private instance methods whose names are never referenced anywhere in
 the indexed project. Since symbol-based references from other files (e.g. Rails callbacks
 declared in a concern) cannot be detected, it is best suited for occasional dead-code sweeps.
+`Style/MissingRespondToMissing` accepts a `respond_to_missing?` defined in another definition
+of the same class or module (e.g. a reopening in another file).
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -28,6 +28,11 @@ module RuboCop
       # delegator.upcase # => FOO
       # ----
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, `respond_to_missing?` defined in another definition of the
+      # same class or module (e.g. a reopening in another file) also
+      # satisfies the check.
+      #
       # @example
       #   # bad
       #   def method_missing(name, *args)
@@ -52,17 +57,68 @@ module RuboCop
       #   end
       #
       class MissingRespondToMissing < Base
+        include ProjectIndexHelp
+
         MSG = 'When using `method_missing`, define `respond_to_missing?`.'
 
         def on_def(node)
           return unless node.method?(:method_missing)
           return if implements_respond_to_missing?(node)
+          return if respond_to_missing_elsewhere?(node)
 
           add_offense(node)
         end
         alias on_defs on_def
 
         private
+
+        # When `AllCops/UseProjectIndex` is enabled, `respond_to_missing?`
+        # defined in another definition of the same class or module (e.g. a
+        # reopening in another file) also satisfies the check. Ancestors are
+        # not consulted: overriding `method_missing` warrants a matching
+        # `respond_to_missing?` for the same class.
+        def respond_to_missing_elsewhere?(node)
+          return false unless project_index
+          return false unless (namespace_node = node.each_ancestor(:class, :module).first)
+
+          declaration = resolve_in_index(namespace_node)
+          return false unless declaration.is_a?(Rubydex::Namespace)
+
+          scope = singleton_definition?(node) ? singleton_of(declaration) : declaration
+          !scope&.member('respond_to_missing?()').nil?
+        rescue StandardError
+          false
+        end
+
+        def singleton_definition?(node)
+          node.defs_type? || node.each_ancestor(:sclass, :class, :module).first&.sclass_type?
+        end
+
+        def singleton_of(declaration)
+          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
+        end
+
+        def resolve_in_index(namespace_node)
+          segments = namespace_node.identifier.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(namespace_node)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(namespace_node)
+          return [] if namespace_node.identifier.absolute?
+
+          namespace_node.each_ancestor(:class, :module)
+                        .map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
 
         def implements_respond_to_missing?(node)
           scope = enclosing_scope(node)

--- a/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
+++ b/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
@@ -134,4 +134,170 @@ RSpec.describe RuboCop::Cop::Style::MissingRespondToMissing, :config do
       end
     RUBY
   end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge('file:///current.rb' => source))
+    end
+
+    it 'does not register an offense when `respond_to_missing?` is defined in a reopening in another file' do
+      source = <<~RUBY
+        class Tool
+          def method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///other.rb' => <<~OTHER
+          class Tool
+            def respond_to_missing?(name, include_private = false)
+              true
+            end
+          end
+        OTHER
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'registers an offense when `respond_to_missing?` is not defined in any definition site' do
+      source = <<~RUBY
+        class Tool
+          def method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(source, 'file:///other.rb' => "class Tool\nend\n")
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Tool
+          def method_missing(name, *args)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+            super
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when only a different class defines `respond_to_missing?`' do
+      source = <<~RUBY
+        class Tool
+          def method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///other.rb' => <<~OTHER
+          class Other
+            def respond_to_missing?(name, include_private = false)
+              true
+            end
+          end
+        OTHER
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Tool
+          def method_missing(name, *args)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+            super
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when only an ancestor defines `respond_to_missing?`' do
+      source = <<~RUBY
+        class Tool < Base
+          def method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///base.rb' => <<~OTHER
+          class Base
+            def respond_to_missing?(name, include_private = false)
+              true
+            end
+          end
+        OTHER
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Tool < Base
+          def method_missing(name, *args)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+            super
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a singleton `method_missing` with a singleton ' \
+       '`respond_to_missing?` in a reopening' do
+      source = <<~RUBY
+        class Tool
+          def self.method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///other.rb' => <<~OTHER
+          class Tool
+            def self.respond_to_missing?(name, include_private = false)
+              true
+            end
+          end
+        OTHER
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'registers an offense for a singleton `method_missing` when only an instance ' \
+       '`respond_to_missing?` exists in a reopening' do
+      source = <<~RUBY
+        class Tool
+          def self.method_missing(name, *args)
+            super
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///other.rb' => <<~OTHER
+          class Tool
+            def respond_to_missing?(name, include_private = false)
+              true
+            end
+          end
+        OTHER
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Tool
+          def self.method_missing(name, *args)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When using `method_missing`, define `respond_to_missing?`.
+            super
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Style/MissingRespondToMissing` only looked for `respond_to_missing?` in the same lexical scope as `method_missing`, so classes that split the pair across reopenings (a common layout for concerns and extensions spread over files) got a false positive at the `method_missing` site.

With `UseProjectIndex` enabled the check is now satisfied by a `respond_to_missing?` in any definition of the same class or module, matching singleton-ness (`def self.method_missing` wants a singleton `respond_to_missing?`). Ancestors are deliberately not consulted: overriding `method_missing` warrants a matching `respond_to_missing?` on the same class, so an inherited one doesn't silence the cop. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
