### PR TITLE
Improve `Style/DisableCopsWithinSourceCodeDirective` performance with memoized Set lookups

### DIFF
--- a/changelog/change_improve_disable_cops_within_source_code_directive_performance.md
+++ b/changelog/change_improve_disable_cops_within_source_code_directive_performance.md
@@ -1,0 +1,1 @@
+* [#15513](https://github.com/rubocop/rubocop/pull/15513): Improve `Style/DisableCopsWithinSourceCodeDirective` performance on large `AllowedCops` and `DisallowedCops` lists by matching directives against memoized sets instead of rebuilding an array lookup per comment. ([@corsonknowles][])

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -77,10 +77,10 @@ module RuboCop
             if directive_cops.include?('all')
               directive_cops
             else
-              directive_cops & disallowed_cops_config
+              directive_cops.uniq.select { |cop| disallowed_cops_config.include?(cop) }
             end
           else
-            directive_cops - allowed_cops
+            directive_cops.reject { |cop| allowed_cops.include?(cop) }
           end
         end
 
@@ -109,7 +109,7 @@ module RuboCop
         end
 
         def allowed_cops
-          Array(cop_config['AllowedCops'])
+          @allowed_cops ||= Array(cop_config['AllowedCops']).to_set
         end
 
         def any_cops_allowed?
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def disallowed_cops_config
-          @disallowed_cops_config ||= Array(cop_config['DisallowedCops'])
+          @disallowed_cops_config ||= Array(cop_config['DisallowedCops']).to_set
         end
       end
     end

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -119,6 +119,19 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       end
     end
 
+    context 'when the same disallowed cop is named twice in one directive' do
+      it 'reports it once and removes the whole directive' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:disable Lint/Void, Lint/Void
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives for `Lint/Void` are not permitted.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo#{trailing_whitespace}
+        RUBY
+      end
+    end
+
     context 'when enabling all cops' do
       it 'registers an offense and corrects' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Follow-up to #15050, which added `DisallowedCops` to `Style/DisableCopsWithinSourceCodeDirective`. Enabling that option across a large monorepo (a 1,000+ entry `DisallowedCops` list) made the cop's matching path the dominant cost, and the same applies to a large `AllowedCops` list.

Set becomes a built in core class in Ruby 4, so I'm interested in making it more common wherever it helps with performance optimizations.

I profiled this repeatedly, full writeup below, and scripts below that:

## The issue

`compute_disallowed_cops` runs once per directive comment. It computes using: `Array#&` / `Array#-`:

```ruby
directive_cops & disallowed_cops_config   # DisallowedCops branch
directive_cops - allowed_cops             # AllowedCops branch
```

Both are O(n+m) 

Above Ruby's small-array threshold of 16 elements, `Array#&` and `Array#-` build an internal hash of the operand rather than scanning it. 

The cost is that they build that hash **again for every comment**, even though the config never changes. 

The sweep of performance profilings at different list lengths (further down) shows the effect as a sharp jump for `Array#&` between 16 and 17 entries.) With a 1,000-entry list and a directive naming one or two cops, each comment pays for a 1,000-entry hash to answer a one-element question.

The fix is to build the lookup structure once. 

Memoize both configs as sets and check membership.

## Stats

Primary target: ~1,000-entry lists, with a range of other sampling points.  

Methodology: 
Ran the real cop through `Commissioner`, 5,000 directive comments per run, best of 5 within a run on Ruby 3.4.10. 
Ratios are given as the range across **three independent runs**

**`DisallowedCops`, 1,004 entries**

| | master | memoized `Array` (`&`/`-`) | **memoized `Set`** |
|---|---|---|---|
| no directive is in the list (0 offenses) | 0.109–0.112s | 0.97–0.98x | **4.33–4.37x** |
| every directive is in the list (5,000 offenses) | 0.336–0.349s | 0.97–1.01x | **1.33–1.40x** |

**`AllowedCops`, 1,004 entries**

| | master | memoized `Array` (`&`/`-`) | **memoized `Set`** |
|---|---|---|---|
| every directive is allowed (0 offenses) | 0.038–0.039s | 1.00–1.03x | **1.51–1.66x** |
| none is allowed (5,000 offenses) | 0.248–0.275s | 1.01–1.02x | **1.04–1.10x** |

Implications from that table:

- **Memoization alone is not sufficient** (0.97–1.03x, noise). `Array(x)` returns `x` itself when `x` is already an Array, so the un-memoized `allowed_cops` was never copying — just method-call overhead. Memoizing matters here only because `.to_set` genuinely does allocate: unmemoized it would cost ~73µs per call on a 1,004-entry list.
- **The win is the lookup structure, and it is largest on clean code.** When every directive is an offense, offense registration and autocorrect dominate and the matching improvement is diluted to 1.1–1.35x. Most real files have few or no offending directives, which is the 1.66x / 4.37x column.

Isolating `compute_disallowed_cops` alone shows the underlying effect more starkly. Over **135,880** directive comments (20 × 6,794) against the 1,004-entry list: `Array#&` 2.345s vs `Set#include?` 0.017s. That is the mechanism, not a user-visible speedup — the end-to-end tables above are the real result, and they are much more modest because directive parsing and offense registration dominate per-comment cost.

### Small lists get marginally slower

There is a tradeoff: below Ruby's `SMALL_ARRAY_LEN` of 16, `Array#&`/`#-` use a linear scan with no block-call overhead, so that highly optimzied structure beats `Set#include?` + `select`/`reject`. Isolating the matching, the crossover is exactly at 16:

| config size | `Array#&` | `Set#include?` |
|---|---|---|
| 0 | 0.0016s | 0.0056s |
| 8 | 0.0041s | 0.0059s |
| 16 | 0.0063s | 0.0061s |
| 17 | 0.0184s | 0.0059s |
| 1004 | 0.8257s | 0.0062s |

End to end at those sizes the difference is within run-to-run noise: measured 0.89–1.03x across two runs on 8- and 16-entry lists, i.e. sometimes marginally slower, sometimes marginally faster, never distinguishable from variance. The matching is a small share of per-comment cost at that size.

In contract, the win at larger sizes of config is *1.33–4.4x.*

A size-conditional hybrid (frozen `Array` with `&`/`-` at or below 16 entries, `Set` above) is possible and I measured it end to end. It is **not** a clear improvement on the unconditional `Set`: at 8 and 16 entries it lands at 0.95–1.01x versus master, essentially the same noise band as the `Set` version, because the small-size difference is not really coming from the matching strategy. At 1,004 entries it is slightly ahead (4.59x vs 4.33x, and 1.41x vs 1.33x). Given it buys ~5% at large sizes and nothing measurable at small ones, in exchange for maintaining two representations of each config, I left it out.

## Why `Set` and not `Hash` or a frozen `Array`

A plain `Hash` with `true` values is fastest by ~7–8% on isolated matching (0.0158s vs 0.0171s), a ~1.3ms difference across 135,880 directive comments. Not worth taking: `Set` says "a collection of cop names" where `Hash[name] = true` does not, and `Set` is already the standard pattern — `lib/rubocop.rb` requires it and cops like `Lint/DuplicateRequire` and `Style/SpecialGlobalVars` use it this way. A memoized frozen `Array` keeps `&`/`-` and, as the tables show, buys nothing. 


Also measured:
`Set.new(Array(v))` vs `Array(v).to_set` differed by ~2% on construction, with the ordering flipping between rehearsal and measurement — noise. Construction is memoized, so it happens once per cop instance either way. That choice came down to reading left-to-right rather than nesting two constructors.

## `Array(...)` is necessary when loading this config

It maps a missing key to an empty collection *and* tolerates a scalar such as `AllowedCops: Lint/Void` written without a list:

| | key absent | array | scalar string |
|---|---|---|---|
| `Array(v).to_set` | `[]` | ok | `["A/B"]` |
| `Set.new(v)` | `[]` | ok | **ArgumentError** |
| `v.to_set` | **NoMethodError** | ok | **NoMethodError** |

Dropping it would reject a config shape the cop accepts today.

## Current API is preserved, including one subtle note

`Array#&` dedupes its result; `Array#-` does not. So the two branches are not interchangeable:

- intersection branch → `uniq.select` (keeps the dedupe)
- difference branch → `reject` (keeps duplicates)

This is observable, because `register_offense` compares `directive_cops.length` with `disallowed_cops.length` to decide whether to delete the whole directive or surgically remove the offending cops. Getting the dedupe wrong would change autocorrect output for a directive naming the same cop twice.

Verified two ways:

1. Compared old and new implementations across all **1,360** combinations of four `AllowedCops` configs × four `DisallowedCops` configs × every directive of length 0–3 drawn from a pool including `all`. **Zero mismatches.** Script below.
2. Added a spec for `# rubocop:disable Lint/Void, Lint/Void`, which passes against unmodified `master` too — it pins existing behavior rather than describing new behavior.

**Full reproduction Equivalence script**

```ruby
require 'set'

def old_impl(directive_cops, allowed, disallowed)
  if disallowed.any?
    directive_cops.include?('all') ? directive_cops : directive_cops & disallowed
  else
    directive_cops - allowed
  end
end

def new_impl(directive_cops, allowed_set, disallowed_set)
  if disallowed_set.any?
    if directive_cops.include?('all')
      directive_cops
    else
      directive_cops.uniq.select { |c| disallowed_set.include?(c) }
    end
  else
    directive_cops.reject { |c| allowed_set.include?(c) }
  end
end

POOL = ['A/One', 'B/Two', 'C/Three', 'all']

configs = []
[[], ['A/One'], ['A/One', 'B/Two'], POOL].each do |allowed|
  [[], ['A/One'], ['B/Two', 'C/Three'], POOL].each do |disallowed|
    configs << [allowed, disallowed]
  end
end

directives = []
(0..3).each { |n| POOL.repeated_permutation(n) { |c| directives << c } }

checked = 0
mismatches = 0
configs.each do |allowed, disallowed|
  a_set = Set.new(allowed)
  d_set = Set.new(disallowed)
  directives.each do |dc|
    checked += 1
    o = old_impl(dc.dup, allowed, disallowed)
    n = new_impl(dc.dup, a_set, d_set)
    next if o == n

    mismatches += 1
    puts "MISMATCH allowed=#{allowed.inspect} disallowed=#{disallowed.inspect} directive=#{dc.inspect}"
    puts "  old=#{o.inspect}  new=#{n.inspect}"
  end
end
puts "checked=#{checked} combinations, mismatches=#{mismatches}"
```

## Reproducible benchmark

Run from a RuboCop checkout with `bundle exec ruby bench.rb`. It drives the real cop through `Commissioner` and swaps only the three methods that differ, so directive parsing, offense registration and autocorrect are identical across variants. It also asserts all three variants report the same offense counts before timing, so a semantics regression fails the benchmark rather than producing a misleading numbers (for example a no-op would be fast but not accurate, and the same for only partial behavior matching).


```ruby
require 'benchmark'
require 'rubocop'
require 'set'

COP = RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective
SIZE = 1004
N = 5_000
REPS = 5

VARIANTS = {
  'master (Array, per-call & / -)' => <<~IMPL,
    def compute_disallowed_cops(directive_cops)
      if disallowed_cops_config.any?
        directive_cops.include?('all') ? directive_cops : directive_cops & disallowed_cops_config
      else
        directive_cops - allowed_cops
      end
    end
    def allowed_cops = Array(cop_config['AllowedCops'])
    def disallowed_cops_config = @disallowed_cops_config ||= Array(cop_config['DisallowedCops'])
  IMPL
  'memoized Array (& / -)' => <<~IMPL,
    def compute_disallowed_cops(directive_cops)
      if disallowed_cops_config.any?
        directive_cops.include?('all') ? directive_cops : directive_cops & disallowed_cops_config
      else
        directive_cops - allowed_cops
      end
    end
    def allowed_cops = @allowed_cops ||= Array(cop_config['AllowedCops']).freeze
    def disallowed_cops_config = @disallowed_cops_config ||= Array(cop_config['DisallowedCops']).freeze
  IMPL
  'memoized Set (select/reject)' => <<~IMPL
    def compute_disallowed_cops(directive_cops)
      if disallowed_cops_config.any?
        if directive_cops.include?('all')
          directive_cops
        else
          directive_cops.uniq.select { |cop| disallowed_cops_config.include?(cop) }
        end
      else
        directive_cops.reject { |cop| allowed_cops.include?(cop) }
      end
    end
    def allowed_cops = @allowed_cops ||= Array(cop_config['AllowedCops']).to_set
    def disallowed_cops_config = @disallowed_cops_config ||= Array(cop_config['DisallowedCops']).to_set
  IMPL
}.freeze

CFG = (1..SIZE).map { |i| "Dept/Cop#{i}" }
IN_LIST  = (1..N).map { |i| "foo#{i} # rubocop:disable #{CFG[i % SIZE]}" }.join("\n") + "\n"
OUT_LIST = (1..N).map { |i| "foo#{i} # rubocop:disable Other/Cop#{i}" }.join("\n") + "\n"

def run_cop(config, src)
  cop = COP.new(config)
  ps = RuboCop::ProcessedSource.new(src, RUBY_VERSION.to_f, 'bench.rb')
  ps.config = config
  ps.registry = RuboCop::Cop::Registry.global
  RuboCop::Cop::Commissioner.new([cop], [], raise_error: true).investigate(ps).offenses.size
end

def timeit
  best = Float::INFINITY
  REPS.times { t = Benchmark.realtime { yield }; best = t if t < best }
  best
end

puts "Ruby #{RUBY_VERSION} — #{SIZE}-entry list, #{N} comments/run, best of #{REPS}"

%w[AllowedCops DisallowedCops].each do |key|
  config = RuboCop::Config.new(
    { 'Style/DisableCopsWithinSourceCodeDirective' => { 'Enabled' => true, key => CFG } }, '/dev/null'
  )
  scenarios = { 'directives in the list' => IN_LIST, 'directives not in the list' => OUT_LIST }
  rows = {}
  offenses = {}
  VARIANTS.each do |label, code|
    COP.class_eval("private\n#{code}", __FILE__, __LINE__)
    offenses[label] = scenarios.transform_values { |s| run_cop(config, s) }
    rows[label] = scenarios.transform_values { |s| timeit { run_cop(config, s) } }
  end
  raise "variants disagree: #{offenses.inspect}" if offenses.values.uniq.size != 1

  puts "\n== #{key}: #{SIZE} entries =="
  scenarios.each_key do |sc|
    base = rows['master (Array, per-call & / -)'][sc]
    puts "  #{sc} -> #{offenses.values.first[sc]} offenses"
    rows.each { |l, v| puts format('    %-32s %.4fs  %.2fx', l, v[sc], base / v[sc]) }
  end
end
```

## Checks

Both scripts above were run verbatim as pasted: the equivalence script prints `checked=1360 combinations, mismatches=0`, and the benchmark reproduces the table (4.37x / 1.40x / 1.57x / 1.10x on that particular run).

- `bundle exec rspec spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb` — 20 examples, 0 failures
- `bundle exec rspec spec/project_spec.rb spec/tasks/changelog_spec.rb` — 1178 examples, 0 failures (changelog format)
- `bundle exec rubocop` on both changed files — no offenses

