### PR TITLE
[Fix #15500] Fix an error for `Lint/LiteralAsCondition`

### DIFF
--- a/changelog/fix_an_error_for_lint_literal_as_condition_20260719171728.md
+++ b/changelog/fix_an_error_for_lint_literal_as_condition_20260719171728.md
@@ -1,0 +1,1 @@
+* [#15500](https://github.com/rubocop/rubocop/issues/15500): Fix an error for `Lint/LiteralAsCondition` when a literal condition has an empty branch. ([@koic][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -254,6 +254,11 @@ module RuboCop
         def correct_if_node(node, cond)
           result = condition_evaluation?(node, cond)
 
+          # When the branch that survives the literal condition is missing,
+          # there is no meaningful correction, so no offense is registered.
+          surviving_branch = result ? node.if_branch : node.else_branch
+          return if surviving_branch.nil? && (node.elsif? || node.else?)
+
           new_node = if node.elsif? && result
                        "else\n  #{range_with_comments(node.if_branch).source}"
                      elsif node.elsif? && !result

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    it "does not register an offense for truthy literal #{lit} in if with an empty body and an else branch" do
+      expect_no_offenses(<<~RUBY)
+        if #{lit}
+        else
+          foo
+        end
+      RUBY
+    end
+
+    it "does not register an offense for truthy literal #{lit} in if with an empty body and an elsif branch" do
+      expect_no_offenses(<<~RUBY)
+        if #{lit}
+        elsif condition
+          foo
+        end
+      RUBY
+    end
+
     it "registers an offense for truthy literal #{lit} in if-elsif" do
       expect_offense(<<~RUBY, lit: lit)
         if condition
@@ -45,6 +63,15 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
           top
         else
           foo
+        end
+      RUBY
+    end
+
+    it "does not register an offense for truthy literal #{lit} in elsif with an empty body" do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          top
+        elsif #{lit}
         end
       RUBY
     end
@@ -139,6 +166,15 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
 
       expect_correction(<<~RUBY)
 
+      RUBY
+    end
+
+    it "does not register an offense for truthy literal #{lit} in unless with an empty else branch" do
+      expect_no_offenses(<<~RUBY)
+        unless #{lit}
+          top
+        else
+        end
       RUBY
     end
 
@@ -516,6 +552,25 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       RUBY
     end
 
+    it "does not register an offense for falsey literal #{lit} in if with an empty else branch" do
+      expect_no_offenses(<<~RUBY)
+        if #{lit}
+          top
+        else
+        end
+      RUBY
+    end
+
+    it "does not register an offense for falsey literal #{lit} in elsif without else" do
+      expect_no_offenses(<<~RUBY)
+        if condition
+          top
+        elsif #{lit}
+          foo
+        end
+      RUBY
+    end
+
     it "registers an offense for falsey literal #{lit} in if-elsif" do
       expect_offense(<<~RUBY, lit: lit)
         if %{lit}
@@ -607,6 +662,15 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
 
       expect_correction(<<~RUBY)
         top
+      RUBY
+    end
+
+    it "does not register an offense for falsey literal #{lit} in unless with an empty body and an else branch" do
+      expect_no_offenses(<<~RUBY)
+        unless #{lit}
+        else
+          foo
+        end
       RUBY
     end
 


### PR DESCRIPTION
Fixes #15500.

This PR fixes an error for `Lint/LiteralAsCondition` when a literal condition has an empty branch.

`correct_if_node` builds the replacement source eagerly before registering an offense and assumes every referenced branch node exists, so plain inspection (without autocorrection) crashed on the following shapes:

```console
$ echo 'if false then foo else end' | rubocop --stdin test.rb --only Lint/LiteralAsCondition
undefined method 'source' for nil (NoMethodError)
```

- `if false ... else end`: `else?` is true but `else_branch` is nil
- `if cond ... elsif false ... end`: falsey `elsif` without `else`
- `if cond ... elsif true end`: truthy `elsif` with an empty body

The same root cause also produced an incorrect autocorrection when the taken branch is empty but another branch exists:

```ruby
if true
else
  foo
end
```

was autocorrected to `foo`, although `foo` can never execute because the truthy condition runs the empty `if` body.

When the branch that survives the literal condition is missing, autocorrection would have to remove the conditional (or the `elsif` clause) entirely. Rather than registering an offense whose correction just deletes code around an explicitly written empty branch, the cop skips these degenerate conditionals altogether, following the policy that an offense the cop cannot meaningfully correct is not registered. An `if` without any `else` keeps its existing offense and removal correction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
