### PR TITLE
Support textDocument/codeAction in the language server

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ InternalAffairs/NodeDestructuring:
 # Offense count: 81
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 193
+  Max: 201
 
 # Offense count: 342
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/changelog/new_support_code_action_requests_in_the_language_server_20260728114607.md
+++ b/changelog/new_support_code_action_requests_in_the_language_server_20260728114607.md
@@ -1,0 +1,1 @@
+* [#15511](https://github.com/rubocop/rubocop/pull/15511): Support `textDocument/codeAction` requests in the built-in language server, so LSP clients that request code actions (Eglot, Helix, Flycheck, ...) can apply RuboCop's autocorrects, not only clients that read them off the published diagnostic. ([@bbatsov][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -50,6 +50,7 @@ module RuboCop
           result: LanguageServer::Protocol::Interface::InitializeResult.new(
             capabilities: LanguageServer::Protocol::Interface::ServerCapabilities.new(
               document_formatting_provider: true,
+              code_action_provider: true,
               text_document_sync: LanguageServer::Protocol::Interface::TextDocumentSyncOptions.new(
                 change: LanguageServer::Protocol::Constant::TextDocumentSyncKind::INCREMENTAL,
                 open_close: true
@@ -105,6 +106,10 @@ module RuboCop
       handle 'textDocument/formatting' do |request|
         uri = request[:params][:textDocument][:uri]
         @server.write(id: request[:id], result: format_file(uri))
+      end
+
+      handle 'textDocument/codeAction' do |request|
+        @server.write(id: request[:id], result: code_actions_for(request[:params]))
       end
 
       handle 'workspace/didChangeConfiguration' do |_request|
@@ -217,6 +222,24 @@ module RuboCop
             end: { line: text.count("\n") + 1, character: 0 }
           }
         }]
+      end
+
+      # Returns the quickfix code actions for a `textDocument/codeAction` request.
+      #
+      # RuboCop attaches each offense's autocorrect and disable-line actions to
+      # the diagnostic it publishes, under the diagnostic's `data` (see
+      # `Diagnostic#to_lsp_diagnostic`).  The LSP spec preserves that `data`
+      # between `textDocument/publishDiagnostics` and `textDocument/codeAction`,
+      # so the client hands the diagnostics back in the request's context and we
+      # can surface their actions without re-analyzing the file.  This makes the
+      # actions available to clients that request code actions rather than
+      # reading them off the diagnostic (Eglot, Helix, Flycheck, ...).
+      def code_actions_for(params)
+        diagnostics = params.dig(:context, :diagnostics) || []
+        only = params.dig(:context, :only)
+
+        diagnostics.flat_map { |diagnostic| diagnostic.dig(:data, :code_actions) || [] }
+                   .select { |action| only.nil? || only.include?(action[:kind]) }
       end
 
       def diagnostic(file_uri, text)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
         result: {
           capabilities: {
             textDocumentSync: { openClose: true, change: 2 },
-            documentFormattingProvider: true
+            documentFormattingProvider: true,
+            codeActionProvider: true
           }
         }
       )
@@ -179,6 +180,88 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           ], uri: 'file:///path/to/file.rb'
         }
       )
+    end
+  end
+
+  describe 'code action' do
+    let(:autocorrect_action) do
+      {
+        title: 'Autocorrect Style/FrozenStringLiteralComment',
+        kind: 'quickfix',
+        isPreferred: true,
+        edit: {
+          documentChanges: [{
+            textDocument: { uri: 'file:///path/to/file.rb', version: nil },
+            edits: [{
+              newText: "# frozen_string_literal: true\n",
+              range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+            }]
+          }]
+        }
+      }
+    end
+    let(:disable_action) do
+      {
+        title: 'Disable Style/FrozenStringLiteralComment for this line',
+        kind: 'quickfix',
+        edit: {
+          documentChanges: [{
+            textDocument: { uri: 'file:///path/to/file.rb', version: nil },
+            edits: [{
+              newText: ' # rubocop:disable Style/FrozenStringLiteralComment',
+              range: { start: { line: 0, character: 6 }, end: { line: 0, character: 6 } }
+            }]
+          }]
+        }
+      }
+    end
+    let(:diagnostic) do
+      {
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        data: { correctable: true, code_actions: [autocorrect_action, disable_action] }
+      }
+    end
+    let(:requests) do
+      [{
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'textDocument/codeAction',
+        params: {
+          textDocument: { uri: 'file:///path/to/file.rb' },
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          context: { diagnostics: [diagnostic], only: ['quickfix'] }
+        }
+      }]
+    end
+
+    it 'returns the quickfix actions the diagnostics carry' do
+      expect(stderr).to eq('')
+      expect(messages.count).to eq(1)
+      expect(messages.first).to eq(
+        jsonrpc: '2.0',
+        id: 5,
+        result: [autocorrect_action, disable_action]
+      )
+    end
+
+    context 'when the request restricts the kinds to ones the actions do not match' do
+      let(:requests) do
+        [{
+          jsonrpc: '2.0',
+          id: 6,
+          method: 'textDocument/codeAction',
+          params: {
+            textDocument: { uri: 'file:///path/to/file.rb' },
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+            context: { diagnostics: [diagnostic], only: ['source.fixAll'] }
+          }
+        }]
+      end
+
+      it 'returns no actions' do
+        expect(stderr).to eq('')
+        expect(messages.first).to eq(jsonrpc: '2.0', id: 6, result: [])
+      end
     end
   end
 


### PR DESCRIPTION
RuboCop's language server already builds each offense's autocorrect and disable-line quickfix actions (`Diagnostic#to_lsp_code_actions`), but it attaches them only to the published diagnostic's `data` and never advertises `codeActionProvider` or handles `textDocument/codeAction`. So only clients that read the actions off the diagnostic (the RuboCop VS Code extension) can apply them; standard clients that request code actions - Eglot, Helix, Flycheck - see the diagnostics but not the fixes.

This advertises the capability and answers the request by returning the actions the diagnostics carry. The LSP spec keeps a diagnostic's `data` between `publishDiagnostics` and `textDocument/codeAction`, so the client passes the diagnostics back in the request's context and the server surfaces their actions without re-analyzing the file. A `context.only` restriction is honored.

Verified with a real client (Flycheck's LSP checker requesting code actions now applies RuboCop's autocorrects).