### PR TITLE
[Fix #14797] Avoid cache writes during server checks

### DIFF
--- a/changelog/fix_avoid_cache_writes_during_server_checks_20260718102006.md
+++ b/changelog/fix_avoid_cache_writes_during_server_checks_20260718102006.md
@@ -1,0 +1,1 @@
+* [#14797](https://github.com/rubocop/rubocop/issues/14797): Avoid cache writes during server checks. ([@sjh9714][])

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -64,9 +64,13 @@ module RuboCop
         # rubocop:enable Metrics/AbcSize
 
         def dir
-          Pathname.new(File.join(cache_path, project_dir_cache_key)).tap do |d|
+          dir_path.tap do |d|
             d.mkpath unless d.exist?
           end
+        end
+
+        def dir_path
+          Pathname.new(File.join(cache_path, project_dir_cache_key))
         end
 
         def cache_path
@@ -87,8 +91,8 @@ module RuboCop
           dir.join('token')
         end
 
-        def pid_path
-          dir.join('pid')
+        def pid_path(create_dir: true)
+          (create_dir ? dir : dir_path).join('pid')
         end
 
         def lock_path
@@ -108,8 +112,9 @@ module RuboCop
         end
 
         def pid_running?
-          Process.kill(0, pid_path.read.to_i) == 1
-        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES, Errno::EROFS, Errno::ENAMETOOLONG
+          Process.kill(0, pid_path(create_dir: false).read.to_i) == 1
+        rescue Errno::ESRCH, Errno::ENOENT, Errno::EACCES, Errno::EROFS, Errno::ENAMETOOLONG,
+               Errno::ENOTDIR
           false
         end
 

--- a/spec/rubocop/server/cache_spec.rb
+++ b/spec/rubocop/server/cache_spec.rb
@@ -181,6 +181,22 @@ RSpec.describe RuboCop::Server::Cache do
     end
 
     describe '.pid_running?', :isolated_environment do
+      it 'does not create the cache directory when checking for a running server' do
+        cache_class.cache_root_path = Dir.pwd
+        cache_root = File.join(Dir.pwd, 'rubocop_cache')
+
+        expect(cache_class).not_to be_pid_running
+        expect(File).not_to exist(cache_root)
+      end
+
+      it 'works when the cache path is a file' do
+        cache_class.cache_root_path = Dir.pwd
+        cache_root = create_empty_file('rubocop_cache')
+
+        expect(cache_class).not_to be_pid_running
+        expect(File).to be_file(cache_root)
+      end
+
       it 'works properly when concurrency with server stopping and cleaning cache dir' do
         expect(described_class).to receive(:pid_path).and_wrap_original do |method|
           result = method.call


### PR DESCRIPTION
## Summary

Fixes #14797.

The initial server-status check now reads its PID path without creating the
server cache directory. Directory creation remains unchanged for code paths
that write server state, while `--cache false` can run when the cache directory
is absent or its path is a regular file.

## Changes

- Separate the server cache path calculation from directory creation for the
  read-only PID check.
- Treat a non-directory cache path as no running server.
- Add focused regression coverage for both no directory creation and an
  existing regular file.

## Testing

- `bundle exec rspec spec/rubocop/server/cache_spec.rb`
- `bundle exec rspec spec/rubocop/server`
- `bundle exec rubocop lib/rubocop/server/cache.rb spec/rubocop/server/cache_spec.rb`
- `bundle exec rake spec`
- `bundle exec rake prism_spec`
- `bundle exec rake`
- `git diff --check origin/master...HEAD`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

Note: I used Codex while preparing this change, reviewed the final diff, and
ran the listed checks locally.