### PR TITLE
Improve `Lint/NameTypo` performance by deferring the literal-name scan

### DIFF
--- a/changelog/change_improve_lint_name_typo_performance_by_deferring_the_literal_name_scan_20260804174456.md
+++ b/changelog/change_improve_lint_name_typo_performance_by_deferring_the_literal_name_scan_20260804174456.md
@@ -1,0 +1,1 @@
+* [#15529](https://github.com/rubocop/rubocop/pull/15529): Improve `Lint/NameTypo` performance by deferring the literal-name scan. ([@connorshea][])

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -129,11 +129,10 @@ module RuboCop
         end
 
         def constant_typo_suggestion(node)
-          return nil if literal_names.include?(node.short_name.to_s)
-
           namespace = resolve_constant_in_index(node.namespace)
           return nil unless namespace.is_a?(Rubydex::Namespace)
           return nil if namespace.find_member(node.short_name.to_s)
+          return nil if literal_names.include?(node.short_name.to_s)
 
           spell_check(node.short_name, constant_member_names(namespace))
         rescue StandardError
@@ -145,10 +144,10 @@ module RuboCop
         def method_typo_suggestion(node)
           setter = setter_call?(node)
           base = setter ? node.method_name.to_s.delete_suffix('=') : node.method_name.to_s
-          return nil if literal_names.include?(base)
 
           declaration = unknown_method_owner(node, base)
           return nil unless declaration
+          return nil if literal_names.include?(base)
 
           suggestion = spell_check(base, method_member_names(declaration))
           suggestion && setter ? "#{suggestion}=" : suggestion


### PR DESCRIPTION
AI Disclosure: This was discovered by having Claude Code profile a lint run to look for performance issues, and then implemented using Claude. I have reviewed it manually and tested it to ensure it works.

`literal_names` walks every symbol and string descendant in a given file and  them into a Set. This was previously being run before the check to decide whether there's any typo candidate, and so was wasting time without a good reason.

Reordering is safe here and causes no regressions.

Measured with `rake prof:run` over RuboCop's own 1737 files with `AllCops/UseProjectIndex` enabled:

  on_send        408 -> 128 samples (-69%), 2.2% -> 0.7% of total
  on_const        80 ->  46 samples (-43%)
  literal_names  336 ->  48 samples (-86%)

I don't think this warrants new tests, but happy to add them.

**Method:** 1742 files (`lib`, `spec`, `tasks`). Project index build and parsing
hoisted out of the timed region; both variants run in one process against the same
index and same parsed sources, interleaved A/B, 5 rounds after warmup.

| Variant | Mean | Stddev | Min |
|---|---|---|---|
| before — `literal_names` first | 0.641s | 0.073s | 0.567s |
| after — index lookup first | **0.305s** | 0.052s | **0.269s** |
| **Change** | **−52.4% (2.10x)** | | **−52.6% (2.11x)** |

Per-round, showing the distributions do not overlap:

| Round | before | after | Speedup |
|---|---|---|---|
| 1 | 0.606s | 0.271s | 2.24x |
| 2 | 0.683s | 0.407s | 1.68x |
| 3 | 0.764s | 0.291s | 2.63x |
| 4 | 0.584s | 0.269s | 2.17x |
| 5 | 0.567s | 0.285s | 1.99x |

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
