### PR TITLE
Fix incompatible autocorrect between `Style/Lambda` and `Style/SymbolProc`

### DIFF
--- a/changelog/fix_incompatible_autocorrect_between_style_lambda_and_style_symbol_proc.md
+++ b/changelog/fix_incompatible_autocorrect_between_style_lambda_and_style_symbol_proc.md
@@ -1,0 +1,1 @@
+* [#15505](https://github.com/rubocop/rubocop/pull/15505): Fix incompatible autocorrect between `Style/Lambda` and `Style/SymbolProc` producing a syntax error like `->(x)(&:method)` when both cops run on `lambda { |x| x.method }`. ([@koic][])

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -61,6 +61,10 @@ module RuboCop
           }
         }.freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::SymbolProc]
+        end
+
         def on_block(node)
           return unless node.lambda?
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::Lambda, :config do
+  describe '.autocorrect_incompatible_with' do
+    it 'declares `Style::SymbolProc` as incompatible to avoid producing `->(x)(&:method)`' do
+      expect(described_class.autocorrect_incompatible_with).to include(RuboCop::Cop::Style::SymbolProc)
+    end
+  end
+
   context 'with enforced `lambda` style' do
     let(:cop_config) { { 'EnforcedStyle' => 'lambda' } }
 


### PR DESCRIPTION
When `lambda { |x| x.method }` is autocorrected with both `Style/Lambda` and `Style/SymbolProc` enabled, each cop produces a correct replacement on its own (`->(x) { x.method }` and `lambda(&:method)` respectively), but the merged result is invalid Ruby like `->(x)(&:method)`.

Declare `Style/SymbolProc` as incompatible with `Style/Lambda` so the two corrections are applied in separate iterations. The final result is the stable form `lambda(&:method)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
