### PR TITLE
[Fix #15501] Improve performance for large literal files

### DIFF
--- a/changelog/change_improve_performance_for_large_literal_files_20260719180145.md
+++ b/changelog/change_improve_performance_for_large_literal_files_20260719180145.md
@@ -1,0 +1,1 @@
+* [#15501](https://github.com/rubocop/rubocop/issues/15501): Improve performance for large literal files. ([@koic][])

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -94,10 +94,10 @@ module RuboCop
             return empty_offenses(node, left, right, EMPTY_MSG)
           end
 
-          start_ok = next_to_newline?(node, left)
+          start_ok = next_to_newline?(tokens, left)
           end_ok = node.single_line? ? false : end_has_own_line?(right)
 
-          issue_offenses(node, left, right, start_ok, end_ok)
+          issue_offenses(node, tokens, left, right, start_ok, end_ok)
         end
         alias on_array_pattern on_array
 
@@ -117,7 +117,7 @@ module RuboCop
           elsif style == :space
             SpaceCorrector.add_space(processed_source, corrector, left, right)
           else
-            compact_corrections(corrector, node, left, right)
+            compact_corrections(corrector, tokens, left, right)
           end
         end
 
@@ -134,8 +134,8 @@ module RuboCop
           cop_config['EnforcedStyleForEmptyBrackets']
         end
 
-        def next_to_newline?(node, token)
-          processed_source.tokens_within(node)[index_for(node, token) + 1].line != token.line
+        def next_to_newline?(tokens, token)
+          tokens[index_for(tokens, token) + 1].line != token.line
         end
 
         def end_has_own_line?(token)
@@ -145,59 +145,64 @@ module RuboCop
           !/\S/.match?(processed_source.lines[line][0..col])
         end
 
-        def index_for(node, token)
-          processed_source.tokens_within(node).index(token)
+        def index_for(tokens, token)
+          tokens.index(token)
         end
 
         def line_and_column_for(token)
           [token.line - 1, token.column - 1]
         end
 
-        def issue_offenses(node, left, right, start_ok, end_ok)
+        # rubocop:disable Metrics/ParameterLists
+        def issue_offenses(node, tokens, left, right, start_ok, end_ok)
           case style
           when :no_space
-            start_ok = next_to_comment?(node, left)
+            start_ok = next_to_comment?(tokens, left)
             no_space_offenses(node, left, right, MSG, start_ok: start_ok, end_ok: end_ok)
           when :space
             space_offenses(node, left, right, MSG, start_ok: start_ok, end_ok: end_ok)
           else
-            compact_offenses(node, left, right, start_ok, end_ok)
+            compact_offenses(node, tokens, left, right, start_ok, end_ok)
           end
         end
+        # rubocop:enable Metrics/ParameterLists
 
-        def next_to_comment?(node, token)
-          processed_source.tokens_within(node)[index_for(node, token) + 1].comment?
+        def next_to_comment?(tokens, token)
+          tokens[index_for(tokens, token) + 1].comment?
         end
 
-        def compact_offenses(node, left, right, start_ok, end_ok)
-          if qualifies_for_compact?(node, left, side: :left)
+        # rubocop:disable Metrics/ParameterLists
+        def compact_offenses(node, tokens, left, right, start_ok, end_ok)
+          if qualifies_for_compact?(tokens, left, side: :left)
             compact_offense(node, left, side: :left)
-          elsif !multi_dimensional_array?(node, left, side: :left)
+          elsif !multi_dimensional_array?(tokens, left, side: :left)
             space_offenses(node, left, nil, MSG, start_ok: start_ok, end_ok: true)
           end
-          if qualifies_for_compact?(node, right)
+
+          if qualifies_for_compact?(tokens, right)
             compact_offense(node, right)
-          elsif !multi_dimensional_array?(node, right)
+          elsif !multi_dimensional_array?(tokens, right)
             space_offenses(node, nil, right, MSG, start_ok: true, end_ok: end_ok)
           end
         end
+        # rubocop:enable Metrics/ParameterLists
 
-        def qualifies_for_compact?(node, token, side: :right)
+        def qualifies_for_compact?(tokens, token, side: :right)
           if side == :right
-            multi_dimensional_array?(node, token) && token.space_before?
+            multi_dimensional_array?(tokens, token) && token.space_before?
           else
-            multi_dimensional_array?(node, token, side: :left) && token.space_after?
+            multi_dimensional_array?(tokens, token, side: :left) && token.space_after?
           end
         end
 
-        def multi_dimensional_array?(node, token, side: :right)
+        def multi_dimensional_array?(tokens, token, side: :right)
           offset = side == :right ? -1 : +1
-          i = index_for(node, token) + offset
-          i += offset while processed_source.tokens_within(node)[i].new_line?
+          i = index_for(tokens, token) + offset
+          i += offset while tokens[i].new_line?
           if side == :right
-            processed_source.tokens_within(node)[i].right_bracket?
+            tokens[i].right_bracket?
           else
-            processed_source.tokens_within(node)[i].left_bracket?
+            tokens[i].left_bracket?
           end
         end
 
@@ -209,14 +214,14 @@ module RuboCop
           end
         end
 
-        def compact_corrections(corrector, node, left, right)
-          if multi_dimensional_array?(node, left, side: :left)
+        def compact_corrections(corrector, tokens, left, right)
+          if multi_dimensional_array?(tokens, left, side: :left)
             compact(corrector, left, :right)
           elsif !left.space_after?
             corrector.insert_after(left.pos, ' ')
           end
 
-          if multi_dimensional_array?(node, right)
+          if multi_dimensional_array?(tokens, right)
             compact(corrector, right, :left)
           elsif !right.space_before?
             corrector.insert_before(right.pos, ' ')

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -91,6 +91,12 @@ module RuboCop
                      status = :uncorrected, corrector = nil)
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
+
+        # Pre-compute the position eagerly because the offense is frozen and
+        # `location.line` / `location.column` are expensive to compute; sorting
+        # many offenses calls them repeatedly through `#<=>`.
+        @line = location.line
+        @column = location.column
         @message = message.freeze
         @cop_name = cop_name.freeze
         @status = status
@@ -104,6 +110,8 @@ module RuboCop
 
       def marshal_load(array)
         @severity, @location, @message, @cop_name, @status = array
+        @line = @location.line
+        @column = @location.column
       end
 
       # @api public
@@ -167,14 +175,10 @@ module RuboCop
       end
 
       # @api private
-      def line
-        location.line
-      end
+      attr_reader :line
 
       # @api private
-      def column
-        location.column
-      end
+      attr_reader :column
 
       # @api private
       def source_line


### PR DESCRIPTION
This PR improves inspection performance for large generated files consisting of huge literals, e.g. `enc/trans/gb18030-tbl.rb` in ruby/ruby (1.36MB, one giant array of 63k inner arrays, yielding 126,724 offenses).

Two hotspots are addressed:

- Sorting offenses: `Offense#line` and `Offense#column` delegated to `location.line` and `location.column`, and each call runs a binary search over the line index in `Parser::Source::Buffer#line_for_position`. `Offense#<=>` compares `line` and `column`, so sorting many offenses performs millions of binary searches during `offenses.sort` in `RuboCop::Runner`. Since `Offense` is frozen on creation, the position cannot be memoized lazily; `@line` and `@column` are now computed eagerly in `initialize` (and in `marshal_load`, which bypasses `initialize`), so each offense runs the binary search once instead of once per comparison. Formatters that print line and column benefit as well.

- `Layout/SpaceInsideArrayLiteralBrackets`: `on_array` called `processed_source.tokens_within(node)` up to three times per array node (`array_brackets`, `next_to_newline?`, and `index_for` / `next_to_comment?`), and the compact style path re-fetched the token slice in `multi_dimensional_array?` as well. Each call repeats the `first_token_index` / `last_token_index` binary searches and allocates a fresh token slice. The token slice obtained once in `on_array` is now passed through to the helpers.

Benchmark with `rubocop -c /dev/null --cache false --format quiet` against `enc/trans/gb18030-tbl.rb`:

- before: 9.43s
- after: 8.77s

Offense counts are unchanged (126,724). Profiles show `Offense#<=>` dropping from 10.0% to 4.0% and the cop from 9.1% to 5.2% of wall time.

Fixes #15501.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
