### PR TITLE
Fix a flaky JRuby timeout in a `Layout/LineLength` performance spec

### DIFF
--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -669,7 +669,9 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
 
   it 'checks a large collection literal with one element per line in a reasonable amount of time' do
     # Should take under a second, but 5 seconds is plenty of margin.
-    Timeout.timeout(5) do
+    # JRuby is given a larger margin because parsing and AST traversal are much slower there,
+    # especially before JIT warmup.
+    Timeout.timeout(RUBY_ENGINE == 'jruby' ? 30 : 5) do
       expect_no_offenses(<<~RUBY)
         [
           #{Array.new(10_000) { |n| format("['%04X', 0x%04X],", n, n) }.join("\n  ")}


### PR DESCRIPTION
The performance regression spec added in 2395698e4 inspects a 10,000-element collection literal under `Timeout.timeout(5)`. On the JRuby CI job this intermittently times out, also on master (e.g. runs 30439430941, 30439290372, and 29981721621 all failed only in the "Spec - JRuby" job on this spec), because parsing and AST traversal are much slower on JRuby than on CRuby, especially before JIT warmup.
The timeouts fire inside rubocop-ast traversal, not in the cop logic, so this is a timing flake rather than a reintroduced quadratic path.

Widen the margin to 30 seconds on JRuby only, instead of skipping the spec there with `broken_on: :jruby`. The spec usually passes on JRuby, and a quadratic regression would take well over 20 seconds even on CRuby for 10,000 elements, so a 30-second budget still catches it on JRuby. The strict 5-second guard remains in effect on the CRuby jobs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
