### PR TITLE
[Fix #14598] Prevent disabling `Style/DisableCopsWithinSourceCodeDirective` via directive comments

### DIFF
--- a/changelog/new_don_t_use_registry_to_h_20260728222417.md
+++ b/changelog/new_don_t_use_registry_to_h_20260728222417.md
@@ -1,0 +1,1 @@
+* [#14598](https://github.com/rubocop/rubocop/issues/14598): Make `Style/DisableCopsWithinSourceCodeDirective` impossible to disable via directive comments when explicitly enabled with `Enabled: true`. ([@rafaelfranca][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -124,6 +124,8 @@ module RuboCop
 
       analyses.each_with_object({}) do |element, hash|
         cop_name, analysis = *element
+        next if prevent_directive_disabling?(cop_name)
+
         hash[cop_name] = cop_line_ranges(analysis)
       end
     end
@@ -225,6 +227,15 @@ module RuboCop
 
     def qualified_cop_name(cop_name)
       Cop::Registry.qualified_cop_name(cop_name.strip, processed_source.file_path)
+    end
+
+    # `Style/DisableCopsWithinSourceCodeDirective` cannot be disabled via
+    # directive comments when it is explicitly enabled with `Enabled: true`.
+    # This prevents users from bypassing the cop by writing a disable
+    # directive that targets this cop itself.
+    def prevent_directive_disabling?(cop_name)
+      cop_name == DirectiveComment::STYLE_DISABLE_COPS_DIRECTIVE_COP &&
+        config.dig(cop_name, 'Enabled') == true
     end
 
     def non_comment_token_line_numbers

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -19,6 +19,10 @@ module RuboCop
       # allowlisting all other cops. `AllowedCops` and `DisallowedCops` should not
       # both be set at the same time; if `DisallowedCops` is set, it takes precedence.
       #
+      # This cop cannot be disabled via directive comments when it is explicitly
+      # enabled with `Enabled: true`. This prevents users from bypassing the cop
+      # with `# rubocop:disable Style/DisableCopsWithinSourceCodeDirective`.
+      #
       # @example
       #   # bad
       #   # rubocop:disable Metrics/AbcSize

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -12,6 +12,8 @@ module RuboCop
     # @api private
     LINT_SYNTAX_COP = "#{LINT_DEPARTMENT}/Syntax"
     # @api private
+    STYLE_DISABLE_COPS_DIRECTIVE_COP = 'Style/DisableCopsWithinSourceCodeDirective'
+    # @api private
     COP_NAME_PATTERN = '([A-Za-z]\w+/)*(?:[A-Za-z]\w+)'
     # @api private
     COP_NAME_PATTERN_NC = '(?:[A-Za-z]\w+/)*[A-Za-z]\w+'

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -861,4 +861,48 @@ RSpec.describe RuboCop::CommentConfig do
       end
     end
   end
+
+  describe 'Style/DisableCopsWithinSourceCodeDirective prevention' do
+    subject(:disabled_ranges) { comment_config.cop_disabled_line_ranges }
+
+    let(:source) do
+      <<~RUBY
+        # rubocop:disable Style/DisableCopsWithinSourceCodeDirective
+        # rubocop:disable Metrics/MethodLength
+        def foo
+        end
+        # rubocop:enable Metrics/MethodLength
+      RUBY
+    end
+
+    context 'when the cop is explicitly enabled' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Style/DisableCopsWithinSourceCodeDirective' => { 'Enabled' => true },
+          'Metrics/MethodLength' => { 'Enabled' => true }
+        )
+      end
+
+      it 'does not add the cop to disabled line ranges' do
+        expect(disabled_ranges).not_to have_key('Style/DisableCopsWithinSourceCodeDirective')
+      end
+
+      it 'still disables other cops' do
+        expect(disabled_ranges).to have_key('Metrics/MethodLength')
+      end
+    end
+
+    context 'when the cop is not enabled' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Style/DisableCopsWithinSourceCodeDirective' => { 'Enabled' => false },
+          'Metrics/MethodLength' => { 'Enabled' => true }
+        )
+      end
+
+      it 'allows the cop to be disabled by directive comments' do
+        expect(disabled_ranges).to have_key('Style/DisableCopsWithinSourceCodeDirective')
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -133,10 +133,14 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
     end
 
     context 'when disabling all cops' do
-      # `rubocop:disable all` disables this cop as well, so its offense is suppressed.
-      it 'does not register an offense' do
-        expect_no_offenses(<<~RUBY)
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
           foo # rubocop:disable all
+              ^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `all` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo#{trailing_whitespace}
         RUBY
       end
     end
@@ -200,6 +204,56 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
 
       expect_correction(<<~RUBY)
         foo # rubocop:disable Lint/Void
+      RUBY
+    end
+  end
+
+  context 'when a directive tries to disable this cop' do
+    it 'registers an offense for the self-disabling directive and remains active' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Style/DisableCopsWithinSourceCodeDirective
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        def foo # rubocop:disable Metrics/CyclomaticComplexity
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        def foo#{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'registers an offense when disabling all cops and remains active' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable all
+        ^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        def foo # rubocop:disable Metrics/CyclomaticComplexity
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        def foo#{trailing_whitespace}
+        end
+      RUBY
+    end
+
+    it 'registers an offense for disabling via department directive and remains active' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Style
+        ^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        def foo # rubocop:disable Metrics/CyclomaticComplexity
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+
+        def foo#{trailing_whitespace}
+        end
       RUBY
     end
   end


### PR DESCRIPTION
When `Style/DisableCopsWithinSourceCodeDirective` is explicitly enabled with `Enabled: true`, it can no longer be disabled via `# rubocop:disable` directive comments. This prevents users from bypassing the cop by writing `# rubocop:disable Style/DisableCopsWithinSourceCodeDirective`, which would defeat its purpose of enforcing that cops are not disabled in source code.

The implementation filters the cop out of `cop_disabled_line_ranges` in `CommentConfig#analyze` when `Enabled: true` is set in the raw config (checked via `config.dig` rather than `config.for_cop` to inspect the user's explicit setting, not the calculated effective value). This means `cop_enabled_at_line?` always returns true for this cop, keeping it active regardless of any disable directives targeting it by name, by department, or via `disable all`.

This is similar to how `Lint/Syntax` is hardcoded to never be disabled, but differs in that the protection is conditional — the cop is disabled by default and only becomes un-disableable when a user explicitly opts in with `Enabled: true`.

Replace #14634.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
