### PR TITLE
Fix Ruby version detection from mise.toml with single quotes

### DIFF
--- a/changelog/fix_ruby_version_detection_from_mise_toml_with_single_quotes_20260803150336.md
+++ b/changelog/fix_ruby_version_detection_from_mise_toml_with_single_quotes_20260803150336.md
@@ -1,0 +1,1 @@
+* [#15522](https://github.com/rubocop/rubocop/pull/15522): Fix Ruby version detection from mise.toml with single quotes. ([@joklek-vinted][])

--- a/lib/rubocop/target_ruby.rb
+++ b/lib/rubocop/target_ruby.rb
@@ -212,7 +212,7 @@ module RuboCop
       end
 
       def pattern
-        /^ruby = "(?<version>\d+\.\d+)/.freeze
+        /^ruby = ["'](?<version>\d+\.\d+)/.freeze
       end
     end
 

--- a/spec/rubocop/target_ruby_spec.rb
+++ b/spec/rubocop/target_ruby_spec.rb
@@ -503,6 +503,15 @@ RSpec.describe RuboCop::TargetRuby, :isolated_environment do
           expect(File).not_to receive(:file?).with(/gems\.locked/)
           expect(target_ruby.version).to eq default_version
         end
+
+        context 'when mise.toml contains a ruby version with single quotes' do
+          let(:mise_toml) { ['[tools]', "ruby = '3.0.0'"] }
+          let(:ruby_version_to_f) { 3.0 }
+
+          it 'reads it to determine the target ruby version' do
+            expect(target_ruby.version).to eq ruby_version_to_f
+          end
+        end
       end
 
       context 'when mise.toml contains different runtimes' do


### PR DESCRIPTION
The correct Ruby version wasn't detected in our project. After some debugging, I noticed that our `mise.toml` had `ruby = '4.0.6'` which didn't get detected with the old regex which was added in https://github.com/rubocop/rubocop/pull/14921.

The [TOML spec](https://toml.io/en/v1.0.0#string) allows for strings with single and double quotes, and the mise docs use examples using single quotes https://mise.jdx.dev/configuration.html.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
