### PR TITLE
Fix flaky `--auto-gen-config` specs by isolating the cache root

### DIFF
--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -6,11 +6,14 @@ require 'tmpdir'
 # or stubbing Dir.pwd get a fresh value.
 RSpec.configure { |c| c.before { RuboCop::PathUtil.reset_pwd } }
 
-RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLength
-  around do |example| # rubocop:disable Metrics/BlockLength
+# rubocop:disable Metrics/BlockLength
+RSpec.shared_context 'isolated environment' do
+  around do |example|
     Dir.mktmpdir do |tmpdir|
       original_home = Dir.home
       original_xdg_config_home = ENV.fetch('XDG_CONFIG_HOME', nil)
+      original_xdg_cache_home = ENV.fetch('XDG_CACHE_HOME', nil)
+      original_rubocop_cache_root = ENV.fetch('RUBOCOP_CACHE_ROOT', nil)
 
       # Make sure to expand all symlinks in the path first. Otherwise we may
       # get mismatched pathnames when loading config files later on.
@@ -22,6 +25,12 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
       Dir.mkdir(virtual_home)
       ENV['HOME'] = virtual_home
       ENV.delete('XDG_CONFIG_HOME')
+
+      # `XDG_CACHE_HOME` and `RUBOCOP_CACHE_ROOT` are set on some CI runners and
+      # would otherwise point the result cache at a fixed directory shared across examples
+      # and parallel test-queue workers, letting one example's cache leak into another.
+      ENV.delete('XDG_CACHE_HOME')
+      ENV.delete('RUBOCOP_CACHE_ROOT')
 
       base_dir = example.metadata[:project_inside_home] ? virtual_home : tmpdir
       root = example.metadata[:root]
@@ -38,6 +47,8 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
       ensure
         ENV['HOME'] = original_home
         ENV['XDG_CONFIG_HOME'] = original_xdg_config_home
+        ENV['XDG_CACHE_HOME'] = original_xdg_cache_home
+        ENV['RUBOCOP_CACHE_ROOT'] = original_rubocop_cache_root
 
         RuboCop::ResultCache.reset_config_cache
         RuboCop::ConfigLoader.clear_options # This also resets RuboCop::FileFinder.root_level
@@ -58,6 +69,7 @@ RSpec.shared_context 'isolated environment' do # rubocop:disable Metrics/BlockLe
     end
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 # Workaround for https://github.com/rubocop/rubocop/issues/12978,
 # there should already be no gemfile in the temp directory

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'isolated environment', :isolated_environment, type: :feature do
+RSpec.describe 'isolated environment', type: :feature do
   include_context 'cli spec behavior'
 
   let(:cli) { RuboCop::CLI.new }
@@ -13,7 +13,7 @@ RSpec.describe 'isolated environment', :isolated_environment, type: :feature do
   #
   # For this test, we shift the root_level down to the work directory so we
   # can place a file above the root_level and ensure it is not loaded.
-  it 'is not affected by a config file above the work directory' do
+  it 'is not affected by a config file above the work directory', :isolated_environment do
     ignored_path = File.expand_path(File.join(RuboCop::FileFinder.root_level, '.rubocop.yml'))
     create_file(ignored_path, ['inherit_from: missing_file.yml'])
 
@@ -24,10 +24,40 @@ RSpec.describe 'isolated environment', :isolated_environment, type: :feature do
     expect(cli.run([])).to eq(0)
   end
 
-  context 'bundler is isolated', :isolated_bundler do
+  context 'bundler is isolated', :isolated_bundler, :isolated_environment do
     it 'has a Gemfile path in the temporary directory' do
       create_empty_file('Gemfile')
       expect(Bundler::SharedHelpers.root.to_s).to eq(Dir.pwd)
+    end
+  end
+
+  # `XDG_CACHE_HOME` and `RUBOCOP_CACHE_ROOT` are set on some CI runners.
+  # If the isolated environment left them in place, the result cache root would resolve to
+  # a fixed directory shared across examples and parallel test-queue workers,
+  # letting one example's cache leak into another and making cache-sensitive specs
+  # (e.g. `--auto-gen-config`) intermittently fail. Each ambient value is set from
+  # an outer `around` so it is in place before the isolated environment is entered,
+  # and the assertion fails if the isolation stops stripping it.
+  {
+    'XDG_CACHE_HOME' => '/tmp/ambient-xdg-cache',
+    'RUBOCOP_CACHE_ROOT' => '/tmp/ambient-rubocop-cache'
+  }.each do |env_var, ambient_path|
+    context "when #{env_var} is set in the ambient environment" do
+      around do |example|
+        original = ENV.fetch(env_var, nil)
+        ENV[env_var] = ambient_path
+        begin
+          example.run
+        ensure
+          ENV[env_var] = original
+        end
+      end
+
+      it 'resolves the cache root under the isolated home, not the ambient path', :isolated_environment do
+        cache_root = RuboCop::CacheConfig.root_dir_from_toplevel_config
+
+        expect(cache_root).to eq(File.join(File.realpath(Dir.home), '.cache', 'rubocop_cache'))
+      end
     end
   end
 end

--- a/spec/rubocop/cache_config_spec.rb
+++ b/spec/rubocop/cache_config_spec.rb
@@ -86,14 +86,12 @@ RSpec.describe RuboCop::CacheConfig do
     end
 
     context 'when RUBOCOP_CACHE_ROOT environment variable is set' do
-      around do |example|
-        original = ENV.fetch('RUBOCOP_CACHE_ROOT', nil)
+      # Set `RUBOCOP_CACHE_ROOT` from within the isolated environment,
+      # which strips the ambient value on entry and restores it on exit.
+      # Setting it from an outer `around` would be wiped by that isolation
+      # before the example runs.
+      before do
         ENV['RUBOCOP_CACHE_ROOT'] = '/tmp/env-cache-root'
-        begin
-          example.run
-        ensure
-          ENV['RUBOCOP_CACHE_ROOT'] = original
-        end
       end
 
       context 'with no CacheRootDirectory in config', :isolated_environment do
@@ -129,14 +127,12 @@ RSpec.describe RuboCop::CacheConfig do
     end
 
     context 'when XDG_CACHE_HOME environment variable is set' do
-      around do |example|
-        original = ENV.fetch('XDG_CACHE_HOME', nil)
+      # Set `XDG_CACHE_HOME` from within the isolated environment,
+      # which strips the ambient value on entry and restores it on exit.
+      # Setting it from an outer `around` would be wiped by that isolation
+      # before the example runs.
+      before do
         ENV['XDG_CACHE_HOME'] = '/tmp/xdg-cache'
-        begin
-          example.run
-        ensure
-          ENV['XDG_CACHE_HOME'] = original
-        end
       end
 
       context 'with no CacheRootDirectory in config', :isolated_environment do


### PR DESCRIPTION
The `isolated environment` shared context isolated `HOME` and `XDG_CONFIG_HOME` per example but left `XDG_CACHE_HOME` and `RUBOCOP_CACHE_ROOT` untouched.

When either is set (as `XDG_CACHE_HOME` is on the CI runners), `CacheConfig` resolves the result cache root to a fixed directory shared across every example and every parallel test-queue worker. `--auto-gen-config` runs with caching enabled via its temporary cache, so a leaked or concurrently-wiped cache entry could make the second inspection phase read stale results and emit an incomplete `.rubocop_todo.yml`, intermittently failing the auto-gen-config specs.

Delete and restore both variables alongside `XDG_CONFIG_HOME` so the cache root falls back to the per-example home directory, and add regression tests that fail if the isolation stops stripping them.

`cache_config_spec.rb` now sets these variables from within the isolated environment (via `before`) instead of an outer `around`, since the latter is now stripped on entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
