### PR TITLE
[Fix #15525] Fix false negatives in Layout/LineLength for Http constant paths

### DIFF
--- a/changelog/fix_false_negatives_in_layout_line_length_20260805020027.md
+++ b/changelog/fix_false_negatives_in_layout_line_length_20260805020027.md
@@ -1,0 +1,1 @@
+* [#15525](https://github.com/rubocop/rubocop/issues/15525): Fix false negatives in `Layout/LineLength` when a constant path like `Http::UploadedFile` matches `URISchemes` case-insensitively. ([@koic][])

--- a/lib/rubocop/cop/mixin/line_length_help.rb
+++ b/lib/rubocop/cop/mixin/line_length_help.rb
@@ -128,7 +128,13 @@ module RuboCop
           # Additionally, the RFC2396_PARSER alias is only available on 3.4 for now.
           # Extra info at https://github.com/ruby/uri/issues/118
           parser = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
-          parser.make_regexp(config.for_cop('Layout/LineLength')['URISchemes'])
+          schemes = config.for_cop('Layout/LineLength')['URISchemes']
+          regexp = parser.make_regexp(schemes)
+
+          # `make_regexp` in uri 1.1.0+ matches schemes case-insensitively, which makes
+          # constant paths like `Http::UploadedFile` look like URIs. Require the exact case
+          # given in `URISchemes`.
+          schemes ? /(?=#{Regexp.union(schemes)}:)#{regexp}/ : regexp
         end
       end
 

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -259,6 +259,34 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
         RUBY
       end
     end
+
+    context 'and AllowQualifiedName option is not enabled' do
+      let(:cop_config) { { 'Max' => 80, 'AllowURI' => true, 'AllowQualifiedName' => false } }
+
+      it 'registers an offense when the excessive characters are part of a constant path containing `Http::`' do
+        expect_offense(<<~RUBY)
+          # The argument passed to obj.do_something must be an instance of Networking::Http::Response
+                                                                                          ^^^^^^^^^^^ Line is too long. [91/80]
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when the excessive characters are part of a URI whose scheme case differs from `URISchemes`' do
+        expect_offense(<<~RUBY)
+          # See: HTTPS://GITHUB.COM/RUBOCOP/RUBOCOP/COMMIT/3B48D8BDF5B1C2E05E35061837309890F04AB08C
+                                                                                          ^^^^^^^^^ Line is too long. [89/80]
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'does not register an offense when the excessive characters are part of a URI matching `URISchemes` exactly' do
+        expect_no_offenses(<<~RUBY)
+          # See: https://github.com/rubocop/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c
+        RUBY
+      end
+    end
   end
 
   context 'when AllowQualifiedName option is enabled' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
       end
     end
 
+    context 'when the excess is a constant path containing `Http::`' do
+      it 'accepts' do
+        expect_no_offenses(<<~RUBY)
+          unless long_variable_name.is_a?(ExampleNamespace::Networking::Http::Response)
+            puts 1
+          end
+        RUBY
+      end
+    end
+
     context 'when the modifier form matches an allowed pattern' do
       let(:line_length_config) { super().merge('AllowedPatterns' => ['^\s*puts']) }
 


### PR DESCRIPTION
The uri gem 1.1.0 (bundled with Ruby 4.0) changed `URI::RFC2396_Parser#make_regexp` to match schemes with a case-insensitive lookahead (`(?i:http|https)`), where uri 1.0.4 and earlier matched them case-sensitively. As a result, constant paths such as `Http::UploadedFile`, `HTTP::Client`, or `Https::Connection` matched the `AllowURI` regexp of `Layout/LineLength`, and a long line ending with such a constant could be exempted as if it contained a URI. The mis-match also leaked into `Style/IfUnlessModifier` and other modifier cops, which consult the same URI exemption through `StatementModifier#allowed_by_uri?`, so they could suggest a modifier form that does not actually fit.

Design decision: prepend a case-sensitive lookahead for the configured `URISchemes` to the regexp built by `make_regexp`, so only schemes written in the exact case given in `URISchemes` are treated as URIs. This restores the longstanding behavior RuboCop had with uri 1.0.4 and earlier and makes the result independent of the installed uri version. Users who want uppercase URIs like `HTTP://EXAMPLE.COM` to be exempted can add the uppercase scheme to `URISchemes`. The alternative of only excluding `scheme::` constant shapes was rejected because it would keep the behavior dependent on the uri gem version.

Note that a trailing constant path can still be exempted by the separate `AllowQualifiedName` option, which is intentional and unchanged.

Fixes #15525.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
