### PR TITLE
Document language server project-index reuse

### DIFF
--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -151,3 +151,6 @@ Index-aware cops automatically pick up the index whenever it is built; no per-co
 - The index is rebuilt once per `rubocop` invocation; no on-disk index is shared between
   runs. Indexing is fast (roughly 100ms for a couple thousand files), but very large
   monorepos will notice the per-run cost on single-file runs.
+- The language server is the exception: it builds the index once per session and reuses it
+  across requests, rebuilding only when a file is saved or a watched file changes. Editing a
+  buffer therefore does not pay the indexing cost on every keystroke.


### PR DESCRIPTION
The project index note said it is rebuilt once per invocation, which is no longer the whole story: the language server now keeps the index across requests within a session and only rebuilds on save or a watched-file change. Spell that out so editor users know they don't pay the indexing cost on every keystroke.