### PR TITLE
Add new `Lint/ArgumentMismatch` cop

### DIFF
--- a/changelog/new_add_new_lint_argument_mismatch_cop_20260804092352.md
+++ b/changelog/new_add_new_lint_argument_mismatch_cop_20260804092352.md
@@ -1,0 +1,1 @@
+* [#15523](https://github.com/rubocop/rubocop/pull/15523): Add new `Lint/ArgumentMismatch` cop. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1659,6 +1659,13 @@ Lint/AmbiguousRegexpLiteral:
   VersionAdded: '0.17'
   VersionChanged: '0.83'
 
+Lint/ArgumentMismatch:
+  Description: >-
+    Checks for calls that pass the wrong number of positional arguments
+    to a method, using the project index.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Lint/ArrayLiteralInRegexp:
   Description: 'Checks for an array literal interpolated inside a regexp.'
   Enabled: pending

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -137,6 +137,10 @@ references and constant-receiver method calls that do not resolve anywhere in th
 when a similarly named alternative exists, and suggests it. `CheckConstants` and
 `CheckMethods` toggle the two checks independently.
 
+`Lint/ArgumentMismatch` (pending) reports calls on a constant receiver (`Foo.bar`) that pass
+the wrong number of positional arguments to a singleton method defined in the project, when
+the receiver and its whole ancestry are resolved in the index.
+
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 
 == Notes

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -13,6 +13,7 @@ module RuboCop
       register_cop :AmbiguousOperatorPrecedence, "#{__dir__}/lint/ambiguous_operator_precedence"
       register_cop :AmbiguousRange, "#{__dir__}/lint/ambiguous_range"
       register_cop :AmbiguousRegexpLiteral, "#{__dir__}/lint/ambiguous_regexp_literal"
+      register_cop :ArgumentMismatch, "#{__dir__}/lint/argument_mismatch"
       register_cop :ArrayLiteralInRegexp, "#{__dir__}/lint/array_literal_in_regexp"
       register_cop :AssignmentInCondition, "#{__dir__}/lint/assignment_in_condition"
       register_cop :BigDecimalNew, "#{__dir__}/lint/big_decimal_new"

--- a/lib/rubocop/cop/lint/argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/argument_mismatch.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for calls that pass the wrong number of positional arguments to a
+      # method whose definition is known from the project index.
+      #
+      # The check is powered by the project-wide index, so it only runs when
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
+      # Without the index the cop does nothing.
+      #
+      # Only calls on constant receivers (`Foo.bar`) are considered, and only
+      # when the receiver resolves in the index, its entire ancestry is resolved
+      # (so a method inherited from a gem or the standard library never produces
+      # an offense), and the called method resolves to a single, unambiguous
+      # signature. Calls that forward arguments (`*`, `**`, `...`) are skipped
+      # because their argument count is not statically known. Keyword arguments
+      # passed to a method that declares no keyword parameters are counted as the
+      # single positional hash they collapse into, matching Ruby's semantics.
+      #
+      # Constructor calls (`Foo.new`) and keyword-argument validation are out of
+      # scope: only positional arity of explicitly defined singleton methods is
+      # checked.
+      #
+      # @example
+      #   # Given the project defines:
+      #   #   class Report
+      #   #     def self.generate(source, format); end
+      #   #   end
+      #
+      #   # bad
+      #   Report.generate(source)
+      #
+      #   # bad
+      #   Report.generate(source, :pdf, :extra)
+      #
+      #   # good
+      #   Report.generate(source, :pdf)
+      #
+      class ArgumentMismatch < Base
+        include ProjectIndexHelp
+
+        MSG = 'Wrong number of arguments to `%<method>s` (given %<given>d, expected %<expected>s).'
+
+        def on_send(node)
+          return unless project_index
+          return unless node.receiver&.const_type?
+
+          shape = resolved_signature_shape(node)
+          return unless shape
+
+          min, max, has_keywords = shape
+          given = positional_argument_count(node, has_keywords)
+          return if given.nil? || arity_satisfied?(given, min, max)
+
+          add_offense(node.loc.selector, message: message(node, given, min, max))
+        end
+        alias on_csend on_send
+
+        private
+
+        def arity_satisfied?(given, min, max)
+          given >= min && (max.nil? || given <= max)
+        end
+
+        def message(node, given, min, max)
+          format(MSG, method: node.method_name, given: given, expected: expected_range(min, max))
+        end
+
+        def expected_range(min, max)
+          return "#{min}+" if max.nil?
+          return min.to_s if min == max
+
+          "#{min}..#{max}"
+        end
+
+        # `[min, max, has_keywords]` for the called singleton method, or nil when
+        # the receiver or its ancestry is not resolved.
+        def resolved_signature_shape(node)
+          declaration = resolve_constant_in_index(node.receiver)
+          return nil unless declaration.is_a?(Rubydex::Namespace)
+          return nil unless fully_resolved_index_ancestry?(declaration)
+
+          singleton_signature_shape(declaration, node.method_name)
+        rescue StandardError
+          nil
+        end
+
+        def singleton_signature_shape(declaration, method_name)
+          member = indexed_singleton_member(declaration, "#{method_name}()")
+          return nil unless member
+
+          definitions = member.definitions.grep(Rubydex::MethodDefinition)
+          return nil if definitions.empty?
+
+          signature_shape(definitions.flat_map(&:signatures))
+        end
+
+        # A single agreed `[min, max, has_keywords]` shape across every signature,
+        # or nil when the method has no signature, forwards arguments, or its
+        # definitions disagree on arity (e.g. reopened with a different one).
+        def signature_shape(signatures)
+          shapes = signatures.filter_map { |signature| shape_for(signature) }.uniq
+          shapes.one? ? shapes.first : nil
+        end
+
+        def shape_for(signature)
+          return nil if signature.forward_parameter
+
+          min = signature.positional_parameters.size + signature.post_parameters.size
+
+          [min, maximum_positional(signature, min), keyword_parameters?(signature)]
+        end
+
+        def maximum_positional(signature, min)
+          return nil if signature.rest_positional_parameter
+
+          min + signature.optional_positional_parameters.size
+        end
+
+        def keyword_parameters?(signature)
+          !signature.keyword_parameters.empty? ||
+            !signature.optional_keyword_parameters.empty? ||
+            !signature.rest_keyword_parameter.nil?
+        end
+
+        # The number of positional arguments the call passes, or nil when it
+        # cannot be determined statically (argument forwarding).
+        def positional_argument_count(node, callee_has_keywords)
+          arguments = node.arguments
+          return nil if forwards_arguments?(arguments)
+
+          arguments = arguments[0...-1] if arguments.last&.block_pass_type?
+          return arguments.size unless (keyword_hash = keyword_hash(arguments.last))
+          return nil if double_splat?(keyword_hash)
+
+          # A keyword-style hash passed to a method with no keyword parameters is
+          # received as a single positional hash argument.
+          callee_has_keywords ? arguments.size - 1 : arguments.size
+        end
+
+        def forwards_arguments?(arguments)
+          arguments.any? do |argument|
+            argument.type?(:splat, :forwarded_args, :forwarded_restarg, :forwarded_kwrestarg)
+          end
+        end
+
+        def keyword_hash(node)
+          node if node&.hash_type? && !node.braces?
+        end
+
+        def double_splat?(hash_node)
+          hash_node.each_child_node.any?(&:kwsplat_type?)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/argument_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/argument_mismatch_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::ArgumentMismatch, :config do
+  it 'does not register an offense without a project index' do
+    expect_no_offenses(<<~RUBY)
+      Report.generate(source)
+    RUBY
+  end
+
+  context 'with a project index', :project_index do
+    # Index the callee definitions together with the inspected call site, which
+    # is inspected as `/call.rb`. This mirrors production, where the file being
+    # linted is part of the whole-project index.
+    def index_with_call(call, callees)
+      cop.project_index = build_index(callees.merge('file:///call.rb' => call))
+    end
+
+    context 'for a fixed-arity singleton method' do
+      let(:callee) do
+        { 'file:///report.rb' => <<~RUBY }
+          class Report
+            def self.generate(source, format); end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when too few arguments are given' do
+        index_with_call('Report.generate(source)', callee)
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Report.generate(source)
+                 ^^^^^^^^ Wrong number of arguments to `generate` (given 1, expected 2).
+        RUBY
+      end
+
+      it 'registers an offense when too many arguments are given' do
+        index_with_call('Report.generate(source, :pdf, :extra)', callee)
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Report.generate(source, :pdf, :extra)
+                 ^^^^^^^^ Wrong number of arguments to `generate` (given 3, expected 2).
+        RUBY
+      end
+
+      it 'does not register an offense when the arity matches' do
+        index_with_call('Report.generate(source, :pdf)', callee)
+
+        expect_no_offenses('Report.generate(source, :pdf)', '/call.rb')
+      end
+
+      it 'does not register an offense for a call that forwards a splat' do
+        index_with_call('Report.generate(*args)', callee)
+
+        expect_no_offenses('Report.generate(*args)', '/call.rb')
+      end
+
+      it 'does not register an offense on a different receiver' do
+        index_with_call('Other.generate(source)', callee)
+
+        expect_no_offenses('Other.generate(source)', '/call.rb')
+      end
+    end
+
+    context 'for optional and rest parameters' do
+      let(:callee) do
+        { 'file:///calc.rb' => <<~RUBY }
+          class Calc
+            def self.add(a, b = 0); end
+            def self.sum(*nums); end
+          end
+        RUBY
+      end
+
+      it 'accepts a call within the optional range' do
+        index_with_call("Calc.add(1)\nCalc.add(1, 2)\n", callee)
+
+        expect_no_offenses(<<~RUBY, '/call.rb')
+          Calc.add(1)
+          Calc.add(1, 2)
+        RUBY
+      end
+
+      it 'registers an offense past the optional maximum' do
+        index_with_call('Calc.add(1, 2, 3)', callee)
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Calc.add(1, 2, 3)
+               ^^^ Wrong number of arguments to `add` (given 3, expected 1..2).
+        RUBY
+      end
+
+      it 'accepts any number of arguments for a rest parameter' do
+        index_with_call("Calc.sum\nCalc.sum(1, 2, 3, 4)\n", callee)
+
+        expect_no_offenses(<<~RUBY, '/call.rb')
+          Calc.sum
+          Calc.sum(1, 2, 3, 4)
+        RUBY
+      end
+    end
+
+    context 'for required plus rest parameters' do
+      let(:callee) do
+        { 'file:///calc.rb' => <<~RUBY }
+          class Calc
+            def self.join(sep, *parts); end
+          end
+        RUBY
+      end
+
+      it 'reports the minimum with a trailing plus' do
+        index_with_call('Calc.join', callee)
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Calc.join
+               ^^^^ Wrong number of arguments to `join` (given 0, expected 1+).
+        RUBY
+      end
+    end
+
+    context 'with keyword arguments' do
+      it 'folds keywords into a positional hash when the method has none' do
+        index_with_call('M.opts(a: 1, b: 2)', 'file:///m.rb' => <<~RUBY)
+          class M
+            def self.opts(hash); end
+          end
+        RUBY
+
+        expect_no_offenses('M.opts(a: 1, b: 2)', '/call.rb')
+      end
+
+      it 'registers an offense when the folded hash overflows the arity' do
+        index_with_call('M.opts(a: 1)', 'file:///m.rb' => <<~RUBY)
+          class M
+            def self.opts; end
+          end
+        RUBY
+
+        expect_offense(<<~RUBY, '/call.rb')
+          M.opts(a: 1)
+            ^^^^ Wrong number of arguments to `opts` (given 1, expected 0).
+        RUBY
+      end
+
+      it 'does not count keywords as positional when the method declares them' do
+        index_with_call('M.build(name, size: 1)', 'file:///m.rb' => <<~RUBY)
+          class M
+            def self.build(name, size:); end
+          end
+        RUBY
+
+        expect_no_offenses('M.build(name, size: 1)', '/call.rb')
+      end
+
+      it 'skips a call that forwards a double splat' do
+        index_with_call('M.build(name, **opts)', 'file:///m.rb' => <<~RUBY)
+          class M
+            def self.build(name); end
+          end
+        RUBY
+
+        expect_no_offenses('M.build(name, **opts)', '/call.rb')
+      end
+    end
+
+    context 'when the method is defined on the instance side' do
+      it 'does not register an offense for an instance method called on the module' do
+        index_with_call('Helper.call(1, 2)', 'file:///helper.rb' => <<~RUBY)
+          module Helper
+            def call(a); end
+          end
+        RUBY
+
+        expect_no_offenses('Helper.call(1, 2)', '/call.rb')
+      end
+    end
+
+    context 'when the ancestry is not fully resolved' do
+      it 'does not register an offense' do
+        index_with_call('Widget.render(1, 2)', 'file:///widget.rb' => <<~RUBY)
+          class Widget < Unknown
+            def self.render(a); end
+          end
+        RUBY
+
+        expect_no_offenses('Widget.render(1, 2)', '/call.rb')
+      end
+    end
+
+    context 'when the method is reopened with a different arity' do
+      it 'does not register an offense when definitions disagree on arity' do
+        index_with_call(
+          'Thing.run(1)',
+          'file:///thing.rb' => "class Thing\n  def self.run(a); end\nend\n",
+          'file:///thing_ext.rb' => "class Thing\n  def self.run(a, b); end\nend\n"
+        )
+
+        expect_no_offenses('Thing.run(1)', '/call.rb')
+      end
+    end
+
+    context 'for inherited singleton methods' do
+      it 'registers an offense against the inherited signature' do
+        index_with_call(
+          'Child.build(1)',
+          'file:///base.rb' => "class Base\n  def self.build(a, b); end\nend\n",
+          'file:///child.rb' => "class Child < Base\nend\n"
+        )
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Child.build(1)
+                ^^^^^ Wrong number of arguments to `build` (given 1, expected 2).
+        RUBY
+      end
+    end
+
+    context 'with safe navigation' do
+      it 'registers an offense on a safe-navigation call' do
+        index_with_call('Report&.generate(source)', 'file:///report.rb' => <<~RUBY)
+          class Report
+            def self.generate(source, format); end
+          end
+        RUBY
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Report&.generate(source)
+                  ^^^^^^^^ Wrong number of arguments to `generate` (given 1, expected 2).
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
A new index-backed cop that flags calls passing the wrong number of positional arguments to a method defined in the project. It builds on the same rubydex machinery as the other cross-file cops, so it only runs when `AllCops/UseProjectIndex` is enabled.

To stay quiet on anything it can't be sure about, it only looks at calls on a constant receiver (`Foo.bar`) where the receiver and its entire ancestry resolve in the index and the method resolves to a single unambiguous signature. Methods reached through gems, the standard library, or dynamic definitions never produce offenses. Argument-forwarding calls (`*`, `**`, `...`) are skipped, and keyword arguments passed to a method with no keyword parameters are counted as the single positional hash they collapse into. Constructor calls (`Foo.new`) and keyword-argument validation are out of scope for now.

Dogfooded across rubocop's own lib and spec (1723 files) with the index on and found zero false positives. Ships as `pending`.