### PR TITLE
Gate Style/ConditionalAssignment autocorrect on reparse validity

### DIFF
--- a/changelog/change_gate_style_conditional_assignment_autocorrect_on_reparse_validity_20260718173941.md
+++ b/changelog/change_gate_style_conditional_assignment_autocorrect_on_reparse_validity_20260718173941.md
@@ -1,0 +1,1 @@
+* [#15497](https://github.com/rubocop/rubocop/pull/15497): Make `Style/ConditionalAssignment` skip cases it cannot safely rewrite instead of emitting invalid code or erroring on unusual branch shapes. ([@bbatsov][])

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -203,6 +203,7 @@ module RuboCop
       class ConditionalAssignment < Base
         include ConditionalAssignmentHelper
         include ConfigurableEnforcedStyle
+        include ReparsedEquivalence
         extend AutoCorrector
 
         MSG = 'Use the return of the conditional for variable assignment and comparison.'
@@ -288,6 +289,7 @@ module RuboCop
           # else slot, but `else_branch` correctly reports there is no `else` clause.
           return unless assignment.else_branch
           return if allowed_single_line?([*branches, else_branch])
+          return unless safe_to_correct?(node)
 
           add_offense(node, message: ASSIGN_TO_CONDITION_MSG) do |corrector|
             autocorrect(corrector, node)
@@ -367,6 +369,7 @@ module RuboCop
           return unless allowed_statements?(branches)
           return if allowed_single_line?(branches)
           return if correction_exceeds_line_limit?(node, branches)
+          return unless safe_to_correct?(node)
 
           add_offense(node) { |corrector| autocorrect(corrector, node) }
         end
@@ -377,6 +380,25 @@ module RuboCop
           else
             move_assignment_outside_condition(corrector, node)
           end
+        end
+
+        # The correction rewrites the conditional structurally, so full AST
+        # equivalence cannot be asserted, but the result must at least reparse
+        # to valid Ruby. Applying the correction to a throwaway buffer here
+        # also exercises the branch-shape handling before an offense is even
+        # reported, so unusual branches that the corrector cannot handle are
+        # left alone instead of crashing or emitting invalid code - the bug
+        # class behind most of this cop's history.
+        def safe_to_correct?(node)
+          correction_parses?(node)
+        rescue StandardError
+          false
+        end
+
+        # `ReparsedEquivalence#correction_parses?` contract: apply the exact
+        # correction this cop would perform.
+        def apply_reparse_correction(corrector, node)
+          autocorrect(corrector, node)
         end
 
         def allowed_statements?(branches)


### PR DESCRIPTION
`Style/ConditionalAssignment`'s correctors rewrite the conditional structurally, and over the years a stream of fixes has patched cases where that rewrite crashed or emitted invalid Ruby on an unusual branch shape (single-line `case`, heredoc branches, indexed assignment, and so on).

This routes both offense paths through `ReparsedEquivalence#correction_parses?` (the same gate `Style/SoleNestedConditional` uses): the correction is applied to a throwaway buffer and must reparse to valid Ruby before the offense is reported, with a rescue so a corrector that raises skips the offense instead of erroring. A future edge shape now degrades to "leave it alone" rather than shipping broken output.

It doesn't replace the existing branch-shape guards, which produce valid corrections the bare gate would only skip; the gate sits beneath them as a backstop. Behavior on everything that currently works is unchanged.
