### PR TITLE
[Fix #15501] Improve `Style/RedundantLineContinuation` performance on adjacent string literals

### DIFF
--- a/changelog/change_improve_style_redundant_line_continuation_performance_on_adjacent_string_20260802214509.md
+++ b/changelog/change_improve_style_redundant_line_continuation_performance_on_adjacent_string_20260802214509.md
@@ -1,0 +1,1 @@
+* [#15519](https://github.com/rubocop/rubocop/pull/15519): Improve `Style/RedundantLineContinuation` performance on files with many adjacent string literals joined by line continuations. ([@koic][])

--- a/lib/rubocop/cop/style/redundant_line_continuation.rb
+++ b/lib/rubocop/cop/style/redundant_line_continuation.rb
@@ -76,6 +76,8 @@ module RuboCop
         LINE_CONTINUATION = '\\'
         LINE_CONTINUATION_PATTERN = /(\\\n)/.freeze
         STRING_TOKEN_TYPES = %i[tSTRING tSTRING_CONTENT].freeze
+        STRING_LITERAL_ENDING_TOKEN_TYPES = %i[tSTRING tSTRING_END].freeze
+        STRING_LITERAL_BEGINNING_TOKEN_TYPES = %i[tSTRING tSTRING_BEG].freeze
 
         def on_new_investigation
           return unless processed_source.ast
@@ -102,7 +104,8 @@ module RuboCop
           candidates = []
 
           each_match_range(processed_source.ast.source_range, LINE_CONTINUATION_PATTERN) do |range|
-            next if within_comment?(range) || within_string_content?(range)
+            next if within_comment?(range) || implicit_string_concatenation?(range)
+            next if within_string_content?(range)
             next if leading_dot_method_chain_with_blank_line?(range)
 
             candidates << range
@@ -115,6 +118,20 @@ module RuboCop
           processed_source.comments.any? do |comment|
             comment.source_range.overlaps?(range)
           end
+        end
+
+        # A backslash directly joining two string literals is never redundant:
+        # removing it moves the second literal onto its own logical line,
+        # severing the implicit string concatenation. Skipping these up front
+        # avoids reparse verification, which is prohibitively slow on generated
+        # files gluing thousands of string fragments with line continuations.
+        def implicit_string_concatenation?(range)
+          tokens = processed_source.sorted_tokens
+
+          token_before = last_token_before(tokens, range)
+          return false unless string_literal_ending_on_line?(token_before, range.line)
+
+          string_literal_beginning_on_line?(first_token_after(tokens, range), range.line + 1)
         end
 
         # A backslash in string content is never a redundant line continuation
@@ -136,6 +153,27 @@ module RuboCop
           return false unless range.source_line.strip.start_with?('.', '&.')
 
           processed_source[range.line].strip.empty?
+        end
+
+        def last_token_before(tokens, range)
+          index = tokens.bsearch_index { |token| token.end_pos > range.begin_pos }
+          index&.positive? ? tokens[index - 1] : nil
+        end
+
+        def first_token_after(tokens, range)
+          tokens.bsearch { |token| token.begin_pos >= range.end_pos }
+        end
+
+        def string_literal_ending_on_line?(token, line)
+          return false unless token
+
+          STRING_LITERAL_ENDING_TOKEN_TYPES.include?(token.type) && token.pos.last_line == line
+        end
+
+        def string_literal_beginning_on_line?(token, line)
+          return false unless token
+
+          STRING_LITERAL_BEGINNING_TOKEN_TYPES.include?(token.type) && token.line == line
         end
 
         def inspect_end_of_ruby_code_line_continuation

--- a/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
+++ b/spec/rubocop/cop/style/redundant_line_continuation_spec.rb
@@ -501,6 +501,29 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
     RUBY
   end
 
+  it 'does not register an offense when consecutive line continuations join two string literals' do
+    expect_no_offenses(<<~'RUBY')
+      foo 'bar' \
+          \
+          'baz'
+    RUBY
+  end
+
+  it 'registers an offense and corrects when a line continuation is followed by a blank line before a string literal' do
+    expect_offense(<<~'RUBY')
+      foo 'bar' \
+                ^ Redundant line continuation.
+
+      'baz'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo 'bar'#{trailing_whitespace}
+
+      'baz'
+    RUBY
+  end
+
   it 'registers an offense for an interpolated string argument followed by line continuation' do
     expect_offense(<<~'RUBY')
       foo("#{bar}", \
@@ -1127,5 +1150,21 @@ RSpec.describe RuboCop::Cop::Style::RedundantLineContinuation, :config do
       def foo = 1 \
         + 2
     RUBY
+  end
+
+  it 'checks a large string concatenation joined by line continuations in a reasonable amount of time' do
+    # Each backslash joins two string literals, so it must be rejected by token inspection alone;
+    # verifying each one with a reparse of the surrounding module would take minutes.
+    # JRuby is given a larger margin because parsing and AST traversal are much slower there,
+    # especially before JIT warm-up.
+    Timeout.timeout(RUBY_ENGINE == 'jruby' ? 30 : 5) do
+      expect_no_offenses(<<~RUBY)
+        module Foo
+          CONST = '' \\
+            #{Array.new(2000) { |i| "'string#{i}' \\" }.join("\n    ")}
+            'last'
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
The follow-up comment on https://github.com/rubocop/rubocop/issues/15501#issuecomment-5079439931 reports that `rubocop ./lib/unicode_normalize/tables.rb` (from ruby/ruby) still takes over a minute. The file inspects in 1.7 seconds with the default configuration; the remaining slowness appears only with `NewCops: enable`, and bisecting the enabled pending cops attributes essentially all of it to `Style/RedundantLineContinuation` (2 minutes 48 seconds in total, of which about 165 seconds is this cop).

The file glues 1,544 string fragments with `"..." \` line continuations inside a single module. Each backslash-newline becomes a reparse-verification candidate, and all of them share one reparse scope: the whole 229KB `module UnicodeNormalize`. None of these backslashes is redundant, so the batched verification in `ReparsedEquivalence#verified_by_reparse` fails and falls back to per-item verification, parsing the 229KB fragment 1,545 times.

Skip such candidates before reparse verification: a backslash that directly joins two string literals is never redundant, because removing it moves the second literal onto its own logical line and severs the implicit string concatenation, which always changes the AST. The check requires a string-literal ending token that ends on the backslash's line and a string-literal beginning token that starts on the immediately following line, found with binary search over the sorted token list.

The line-adjacency conditions are what make the check exact. Restoring the pre-reparse guard removed in 65f56b9c8 (`/["']\s*\\\z/` on the source line) would reintroduce the false negative that rewrite fixed: a continuation after the last string of a concatenation chain is redundant and must keep being reported, and so must a continuation followed by a blank line before a string literal, which only the line-adjacency conditions distinguish from genuine concatenation.

Benchmark with the reporter's configuration (`NewCops: enable`) against `lib/unicode_normalize/tables.rb`:

- before: 2 minutes 48 seconds
- after: 2.1 seconds

Offense counts are unchanged (17,209). `--only Style/RedundantLineContinuation` drops from over 60 seconds to 0.8 seconds.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
