### PR TITLE
[Fix #15499] Fix an error for `Lint/UselessRuby2Keywords`

### DIFF
--- a/changelog/fix_an_error_for_lint_useless_ruby2_keywords_20260719171506.md
+++ b/changelog/fix_an_error_for_lint_useless_ruby2_keywords_20260719171506.md
@@ -1,0 +1,1 @@
+* [#15499](https://github.com/rubocop/rubocop/issues/15499): Fix an error for `Lint/UselessRuby2Keywords` when `ruby2_keywords` is used with a symbol but no method definition is found. ([@koic][])

--- a/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
+++ b/lib/rubocop/cop/lint/useless_ruby2_keywords.rb
@@ -116,6 +116,8 @@ module RuboCop
             # so stop searching once a class/module boundary is crossed without a match.
             return nil if ancestor.type?(:class, :module, :sclass)
           end
+
+          nil
         end
 
         # `ruby2_keywords` is only allowed if there's a `restarg` and no keyword arguments

--- a/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
+++ b/spec/rubocop/cop/lint/useless_ruby2_keywords_spec.rb
@@ -120,6 +120,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessRuby2Keywords, :config do
       RUBY
     end
 
+    it 'does not register an offense when no method definition is found in a block' do
+      expect_no_offenses(<<~RUBY)
+        do_something do
+          ruby2_keywords :foo
+        end
+      RUBY
+    end
+
     it 'does not register an offense when the `def` is at a different depth' do
       expect_no_offenses(<<~RUBY)
         class C


### PR DESCRIPTION
This PR fixes an error for `Lint/UselessRuby2Keywords` when `ruby2_keywords` is used with a symbol but no method definition is found.

https://github.com/rubocop/rubocop/commit/ac72066f6 rewrote `find_method_definition` from an `each_ancestor.lazy` chain into a block form. When the ancestor walk finishes without https://github.com/rubocop/rubocop/commit/ac72066f6 finding a definition and without crossing a class/module boundary (e.g. `ruby2_keywords :foo` inside a top-level block), `each_ancestor` with a block returns its receiver, so the `ruby2_keywords` send node itself leaked out as the found definition. `SendNode#arguments` returns an `Array`, which does not respond to `each_child_node`:

```console
$ echo 'do_something do ruby2_keywords :foo end' | rubocop --stdin test.rb --only Lint/UselessRuby2Keywords
undefined method 'each_child_node' for an instance of Array (NoMethodError)
```

This commit returns `nil` explicitly when no definition is found, restoring the behavior before https://github.com/rubocop/rubocop/commit/ac72066f6 where the cop stays silent when it cannot find the method definition.

Fixes #15499.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
