### PR TITLE
Skip inherited-method overrides in rename-suggesting Naming cops

### DIFF
--- a/changelog/fix_skip_inherited_method_overrides_in_rename_suggesting_naming_cops_20260716151754.md
+++ b/changelog/fix_skip_inherited_method_overrides_in_rename_suggesting_naming_cops_20260716151754.md
@@ -1,0 +1,1 @@
+* [#15488](https://github.com/rubocop/rubocop/pull/15488): Fix false positives for `Naming/PredicatePrefix` and `Naming/AccessorMethodName` when the method overrides an ancestor method defined in the project (`UseProjectIndex`). ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2887,6 +2887,7 @@ Migration/DepartmentName:
 Naming/AccessorMethodName:
   Description: Checks the naming of accessor methods for get_/set_.
   StyleGuide: '#accessor_mutator_method_names'
+  VersionChanged: '<<next>>'
   Enabled: true
   VersionAdded: '0.50'
 
@@ -3163,7 +3164,7 @@ Naming/PredicatePrefix:
   StyleGuide: '#bool-methods-qmark'
   Enabled: true
   VersionAdded: '0.50'
-  VersionChanged: '1.75'
+  VersionChanged: '<<next>>'
   # Predicate name prefixes.
   NamePrefix:
     - is_

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -81,6 +81,8 @@ of the same class or module (e.g. a reopening in another file).
 `Lint/InheritException` also reports classes that inherit from `Exception` indirectly, through
 a parent class defined elsewhere in the project.
 `Style/StaticClass` does not report classes that are subclassed anywhere in the project.
+`Naming/PredicatePrefix` and `Naming/AccessorMethodName` do not suggest renaming methods
+that override a method defined by an ancestor elsewhere in the project.
 
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -11,6 +11,11 @@ module RuboCop
       # Getters (`get_attribute`) must have no arguments to be registered,
       # and setters (`set_attribute(value)`) must have exactly one.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, methods that override a method defined by an ancestor
+      # elsewhere in the project are not reported, since renaming an override
+      # breaks the inherited contract.
+      #
       # @example
       #   # bad
       #   def set_attribute(value)
@@ -36,12 +41,15 @@ module RuboCop
       #   def set_value
       #   end
       class AccessorMethodName < Base
+        include ProjectIndexHelp
+
         MSG_READER = 'Do not prefix reader method names with `get_`.'
         MSG_WRITER = 'Do not prefix writer method names with `set_`.'
 
         def on_def(node)
           return unless proper_attribute_name?(node)
           return unless bad_reader_name?(node) || bad_writer_name?(node)
+          return if overrides_inherited_method?(node)
 
           message = message(node)
 
@@ -71,6 +79,54 @@ module RuboCop
           node.method_name.to_s.start_with?('set_') &&
             node.arguments.one? &&
             node.first_argument.arg_type?
+        end
+
+        # When `AllCops/UseProjectIndex` is enabled, methods that override a
+        # method defined by an ancestor elsewhere in the project are not
+        # reported: renaming an override breaks the inherited contract.
+        def overrides_inherited_method?(node)
+          return false unless project_index
+          return false unless (namespace_node = node.each_ancestor(:class, :module).first)
+
+          declaration = resolve_in_index(namespace_node)
+          return false unless declaration.is_a?(Rubydex::Namespace)
+
+          scope = node.defs_type? ? singleton_of(declaration) : declaration
+          !scope.nil? && inherited_member?(scope, "#{node.method_name}()")
+        rescue StandardError
+          false
+        end
+
+        def inherited_member?(scope, member_name)
+          scope.ancestors.any? do |ancestor|
+            ancestor.name != scope.name && ancestor.member(member_name)
+          end
+        end
+
+        def singleton_of(declaration)
+          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
+        end
+
+        def resolve_in_index(namespace_node)
+          segments = namespace_node.identifier.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(namespace_node)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(namespace_node)
+          return [] if namespace_node.identifier.absolute?
+
+          namespace_node.each_ancestor(:class, :module)
+                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
       end
     end

--- a/lib/rubocop/cop/naming/predicate_prefix.rb
+++ b/lib/rubocop/cop/naming/predicate_prefix.rb
@@ -21,6 +21,11 @@ module RuboCop
       # offenses if the method has a Sorbet `sig` with a return type of
       # `T::Boolean`. Dynamic methods are not supported with this configuration.
       #
+      # When `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is
+      # installed, methods that override a method defined by an ancestor
+      # elsewhere in the project are not reported, since renaming an override
+      # breaks the inherited contract.
+      #
       # @example NamePrefix: ['is_', 'has_', 'have_'] (default)
       #   # bad
       #   def is_even(value)
@@ -101,6 +106,7 @@ module RuboCop
       #   def_node_matcher(:even?) { |value| }
       #
       class PredicatePrefix < Base
+        include ProjectIndexHelp
         include AllowedMethods
 
         # @!method dynamic_method_define(node)
@@ -124,16 +130,22 @@ module RuboCop
         end
 
         def on_def(node)
-          predicate_prefixes.each do |prefix|
-            method_name = node.method_name.to_s
+          method_name = node.method_name.to_s
+          offending_prefixes = offending_prefixes_for(node, method_name)
+          return if offending_prefixes.empty? || overrides_inherited_method?(node)
 
-            next if allowed_method_name?(method_name, prefix)
-            next if use_sorbet_sigs? && !sorbet_sig?(node, return_type: 'T::Boolean')
-
+          offending_prefixes.each do |prefix|
             add_offense(
               node.loc.name,
               message: message(method_name, expected_name(method_name, prefix))
             )
+          end
+        end
+
+        def offending_prefixes_for(node, method_name)
+          predicate_prefixes.reject do |prefix|
+            allowed_method_name?(method_name, prefix) ||
+              (use_sorbet_sigs? && !sorbet_sig?(node, return_type: 'T::Boolean'))
           end
         end
         alias on_defs on_def
@@ -197,6 +209,54 @@ module RuboCop
 
         def method_definition_macro?(macro_name)
           cop_config['MethodDefinitionMacros'].include?(macro_name.to_s)
+        end
+
+        # When `AllCops/UseProjectIndex` is enabled, methods that override a
+        # method defined by an ancestor elsewhere in the project are not
+        # reported: renaming an override breaks the inherited contract.
+        def overrides_inherited_method?(node)
+          return false unless project_index
+          return false unless (namespace_node = node.each_ancestor(:class, :module).first)
+
+          declaration = resolve_in_index(namespace_node)
+          return false unless declaration.is_a?(Rubydex::Namespace)
+
+          scope = node.defs_type? ? singleton_of(declaration) : declaration
+          !scope.nil? && inherited_member?(scope, "#{node.method_name}()")
+        rescue StandardError
+          false
+        end
+
+        def inherited_member?(scope, member_name)
+          scope.ancestors.any? do |ancestor|
+            ancestor.name != scope.name && ancestor.member(member_name)
+          end
+        end
+
+        def singleton_of(declaration)
+          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
+        end
+
+        def resolve_in_index(namespace_node)
+          segments = namespace_node.identifier.const_name.split('::')
+
+          declaration = project_index.resolve_constant(
+            segments.first, lexical_nesting(namespace_node)
+          )
+          segments.drop(1).each do |segment|
+            return nil unless declaration.is_a?(Rubydex::Namespace)
+
+            declaration = project_index.resolve_constant(segment, [declaration.name])
+          end
+
+          declaration
+        end
+
+        def lexical_nesting(namespace_node)
+          return [] if namespace_node.identifier.absolute?
+
+          namespace_node.each_ancestor(:class, :module)
+                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
       end
     end

--- a/spec/rubocop/cop/naming/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/naming/accessor_method_name_spec.rb
@@ -184,4 +184,52 @@ RSpec.describe RuboCop::Cop::Naming::AccessorMethodName, :config do
       end
     RUBY
   end
+
+  context 'with a project index', :project_index do
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    it 'does not register an offense when the method overrides an ancestor method' do
+      source = <<~RUBY
+        class Child < Base
+          def get_value
+            @value
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///current.rb' => source,
+        'file:///base.rb' => "class Base\n  def get_value\n    nil\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'registers an offense when no ancestor defines the method' do
+      source = <<~RUBY
+        class Child < Base
+          def get_value
+            @value
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///current.rb' => source,
+        'file:///base.rb' => "class Base\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Child < Base
+          def get_value
+              ^^^^^^^^^ Do not prefix reader method names with `get_`.
+            @value
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/naming/predicate_prefix_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_prefix_spec.rb
@@ -221,4 +221,54 @@ RSpec.describe RuboCop::Cop::Naming::PredicatePrefix, :config do
       RUBY
     end
   end
+
+  context 'with a project index', :project_index do
+    let(:cop_config) { { 'ForbiddenPrefixes' => %w[is_], 'NamePrefix' => %w[is_] } }
+
+    def build_index(sources)
+      graph = Rubydex::Graph.new
+      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+      graph.resolve
+      graph
+    end
+
+    it 'does not register an offense when the method overrides an ancestor method' do
+      source = <<~RUBY
+        class Child < Base
+          def is_ready
+            true
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///current.rb' => source,
+        'file:///base.rb' => "class Base\n  def is_ready\n    false\n  end\nend\n"
+      )
+
+      expect_no_offenses(source, 'current.rb')
+    end
+
+    it 'registers an offense when no ancestor defines the method' do
+      source = <<~RUBY
+        class Child < Base
+          def is_ready
+            true
+          end
+        end
+      RUBY
+      cop.project_index = build_index(
+        'file:///current.rb' => source,
+        'file:///base.rb' => "class Base\nend\n"
+      )
+
+      expect_offense(<<~RUBY, 'current.rb')
+        class Child < Base
+          def is_ready
+              ^^^^^^^^ Rename `is_ready` to `ready?`.
+            true
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Naming/PredicatePrefix` and `Naming/AccessorMethodName` suggest renames (`is_foo` to `foo?`, `get_value` to `value`), but when the flagged method overrides one defined by an ancestor, following the suggestion breaks the inherited contract; the rename belongs at the ancestor, if anywhere. With `UseProjectIndex` enabled, both cops now skip methods that override an ancestor method defined elsewhere in the project (matching singleton-ness).

Gem-defined base methods stay invisible to the index, so those overrides are still reported, same as today. The index only suppresses when it can prove the override. Without the index the behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
