### PR TITLE
Consolidate project-index resolution helpers into ProjectIndexHelp

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -219,6 +219,7 @@ RSpec/SpecFilePathFormat:
     RedundantLetRuboCopConfigNew: redundant_let_rubocop_config_new
   Exclude:
     - spec/rubocop/cop/mixin/enforce_superclass_spec.rb
+    - spec/rubocop/cop/mixin/project_index_help_spec.rb
 
 RSpec/MessageSpies:
   EnforcedStyle: receive

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -66,6 +66,8 @@ module RuboCop
       #   Login
       #
       class ConstantResolution < Base
+        include ProjectIndexHelp
+
         MSG = 'Fully qualify this constant to avoid possibly ambiguous resolution.'
 
         # @!method unqualified_const?(node)

--- a/lib/rubocop/cop/lint/constant_resolution.rb
+++ b/lib/rubocop/cop/lint/constant_resolution.rb
@@ -91,28 +91,13 @@ module RuboCop
         # index cannot resolve at all (e.g. constants from gems), are not
         # reported.
         def ambiguous_resolution?(node)
-          relative = project_index.resolve_constant(node.short_name.to_s, lexical_nesting(node))
-          absolute = project_index.resolve_constant(node.short_name.to_s, [])
+          name = node.short_name.to_s
+          relative = project_index.resolve_constant(name, lexical_nesting_of(node))
+          absolute = project_index.resolve_constant(name, [])
 
           !relative.nil? && !absolute.nil? && relative.name != absolute.name
         rescue StandardError
           false
-        end
-
-        def lexical_nesting(node)
-          scopes = node.each_ancestor(:class, :module).reject do |ancestor|
-            in_superclass_expression?(node, ancestor)
-          end
-
-          scopes.map { |ancestor| ancestor.identifier.const_name }.reverse
-        end
-
-        # A constant in the superclass expression resolves in the scopes
-        # enclosing the class definition, not inside it.
-        def in_superclass_expression?(node, ancestor)
-          ancestor.class_type? &&
-            ancestor.parent_class&.each_descendant(:const)
-                    &.any? { |descendant| descendant.equal?(node) }
         end
 
         def const_name?(name)

--- a/lib/rubocop/cop/lint/deprecated_reference.rb
+++ b/lib/rubocop/cop/lint/deprecated_reference.rb
@@ -83,7 +83,7 @@ module RuboCop
           return unless project_index
           return if node.parent&.defined_module
 
-          declaration = resolve_constant_node(node)
+          declaration = resolve_constant_in_index(node)
           return unless declaration && deprecated?(declaration)
           return if within_deprecated_definition?(node)
 
@@ -108,17 +108,17 @@ module RuboCop
           return nil unless namespace.is_a?(Rubydex::Namespace)
 
           if singleton_context?(node)
-            singleton_member(namespace, "#{node.method_name}()")
+            indexed_singleton_member(namespace, "#{node.method_name}()")
           else
             namespace.find_member("#{node.method_name}()")
           end
         end
 
         def const_receiver_declaration(node, receiver)
-          namespace = resolve_constant_node(receiver)
+          namespace = resolve_constant_in_index(receiver)
           return nil unless namespace.is_a?(Rubydex::Namespace)
 
-          singleton_member(namespace, "#{node.method_name}()")
+          indexed_singleton_member(namespace, "#{node.method_name}()")
         end
 
         def enclosing_namespace(node)
@@ -126,47 +126,8 @@ module RuboCop
           return project_index['Object'] unless namespace_node
 
           @namespace_cache.fetch(namespace_node) do
-            @namespace_cache[namespace_node] = resolve_constant_node(namespace_node.identifier)
+            @namespace_cache[namespace_node] = resolve_constant_in_index(namespace_node.identifier)
           end
-        end
-
-        # Resolves a constant the way Ruby does: the first segment through the
-        # lexical nesting and every following segment inside the previous one.
-        # (Qualified names cannot be passed to `resolve_constant` as a whole,
-        # since it only applies the nesting to the full name.)
-        def resolve_constant_node(const_node)
-          segments = const_node.const_name.split('::')
-          nesting = const_node.absolute? ? [] : lexical_nesting(const_node)
-
-          declaration = project_index.resolve_constant(segments.first, nesting)
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(node)
-          node.each_ancestor(:class, :module)
-              .map { |ancestor| ancestor.identifier.const_name }.reverse
-        end
-
-        # A namespace without any singleton method has no singleton-class
-        # declaration of its own, so the lookup starts from the first ancestor
-        # that has one; its `find_member` covers the rest of the chain.
-        def singleton_member(namespace, member_name)
-          namespace.ancestors.each do |ancestor|
-            singleton = singleton_of(ancestor)
-            return singleton.find_member(member_name) if singleton
-          end
-
-          nil
-        end
-
-        def singleton_of(namespace)
-          project_index["#{namespace.name}::<#{namespace.name.split('::').last}>"]
         end
 
         # Whether an implicit-receiver call runs with the class or module itself

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -73,7 +73,7 @@ module RuboCop
             add_offense(parent_class, message: message(parent_class)) do |corrector|
               corrector.replace(parent_class, preferred_base_class)
             end
-          elsif (via = inherits_exception_via(node, parent_class))
+          elsif (via = inherits_exception_via(parent_class))
             # No autocorrection: the `Exception` inheritance lives at another
             # class' definition site, possibly in another file.
             message = format(INDIRECT_MSG, prefer: preferred_base_class, via: via)
@@ -107,10 +107,10 @@ module RuboCop
         # is not indexed, so a chain ending in it shows up as an ancestor whose
         # superclass reference is unresolved and literally named `Exception`.
         # Returns the name of that ancestor, or `nil`.
-        def inherits_exception_via(node, parent_class)
+        def inherits_exception_via(parent_class)
           return nil unless project_index && parent_class.const_type?
 
-          declaration = resolve_in_index(node, parent_class)
+          declaration = resolve_constant_in_index(parent_class)
           return nil unless declaration.is_a?(Rubydex::Class)
 
           exception_ancestor(declaration)&.name
@@ -132,30 +132,6 @@ module RuboCop
             superclass.is_a?(Rubydex::UnresolvedConstantReference) &&
               superclass.name.delete_prefix('::') == 'Exception'
           end
-        end
-
-        def resolve_in_index(node, parent_class)
-          segments = parent_class.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(node, parent_class)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        # The superclass expression resolves in the scopes enclosing the class
-        # definition, not inside it.
-        def lexical_nesting(node, parent_class)
-          return [] if parent_class.absolute?
-
-          node.each_ancestor(:class, :module)
-              .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
 
         def inherit_exception_class_with_omitted_namespace?(class_node)

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -172,7 +172,7 @@ module RuboCop
         def index_verified_stateless_ancestry?(class_node)
           return false unless project_index
 
-          declaration = resolve_in_index(class_node)
+          declaration = resolve_constant_in_index(class_node.identifier)
           return false unless declaration.is_a?(Rubydex::Class)
 
           ancestors = declaration.ancestors.to_a
@@ -180,18 +180,6 @@ module RuboCop
           return false if inherited.any? { |ancestor| ancestor.member('initialize()') }
 
           ancestors.all? { |ancestor| resolved_ancestry_definitions?(ancestor) }
-        end
-
-        def resolve_in_index(class_node)
-          identifier = class_node.identifier
-          nesting = if identifier.absolute?
-                      []
-                    else
-                      class_node.each_ancestor(:class, :module)
-                                .map { |ancestor| ancestor.identifier.const_name }.reverse
-                    end
-
-          project_index.resolve_constant(identifier.const_name, nesting)
         end
 
         def resolved_ancestry_definitions?(declaration)

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -98,36 +98,10 @@ module RuboCop
         end
 
         def method_declaration(node, namespace_node)
-          namespace = resolve_namespace(namespace_node)
+          namespace = resolve_constant_in_index(namespace_node.identifier)
           return nil unless namespace.is_a?(Rubydex::Namespace)
 
           namespace.member("#{node.method_name}()")
-        end
-
-        # Resolves the enclosing namespace segment by segment, since
-        # `resolve_constant` does not resolve qualified names against
-        # a lexical nesting.
-        def resolve_namespace(namespace_node)
-          identifier = namespace_node.identifier
-          segments = identifier.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(namespace_node, identifier)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(namespace_node, identifier)
-          return [] if identifier.absolute?
-
-          namespace_node.each_ancestor(:class, :module)
-                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
 
         def referenced?(method_name)

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -57,7 +57,10 @@ module RuboCop
       # Resolves a constant node the way Ruby does: the first segment through
       # the lexical nesting and every following segment inside the previous
       # one. (Qualified names cannot be passed to `resolve_constant` as a
-      # whole, since it only applies the nesting to the full name.)
+      # whole, since it only applies the nesting to the full name. Later
+      # segments use `find_member` — the namespace and its ancestors — since
+      # `resolve_constant` cannot take an already-resolved namespace as the
+      # scope, only names as they appear in source.)
       def resolve_constant_in_index(const_node)
         segments = const_node.const_name.split('::')
         nesting = const_node.absolute? ? [] : lexical_nesting_of(const_node)
@@ -66,7 +69,7 @@ module RuboCop
         segments.drop(1).each do |segment|
           return nil unless declaration.is_a?(Rubydex::Namespace)
 
-          declaration = project_index.resolve_constant(segment, [declaration.name])
+          declaration = declaration.find_member(segment)
         end
 
         declaration

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -17,6 +17,14 @@ module RuboCop
       # remains after stripping `file://` from a `file:///C:/...` URI.
       WINDOWS_DRIVE_PREFIX = %r{\A/(?=[A-Za-z]:[/\\])}.freeze
 
+      class << self
+        # The signature is a property of the index, not of the cop, and computing
+        # it stats every indexed file, so all cops sharing an index share one
+        # computation. A single-entry cache (instead of a hash keyed by index)
+        # avoids retaining stale graphs in long-lived processes.
+        attr_accessor :cached_index_signature
+      end
+
       def external_dependency_checksum
         return nil unless project_index
 
@@ -116,6 +124,15 @@ module RuboCop
       end
 
       def project_index_signature
+        index, signature = ProjectIndexHelp.cached_index_signature
+        return signature if index.equal?(project_index)
+
+        compute_project_index_signature.tap do |computed|
+          ProjectIndexHelp.cached_index_signature = [project_index, computed]
+        end
+      end
+
+      def compute_project_index_signature
         project_index.documents.filter_map do |doc|
           uri = doc.uri
           next if uri == BUILTIN_DOCUMENT_URI

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -46,6 +46,75 @@ module RuboCop
         definitions_in_other_files(definitions).first
       end
 
+      # Resolves a constant node the way Ruby does: the first segment through
+      # the lexical nesting and every following segment inside the previous
+      # one. (Qualified names cannot be passed to `resolve_constant` as a
+      # whole, since it only applies the nesting to the full name.)
+      def resolve_constant_in_index(const_node)
+        segments = const_node.const_name.split('::')
+        nesting = const_node.absolute? ? [] : lexical_nesting_of(const_node)
+
+        declaration = project_index.resolve_constant(segments.first, nesting)
+        segments.drop(1).each do |segment|
+          return nil unless declaration.is_a?(Rubydex::Namespace)
+
+          declaration = project_index.resolve_constant(segment, [declaration.name])
+        end
+
+        declaration
+      end
+
+      # The lexical nesting the node's constants resolve through, outermost
+      # first. Only scopes whose *body* contains the node count: a class or
+      # module's identifier and superclass expression are evaluated before its
+      # scope exists, so ancestors reached through them are excluded.
+      def lexical_nesting_of(node)
+        nesting = []
+        child = node
+
+        node.each_ancestor do |ancestor|
+          if ancestor.type?(:class, :module) && child.equal?(ancestor.body)
+            nesting << ancestor.identifier.const_name
+          end
+          child = ancestor
+        end
+
+        nesting.reverse
+      end
+
+      # The declaration of `declaration`'s singleton class, or nil when no
+      # singleton method is defined on it anywhere in the project.
+      def indexed_singleton_of(declaration)
+        project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
+      end
+
+      # A namespace without any singleton method has no singleton-class
+      # declaration of its own, so the lookup starts from the first ancestor
+      # that has one; its `find_member` covers the rest of the chain.
+      def indexed_singleton_member(namespace, member_name)
+        namespace.ancestors.each do |ancestor|
+          singleton = indexed_singleton_of(ancestor)
+          return singleton.find_member(member_name) if singleton
+        end
+
+        nil
+      end
+
+      # Whether an ancestor of `scope` other than `scope` itself defines
+      # `member_name`.
+      def inherited_index_member?(scope, member_name)
+        scope.ancestors.any? do |ancestor|
+          ancestor.name != scope.name && ancestor.member(member_name)
+        end
+      end
+
+      def same_file?(path, other)
+        return true if File.identical?(path, other)
+
+        normalized = [path, other].map { |p| File.expand_path(p).tr('\\', '/') }
+        normalized.uniq.one? || (Platform.windows? && normalized[0].casecmp?(normalized[1]))
+      end
+
       def project_index_signature
         project_index.documents.filter_map do |doc|
           uri = doc.uri

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -88,45 +88,13 @@ module RuboCop
           return false unless project_index
           return false unless (namespace_node = node.each_ancestor(:class, :module).first)
 
-          declaration = resolve_in_index(namespace_node)
+          declaration = resolve_constant_in_index(namespace_node.identifier)
           return false unless declaration.is_a?(Rubydex::Namespace)
 
-          scope = node.defs_type? ? singleton_of(declaration) : declaration
-          !scope.nil? && inherited_member?(scope, "#{node.method_name}()")
+          scope = node.defs_type? ? indexed_singleton_of(declaration) : declaration
+          !scope.nil? && inherited_index_member?(scope, "#{node.method_name}()")
         rescue StandardError
           false
-        end
-
-        def inherited_member?(scope, member_name)
-          scope.ancestors.any? do |ancestor|
-            ancestor.name != scope.name && ancestor.member(member_name)
-          end
-        end
-
-        def singleton_of(declaration)
-          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
-        end
-
-        def resolve_in_index(namespace_node)
-          segments = namespace_node.identifier.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(namespace_node)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(namespace_node)
-          return [] if namespace_node.identifier.absolute?
-
-          namespace_node.each_ancestor(:class, :module)
-                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
       end
     end

--- a/lib/rubocop/cop/naming/predicate_prefix.rb
+++ b/lib/rubocop/cop/naming/predicate_prefix.rb
@@ -218,45 +218,13 @@ module RuboCop
           return false unless project_index
           return false unless (namespace_node = node.each_ancestor(:class, :module).first)
 
-          declaration = resolve_in_index(namespace_node)
+          declaration = resolve_constant_in_index(namespace_node.identifier)
           return false unless declaration.is_a?(Rubydex::Namespace)
 
-          scope = node.defs_type? ? singleton_of(declaration) : declaration
-          !scope.nil? && inherited_member?(scope, "#{node.method_name}()")
+          scope = node.defs_type? ? indexed_singleton_of(declaration) : declaration
+          !scope.nil? && inherited_index_member?(scope, "#{node.method_name}()")
         rescue StandardError
           false
-        end
-
-        def inherited_member?(scope, member_name)
-          scope.ancestors.any? do |ancestor|
-            ancestor.name != scope.name && ancestor.member(member_name)
-          end
-        end
-
-        def singleton_of(declaration)
-          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
-        end
-
-        def resolve_in_index(namespace_node)
-          segments = namespace_node.identifier.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(namespace_node)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(namespace_node)
-          return [] if namespace_node.identifier.absolute?
-
-          namespace_node.each_ancestor(:class, :module)
-                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
       end
     end

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -108,7 +108,7 @@ module RuboCop
         def indexed_namespace_keyword(node)
           return nil unless project_index
 
-          declaration = resolve_in_index(node.identifier.namespace.const_name, node)
+          declaration = resolve_constant_in_index(node.identifier.namespace)
 
           case declaration
           when Rubydex::Class then 'class'
@@ -156,7 +156,7 @@ module RuboCop
         def compactible_namespace?(node)
           return true unless project_index
 
-          declaration = resolve_in_index(node.identifier.const_name, node)
+          declaration = resolve_constant_in_index(node.identifier)
           return false unless declaration.is_a?(Rubydex::Namespace)
 
           declaration.definitions.any? { |definition| definition_elsewhere?(definition, node) }
@@ -172,22 +172,6 @@ module RuboCop
           # A path that cannot be converted or compared cannot prove the
           # namespace is defined elsewhere; err on not correcting.
           false
-        end
-
-        def same_file?(path, other)
-          return true if File.identical?(path, other)
-
-          normalized = [path, other].map { |p| File.expand_path(p).tr('\\', '/') }
-          normalized.uniq.one? || (Platform.windows? && normalized[0].casecmp?(normalized[1]))
-        end
-
-        def resolve_in_index(const_name, node)
-          project_index.resolve_constant(const_name, lexical_nesting(node))
-        end
-
-        def lexical_nesting(node)
-          node.each_ancestor(:class, :module).map { |ancestor| ancestor.identifier.const_name }
-                                             .reverse
         end
 
         def compact_node(corrector, node)

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -137,7 +137,7 @@ module RuboCop
         def documented_elsewhere?(node)
           return false unless project_index
 
-          declaration = resolve_in_index(node)
+          declaration = resolve_constant_in_index(node.identifier)
           return false unless declaration.is_a?(Rubydex::Namespace)
 
           declaration.definitions.any? do |definition|
@@ -147,39 +147,12 @@ module RuboCop
           false
         end
 
-        def resolve_in_index(node)
-          identifier = node.identifier
-          segments = identifier.const_name.split('::')
-          nesting = identifier.absolute? ? [] : lexical_nesting(node)
-
-          declaration = project_index.resolve_constant(segments.first, nesting)
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(node)
-          node.each_ancestor(:class, :module)
-              .map { |ancestor| ancestor.identifier.const_name }.reverse
-        end
-
         def other_definition?(definition, node)
           location = definition.location
           return false unless location.uri.start_with?(FILE_URI_PREFIX)
 
           !same_file?(location.to_file_path, processed_source.file_path) ||
             location.to_display.start_line != node.first_line
-        end
-
-        def same_file?(path, other)
-          return true if File.identical?(path, other)
-
-          normalized = [path, other].map { |p| File.expand_path(p).tr('\\', '/') }
-          normalized.uniq.one? || (Platform.windows? && normalized[0].casecmp?(normalized[1]))
         end
 
         def documenting_comments?(definition)

--- a/lib/rubocop/cop/style/missing_respond_to_missing.rb
+++ b/lib/rubocop/cop/style/missing_respond_to_missing.rb
@@ -81,10 +81,10 @@ module RuboCop
           return false unless project_index
           return false unless (namespace_node = node.each_ancestor(:class, :module).first)
 
-          declaration = resolve_in_index(namespace_node)
+          declaration = resolve_constant_in_index(namespace_node.identifier)
           return false unless declaration.is_a?(Rubydex::Namespace)
 
-          scope = singleton_definition?(node) ? singleton_of(declaration) : declaration
+          scope = singleton_definition?(node) ? indexed_singleton_of(declaration) : declaration
           !scope&.member('respond_to_missing?()').nil?
         rescue StandardError
           false
@@ -92,32 +92,6 @@ module RuboCop
 
         def singleton_definition?(node)
           node.defs_type? || node.each_ancestor(:sclass, :class, :module).first&.sclass_type?
-        end
-
-        def singleton_of(declaration)
-          project_index["#{declaration.name}::<#{declaration.name.split('::').last}>"]
-        end
-
-        def resolve_in_index(namespace_node)
-          segments = namespace_node.identifier.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(namespace_node)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(namespace_node)
-          return [] if namespace_node.identifier.absolute?
-
-          namespace_node.each_ancestor(:class, :module)
-                        .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
 
         def implements_respond_to_missing?(node)

--- a/lib/rubocop/cop/style/static_class.rb
+++ b/lib/rubocop/cop/style/static_class.rb
@@ -74,34 +74,12 @@ module RuboCop
         def subclassed_in_project?(class_node)
           return false unless project_index
 
-          declaration = resolve_in_index(class_node)
+          declaration = resolve_constant_in_index(class_node.identifier)
           return false unless declaration.is_a?(Rubydex::Class)
 
           declaration.descendants.any? { |descendant| descendant.name != declaration.name }
         rescue StandardError
           false
-        end
-
-        def resolve_in_index(class_node)
-          segments = class_node.identifier.const_name.split('::')
-
-          declaration = project_index.resolve_constant(
-            segments.first, lexical_nesting(class_node)
-          )
-          segments.drop(1).each do |segment|
-            return nil unless declaration.is_a?(Rubydex::Namespace)
-
-            declaration = project_index.resolve_constant(segment, [declaration.name])
-          end
-
-          declaration
-        end
-
-        def lexical_nesting(class_node)
-          return [] if class_node.identifier.absolute?
-
-          class_node.each_ancestor(:class, :module)
-                    .map { |ancestor| ancestor.identifier.const_name }.reverse
         end
 
         def autocorrect(corrector, class_node)

--- a/spec/rubocop/cop/lint/constant_resolution_spec.rb
+++ b/spec/rubocop/cop/lint/constant_resolution_spec.rb
@@ -129,13 +129,6 @@ RSpec.describe RuboCop::Cop::Lint::ConstantResolution, :config do
   context 'with a project index', :project_index do
     let(:cop_config) { {} }
 
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge('file:///current.rb' => source))
     end

--- a/spec/rubocop/cop/lint/deprecated_reference_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_reference_spec.rb
@@ -12,13 +12,6 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedReference, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(sources = {})
       build_index(sources.merge('file:///lib/current.rb' => current_source))
     end

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -199,13 +199,6 @@ RSpec.describe RuboCop::Cop::Lint::InheritException, :config do
   context 'with a project index', :project_index do
     let(:cop_config) { { 'EnforcedStyle' => 'standard_error' } }
 
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge('file:///current.rb' => source))
     end

--- a/spec/rubocop/cop/lint/missing_super_spec.rb
+++ b/spec/rubocop/cop/lint/missing_super_spec.rb
@@ -260,13 +260,6 @@ RSpec.describe RuboCop::Cop::Lint::MissingSuper, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(sources = {})
       build_index(sources.merge('file:///lib/current.rb' => current_source))
     end

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -13,13 +13,6 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(sources = {})
       build_index(sources.merge('file:///lib/current.rb' => current_source))
     end

--- a/spec/rubocop/cop/mixin/project_index_help_spec.rb
+++ b/spec/rubocop/cop/mixin/project_index_help_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::ProjectIndexHelp, :project_index do
 
       attr_accessor :project_index
 
-      public :project_index_signature
+      public :project_index_signature, :resolve_constant_in_index
     end
   end
 
@@ -16,6 +16,28 @@ RSpec.describe RuboCop::Cop::ProjectIndexHelp, :project_index do
     sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
     graph.resolve
     graph
+  end
+
+  describe '#resolve_constant_in_index' do
+    it 'resolves a qualified reference to a member of a nested namespace' do
+      source = <<~RUBY
+        module A
+          module B
+            class C
+            end
+          end
+
+          B::C
+        end
+      RUBY
+      helper = helper_class.new
+      helper.project_index = build_index('file:///nested.rb' => source)
+
+      processed = RuboCop::ProcessedSource.new(source, RUBY_VERSION.to_f)
+      ref = processed.ast.each_node(:const).find { |node| node.const_name == 'B::C' }
+
+      expect(helper.resolve_constant_in_index(ref).name).to eq('A::B::C')
+    end
   end
 
   describe '#project_index_signature' do

--- a/spec/rubocop/cop/mixin/project_index_help_spec.rb
+++ b/spec/rubocop/cop/mixin/project_index_help_spec.rb
@@ -11,13 +11,6 @@ RSpec.describe RuboCop::Cop::ProjectIndexHelp, :project_index do
     end
   end
 
-  def build_index(sources)
-    graph = Rubydex::Graph.new
-    sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-    graph.resolve
-    graph
-  end
-
   describe '#resolve_constant_in_index' do
     it 'resolves a qualified reference to a member of a nested namespace' do
       source = <<~RUBY

--- a/spec/rubocop/cop/mixin/project_index_help_spec.rb
+++ b/spec/rubocop/cop/mixin/project_index_help_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ProjectIndexHelp, :project_index do
+  let(:helper_class) do
+    Class.new do
+      include RuboCop::Cop::ProjectIndexHelp
+
+      attr_accessor :project_index
+
+      public :project_index_signature
+    end
+  end
+
+  def build_index(sources)
+    graph = Rubydex::Graph.new
+    sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+    graph.resolve
+    graph
+  end
+
+  describe '#project_index_signature' do
+    it 'is computed once per index across cops sharing it' do
+      index = build_index('file:///foo.rb' => "class Foo\nend\n")
+      first, second = Array.new(2) do
+        helper_class.new.tap { |helper| helper.project_index = index }
+      end
+
+      expect(first.project_index_signature).to eq(second.project_index_signature)
+      expect(second.project_index_signature).to be(first.project_index_signature)
+    end
+
+    it 'is recomputed when the index changes' do
+      first = helper_class.new.tap do |helper|
+        helper.project_index = build_index('file:///foo.rb' => "class Foo\nend\n")
+      end
+      second = helper_class.new.tap do |helper|
+        helper.project_index = build_index('file:///bar.rb' => "class Bar\nend\n")
+      end
+
+      expect(first.project_index_signature).not_to eq(second.project_index_signature)
+    end
+  end
+end

--- a/spec/rubocop/cop/naming/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/naming/accessor_method_name_spec.rb
@@ -186,13 +186,6 @@ RSpec.describe RuboCop::Cop::Naming::AccessorMethodName, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     it 'does not register an offense when the method overrides an ancestor method' do
       source = <<~RUBY
         class Child < Base

--- a/spec/rubocop/cop/naming/predicate_prefix_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_prefix_spec.rb
@@ -225,13 +225,6 @@ RSpec.describe RuboCop::Cop::Naming::PredicatePrefix, :config do
   context 'with a project index', :project_index do
     let(:cop_config) { { 'ForbiddenPrefixes' => %w[is_], 'NamePrefix' => %w[is_] } }
 
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     it 'does not register an offense when the method overrides an ancestor method' do
       source = <<~RUBY
         class Child < Base

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -915,13 +915,6 @@ RSpec.describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     context 'EnforcedStyle: nested' do
       let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
 

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -572,13 +572,6 @@ RSpec.describe RuboCop::Cop::Style::Documentation, :config do
       path.start_with?('/') ? "file://#{path}" : "file:///#{path}"
     end
 
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge(file_uri(current_path) => source))
     end

--- a/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
+++ b/spec/rubocop/cop/style/missing_respond_to_missing_spec.rb
@@ -136,13 +136,6 @@ RSpec.describe RuboCop::Cop::Style::MissingRespondToMissing, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge('file:///current.rb' => source))
     end

--- a/spec/rubocop/cop/style/redundant_constant_base_spec.rb
+++ b/spec/rubocop/cop/style/redundant_constant_base_spec.rb
@@ -111,13 +111,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantConstantBase, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge('file:///current.rb' => source))
     end

--- a/spec/rubocop/cop/style/static_class_spec.rb
+++ b/spec/rubocop/cop/style/static_class_spec.rb
@@ -153,13 +153,6 @@ RSpec.describe RuboCop::Cop::Style::StaticClass, :config do
   end
 
   context 'with a project index', :project_index do
-    def build_index(sources)
-      graph = Rubydex::Graph.new
-      sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
-      graph.resolve
-      graph
-    end
-
     def index_with_current(source, sources = {})
       build_index(sources.merge('file:///current.rb' => source))
     end

--- a/spec/support/project_index_metadata.rb
+++ b/spec/support/project_index_metadata.rb
@@ -13,6 +13,15 @@ module ProjectIndexSpecHelpers
     'AllowSymlinksInCacheRootDirectory' => true
   }.freeze
 
+  # Builds a resolved in-memory index from a `uri => source` hash, for specs
+  # that exercise index-aware cop logic directly.
+  def build_index(sources)
+    graph = Rubydex::Graph.new
+    sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+    graph.resolve
+    graph
+  end
+
   def write_rubocop_config(tmpdir, config)
     merged = config.dup
     merged['AllCops'] = DEFAULT_ALL_COPS.merge(merged.fetch('AllCops', {}))


### PR DESCRIPTION
The index-aware cops that landed recently each carried private copies of the same constant-resolution machinery (segmented `resolve_constant`, lexical-nesting computation, singleton lookup, hardened path comparison). This moves them into the shared `ProjectIndexHelp` mixin, net -200 lines, no user-visible change.

The shared `lexical_nesting_of` computes nesting through scope bodies only, which handles the two positions the per-cop copies special-cased or missed: a class/module identifier and a superclass expression are both evaluated before the scope exists, so ancestors reached through them are excluded.

Also fixes `Lint/ConstantResolution` missing the mixin include, so its cached results now invalidate when constant declarations change in other files.

The cache-invalidation signature (a stat sweep over every indexed file) was memoized per cop instance, so cached runs swept the file list once per index cop, a dozen times on this repo. That's now shared as one computation per index.

`Style/RedundantConstantBase` deliberately keeps its own nesting logic: its cbase check treats definition identifiers differently on purpose (removing `::` from `class ::Foo` is never a pure rename).
