### PR TITLE
[Fix #15507] Fix a false positive for `Naming/VariableNumber`

### DIFF
--- a/changelog/fix_a_false_positive_for_naming_variable_number.md
+++ b/changelog/fix_a_false_positive_for_naming_variable_number.md
@@ -1,0 +1,1 @@
+* [#15507](https://github.com/rubocop/rubocop/issues/15507): Fix a false positive for `Naming/VariableNumber` when using an empty symbol hash key. ([@koic][])

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -132,7 +132,9 @@ module RuboCop
 
         def on_sym(node)
           @node = node
-          return if allowed_identifier?(node.value)
+
+          # Prism parses a quoted empty hash key (`{ "": value }`) as an empty symbol node.
+          return if node.value.empty? || allowed_identifier?(node.value)
 
           check_name(node, node.value, node) if cop_config['CheckSymbols']
         end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     end
   end
 
+  shared_examples 'accepts empty symbol' do
+    # Prism parses a quoted empty hash key as an empty symbol node,
+    # whereas the parser gem emits a `dsym` node.
+    it 'accepts an empty symbol hash key', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        x = { "": [] }
+      RUBY
+    end
+  end
+
   context 'when configured for snake_case' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
@@ -69,6 +79,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'snake_case', '_1'
 
     it_behaves_like 'accepts integer symbols'
+    it_behaves_like 'accepts empty symbol'
 
     it 'registers an offense for normal case numbering in symbol' do
       expect_offense(<<~RUBY)
@@ -143,6 +154,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'normalcase', '_1'
 
     it_behaves_like 'accepts integer symbols'
+    it_behaves_like 'accepts empty symbol'
 
     it 'registers an offense for snake case numbering in symbol' do
       expect_offense(<<~RUBY)
@@ -212,6 +224,7 @@ RSpec.describe RuboCop::Cop::Naming::VariableNumber, :config do
     it_behaves_like 'accepts', 'non_integer', '_1'
 
     it_behaves_like 'accepts integer symbols'
+    it_behaves_like 'accepts empty symbol'
 
     it 'registers an offense for snake case numbering in symbol' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes #15507.

`Naming/VariableNumber` registered an offense for an empty symbol hash key (`{ "": [] }`) because the empty name matches none of the supported numbering formats, each of which requires at least one character. An empty symbol contains no number, so no numbering style applies and the cop now ignores it.

This only reproduces when the source is parsed by Prism, which translates the quoted empty hash key to an empty `sym` node. The parser gem emits a `dsym` node for it, which never reaches `on_sym`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
