### PR TITLE
Add new Lint/NameTypo cop

### DIFF
--- a/changelog/new_add_new_lint_name_typo_cop_20260717073610.md
+++ b/changelog/new_add_new_lint_name_typo_cop_20260717073610.md
@@ -1,0 +1,1 @@
+* [#15491](https://github.com/rubocop/rubocop/pull/15491): Add new `Lint/NameTypo` cop. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2176,6 +2176,16 @@ Lint/MultipleComparison:
   VersionAdded: '0.47'
   VersionChanged: '1.1'
 
+Lint/NameTypo:
+  Description: >-
+    Checks for probable typos in constant and method names,
+    using the project index.
+  Enabled: pending
+  CheckConstants: true
+  CheckMethods: true
+  AllowedNames: []
+  VersionAdded: '<<next>>'
+
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'
   StyleGuide: '#no-nested-methods'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -132,6 +132,11 @@ makes the cop practical to enable without `Only`/`Ignore` lists.
 `Style/Documentation` accepts a reopened class or module when any of its other definition
 sites carries a documentation comment, instead of requiring a comment at every reopening.
 
+`Lint/NameTypo` (pending) is entirely powered by the index: it reports qualified constant
+references and constant-receiver method calls that do not resolve anywhere in the project
+when a similarly named alternative exists, and suggests it. `CheckConstants` and
+`CheckMethods` toggle the two checks independently.
+
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 
 == Notes

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -80,6 +80,7 @@ module RuboCop
       register_cop :MixedCaseRange, "#{__dir__}/lint/mixed_case_range"
       register_cop :MixedRegexpCaptureTypes, "#{__dir__}/lint/mixed_regexp_capture_types"
       register_cop :MultipleComparison, "#{__dir__}/lint/multiple_comparison"
+      register_cop :NameTypo, "#{__dir__}/lint/name_typo"
       register_cop :NestedMethodDefinition, "#{__dir__}/lint/nested_method_definition"
       register_cop :NestedPercentLiteral, "#{__dir__}/lint/nested_percent_literal"
       register_cop :NextWithoutAccumulator, "#{__dir__}/lint/next_without_accumulator"

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -179,31 +179,9 @@ module RuboCop
           inherited = ancestors.reject { |ancestor| ancestor.name == declaration.name }
           return false if inherited.any? { |ancestor| ancestor.member('initialize()') }
 
-          ancestors.all? { |ancestor| resolved_ancestry_definitions?(ancestor) }
-        end
-
-        def resolved_ancestry_definitions?(declaration)
-          declaration.definitions.all? do |definition|
-            superclass_reference_resolved?(definition) && mixin_references_resolved?(definition)
-          end
-        end
-
-        def superclass_reference_resolved?(definition)
-          return true unless definition.is_a?(Rubydex::ClassDefinition)
-
-          !definition.superclass.is_a?(Rubydex::UnresolvedConstantReference)
-        end
-
-        def mixin_references_resolved?(definition)
-          return true unless definition.respond_to?(:mixins)
-
-          definition.mixins.none? do |mixin|
-            # `extend` affects the singleton class and cannot introduce an
-            # inherited `initialize`.
-            next false if mixin.is_a?(Rubydex::Extend)
-
-            mixin.constant_reference.is_a?(Rubydex::UnresolvedConstantReference)
-          end
+          # `extend` affects the singleton class and cannot introduce an
+          # inherited `initialize`, so unresolved extends are tolerated.
+          fully_resolved_index_ancestry?(declaration, ignore_extend: true)
         end
       end
     end

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+begin
+  require 'did_you_mean'
+rescue LoadError
+  nil
+end
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for probable typos in constant and method names: a name that
+      # does not resolve anywhere in the project, used in a namespace the
+      # project does define, with a close-named sibling to suggest instead.
+      #
+      # The check is powered by the project-wide index, so it only runs when
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
+      # Without the index the cop does nothing.
+      #
+      # Constants are checked only in qualified references (`Foo::Bar`) whose
+      # namespace resolves in the index; bare names cannot be distinguished
+      # from constants provided by gems or the standard library. Methods are
+      # checked only in calls on constant receivers (`Foo.bar`) whose entire
+      # indexed ancestry is resolved, so methods gained through gem classes or
+      # dynamic definitions never produce offenses. In both cases an offense
+      # requires a similarly named alternative to exist — an unknown name
+      # alone is not reported, since the index does not see gems or the
+      # standard library.
+      #
+      # Names that appear as symbols or inside string literals in the same
+      # file are never reported, since they usually belong to runtime
+      # definitions the index cannot see (`stub_const`, `const_set`,
+      # `define_method`, and the like).
+      #
+      # @example
+      #   # bad - Services::UserCraetor is not defined, Services::UserCreator is
+      #   Services::UserCraetor.new
+      #
+      #   # good
+      #   Services::UserCreator.new
+      #
+      #   # bad - Report.generate_sumary is not defined, Report.generate_summary is
+      #   Report.generate_sumary
+      #
+      #   # good
+      #   Report.generate_summary
+      #
+      # @example CheckConstants: false
+      #   # good - constant references are not checked
+      #   Services::UserCraetor.new
+      #
+      # @example CheckMethods: false
+      #   # good - method calls are not checked
+      #   Report.generate_sumary
+      #
+      # @example AllowedNames: ['generate_sumary']
+      #   # good - the name is explicitly allowed
+      #   Report.generate_sumary
+      #
+      class NameTypo < Base
+        include ProjectIndexHelp
+
+        CONSTANT_MSG = 'Possible typo: `%<name>s` is not defined in `%<namespace>s`. ' \
+                       'Did you mean `%<suggestion>s`?'
+        METHOD_MSG = 'Possible typo: `%<receiver>s` does not respond to `%<name>s`. ' \
+                     'Did you mean `%<suggestion>s`?'
+
+        METHOD_MEMBER_REGEXP = /#([a-zA-Z_]\w*[?!]?)\(\)\z/.freeze
+        LITERAL_IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!]?/.freeze
+
+        def on_const(node)
+          return unless check?('CheckConstants') && checkable_constant?(node)
+
+          suggestion = constant_typo_suggestion(node)
+          return unless suggestion
+
+          message = format(CONSTANT_MSG, name: node.short_name,
+                                         namespace: node.namespace.const_name,
+                                         suggestion: suggestion)
+          add_offense(node.loc.name, message: message)
+        end
+
+        def on_send(node)
+          return unless check?('CheckMethods')
+          return unless node.receiver&.const_type?
+          return if allowed_name?(node.method_name) || defined_check?(node)
+
+          suggestion = method_typo_suggestion(node)
+          return unless suggestion
+
+          message = format(METHOD_MSG, receiver: node.receiver.const_name,
+                                       name: node.method_name,
+                                       suggestion: suggestion)
+          add_offense(node.loc.selector, message: message)
+        end
+        alias on_csend on_send
+
+        def on_new_investigation
+          @literal_names = nil
+          super
+        end
+
+        private
+
+        def check?(key)
+          project_index && defined?(DidYouMean::SpellChecker) && cop_config.fetch(key, true)
+        end
+
+        def checkable_constant?(node)
+          node.namespace&.const_type? &&
+            !allowed_name?(node.short_name) &&
+            !definition_identifier?(node) && !defined_check?(node)
+        end
+
+        def allowed_name?(name)
+          cop_config.fetch('AllowedNames', []).include?(name.to_s)
+        end
+
+        # The last segment of a class, module or constant definition is being
+        # defined, not referenced.
+        def definition_identifier?(node)
+          node.parent&.defined_module
+        end
+
+        # `defined?(Foo::Bar)` probes whether a name exists; unknown names
+        # there are deliberate.
+        def defined_check?(node)
+          node.each_ancestor(:defined?).any?
+        end
+
+        def constant_typo_suggestion(node)
+          return nil if literal_names.include?(node.short_name.to_s)
+
+          namespace = resolve_constant_in_index(node.namespace)
+          return nil unless namespace.is_a?(Rubydex::Namespace)
+          return nil if namespace.find_member(node.short_name.to_s)
+
+          spell_check(node.short_name, constant_member_names(namespace))
+        rescue StandardError
+          nil
+        end
+
+        # Writers are indexed under the reader's name, so setter calls are
+        # verified and spell-checked through the base name.
+        def method_typo_suggestion(node)
+          setter = setter_call?(node)
+          base = setter ? node.method_name.to_s.delete_suffix('=') : node.method_name.to_s
+          return nil if literal_names.include?(base)
+
+          declaration = unknown_method_owner(node, base)
+          return nil unless declaration
+
+          suggestion = spell_check(base, method_member_names(declaration))
+          suggestion && setter ? "#{suggestion}=" : suggestion
+        rescue StandardError
+          nil
+        end
+
+        # The receiver's declaration when it resolves in the index, its whole
+        # ancestry is resolved, and the method is not found — nil otherwise.
+        def unknown_method_owner(node, base)
+          declaration = resolve_constant_in_index(node.receiver)
+          return nil unless declaration.is_a?(Rubydex::Namespace)
+          return nil if responds_in_index?(declaration, node.method_name.to_s, base)
+          return nil unless fully_resolved_index_ancestry?(declaration)
+
+          declaration
+        end
+
+        def setter_call?(node)
+          node.assignment_method? && !node.operator_method?
+        end
+
+        def responds_in_index?(declaration, name, base)
+          # Instance methods of a module are also callable on the module
+          # itself when exposed with `module_function`.
+          [name, base].uniq.any? do |candidate|
+            member_name = "#{candidate}()"
+            indexed_singleton_member(declaration, member_name) ||
+              declaration.find_member(member_name)
+          end
+        end
+
+        # Names mentioned as symbols or inside string literals in the current
+        # file belong to runtime definitions (`stub_const`, `const_set`,
+        # `define_method`) that the index cannot see.
+        def literal_names
+          @literal_names ||=
+            processed_source.ast.each_descendant(:sym, :str)
+                            .with_object(Set.new) do |literal, names|
+              if literal.sym_type?
+                names << literal.value.to_s
+              else
+                literal.value.scan(LITERAL_IDENTIFIER_PATTERN) { |token| names << token }
+              end
+            end
+        end
+
+        def constant_member_names(namespace)
+          namespace.members.filter_map do |member|
+            name = member.name
+            name.split('::').last unless name.include?('#') || name.include?('<')
+          end
+        end
+
+        def method_member_names(declaration)
+          scopes = declaration.ancestors.filter_map { |ancestor| indexed_singleton_of(ancestor) }
+          scopes << declaration
+
+          scopes.flat_map do |scope|
+            scope.members.filter_map { |member| member.name[METHOD_MEMBER_REGEXP, 1] }
+          end
+        end
+
+        def spell_check(name, dictionary)
+          return nil if dictionary.empty?
+
+          DidYouMean::SpellChecker.new(dictionary: dictionary.uniq).correct(name.to_s).first
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -119,6 +119,38 @@ module RuboCop
         end
       end
 
+      # Whether every link of the declaration's ancestry is resolved in the
+      # index: no definition of any ancestor has an unresolved superclass or
+      # mixin reference. Unresolved links silently vanish from `ancestors`,
+      # so this is the completeness check that must pass before reasoning
+      # about what an ancestry does or does not define. `extend` mixins only
+      # affect the singleton class; pass `ignore_extend: true` when reasoning
+      # about instance-side ancestry only.
+      def fully_resolved_index_ancestry?(declaration, ignore_extend: false)
+        declaration.ancestors.all? do |ancestor|
+          ancestor.definitions.all? do |definition|
+            resolved_superclass_reference?(definition) &&
+              resolved_mixin_references?(definition, ignore_extend: ignore_extend)
+          end
+        end
+      end
+
+      def resolved_superclass_reference?(definition)
+        return true unless definition.is_a?(Rubydex::ClassDefinition)
+
+        !definition.superclass.is_a?(Rubydex::UnresolvedConstantReference)
+      end
+
+      def resolved_mixin_references?(definition, ignore_extend: false)
+        return true unless definition.respond_to?(:mixins)
+
+        definition.mixins.none? do |mixin|
+          next false if ignore_extend && mixin.is_a?(Rubydex::Extend)
+
+          mixin.constant_reference.is_a?(Rubydex::UnresolvedConstantReference)
+        end
+      end
+
       def same_file?(path, other)
         return true if File.identical?(path, other)
 

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
+  it 'does not register an offense without a project index' do
+    expect_no_offenses(<<~RUBY)
+      Services::UserCraetor.new
+      Report.generate_sumary
+    RUBY
+  end
+
+  context 'with a project index', :project_index do
+    context 'for constant references' do
+      before do
+        cop.project_index = build_index(
+          'file:///services.rb' => <<~RUBY
+            module Services
+              class UserCreator
+                class Params; end
+              end
+
+              class UserDeleter; end
+            end
+          RUBY
+        )
+      end
+
+      it 'registers an offense for a typo in a qualified constant' do
+        expect_offense(<<~RUBY)
+          Services::UserCraetor.new
+                    ^^^^^^^^^^^ Possible typo: `UserCraetor` is not defined in `Services`. Did you mean `UserCreator`?
+        RUBY
+      end
+
+      it 'registers an offense for a typo in an intermediate segment' do
+        expect_offense(<<~RUBY)
+          Services::UserCraetor::Params.new
+                    ^^^^^^^^^^^ Possible typo: `UserCraetor` is not defined in `Services`. Did you mean `UserCreator`?
+        RUBY
+      end
+
+      it 'does not register an offense when the constant resolves' do
+        expect_no_offenses(<<~RUBY)
+          Services::UserCreator.new
+        RUBY
+      end
+
+      it 'does not register an offense when no similarly named sibling exists' do
+        expect_no_offenses(<<~RUBY)
+          Services::Middleware.new
+        RUBY
+      end
+
+      it 'does not register an offense for an unqualified reference' do
+        expect_no_offenses(<<~RUBY)
+          UserCraetor.new
+        RUBY
+      end
+
+      it 'does not register an offense when the namespace is not indexed' do
+        expect_no_offenses(<<~RUBY)
+          External::UserCraetor.new
+        RUBY
+      end
+
+      it 'does not register an offense for a definition of a new member' do
+        expect_no_offenses(<<~RUBY)
+          class Services::UserRestorer; end
+        RUBY
+      end
+
+      it 'does not register an offense inside defined?' do
+        expect_no_offenses(<<~RUBY)
+          defined?(Services::UserCraetor)
+        RUBY
+      end
+
+      it 'does not register an offense when the name appears in a string literal' do
+        expect_no_offenses(<<~RUBY)
+          stub_const('Services::UserCraetor', Class.new)
+          Services::UserCraetor.new
+        RUBY
+      end
+
+      context 'when CheckConstants is false' do
+        let(:cop_config) { { 'CheckConstants' => false } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Services::UserCraetor.new
+          RUBY
+        end
+      end
+
+      context 'when the name is allowed' do
+        let(:cop_config) { { 'AllowedNames' => ['UserCraetor'] } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Services::UserCraetor.new
+          RUBY
+        end
+      end
+    end
+
+    context 'for method calls' do
+      before do
+        cop.project_index = build_index(
+          'file:///report.rb' => <<~RUBY
+            class Report
+              def self.generate_summary; end
+              def self.generate_details; end
+            end
+
+            module Formatting
+              module_function
+
+              def indent_text(text); end
+            end
+          RUBY
+        )
+      end
+
+      it 'registers an offense for a typo in a singleton method call' do
+        expect_offense(<<~RUBY)
+          Report.generate_sumary
+                 ^^^^^^^^^^^^^^^ Possible typo: `Report` does not respond to `generate_sumary`. Did you mean `generate_summary`?
+        RUBY
+      end
+
+      it 'registers an offense for a typo with safe navigation' do
+        expect_offense(<<~RUBY)
+          Report&.generate_sumary
+                  ^^^^^^^^^^^^^^^ Possible typo: `Report` does not respond to `generate_sumary`. Did you mean `generate_summary`?
+        RUBY
+      end
+
+      it 'registers an offense for a typo in a module_function call' do
+        expect_offense(<<~RUBY)
+          Formatting.indent_txet('foo')
+                     ^^^^^^^^^^^ Possible typo: `Formatting` does not respond to `indent_txet`. Did you mean `indent_text`?
+        RUBY
+      end
+
+      it 'does not register an offense when the method exists' do
+        expect_no_offenses(<<~RUBY)
+          Report.generate_summary
+        RUBY
+      end
+
+      it 'does not register an offense for a module_function method' do
+        expect_no_offenses(<<~RUBY)
+          Formatting.indent_text('foo')
+        RUBY
+      end
+
+      it 'does not register an offense when no similarly named method exists' do
+        expect_no_offenses(<<~RUBY)
+          Report.download
+        RUBY
+      end
+
+      it 'does not register an offense when the receiver is not indexed' do
+        expect_no_offenses(<<~RUBY)
+          External.generate_sumary
+        RUBY
+      end
+
+      it 'does not register an offense without a constant receiver' do
+        expect_no_offenses(<<~RUBY)
+          report.generate_sumary
+        RUBY
+      end
+
+      it 'does not register an offense inside defined?' do
+        expect_no_offenses(<<~RUBY)
+          defined?(Report.generate_sumary)
+        RUBY
+      end
+
+      it 'does not register an offense when the name appears as a symbol' do
+        expect_no_offenses(<<~RUBY)
+          Report.define_singleton_method(:generate_sumary) { nil }
+          Report.generate_sumary
+        RUBY
+      end
+
+      context 'with attribute accessors' do
+        before do
+          cop.project_index = build_index(
+            'file:///config.rb' => <<~RUBY
+              class Config
+                class << self
+                  attr_accessor :debug_mode
+                end
+              end
+            RUBY
+          )
+        end
+
+        it 'does not register an offense for a setter backed by attr_accessor' do
+          expect_no_offenses(<<~RUBY)
+            Config.debug_mode = true
+          RUBY
+        end
+
+        it 'registers an offense for a typo in a setter call' do
+          expect_offense(<<~RUBY)
+            Config.debug_mdoe = true
+                   ^^^^^^^^^^ Possible typo: `Config` does not respond to `debug_mdoe=`. Did you mean `debug_mode=`?
+          RUBY
+        end
+      end
+
+      context 'when the ancestry is not fully resolved' do
+        before do
+          cop.project_index = build_index(
+            'file:///report.rb' => <<~RUBY
+              class Report < External::Base
+                def self.generate_summary; end
+              end
+            RUBY
+          )
+        end
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Report.generate_sumary
+          RUBY
+        end
+      end
+
+      context 'when CheckMethods is false' do
+        let(:cop_config) { { 'CheckMethods' => false } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Report.generate_sumary
+          RUBY
+        end
+      end
+
+      context 'when the name is allowed' do
+        let(:cop_config) { { 'AllowedNames' => ['generate_sumary'] } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Report.generate_sumary
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a pending, index-powered `Lint/NameTypo` cop that reports probable typos in constant and method names: names that don't resolve anywhere in the project, used in a namespace the project does define, with a close-named sibling to suggest (via `DidYouMean::SpellChecker`).

Two knobs control the scope: `CheckConstants` (qualified constant references whose namespace resolves in the index) and `CheckMethods` (calls on constant receivers whose indexed ancestry is fully resolved), plus `AllowedNames` as an escape hatch. No autocorrect, since suggestions need human judgment.

Precision was the design driver, so an offense requires the surrounding namespace to be provably known and a similarly named alternative to exist. Names mentioned as symbols or in string literals in the same file are skipped (`stub_const`, `const_set`, `define_method` and friends), and setter calls are verified through the reader name since attr writers are indexed under it.

Also promotes `Lint/MissingSuper`'s resolved-ancestry completeness guard into `ProjectIndexHelp`, since this cop needs the same check.
