### PR TITLE
Language server usability and performance improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - lib/rubocop/config_obsoletion.rb
+    - lib/rubocop/lsp/routes.rb
     - lib/rubocop/options.rb
 
 Metrics/ModuleLength:

--- a/changelog/change_advertise_execute_command_provider_in_the_language_server_20260803115011.md
+++ b/changelog/change_advertise_execute_command_provider_in_the_language_server_20260803115011.md
@@ -1,0 +1,1 @@
+* [#15521](https://github.com/rubocop/rubocop/pull/15521): Advertise `executeCommandProvider` and the supported code action kinds in the language server's capabilities, so clients can discover the `rubocop.formatAutocorrects` and `rubocop.formatAutocorrectsAll` commands. ([@bbatsov][])

--- a/changelog/change_cache_the_lsp_project_index_across_requests_20260803114916.md
+++ b/changelog/change_cache_the_lsp_project_index_across_requests_20260803114916.md
@@ -1,0 +1,1 @@
+* [#15521](https://github.com/rubocop/rubocop/pull/15521): Improve language server performance by caching the project index across requests instead of rebuilding it on every keystroke when `AllCops/UseProjectIndex` is enabled. ([@bbatsov][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -21,6 +21,10 @@ module RuboCop
         RuboCop::CLI::Command::AutoGenerateConfig::AUTO_GENERATED_FILE
       ].freeze
 
+      # Commands handled by `workspace/executeCommand`. Advertised to the client
+      # via `executeCommandProvider` so it knows which commands it can invoke.
+      EXECUTE_COMMANDS = %w[rubocop.formatAutocorrects rubocop.formatAutocorrectsAll].freeze
+
       def self.handle(name, &block)
         define_method(:"handle_#{name}", &block)
       end
@@ -50,7 +54,12 @@ module RuboCop
           result: LanguageServer::Protocol::Interface::InitializeResult.new(
             capabilities: LanguageServer::Protocol::Interface::ServerCapabilities.new(
               document_formatting_provider: true,
-              code_action_provider: true,
+              code_action_provider: LanguageServer::Protocol::Interface::CodeActionOptions.new(
+                code_action_kinds: [LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX]
+              ),
+              execute_command_provider: LanguageServer::Protocol::Interface::ExecuteCommandOptions.new(
+                commands: EXECUTE_COMMANDS
+              ),
               text_document_sync: LanguageServer::Protocol::Interface::TextDocumentSyncOptions.new(
                 change: LanguageServer::Protocol::Constant::TextDocumentSyncKind::INCREMENTAL,
                 open_close: true

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -117,13 +117,17 @@ module RuboCop
       end
 
       handle 'workspace/didChangeWatchedFiles' do |request|
-        changed = request[:params][:changes].any? do |change|
+        config_changed = request[:params][:changes].any? do |change|
           CONFIGURATION_FILE_PATTERNS.any? { |path| change[:uri].end_with?(path) }
         end
 
-        if changed
+        if config_changed
           Logger.log('Configuration file changed; restart required')
           @server.stop
+        else
+          # A watched source file changed on disk, so the project index may be
+          # stale; drop it so the next diagnostics run rebuilds it.
+          @server.reset_project_index
         end
       end
 
@@ -164,7 +168,9 @@ module RuboCop
       end
 
       handle 'textDocument/didSave' do |_request|
-        # Nothing to do
+        # The buffer's contents are now on disk, so the project index may be
+        # stale; drop it so the next diagnostics run rebuilds it.
+        @server.reset_project_index
       end
 
       handle '$/cancelRequest' do |_request|

--- a/lib/rubocop/lsp/runtime.rb
+++ b/lib/rubocop/lsp/runtime.rb
@@ -43,6 +43,10 @@ module RuboCop
         @runner.formatted_source
       end
 
+      def reset_project_index
+        @runner.reset_project_index
+      end
+
       def offenses(path, text, document_encoding = nil, prism_result: nil)
         diagnostic_options = {}
         diagnostic_options[:only] = config_only_options if @lint_mode || @layout_mode

--- a/lib/rubocop/lsp/server.rb
+++ b/lib/rubocop/lsp/server.rb
@@ -61,6 +61,10 @@ module RuboCop
         @runtime.layout_mode = options[:layout_mode]
       end
 
+      def reset_project_index
+        @runtime.reset_project_index
+      end
+
       def stop(&block)
         at_exit(&block) if block
         exit

--- a/lib/rubocop/lsp/stdin_runner.rb
+++ b/lib/rubocop/lsp/stdin_runner.rb
@@ -60,7 +60,27 @@ module RuboCop
         @options[:stdin]
       end
 
+      # Drop the cached project index so the next run rebuilds it. Called when a
+      # file is saved or a watched file changes, i.e. when the on-disk state the
+      # index is derived from may have changed.
+      def reset_project_index
+        @project_index = nil
+        @project_index_built = false
+      end
+
       private
+
+      # The project index is built from files on disk, not from the in-memory
+      # buffer, so it does not change while the user is typing. Build it once and
+      # reuse it across runs instead of re-walking and re-indexing the whole
+      # project on every request; `reset_project_index` drops the cache when the
+      # on-disk state changes.
+      def build_project_index(target_files)
+        return if @project_index_built
+
+        super
+        @project_index_built = true
+      end
 
       def file_finished(_file, offenses)
         @offenses = offenses

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -1731,4 +1731,40 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       result
     end
   end
+
+  describe 'when a document is saved' do
+    let(:requests) do
+      [{
+        jsonrpc: '2.0',
+        method: 'textDocument/didSave',
+        params: { textDocument: { uri: 'file:///path/to/file.rb' } }
+      }]
+    end
+
+    it 'refreshes the project index' do
+      # rubocop:disable RSpec/AnyInstance
+      expect_any_instance_of(RuboCop::Lsp::StdinRunner).to receive(:reset_project_index)
+      # rubocop:enable RSpec/AnyInstance
+
+      result
+    end
+  end
+
+  describe 'when a watched source file changes' do
+    let(:requests) do
+      [{
+        jsonrpc: '2.0',
+        method: 'workspace/didChangeWatchedFiles',
+        params: { changes: [{ uri: 'file:///path/to/other.rb' }] }
+      }]
+    end
+
+    it 'refreshes the project index' do
+      # rubocop:disable RSpec/AnyInstance
+      expect_any_instance_of(RuboCop::Lsp::StdinRunner).to receive(:reset_project_index)
+      # rubocop:enable RSpec/AnyInstance
+
+      result
+    end
+  end
 end

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
           capabilities: {
             textDocumentSync: { openClose: true, change: 2 },
             documentFormattingProvider: true,
-            codeActionProvider: true
+            codeActionProvider: { codeActionKinds: ['quickfix'] },
+            executeCommandProvider: {
+              commands: ['rubocop.formatAutocorrects', 'rubocop.formatAutocorrectsAll']
+            }
           }
         }
       )

--- a/spec/rubocop/lsp/stdin_runner_spec.rb
+++ b/spec/rubocop/lsp/stdin_runner_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Lsp::StdinRunner do
+  # Exercise the caching logic in isolation, without the heavy runner setup
+  # that a full `new` would trigger.
+  let(:runner) { described_class.allocate }
+
+  describe 'project index caching' do
+    before do
+      allow(runner).to receive_messages(project_index_enabled?: true, project_index_files: [])
+    end
+
+    it 'builds the project index once and reuses it across runs' do
+      expect(RuboCop::ProjectIndexLoader).to receive(:build_index).once.and_return(:index)
+
+      3.times { runner.send(:build_project_index, ['a.rb']) }
+    end
+
+    it 'rebuilds the project index after it is reset' do
+      expect(RuboCop::ProjectIndexLoader).to receive(:build_index).twice.and_return(:index)
+
+      runner.send(:build_project_index, ['a.rb'])
+      runner.reset_project_index
+      runner.send(:build_project_index, ['a.rb'])
+    end
+  end
+end


### PR DESCRIPTION
Two independent language server improvements, one commit each.

The first is the one that matters for performance. With `AllCops/UseProjectIndex` enabled the language server rebuilt the whole-project index on every request, so each keystroke re-walked and re-indexed the entire project (and every bundled gem when `ProjectIndexIncludesGems` is on). The index is built from files on disk, not from the in-memory buffer, so it doesn't change while you type. It's now built once and reused, and dropped when a file is saved or a watched file changes. On this repo a diagnostics run goes from ~126ms to ~32ms.

The second advertises `executeCommandProvider` in the server capabilities. The server already handles `rubocop.formatAutocorrects` and `rubocop.formatAutocorrectsAll`, but never registered them, so clients that only send commands the server advertises had no way to reach them. It also declares the code action kinds the server supports.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/