### PR TITLE
Validate `AutocorrectNotice` only when autocorrecting in `Style/Copyright`

### DIFF
--- a/changelog/change_validate_autocorrect_notice_only_when_autocorrecting.md
+++ b/changelog/change_validate_autocorrect_notice_only_when_autocorrecting.md
@@ -1,0 +1,1 @@
+* [#15490](https://github.com/rubocop/rubocop/pull/15490): Change `Style/Copyright` to validate `AutocorrectNotice` only when autocorrection is requested (`-a`/`-A`), so plain inspection no longer raises a warning. ([@koic][])

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -25,20 +25,25 @@ module RuboCop
         MSG = 'Include a copyright notice matching /%<notice>s/ before any code.'
         AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in your RuboCop config'
 
+        # rubocop:disable Metrics/AbcSize
         def on_new_investigation
           return if notice.empty? || notice_found?(processed_source)
 
-          verify_autocorrect_notice!
           message = format(MSG, notice: notice)
           if processed_source.blank?
             add_global_offense(message)
           else
             offense_range = source_range(processed_source.buffer, 1, 0)
             add_offense(offense_range, message: message) do |corrector|
+              next unless autocorrect?
+
+              verify_autocorrect_notice!
+
               autocorrect(corrector)
             end
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -119,6 +119,34 @@ RSpec.describe RuboCop::Cop::Style::Copyright, :config do
     end
   end
 
+  context 'when the copyright notice is missing and no `AutocorrectNotice` is configured' do
+    include_context 'mock console output'
+
+    before { cop_config['AutocorrectNotice'] = nil }
+
+    # Investigate through a team without `raise_error` so that a raised `RuboCop::Warning`
+    # is reported to stderr the way the runner does it, instead of being re-raised by
+    # the default spec harness.
+    def investigate_source(autocorrect:)
+      cop.instance_variable_get(:@options)[:autocorrect] = autocorrect
+      processed_source = parse_source("names = []\n")
+      RuboCop::Cop::Team.new([cop], configuration).investigate(processed_source)
+    end
+
+    it 'warns on stderr when autocorrection is requested' do
+      investigate_source(autocorrect: true)
+
+      expect($stderr.string).to include(described_class::AUTOCORRECT_EMPTY_WARNING)
+    end
+
+    it 'registers an offense without warning on stderr during inspection' do
+      report = investigate_source(autocorrect: false)
+
+      expect(report.offenses.size).to eq(1)
+      expect($stderr.string).to be_empty
+    end
+  end
+
   context 'when the copyright notice comes after any code' do
     it 'adds an offense' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'


### PR DESCRIPTION
`Style/Copyright` requires an `AutocorrectNotice` only to build the text it inserts during autocorrection. Until now the cop verified that setting eagerly during every run, so a plain `rubocop` inspection raised a `RuboCop::Warning` and aborted whenever `AutocorrectNotice` was unset or did not match `Notice`, even though no autocorrection was requested.

This was surprising compared with other cops: simply listing offenses should not demand autocorrect-only configuration. Move the verification into the autocorrection path so the warning is raised only when autocorrection is actually requested (`rubocop -a` / `rubocop -A`). A plain inspection now reports the offense without raising.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
