### PR TITLE
Fix an incorrect autocorrect for `Style/ArrayIntersect`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_array_intersect_20260709105210.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_array_intersect_20260709105210.md
@@ -1,0 +1,1 @@
+* [#15515](https://github.com/rubocop/rubocop/pull/15515): Fix an incorrect autocorrect for `Style/ArrayIntersect` when using safe navigation `none?` with a block. ([@koic][])

--- a/lib/rubocop/cop/style/array_intersect.rb
+++ b/lib/rubocop/cop/style/array_intersect.rb
@@ -164,11 +164,7 @@ module RuboCop
           return unless (captures = any_none_block_intersection(node))
 
           receiver, method_name, argument, block_method = captures
-
-          # `include?` is defined with different semantics on many non-array classes
-          # (e.g. `String#include?` checks for substrings), so it is only a reliable
-          # signal of an intersection check when the receiver is an array literal.
-          return if block_method == :include? && !argument.array_type?
+          return if uncorrectable_block_intersection?(node, method_name, argument, block_method)
 
           dot = node.send_node.loc.dot.source
           bang = method_name == :any? ? '' : '!'
@@ -196,6 +192,17 @@ module RuboCop
 
         def straight?(method_name)
           STRAIGHT_METHODS.include?(method_name.to_sym)
+        end
+
+        def uncorrectable_block_intersection?(node, method_name, argument, block_method)
+          # `a&.none? { |elem| b.include?(elem) }` returns `nil` when `a` is `nil`,
+          # but the negated rewrite `!a&.intersect?(b)` returns `true` there, flipping the result.
+          return true if method_name == :none? && node.send_node.safe_navigation?
+
+          # `include?` is defined with different semantics on many non-array classes
+          # (e.g. `String#include?` checks for substrings), so it is only a reliable
+          # signal of an intersection check when the receiver is an array literal.
+          block_method == :include? && !argument.array_type?
         end
 
         def register_offense(node, replacement)

--- a/spec/rubocop/cop/style/array_intersect_spec.rb
+++ b/spec/rubocop/cop/style/array_intersect_spec.rb
@@ -479,14 +479,24 @@ RSpec.describe RuboCop::Cop::Style::ArrayIntersect, :config do
         RUBY
       end
 
-      it 'registers an offense when using `array1&.none? { |e| array2.member?(e) }`' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense when using `array1&.none? { |e| array2.member?(e) }` ' \
+         '(the rewrite would flip the `nil` result)' do
+        expect_no_offenses(<<~RUBY)
           array1&.none? { |e| array2.member?(e) }
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!array1&.intersect?(array2)` instead of `array1&.none? { |e| array2.member?(e) }`.
         RUBY
+      end
 
-        expect_correction(<<~RUBY)
-          !array1&.intersect?(array2)
+      it 'does not register an offense when using `array1&.none? { |e| array2.include?(e) }` ' \
+         '(the rewrite would flip the `nil` result)' do
+        expect_no_offenses(<<~RUBY)
+          array1&.none? { |e| array2.include?(e) }
+        RUBY
+      end
+
+      it 'does not register an offense when using `array1&.none? { array2.include?(_1) }` ' \
+         '(the rewrite would flip the `nil` result)' do
+        expect_no_offenses(<<~RUBY)
+          array1&.none? { array2.include?(_1) }
         RUBY
       end
 


### PR DESCRIPTION
`Style/ArrayIntersect` autocorrected the block form with safe navigation and a negated predicate:

```ruby
a&.none? { |elem| b.include?(elem) }
```

to:

```ruby
!a&.intersect?(b)
```

When `a` is `nil`, the original code returns `nil` (falsy), but the rewritten code returns `!nil`, that is `true`, flipping the result.

The `on_send` path already skips this shape: d9852f11c added a guard that suppresses the offense for `a&.intersection(b)&.none?` because the negated rewrite flips the `nil` result, and there is no replacement that preserves the semantics without restructuring the expression. This change applies the same design decision to the block, numblock, and itblock forms handled by `on_block`, so no offense is registered for them either.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
