### PR TITLE
[Fix #9570] Fix false negatives in `Layout/ClassStructure`

### DIFF
--- a/changelog/fix_false_negatives_in_layout_class_structure_20260710174208.md
+++ b/changelog/fix_false_negatives_in_layout_class_structure_20260710174208.md
@@ -1,0 +1,1 @@
+* [#9570](https://github.com/rubocop/rubocop/issues/9570): Fix false negatives in `Layout/ClassStructure` when using `private_class_method` or `public_class_method` def modifiers. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -518,7 +518,7 @@ Layout/ClassStructure:
   Enabled: false
   SafeAutoCorrect: false
   VersionAdded: '0.52'
-  VersionChanged: '1.53'
+  VersionChanged: '<<next>>'
   Categories:
     module_inclusion:
       - include
@@ -531,6 +531,7 @@ Layout/ClassStructure:
     - initializer
     - public_methods
     - protected_methods
+    - private_class_methods
     - private_methods
 
 Layout/ClosingHeredocIndentation:

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -372,6 +372,12 @@ module RuboCop
 
       private
 
+      ### Reserved for Commissioner
+
+      private_class_method def self.restrict_on_send
+        @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
+      end
+
       ### Reserved for Cop::Cop
 
       def callback_argument(range)
@@ -398,10 +404,6 @@ module RuboCop
 
       def current_offenses
         @current_offenses ||= []
-      end
-
-      private_class_method def self.restrict_on_send
-        @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
       end
 
       EMPTY_OFFENSES = [].freeze

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -251,7 +251,7 @@ module RuboCop
           key = category || name
           visibility_key =
             if node.def_modifier?
-              "#{name}_methods"
+              name.end_with?('_class_method') ? "#{name}s" : "#{name}_methods"
             else
               "#{node_visibility(node)}_#{key}"
             end

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
           protected_methods
           private_attribute_macros
           private_delegate
+          private_class_methods
           private_methods
         ],
         'Categories' => {
@@ -586,6 +587,82 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
 
           private def baz; end
 
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects public class method with modifier declared after private class method with modifier' do
+      expect_offense(<<~RUBY)
+        class A
+          private_class_method def self.do_internal_work
+          end
+
+          public_class_method def self.do_something
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `public_class_methods` is supposed to appear before `private_class_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          public_class_method def self.do_something
+          end
+          private_class_method def self.do_internal_work
+          end
+
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when public class method with modifier is declared before private class method with modifier' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          public_class_method def self.do_something
+          end
+
+          private_class_method def self.do_internal_work
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects private class method with modifier declared after private instance method' do
+      expect_offense(<<~RUBY)
+        class A
+          private
+
+          def do_something
+          end
+
+          private_class_method def self.do_internal_work
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `private_class_methods` is supposed to appear before `private_methods`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class A
+          private
+
+          private_class_method def self.do_internal_work
+          end
+          def do_something
+          end
+
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when private class method with modifier is declared before private instance method' do
+      expect_no_offenses(<<~RUBY)
+        class A
+          private
+
+          private_class_method def self.do_internal_work
+          end
+
+          def do_something
+          end
         end
       RUBY
     end


### PR DESCRIPTION
This commit fixes false negatives in `Layout/ClassStructure` when using `private_class_method` or `public_class_method` def modifiers.

These modifiers were classified as `private_class_method_methods` and `public_class_method_methods`, categories that cannot appear in any `ExpectedOrder`, so misordered class method definitions using them were never reported. They are now classified as `private_class_methods` and `public_class_methods`, matching how `private def foo` maps to `private_methods`.

Design decision: `private_class_methods` is also appended to the default `ExpectedOrder` so that the fix is effective out of the box. It goes last, after `private_methods`, following the convention that private definitions are grouped near the end of a class body. `Cop::Base#restrict_on_send` is moved to the end of its class to comply with the new default order, which RuboCop's own configuration inherits.

Fixes #9570.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
