### PR TITLE
Skip subclassed classes in `Style/StaticClass`

### DIFF
--- a/changelog/fix_skip_subclassed_classes_in_style_static_class_20260716150707.md
+++ b/changelog/fix_skip_subclassed_classes_in_style_static_class_20260716150707.md
@@ -1,0 +1,1 @@
+* [#15485](https://github.com/rubocop/rubocop/pull/15485): Fix a false positive for `Style/StaticClass` when the class is subclassed elsewhere in the project (`UseProjectIndex`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5855,6 +5855,7 @@ Style/StabbyLambdaParentheses:
 Style/StaticClass:
   Description: 'Prefer modules to classes with only class methods.'
   StyleGuide: '#modules-vs-classes'
+  VersionChanged: '<<next>>'
   Enabled: false
   Safe: false
   VersionAdded: '1.3'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -80,6 +80,7 @@ declared in a concern) cannot be detected, it is best suited for occasional dead
 of the same class or module (e.g. a reopening in another file).
 `Lint/InheritException` also reports classes that inherit from `Exception` indirectly, through
 a parent class defined elsewhere in the project.
+`Style/StaticClass` does not report classes that are subclassed anywhere in the project.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/style/static_class.rb
+++ b/lib/rubocop/cop/style/static_class.rb
@@ -12,6 +12,11 @@ module RuboCop
       #   for some other subclass, monkey-patched with instance methods or
       #   a dummy instance is instantiated from it somewhere.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, classes that are subclassed anywhere in the project are
+      # not reported, since converting them to modules would break their
+      # subclasses.
+      #
       # @example
       #   # bad
       #   class SomeClass
@@ -44,6 +49,7 @@ module RuboCop
       #   end
       #
       class StaticClass < Base
+        include ProjectIndexHelp
         include RangeHelp
         include VisibilityHelp
         extend AutoCorrector
@@ -53,6 +59,7 @@ module RuboCop
         def on_class(class_node)
           return if class_node.parent_class
           return unless class_convertible_to_module?(class_node)
+          return if subclassed_in_project?(class_node)
 
           add_offense(class_node) do |corrector|
             autocorrect(corrector, class_node)
@@ -60,6 +67,42 @@ module RuboCop
         end
 
         private
+
+        # When `AllCops/UseProjectIndex` is enabled, a class with descendants
+        # anywhere in the project is not reported: converting it to a module
+        # would break its subclasses.
+        def subclassed_in_project?(class_node)
+          return false unless project_index
+
+          declaration = resolve_in_index(class_node)
+          return false unless declaration.is_a?(Rubydex::Class)
+
+          declaration.descendants.any? { |descendant| descendant.name != declaration.name }
+        rescue StandardError
+          false
+        end
+
+        def resolve_in_index(class_node)
+          segments = class_node.identifier.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(class_node)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(class_node)
+          return [] if class_node.identifier.absolute?
+
+          class_node.each_ancestor(:class, :module)
+                    .map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
 
         def autocorrect(corrector, class_node)
           corrector.replace(class_node.loc.keyword, 'module')

--- a/spec/rubocop/cop/style/static_class_spec.rb
+++ b/spec/rubocop/cop/style/static_class_spec.rb
@@ -151,4 +151,67 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
       end
     RUBY
   end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge('file:///current.rb' => source))
+    end
+
+    it 'does not register an offense when the class is subclassed in another file' do
+      source = <<~RUBY
+        class Tools
+          def self.hammer
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///sub.rb' => "class PowerTools < Tools\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'registers an offense when no subclass exists in the project' do
+      source = <<~RUBY
+        class Tools
+          def self.hammer
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///other.rb' => "class Unrelated\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Tools
+        ^^^^^^^^^^^ Prefer modules to classes with only class methods.
+          def self.hammer
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when subclassed transitively' do
+      source = <<~RUBY
+        class Tools
+          def self.hammer
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///mid.rb' => "class GardenTools < Tools\nend\n",
+        'file:///sub.rb' => "class PowerTools < GardenTools\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+  end
 end


### PR DESCRIPTION
One documented reason `Style/StaticClass`' autocorrection is unsafe: the class might be subclassed elsewhere, and converting it to a module then breaks the subclass. With `UseProjectIndex` enabled, the cop now checks the index's descendants and skips classes that are subclassed anywhere in the project (including transitively). Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
