### PR TITLE
[Fix #15526] Fix false positives in Layout/MultilineMethodCallIndentation for lines with multiple blocks

### DIFF
--- a/changelog/fix_false_positives_in_layout_multiline_method_call_indentation_20260805022711.md
+++ b/changelog/fix_false_positives_in_layout_multiline_method_call_indentation_20260805022711.md
@@ -1,0 +1,1 @@
+* [#15526](https://github.com/rubocop/rubocop/issues/15526): Fix false positives in `Layout/MultilineMethodCallIndentation` when a line has multiple single-line blocks before a multiline block. ([@koic][])

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -423,11 +423,11 @@ module RuboCop
         end
 
         def leftmost_call_on_same_line(node)
-          current = node.any_block_type? ? node.send_node : node
-          while current.receiver&.call_type? &&
-                current.receiver.loc?(:dot) &&
-                current.receiver.loc.dot.line == current.loc.dot.line
-            current = current.receiver
+          current = unwrap_block_node(node)
+          while (receiver = unwrap_block_node(current.receiver)) &&
+                receiver.call_type? && receiver.loc?(:dot) &&
+                receiver.loc.dot.line == current.loc.dot.line
+            current = receiver
           end
           current
         end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -1165,6 +1165,53 @@ RSpec.describe RuboCop::Cop::Layout::MultilineMethodCallIndentation, :config do
       RUBY
     end
 
+    it 'accepts aligned method chain when line has multiple single-line blocks before a multiline block' do
+      expect_no_offenses(<<~RUBY)
+        obj
+          .foo { _1.a }.bar { _1.b }
+          .each do |x|
+          do_something(x)
+        end
+      RUBY
+    end
+
+    it 'accepts aligned method chain when line has multiple single-line blocks before a method call' do
+      expect_no_offenses(<<~RUBY)
+        obj
+          .foo { _1.a }.bar { _1.b }
+          .baz(x)
+      RUBY
+    end
+
+    it 'accepts aligned method chain when line has multiple single-line blocks with safe navigation' do
+      expect_no_offenses(<<~RUBY)
+        obj
+          &.foo { _1.a }&.bar { _1.b }
+          &.each do |x|
+          do_something(x)
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects misaligned method call after multiple single-line blocks' do
+      expect_offense(<<~RUBY)
+        obj
+          .foo { _1.a }.bar { _1.b }
+            .each do |x|
+            ^^^^^ Align `.each` with `.foo` on line 2.
+            do_something(x)
+          end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        obj
+          .foo { _1.a }.bar { _1.b }
+          .each do |x|
+          do_something(x)
+        end
+      RUBY
+    end
+
     it 'accepts aligned method chained after single-line block on both calls' do
       expect_no_offenses(<<~RUBY)
         (0..foo).bar { baz }


### PR DESCRIPTION
When a chain line contains more than one single-line block, e.g.:

```ruby
users
  .group_by { _1[:name] }.transform_values { _1.pluck(:id) }
  .each do |name, user_ids|
  p(name, user_ids)
end
```

the cop reported "Align `.each` with `.transform_values`" even though `.each` is aligned with `.group_by`, and autocorrected to a misaligned layout. A plain method call continuation (`.page(x)`), three blocks on one line, and the safe navigation form were affected the same way.

`leftmost_call_on_same_line`, introduced by the fix for #15122, walks up the receiver chain only while the receiver is a call node. Since `BlockNode#single_line?` is based on the brace positions, the receiver of `.each` counts as a single-line block receiver and enters this walk, but the walk stopped at `.group_by { ... }` because that receiver is a block node, not a call node, and returned `.transform_values`. The #15122 shape (`.dup.sort_by { ... }`) worked only because its receiver was a plain send node.

Unwrap block receivers with the existing `unwrap_block_node` helper while walking, so the walk continues through single-line blocks to the leftmost call on the continuation's starting line. This follows the design decision of #15122: the alignment base is the leftmost call on that line even when earlier calls on the line carry blocks. As a consequence, a continuation that was previously aligned under the last block's method (the old offense's autocorrect result) is now reported and re-aligned to the leftmost call.

Fixes #15526.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
