### PR TITLE
Fix Lint/DuplicateMethods false positives for Class.new in named-receiver calls

### DIFF
--- a/changelog/fix_false_positives_in_lint_duplicate_methods_for_anonymous_classes_passed_to_method_calls.md
+++ b/changelog/fix_false_positives_in_lint_duplicate_methods_for_anonymous_classes_passed_to_method_calls.md
@@ -1,0 +1,1 @@
+* [#15058](https://github.com/rubocop/rubocop/issues/15058): Fix false positives in `Lint/DuplicateMethods` for anonymous classes (`Class.new`) passed as arguments to the same named-receiver method call (e.g. `T.cast`). Each `Class.new` block is an independent class, so methods defined in different blocks should not be treated as duplicates. ([@rafaelfranca][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -235,6 +235,13 @@ module RuboCop
             ...)
         PATTERN
 
+        # @!method class_new_block?(node)
+        def_node_matcher :class_new_block?, <<~PATTERN
+          (block
+            (send (const _ :Class) :new ...)
+            ...)
+        PATTERN
+
         def on_send(node) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
           name, original_name = alias_method?(node)
 
@@ -352,11 +359,25 @@ module RuboCop
           parent = anon_block.parent
           return unless parent&.type?(:any_block, :begin, :call, :casgn, :any_def)
 
-          if (receiver = named_receiver(parent))
+          if (receiver = scope_receiver(parent, anon_block))
             "#{receiver.source}.#{parent.method_name}"
           elsif !parent.begin_type? || parent.parent&.any_block_type?
-            source_location(anon_block)
+            anon_block_identity(anon_block)
           end
+        end
+
+        # When a Class.new block is passed as an argument to a named-receiver
+        # method call (e.g. T.cast(Class.new(Base) do ... end, ...)), the
+        # receiver-based scope id (e.g. "T.cast") is the same for every call,
+        # causing false positives for methods defined in distinct anonymous
+        # classes. Return nil so the block falls through to the unique
+        # source-location-based scope id.
+        # Module.new blocks are excluded because they may be intentionally
+        # mixed into the same target via prepend/include/extend.
+        def scope_receiver(parent, anon_block)
+          return if class_new_block?(anon_block) && parent.call_type?
+
+          named_receiver(parent)
         end
 
         def named_receiver(node)
@@ -558,6 +579,16 @@ module RuboCop
         def index_source_location(definition)
           location = definition.location
           "#{smart_path(location.to_file_path)}:#{location.to_display.start_line}"
+        end
+
+        # Internal identity for an anonymous block, used as a scope key.
+        # Includes the source range's begin position to distinguish blocks
+        # that share the same line (e.g. two Class.new calls separated by `;`).
+        # The user-facing offense message still uses `source_location`, which
+        # shows only `path:line`.
+        def anon_block_identity(anon_block)
+          range = anon_block.source_range
+          "#{smart_path(range.source_buffer.name)}:#{range.line}:#{range.begin_pos}"
         end
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1247,6 +1247,59 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
   end
 
   it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'passed to the same named-receiver method call' do
+    expect_no_offenses(<<~RUBY)
+      T.cast(
+        Class.new(Base) do
+          def perform
+            1
+          end
+        end,
+        T.class_of(Base)
+      )
+
+      T.cast(
+        Class.new(Base) do
+          def perform
+            2
+          end
+        end,
+        T.class_of(Base)
+      )
+    RUBY
+  end
+
+  it 'does not register an offense for the same class method in different Class.new blocks ' \
+     'passed to the same named-receiver method call' do
+    expect_no_offenses(<<~RUBY)
+      T.cast(
+        Class.new(Base) do
+          def self.perform
+            1
+          end
+        end,
+        T.class_of(Base)
+      )
+
+      T.cast(
+        Class.new(Base) do
+          def self.perform
+            2
+          end
+        end,
+        T.class_of(Base)
+      )
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
+     'on the same line passed to the same named-receiver method call' do
+    expect_no_offenses(<<~RUBY)
+      T.cast(Class.new(Base) { def perform; 1; end }, T.class_of(Base)); T.cast(Class.new(Base) { def perform; 2; end }, T.class_of(Base))
+    RUBY
+  end
+
+  it 'does not register an offense for the same instance method in different Class.new blocks ' \
      'inside blocks with multiple statements' do
     expect_no_offenses(<<~RUBY)
       foo do


### PR DESCRIPTION
When a `Class.new` block is passed as an argument to a named-receiver method call (e.g. `T.cast(Class.new(Base) do; def perform; end; end, ...)`), `anon_block_scope_id` computed the scope key as `"T.cast"` — the receiver plus method name of the enclosing call. Multiple `Class.new` blocks wrapped in the same call all shared that key, so their methods collided as false duplicates.

Fix: `scope_receiver` returns `nil` for `Class.new` blocks in call context, making them fall through to a source-location-based scope key. The key now includes `source_range.begin_pos` so same-line blocks are also distinguished. `Module.new` blocks are unaffected to preserve prepend/include/extend same-target detection.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
