### PR TITLE
[Fix #15517] Fix false positives in `Lint/RedundantSafeNavigation`

### DIFF
--- a/changelog/fix_false_positives_in_lint_redundant_safe_navigation_20260802220212.md
+++ b/changelog/fix_false_positives_in_lint_redundant_safe_navigation_20260802220212.md
@@ -1,0 +1,1 @@
+* [#15517](https://github.com/rubocop/rubocop/issues/15517): Fix false positives in `Lint/RedundantSafeNavigation` when `InferNonNilReceiver` is enabled and the receiver name is rebound by a nested block (`it` or a shadowed block parameter). ([@koic][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -12,6 +12,8 @@ module RuboCop
             @receiver = receiver
             @additional_nil_methods = additional_nil_methods
             @checked_nodes = {}.compare_by_identity
+            @receiver_binding_name = binding_name(receiver)
+            @receiver_binding_scope = binding_scope(receiver) if @receiver_binding_name
           end
 
           def cant_be_nil?
@@ -34,7 +36,9 @@ module RuboCop
             when :def, :defs, :class, :module, :sclass
               return false
             when :send
-              return non_nil_method?(node.method_name) if node.receiver == receiver
+              if node.receiver == receiver && same_binding_as_receiver?(node.receiver)
+                return non_nil_method?(node.method_name)
+              end
 
               node.arguments.each do |argument|
                 return true if _cant_be_nil?(argument, receiver)
@@ -107,9 +111,61 @@ module RuboCop
           # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
           def non_nil_condition?(condition, node)
-            return true if condition == node
+            return true if condition == node && same_binding_as_receiver?(condition)
+            return false unless condition.csend_type?
 
-            condition.csend_type? && csend_root_receiver(condition) == node
+            root_receiver = csend_root_receiver(condition)
+
+            root_receiver == node && same_binding_as_receiver?(root_receiver)
+          end
+
+          # Structurally equal occurrences can be different variables: `it` binds to
+          # its innermost block, and a block parameter can shadow an outer variable of
+          # the same name. Evidence about such a receiver only holds when both occurrences
+          # resolve to the same binding.
+          def same_binding_as_receiver?(occurrence)
+            return true unless @receiver_binding_name
+
+            binding_scope(occurrence).equal?(@receiver_binding_scope)
+          end
+
+          # The name whose binding can differ between structurally equal occurrences:
+          # a local variable (block parameters included), or a bare `it` call, which is
+          # how `it` parses when the target Ruby version is below 3.4 even though the code
+          # may run on 3.4+ where `it` is the implicit block parameter.
+          def binding_name(node)
+            if node.lvar_type?
+              node.children.first
+            elsif node.send_type? && !node.receiver && node.method?(:it) && node.arguments.empty?
+              :it
+            end
+          end
+
+          def binding_scope(occurrence)
+            node = occurrence
+
+            while (parent = node.parent)
+              case parent.type
+              when :block, :numblock, :itblock
+                # Only the body is inside the block's scope; the send node and the arguments of
+                # the block node evaluate in the outer scope.
+                return parent if parent.body.equal?(node) && block_binds_name?(parent)
+              when :def, :defs, :class, :module, :sclass
+                return parent
+              end
+
+              node = parent
+            end
+
+            nil
+          end
+
+          def block_binds_name?(block_node)
+            name = @receiver_binding_name
+
+            return true if block_node.argument_list.any? { |argument| argument.name == name }
+
+            name == :it && block_node.arguments.empty?
           end
 
           # Whether control reaches `node` by falling through its left siblings rather than by

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -1023,6 +1023,210 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when `it` in a nested block refers to a different implicit parameter', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        foo.map { it.map { it&.bar } }
+      RUBY
+    end
+
+    it 'does not register an offense when `it` in a nested block refers to a different implicit parameter with Ruby 3.3 analysis', :ruby33 do
+      expect_no_offenses(<<~RUBY)
+        foo.map { it.map { it&.bar } }
+      RUBY
+    end
+
+    it 'does not register an offense when a nested block parameter shadows the outer one' do
+      expect_no_offenses(<<~RUBY)
+        foo.map { |v| v.map { |v| v&.bar } }
+      RUBY
+    end
+
+    it 'does not register an offense when a shadowing block parameter is guarded by the outer parameter as a condition' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            bar { |v| v&.baz }
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `it` in a nested block is guarded by the outer `it` as a condition', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        foo.each do
+          if it
+            bar { it&.baz }
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when method is called on `it` in the same block', :ruby34 do
+      expect_offense(<<~RUBY)
+        foo.each do
+          it.bar
+          it&.baz
+            ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.each do
+          it.bar
+          it.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when method is called on `it` in the same block with Ruby 3.3 analysis', :ruby33 do
+      expect_offense(<<~RUBY)
+        foo.each do
+          it.bar
+          it&.baz
+            ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.each do
+          it.bar
+          it.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when an outer variable is used in a block without shadowing' do
+      expect_offense(<<~RUBY)
+        val = foo
+        val.bar
+        baz.each { val&.qux }
+                      ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+      RUBY
+
+      expect_correction(<<~RUBY)
+        val = foo
+        val.bar
+        baz.each { val.qux }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when a block parameter is guarded by itself as a condition in the same block' do
+      expect_offense(<<~RUBY)
+        foo.each do |v|
+          if v
+            v&.bar
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.each do |v|
+          if v
+            v.bar
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a variable in a method definition nested in a block is guarded by a same-named outer parameter' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            def m
+              v = bar
+              v&.baz
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `it` in a method definition nested in a block is guarded by the outer `it` as a condition', :ruby33 do
+      expect_no_offenses(<<~RUBY)
+        foo.each do
+          if it
+            def m
+              it&.bar
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a variable in a singleton method definition nested in a block is guarded by a same-named outer parameter' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            def self.m
+              v = bar
+              v&.baz
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a variable in a class body nested in a block is guarded by a same-named outer parameter' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            class C
+              v = bar
+              v&.baz
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a variable in a module body nested in a block is guarded by a same-named outer parameter' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            module M
+              v = bar
+              v&.baz
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a variable in a singleton class body nested in a block is guarded by a same-named outer parameter' do
+      expect_no_offenses(<<~RUBY)
+        foo.each do |v|
+          if v
+            class << self
+              v = bar
+              v&.baz
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when method is called on a same-named parameter of a sibling block' do
+      expect_no_offenses(<<~RUBY)
+        foo.each { |v| v.bar }
+        baz.each { |v| v&.qux }
+      RUBY
+    end
+
+    it 'does not register an offense when method is called on a numbered parameter of a sibling block' do
+      expect_no_offenses(<<~RUBY)
+        foo.each { _1.bar }
+        baz.each { _1&.qux }
+      RUBY
+    end
+
+    it 'does not register an offense when method is called on `it` of a sibling block', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        foo.each { it.bar }
+        baz.each { it&.qux }
+      RUBY
+    end
   end
 
   it 'registers an offense when `&.` is used for `to_s`' do


### PR DESCRIPTION
With `InferNonNilReceiver: true`, the cop registered an offense for the safe navigation in `values.map { it.map { it&.upcase } }` and in `values.map { |val| val.map { |val| val&.upcase } }`, and autocorrection produced code that raises NoMethodError when the collection contains nil. The inner `it` (or the shadowing inner `val`) is a different variable from the outer one, but `Lint::Utils::NilReceiverChecker` matches evidence with structural node equality, so a method call on the outer variable counted as proof that the inner one cannot be nil. The `sole_condition_of_parent_if?` path had the same confusion for code like `list.each { if it; foo { it&.bar }; end }`. Nested numbered parameter blocks cannot hit this because Ruby rejects them as a syntax error.

Require the same binding in addition to structural equality when the receiver is scope-sensitive: a local variable, or a bare `it` call. The binding scope of an occurrence is the nearest enclosing block that binds the name, or else the nearest method/class definition. Two design points:

- A block node's send node and arguments evaluate in the outer scope even though they sit inside the block node structurally, so an occurrence resolves to a block only when the climb enters the block through its body. This is what distinguishes the outer `it` in `it.map { ... }` from the inner one.
- A bare `it` call, which is how `it` parses when the target Ruby version is below 3.4, is treated as bound by the nearest block without ordinary parameters regardless of the target version, because the analyzed code may still run on Ruby 3.4+ where `it` is the implicit block parameter (the reporter analyzed as Ruby 2.7 while running Ruby 4.0). For a genuine `it` method this only suppresses cross-block evidence, which is the conservative direction for an unsafe inference.

An outer variable used inside a non-shadowing block still resolves past the block to the same binder as the evidence, so inference such as `val = foo; val.bar; baz.each { val&.qux }` keeps reporting an offense.

A local variable can never be confused with a method call receiver because `(lvar :x)` and `(send nil :x)` already differ structurally; plain method-call receivers are unaffected by this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
