### PR TITLE
Add DelegatingMethods option to Lint/DuplicateMethods

### DIFF
--- a/changelog/new_add_delegating_methods_option_to_lint_duplicate_methods_20260718174857.md
+++ b/changelog/new_add_delegating_methods_option_to_lint_duplicate_methods_20260718174857.md
@@ -1,0 +1,1 @@
+* [#15498](https://github.com/rubocop/rubocop/pull/15498): Add `DelegatingMethods` option to `Lint/DuplicateMethods` to register custom `delegate`-shaped methods. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1887,6 +1887,13 @@ Lint/DuplicateMethods:
   Enabled: true
   VersionAdded: '0.29'
   VersionChanged: '<<next>>'
+  # Methods that define instance methods by delegation, in the style of
+  # Active Support's `delegate` (`delegate :foo, :bar, to: :target`). Register
+  # a project's own `delegate`-shaped macros here so the cop recognizes the
+  # methods they define. Only takes effect when `AllCops/ActiveSupportExtensionsEnabled`
+  # is `true`.
+  DelegatingMethods:
+    - delegate
 
 Lint/DuplicateRegexpCharacterClassElement:
   Description: 'Checks for duplicate elements in Regexp character classes.'

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -129,6 +129,18 @@ module RuboCop
       #     delegate :foo, to: :bar
       #   end
       #
+      # @example DelegatingMethods: ['delegate', 'expose'] (default: ['delegate'])
+      #   # A project's own `delegate`-shaped macros can be registered so the
+      #   # methods they define are recognized (with
+      #   # `AllCops/ActiveSupportExtensionsEnabled: true`).
+      #
+      #   # bad
+      #   def foo
+      #     1
+      #   end
+      #
+      #   expose :foo, to: :bar
+      #
       class DuplicateMethods < Base # rubocop:disable Metrics/ClassLength
         include ProjectIndexHelp
 
@@ -139,9 +151,10 @@ module RuboCop
         # and the method name.
         INDEXABLE_METHOD_NAME =
           /\A(?<owner>[A-Z]\w*(?:::[A-Z]\w*)*)(?<separator>[#.])(?<name>[^#.]+)\z/.freeze
-        RESTRICT_ON_SEND = %i[alias_method attr_reader attr_writer attr_accessor attr
-                              delegate def_delegator def_instance_delegator def_delegators
-                              def_instance_delegators].freeze
+        # No `RESTRICT_ON_SEND`: the delegating method names are configurable
+        # (`DelegatingMethods`), so `on_send` must see every call. The handler
+        # returns quickly for calls that are not method definitions, and
+        # benchmarks show no measurable cost over the previous fixed list.
 
         def initialize(config = nil, options = nil)
           super
@@ -199,9 +212,12 @@ module RuboCop
           (send nil? :alias_method (sym $_name) (sym $_original_name))
         PATTERN
 
-        # @!method delegate_method?(node)
-        def_node_matcher :delegate_method?, <<~PATTERN
-          (send nil? :delegate
+        # Matches the argument shape of an Active Support `delegate` call
+        # (`delegate :a, :b, to: :target`), regardless of the method name; the
+        # name is checked separately against `DelegatingMethods`.
+        # @!method delegate_args(node)
+        def_node_matcher :delegate_args, <<~PATTERN
+          (send nil? _
             ({sym str} $_)+
             (hash <(pair (sym :to) {sym str}) ...>)
           )
@@ -255,7 +271,7 @@ module RuboCop
             found_instance_method(node, name)
           elsif (attr = node.attribute_accessor?)
             on_attr(node, *attr)
-          elsif active_support_extensions_enabled? && (names = delegate_method?(node))
+          elsif delegating_method?(node) && (names = delegate_args(node))
             return if inside_condition?(node)
 
             on_delegate(node, names)
@@ -296,6 +312,19 @@ module RuboCop
         def message_for_dup(node, method_name, key)
           format(MSG, method: method_name, defined: source_location(@definitions[key]),
                       current: source_location(node))
+        end
+
+        # Recognizing a delegating call as a method definition is Active
+        # Support behavior, so it stays gated on `ActiveSupportExtensionsEnabled`
+        # as it was when only `delegate` was supported. `DelegatingMethods` lets
+        # a project register its own `delegate`-shaped macros.
+        def delegating_method?(node)
+          active_support_extensions_enabled? &&
+            delegating_methods.include?(node.method_name.to_s)
+        end
+
+        def delegating_methods
+          cop_config.fetch('DelegatingMethods', ['delegate'])
         end
 
         def on_delegate(node, method_names)

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -699,6 +699,71 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
           end
         RUBY
       end
+
+      it "does not register an offense for an unregistered delegating method in #{type}" do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+
+            expose :some_method, to: :foo
+          end
+        RUBY
+      end
+    end
+
+    context 'with a custom `DelegatingMethods` and `ActiveSupportExtensionsEnabled: true`' do
+      let(:config) do
+        RuboCop::Config.new(
+          'AllCops' => { 'ActiveSupportExtensionsEnabled' => true },
+          'Lint/DuplicateMethods' => { 'DelegatingMethods' => %w[delegate expose] }
+        )
+      end
+
+      it "registers an offense for a registered custom delegating method in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            expose :some_method, to: :foo
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `#{receiver}#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+
+      it "still registers an offense for the built-in `delegate` in #{type}" do
+        expect_offense(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            delegate :some_method, to: :foo
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method `#{receiver}#some_method` is defined at both example.rb:2 and example.rb:5.
+          end
+        RUBY
+      end
+    end
+
+    context 'with a custom `DelegatingMethods` and `ActiveSupportExtensionsEnabled: false`' do
+      let(:config) do
+        RuboCop::Config.new(
+          'AllCops' => { 'ActiveSupportExtensionsEnabled' => false },
+          'Lint/DuplicateMethods' => { 'DelegatingMethods' => %w[delegate expose] }
+        )
+      end
+
+      it "does not register an offense for a custom delegating method in #{type}" do
+        expect_no_offenses(<<~RUBY, 'example.rb')
+          #{opening_line}
+            def some_method
+              implement 1
+            end
+            expose :some_method, to: :foo
+          end
+        RUBY
+      end
     end
 
     context 'when `AllCops/ActiveSupportExtensionsEnabled: false`' do


### PR DESCRIPTION
`Lint/DuplicateMethods` recognizes a delegating call like `delegate :foo, to: :bar` as a definition of `#foo`, so it can flag a real `def foo` alongside it. Support for these delegation macros has grown by hardcoding: Active Support's `delegate` (#14181), its `prefix` argument (#14183), `Forwardable` (#14798). Every project with its own `delegate`-shaped macro has to wait for another such change.

This makes the delegate-shaped method names configurable via a new `DelegatingMethods` option (default `['delegate']`), so a project can register its own macros:

```yaml
Lint/DuplicateMethods:
  DelegatingMethods:
    - delegate
    - expose
```

As before, these are only recognized when `AllCops/ActiveSupportExtensionsEnabled` is true. `Forwardable`'s `def_delegator`/`def_delegators` stay built-in (their names are fixed by the stdlib).

The fixed `RESTRICT_ON_SEND` list is dropped so `on_send` sees the configured names; it's a class-level constant that can't vary per config. No measurable perf difference, since the cop already visits every definition node.
