### PR TITLE
[Fix #9571] Fix false negatives in `Layout/ClassStructure`

### DIFF
--- a/changelog/fix_false_negatives_for_layout_class_structure_20260710173909.md
+++ b/changelog/fix_false_negatives_for_layout_class_structure_20260710173909.md
@@ -1,0 +1,1 @@
+* [#9571](https://github.com/rubocop/rubocop/issues/9571): Fix false negatives in `Layout/ClassStructure` when class body elements are wrapped in `begin` blocks. ([@koic][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -283,7 +283,7 @@ module RuboCop
           # Exploding such a node into its children would yield non-node values (e.g. a
           # method-name `Symbol` from a `csend`) and crash later checks.
           if class_def.type?(:begin, :kwbegin)
-            class_def.children.compact
+            flatten_class_elements(class_def)
           else
             [class_def]
           end
@@ -294,6 +294,12 @@ module RuboCop
             classification.to_s.end_with?('=') ||
             expected_order.index(classification).nil? ||
             private_constant?(node)
+        end
+
+        def flatten_class_elements(node)
+          node.children.compact.flat_map do |child|
+            child.kwbegin_type? ? flatten_class_elements(child) : [child]
+          end
         end
 
         def ignore_for_autocorrect?(node, sibling)

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -162,6 +162,77 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     end
   end
 
+  context 'when class body elements are wrapped in a begin block' do
+    it 'registers an offense and corrects misordered elements inside a begin block' do
+      expect_offense(<<~RUBY)
+        class Foo
+          begin
+            private def do_internal_work; end
+            public def do_something; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          begin
+            public def do_something; end
+            private def do_internal_work; end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects misordered elements inside nested begin blocks' do
+      expect_offense(<<~RUBY)
+        class Foo
+          begin
+            begin
+              private def do_internal_work; end
+              public def do_something; end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          begin
+            begin
+              public def do_something; end
+              private def do_internal_work; end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for ordered elements inside a begin block' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          begin
+            public def do_something; end
+            private def do_internal_work; end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not get confused by a begin block with a rescue clause' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          begin
+            require 'optional_dependency'
+          rescue LoadError
+            nil
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'registers an offense and corrects when public instance method is before class method' do
     expect_offense(<<~RUBY)
       class Foo


### PR DESCRIPTION
This commit fixes false negatives in `Layout/ClassStructure` when class body elements are wrapped in `begin` blocks. Such elements were previously invisible to the cop because only the top-level statements of the class body were walked, so misordered definitions inside `begin` blocks were never reported.

An explicit `begin` block without a `rescue` clause merely groups statements, so its children take part in the class structure order. A `begin` block with a `rescue` clause is left alone: its child is a `rescue` node, which is not classifiable and is ignored as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
