### PR TITLE
Centralize the modifier line-fit check in StatementModifier

### DIFF
--- a/changelog/change_make_modifier_cops_respect_layout_line_length_exemptions_20260717083617.md
+++ b/changelog/change_make_modifier_cops_respect_layout_line_length_exemptions_20260717083617.md
@@ -1,0 +1,1 @@
+* [#15493](https://github.com/rubocop/rubocop/pull/15493): Make `Style/IfUnlessModifier`, `Style/WhileUntilModifier`, `Style/GuardClause`, and other modifier cops respect `Layout/LineLength` exemptions (allowed patterns, cop directives, allowed URIs) when checking whether the modifier form fits on one line. ([@bbatsov][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -5,6 +5,7 @@ module RuboCop
     # Common functionality for modifier cops.
     module StatementModifier
       include LineLengthHelp
+      include AllowedPattern
 
       private
 
@@ -35,16 +36,51 @@ module RuboCop
       end
 
       def modifier_fits_on_single_line?(node)
-        return true unless max_line_length
-
-        length_in_modifier_form(node) <= max_line_length
+        acceptable_line_length?(line_in_modifier_form(node), node.first_line)
       end
 
-      def length_in_modifier_form(node)
+      def line_in_modifier_form(node)
         keyword_element = node.loc.keyword
         code_before = keyword_element.source_line[0...keyword_element.column]
-        expression = to_modifier_form(node)
-        line_length("#{code_before}#{expression}#{code_after(node)}")
+
+        "#{code_before}#{to_modifier_form(node)}#{code_after(node)}"
+      end
+
+      # Rather than comparing the rendered modifier form against the bare
+      # maximum, ask the question `Layout/LineLength` would: a line the user's
+      # configuration exempts (`Layout/LineLength` disabled at that line, an
+      # allowed pattern, an allowed cop directive, an allowed URI) fits by
+      # definition. This keeps every modifier cop consistent with
+      # `Layout/LineLength` instead of each reimplementing part of its policy.
+      def acceptable_line_length?(line, line_number)
+        return true unless max_line_length
+        return true if line_length(line) <= max_line_length
+        return true unless line_length_enabled_at_line?(line_number)
+        return true if matches_allowed_pattern?(line)
+
+        if allow_cop_directives? && directive_on_source_line?(line_number - 1)
+          return line_length_without_directive(line) <= max_line_length
+        end
+
+        allowed_by_uri?(line)
+      end
+
+      def allowed_by_uri?(line)
+        return false unless allow_uri?
+
+        uri_range = find_excessive_range(line, :uri)
+        !uri_range.nil? && allowed_position?(line, uri_range)
+      end
+
+      def line_length_enabled_at_line?(line)
+        processed_source.comment_config.cop_enabled_at_line?('Layout/LineLength', line)
+      end
+
+      # `Layout/LineLength`'s allowed patterns, so a modifier line that the
+      # user has configured that cop to accept is not flagged for length here.
+      def allowed_patterns
+        line_length_config = config.for_cop('Layout/LineLength')
+        line_length_config['AllowedPatterns'] || line_length_config['IgnoredPatterns'] || []
       end
 
       def to_modifier_form(node)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -72,10 +72,8 @@ module RuboCop
       #     do_something
       #   end
       #
-      class IfUnlessModifier < Base # rubocop:disable Metrics/ClassLength
+      class IfUnlessModifier < Base
         include StatementModifier
-        include LineLengthHelp
-        include AllowedPattern
         include RangeHelp
         include CommentsHelp
         extend AutoCorrector
@@ -188,52 +186,9 @@ module RuboCop
           max_line_length.between?(source_length - comment.source_range.length, source_length)
         end
 
-        def allowed_patterns
-          line_length_config = config.for_cop('Layout/LineLength')
-          line_length_config['AllowedPatterns'] || line_length_config['IgnoredPatterns'] || []
-        end
-
         def too_long_single_line?(node)
-          return false unless max_line_length
-
           range = node.source_range
-          return false unless range.single_line?
-          return false unless line_length_enabled_at_line?(range.first_line)
-
-          line = range.source_line
-          return false if line_length(line) <= max_line_length
-
-          too_long_line_based_on_config?(range, line)
-        end
-
-        def too_long_line_based_on_config?(range, line)
-          return false if matches_allowed_pattern?(line)
-
-          too_long = too_long_line_based_on_allow_cop_directives?(range, line)
-          return too_long unless too_long == :undetermined
-
-          too_long_line_based_on_allow_uri?(line)
-        end
-
-        def too_long_line_based_on_allow_cop_directives?(range, line)
-          if allow_cop_directives? && directive_on_source_line?(range.line - 1)
-            return line_length_without_directive(line) > max_line_length
-          end
-
-          :undetermined
-        end
-
-        def too_long_line_based_on_allow_uri?(line)
-          if allow_uri?
-            uri_range = find_excessive_range(line, :uri)
-            return false if uri_range && allowed_position?(line, uri_range)
-          end
-
-          true
-        end
-
-        def line_length_enabled_at_line?(line)
-          processed_source.comment_config.cop_enabled_at_line?('Layout/LineLength', line)
+          range.single_line? && !acceptable_line_length?(range.source_line, range.first_line)
         end
 
         def named_capture_in_condition?(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -21,6 +21,54 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
   it_behaves_like 'condition modifier cop', :if, extra
   it_behaves_like 'condition modifier cop', :unless, extra
 
+  context 'multiline if whose modifier form is long but allowed by `Layout/LineLength`' do
+    let(:long_url) { 'https://some.example.com/with/a/rather?long&and=very&complicated=path' }
+
+    context 'when the excess is an allowed URI' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          if url == '#{long_url}'
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            puts 1
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts 1 if url == '#{long_url}'
+        RUBY
+      end
+
+      context 'and AllowURI is false' do
+        let(:allow_uri) { false }
+
+        it 'accepts' do
+          expect_no_offenses(<<~RUBY)
+            if url == '#{long_url}'
+              puts 1
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'when the modifier form matches an allowed pattern' do
+      let(:line_length_config) { super().merge('AllowedPatterns' => ['^\s*puts']) }
+
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          if condition_with_a_rather_long_name_taking_up_space
+          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+            puts 'a long message that would not fit within the configured maximum'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          puts 'a long message that would not fit within the configured maximum' if condition_with_a_rather_long_name_taking_up_space
+        RUBY
+      end
+    end
+  end
+
   context 'modifier if that does not fit on one line' do
     let(:spaces) { ' ' * 59 }
     let(:body) { "puts '#{spaces}'" }

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -129,4 +129,39 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilModifier, :config do
       RUBY
     end
   end
+
+  context 'when the modifier form is long but allowed by `Layout/LineLength`' do
+    let(:other_cops) do
+      { 'Layout/LineLength' => { 'Enabled' => true, 'Max' => 40, 'AllowURI' => allow_uri } }
+    end
+    let(:allow_uri) { true }
+    let(:long_url) { 'https://example.com/a/rather/long/path?with=query' }
+
+    context 'when the excess is an allowed URI' do
+      it 'registers an offense and corrects to modifier form' do
+        expect_offense(<<~RUBY)
+          while url == '#{long_url}'
+          ^^^^^ Favor modifier `while` usage when having a single-line body.
+            step
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          step while url == '#{long_url}'
+        RUBY
+      end
+    end
+
+    context 'when AllowURI is false' do
+      let(:allow_uri) { false }
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          while url == '#{long_url}'
+            step
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `StatementModifier` modifier cops all answer the same question (would this fit on one line as a modifier) but did it inconsistently. `Style/IfUnlessModifier` reimplemented part of `Layout/LineLength`'s policy for its "too long" direction while comparing against the bare maximum for its "fits" direction; the others (`WhileUntilModifier`, `GuardClause`, `MultilineIfModifier`, `IfUnlessModifierOfIfUnless`) only ever compared against the bare maximum. So a modifier line that `Layout/LineLength` is configured to allow (an allowed pattern, a cop directive, an allowed URI, or the cop disabled at that line) would be judged too long here even though the project accepts it.

This moves the line-fit decision into `StatementModifier` as a single predicate that mirrors `Layout/LineLength`'s exemption ladder, so every modifier cop is consistent with it and with itself. `Style/IfUnlessModifier` keeps only its own message dispatch and correction logic (and its now-unneeded `Metrics/ClassLength` disable drops out).
