### PR TITLE
Report only ambiguous constants in `Lint/ConstantResolution`

### DIFF
--- a/changelog/change_report_only_ambiguous_constants_in_lint_constant_resolution_with_the_index_20260716151339.md
+++ b/changelog/change_report_only_ambiguous_constants_in_lint_constant_resolution_with_the_index_20260716151339.md
@@ -1,0 +1,1 @@
+* [#15487](https://github.com/rubocop/rubocop/pull/15487): Change `Lint/ConstantResolution` to report only genuinely ambiguous constants when `UseProjectIndex` is enabled. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1715,6 +1715,7 @@ Lint/ConstantReassignment:
 
 Lint/ConstantResolution:
   Description: 'Checks that constants are fully qualified with `::`.'
+  VersionChanged: '<<next>>'
   Enabled: false
   VersionAdded: '0.86'
   # Restrict this cop to only looking at certain names

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -94,6 +94,9 @@ no-op `Object#initialize`. This removes the need to list project-local abstract 
 `AllowedParentClasses`.
 `Style/RedundantConstantBase` also reports a leading `::` inside a namespace when the
 constant provably resolves identically without it.
+`Lint/ConstantResolution` reports only genuinely ambiguous constants - those that resolve to a
+different declaration through the surrounding nesting than they would fully qualified - which
+makes the cop practical to enable without `Only`/`Ignore` lists.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -20,6 +20,12 @@ module RuboCop
       # to prevent conflicting rules. This is because it respects user configurations
       # that want to enable this cop which is disabled by default.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, only genuinely ambiguous constants are reported: those
+      # that resolve to a different declaration through the surrounding
+      # nesting than they would fully qualified. This makes the cop practical
+      # to enable without `Only`/`Ignore` lists.
+      #
       # @example
       #   # By default checks every constant
       #
@@ -69,11 +75,43 @@ module RuboCop
 
         def on_const(node)
           return if !unqualified_const?(node) || node.parent&.defined_module || node.loc.nil?
+          return if project_index && !ambiguous_resolution?(node)
 
           add_offense(node)
         end
 
         private
+
+        # When `AllCops/UseProjectIndex` is enabled, only genuinely ambiguous
+        # references are reported: the constant resolves to a different
+        # declaration through the lexical nesting than it would fully
+        # qualified. Names that resolve identically either way, or that the
+        # index cannot resolve at all (e.g. constants from gems), are not
+        # reported.
+        def ambiguous_resolution?(node)
+          relative = project_index.resolve_constant(node.short_name.to_s, lexical_nesting(node))
+          absolute = project_index.resolve_constant(node.short_name.to_s, [])
+
+          !relative.nil? && !absolute.nil? && relative.name != absolute.name
+        rescue StandardError
+          false
+        end
+
+        def lexical_nesting(node)
+          scopes = node.each_ancestor(:class, :module).reject do |ancestor|
+            in_superclass_expression?(node, ancestor)
+          end
+
+          scopes.map { |ancestor| ancestor.identifier.const_name }.reverse
+        end
+
+        # A constant in the superclass expression resolves in the scopes
+        # enclosing the class definition, not inside it.
+        def in_superclass_expression?(node, ancestor)
+          ancestor.class_type? &&
+            ancestor.parent_class&.each_descendant(:const)
+                    &.any? { |descendant| descendant.equal?(node) }
+        end
 
         def const_name?(name)
           name = name.to_s

--- a/spec/rubocop/cop/lint/constant_resolution_spec.rb
+++ b/spec/rubocop/cop/lint/constant_resolution_spec.rb
@@ -125,4 +125,71 @@ RSpec.describe RuboCop::Cop::Lint::ConstantResolution, :config do
       RUBY
     end
   end
+
+  context 'with a project index', :project_index do
+    let(:cop_config) { {} }
+
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    def index_with_current(source, sources = {})
+      build_index(sources.merge('file:///current.rb' => source))
+    end
+
+    it 'registers an offense when the constant is shadowed by the surrounding nesting' do
+      source = <<~RUBY
+        module App
+          def self.load
+            Config.load
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source,
+        'file:///config.rb' => "class Config\nend\n",
+        'file:///app_config.rb' => "module App\n  class Config\n  end\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        module App
+          def self.load
+            Config.load
+            ^^^^^^ Fully qualify this constant to avoid possibly ambiguous resolution.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the constant resolves identically either way' do
+      source = <<~RUBY
+        module App
+          def self.load
+            Config.load
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(
+        source, 'file:///config.rb' => "class Config\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'does not register an offense when the constant is not in the index' do
+      source = <<~RUBY
+        module App
+          def self.parse(json)
+            JSON.parse(json)
+          end
+        end
+      RUBY
+      cop.project_index = index_with_current(source)
+
+      expect_no_offenses(source, 'current.rb')
+    end
+  end
 end


### PR DESCRIPTION
`Lint/ConstantResolution` flags every unqualified constant, which is why it ships disabled by default and its own docs concede it needs `Only`/`Ignore` lists to be usable. With `UseProjectIndex` enabled it now reports only genuinely ambiguous references: constants that resolve to a different declaration through the surrounding lexical nesting than they would fully qualified, the actual conflict the cop was written to prevent. Unresolvable names (gem constants) are not reported.

That turns the cop from "qualify everything" into "qualify what's actually ambiguous", which should finally make it practical to enable. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
