### PR TITLE
Flag provably unshadowed `::` in `Style/RedundantConstantBase`

### DIFF
--- a/changelog/fix_flag_provably_unshadowed__in_style_redundant_constant_base_20260716151125.md
+++ b/changelog/fix_flag_provably_unshadowed__in_style_redundant_constant_base_20260716151125.md
@@ -1,0 +1,1 @@
+* [#15486](https://github.com/rubocop/rubocop/pull/15486): Fix false negatives for `Style/RedundantConstantBase` inside namespaces when the constant provably resolves identically without `::` (`UseProjectIndex`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5424,6 +5424,7 @@ Style/RedundantConditional:
 
 Style/RedundantConstantBase:
   Description: Avoid redundant `::` prefix on constant.
+  VersionChanged: '<<next>>'
   Enabled: pending
   VersionAdded: '1.40'
 

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -92,6 +92,8 @@ would raise `NameError` at load time).
 in the index and no ancestor defines `initialize` - in that case `super` would only reach the
 no-op `Object#initialize`. This removes the need to list project-local abstract base classes in
 `AllowedParentClasses`.
+`Style/RedundantConstantBase` also reports a leading `::` inside a namespace when the
+constant provably resolves identically without it.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -103,7 +103,7 @@ module RuboCop
       # :nodoc:
       def to_range(node_or_range)
         range = case node_or_range
-                when ::RuboCop::AST::Node, ::Parser::Source::Comment
+                when RuboCop::AST::Node, ::Parser::Source::Comment
                   node_or_range.source_range
                 when ::Parser::Source::Range
                   node_or_range

--- a/lib/rubocop/cop/style/redundant_constant_base.rb
+++ b/lib/rubocop/cop/style/redundant_constant_base.rb
@@ -14,6 +14,11 @@ module RuboCop
       # to prevent conflicting rules. This is because it respects user configurations
       # that want to enable `Lint/ConstantResolution` cop which is disabled by default.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, a leading `::` inside a namespace is also reported when the
+      # constant provably resolves to the same declaration with and without
+      # the base, i.e. nothing in the surrounding nesting shadows it.
+      #
       # @example
       #   # bad
       #   ::Const
@@ -41,13 +46,14 @@ module RuboCop
       #     ::Const
       #   end
       class RedundantConstantBase < Base
+        include ProjectIndexHelp
         extend AutoCorrector
 
         MSG = 'Remove redundant `::`.'
 
         def on_cbase(node)
           return if lint_constant_resolution_cop_enabled?
-          return unless bad?(node)
+          return unless bad?(node) || provably_unshadowed?(node)
 
           add_offense(node) do |corrector|
             corrector.remove(node)
@@ -55,6 +61,36 @@ module RuboCop
         end
 
         private
+
+        # When `AllCops/UseProjectIndex` is enabled, `::` inside a namespace is
+        # also redundant when the first constant segment resolves to the same
+        # declaration with and without the base, i.e. nothing in the
+        # surrounding nesting shadows it.
+        def provably_unshadowed?(node)
+          return false unless project_index
+          return false unless (segment = first_constant_segment(node))
+
+          nesting = module_nesting_ancestors_of(node)
+                    .map { |ancestor| ancestor.identifier.const_name }.reverse
+
+          !nesting.empty? && same_resolution?(segment, nesting)
+        rescue StandardError
+          false
+        end
+
+        def same_resolution?(segment, nesting)
+          relative = project_index.resolve_constant(segment, nesting)
+          absolute = project_index.resolve_constant(segment, [])
+
+          !relative.nil? && !absolute.nil? && relative.name == absolute.name
+        end
+
+        def first_constant_segment(node)
+          parent = node.parent
+          return nil unless parent&.const_type?
+
+          parent.short_name.to_s
+        end
 
         def lint_constant_resolution_cop_enabled?
           lint_constant_resolution_config.fetch('Enabled', false)

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -6,7 +6,7 @@ require 'yard'
 # Class for generating documentation of all cops departments
 # @api private
 class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
-  include ::RuboCop::Cop::Documentation
+  include RuboCop::Cop::Documentation
 
   CopData = Struct.new(
     :cop, :description, :example_objects, :safety_objects, :see_objects, :config, keyword_init: true

--- a/spec/rubocop/cop/style/redundant_constant_base_spec.rb
+++ b/spec/rubocop/cop/style/redundant_constant_base_spec.rb
@@ -109,4 +109,77 @@ RSpec.describe RuboCop::Cop::Style::RedundantConstantBase, :config do
       end
     end
   end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge('file:///current.rb' => source))
+    end
+
+    it 'registers an offense inside a namespace when nothing shadows the constant' do
+      source = <<~RUBY
+        module App
+          def self.load
+            ::Config.load
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///config.rb' => "class Config\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        module App
+          def self.load
+            ::Config.load
+            ^^ Remove redundant `::`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module App
+          def self.load
+            Config.load
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the namespace shadows the constant' do
+      source = <<~RUBY
+        module App
+          def self.load
+            ::Config.load
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///config.rb' => "class Config\nend\n",
+        'file:///app_config.rb' => "module App\n  class Config\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'does not register an offense when the constant is not in the index' do
+      source = <<~RUBY
+        module App
+          def self.parse(json)
+            ::JSON.parse(json)
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(source)
+
+      expect_no_offenses(source, 'current.rb')
+    end
+  end
 end

--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -64,7 +64,7 @@ module RuboCop
     # A parallel spec runner implementation, heavily inspired by
     # `TestQueue::Runner::RSpec`, but modified so that it takes an argument
     # (an array of paths of specs to run) instead of relying on ARGV.
-    class ParallelRunner < ::TestQueue::Runner
+    class ParallelRunner < TestQueue::Runner
       SUMMARY_REGEXP = /(?<=# SUMMARY BEGIN\n).*(?=\n# SUMMARY END)/m.freeze
       FAILURE_OUTPUT_REGEXP = /(?<=# FAILURES BEGIN\n\n).*(?=# FAILURES END)/m.freeze
       RERUN_REGEXP = /(?<=# RERUN BEGIN\n).+(?=\n# RERUN END)/m.freeze
@@ -137,7 +137,7 @@ module RuboCop
 
     # A TestQueue framework that is explicitly given RSpec arguments instead of
     # implicitly reading ARGV.
-    class Framework < ::TestQueue::TestFramework::RSpec
+    class Framework < TestQueue::TestFramework::RSpec
       def initialize(rspec_args)
         super()
         formatter_args = %w[


### PR DESCRIPTION
The cop only flagged a leading `::` at the top level, because inside any namespace a lexically closer constant could shadow the name, making all namespaced usage a blanket false negative. With `UseProjectIndex` enabled, `::` inside a namespace is now reported too when the first constant segment provably resolves to the same declaration with and without the base. Unresolvable names (gem constants like `::JSON`) stay unflagged, since the index can't rule out shadowing for them.

The new check turned up two real hits in this repo's `tasks/spec_runner.rake` (`::TestQueue` inside `module RuboCop`, with `TestQueue` reopened at top level in the same file), fixed here. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
