### PR TITLE
Detect indirect `Exception` inheritance in `Lint/InheritException`

### DIFF
--- a/changelog/fix_detect_indirect_exception_inheritance_in_lint_inherit_exception_20260716150447.md
+++ b/changelog/fix_detect_indirect_exception_inheritance_in_lint_inherit_exception_20260716150447.md
@@ -1,0 +1,1 @@
+* [#15484](https://github.com/rubocop/rubocop/pull/15484): Fix false negatives for `Lint/InheritException` when `Exception` is inherited indirectly through a project class (`UseProjectIndex`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2068,7 +2068,7 @@ Lint/InheritException:
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.41'
-  VersionChanged: '1.26'
+  VersionChanged: '<<next>>'
   # The default base class in favour of `Exception`.
   EnforcedStyle: standard_error
   SupportedStyles:

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -78,6 +78,8 @@ the indexed project. Since symbol-based references from other files (e.g. Rails 
 declared in a concern) cannot be detected, it is best suited for occasional dead-code sweeps.
 `Style/MissingRespondToMissing` accepts a `respond_to_missing?` defined in another definition
 of the same class or module (e.g. a reopening in another file).
+`Lint/InheritException` also reports classes that inherit from `Exception` indirectly, through
+a parent class defined elsewhere in the project.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -12,6 +12,11 @@ module RuboCop
       #   exception class handle `StandardError` and its subclasses,
       #   but not `Exception` and its subclasses.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, indirect inheritance is also detected: a class whose parent
+      # (defined anywhere in the project) ultimately inherits from `Exception`
+      # is reported, without autocorrection.
+      #
       # @example EnforcedStyle: standard_error (default)
       #   # bad
       #
@@ -39,9 +44,11 @@ module RuboCop
       #   C = Class.new(RuntimeError)
       class InheritException < Base
         include ConfigurableEnforcedStyle
+        include ProjectIndexHelp
         extend AutoCorrector
 
         MSG = 'Inherit from `%<prefer>s` instead of `Exception`.'
+        INDIRECT_MSG = 'Inherit from `%<prefer>s` instead of `Exception` (inherited via `%<via>s`).'
         PREFERRED_BASE_CLASS = {
           runtime_error: 'RuntimeError',
           standard_error: 'StandardError'
@@ -57,13 +64,20 @@ module RuboCop
         PATTERN
 
         def on_class(node)
-          return unless node.parent_class && exception_class?(node.parent_class)
-          return if inherit_exception_class_with_omitted_namespace?(node)
+          parent_class = node.parent_class
+          return unless parent_class
 
-          message = message(node.parent_class)
+          if exception_class?(parent_class)
+            return if inherit_exception_class_with_omitted_namespace?(node)
 
-          add_offense(node.parent_class, message: message) do |corrector|
-            corrector.replace(node.parent_class, preferred_base_class)
+            add_offense(parent_class, message: message(parent_class)) do |corrector|
+              corrector.replace(parent_class, preferred_base_class)
+            end
+          elsif (via = inherits_exception_via(node, parent_class))
+            # No autocorrection: the `Exception` inheritance lives at another
+            # class' definition site, possibly in another file.
+            message = format(INDIRECT_MSG, prefer: preferred_base_class, via: via)
+            add_offense(parent_class, message: message)
           end
         end
 
@@ -86,6 +100,62 @@ module RuboCop
 
         def exception_class?(class_node)
           class_node.const_name == 'Exception'
+        end
+
+        # When `AllCops/UseProjectIndex` is enabled, indirect inheritance is
+        # detected by walking the parent's indexed ancestry: `Exception` itself
+        # is not indexed, so a chain ending in it shows up as an ancestor whose
+        # superclass reference is unresolved and literally named `Exception`.
+        # Returns the name of that ancestor, or `nil`.
+        def inherits_exception_via(node, parent_class)
+          return nil unless project_index && parent_class.const_type?
+
+          declaration = resolve_in_index(node, parent_class)
+          return nil unless declaration.is_a?(Rubydex::Class)
+
+          exception_ancestor(declaration)&.name
+        rescue StandardError
+          nil
+        end
+
+        def exception_ancestor(declaration)
+          declaration.ancestors.find do |ancestor|
+            ancestor.is_a?(Rubydex::Class) && exception_superclass_reference?(ancestor)
+          end
+        end
+
+        def exception_superclass_reference?(ancestor)
+          ancestor.definitions.any? do |definition|
+            next false unless definition.is_a?(Rubydex::ClassDefinition)
+
+            superclass = definition.superclass
+            superclass.is_a?(Rubydex::UnresolvedConstantReference) &&
+              superclass.name.delete_prefix('::') == 'Exception'
+          end
+        end
+
+        def resolve_in_index(node, parent_class)
+          segments = parent_class.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(node, parent_class)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        # The superclass expression resolves in the scopes enclosing the class
+        # definition, not inside it.
+        def lexical_nesting(node, parent_class)
+          return [] if parent_class.absolute?
+
+          node.each_ancestor(:class, :module)
+              .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
 
         def inherit_exception_class_with_omitted_namespace?(class_node)

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -195,4 +195,89 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
       end
     end
   end
+
+  context 'with a project index', :project_index do
+    let(:cop_config) { { 'EnforcedStyle' => 'standard_error' } }
+
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge('file:///current.rb' => source))
+    end
+
+    it 'registers an offense without autocorrection when the parent inherits `Exception` in another file' do
+      source = <<~RUBY
+        class MyError < BaseError
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///base.rb' => "class BaseError < Exception\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class MyError < BaseError
+                        ^^^^^^^^^ Inherit from `StandardError` instead of `Exception` (inherited via `BaseError`).
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense when `Exception` is inherited two hops away' do
+      source = <<~RUBY
+        class MyError < MidError
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///mid.rb' => "class MidError < BaseError\nend\n",
+        'file:///base.rb' => "class BaseError < Exception\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class MyError < MidError
+                        ^^^^^^^^ Inherit from `StandardError` instead of `Exception` (inherited via `BaseError`).
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the parent inherits `StandardError` in another file' do
+      source = <<~RUBY
+        class MyError < BaseError
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///base.rb' => "class BaseError < StandardError\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'does not register an offense when the parent inherits an unresolvable class' do
+      source = <<~RUBY
+        class MyError < BaseError
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///base.rb' => "class BaseError < SomeGemError\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'does not register an offense when the parent is not in the index' do
+      source = <<~RUBY
+        class MyError < SomeGemError
+        end
+      RUBY
+      cop.project_index = index_with_current(source)
+
+      expect_no_offenses(source, 'current.rb')
+    end
+  end
 end


### PR DESCRIPTION
With `UseProjectIndex` enabled, the cop now walks the parent's indexed ancestry, so `class MyError < BaseError` is reported when `BaseError` (defined anywhere in the project) ultimately inherits from `Exception`. `Exception` itself is never indexed, so a chain ending in it surfaces as an ancestor whose superclass reference is unresolved and literally named `Exception`, which cleanly separates it from chains ending in `StandardError` or in unresolvable gem classes (those stay unflagged).

Indirect offenses carry no autocorrection, since the `Exception` inheritance lives at another class' definition site, possibly in another file, and the message names the culprit class. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
