### PR TITLE
Improve `Lint/DeprecatedReference` performance by short-circuiting `deprecated?`

### DIFF
--- a/changelog/change_improve_deprecated_reference_perf_by_short_circuiting_20260804182005.md
+++ b/changelog/change_improve_deprecated_reference_perf_by_short_circuiting_20260804182005.md
@@ -1,0 +1,1 @@
+* [#15530](https://github.com/rubocop/rubocop/pull/15530): Improve `Lint/DeprecatedReference` performance by short-circuiting `deprecated?`. ([@connorshea][])

--- a/lib/rubocop/cop/lint/deprecated_reference.rb
+++ b/lib/rubocop/cop/lint/deprecated_reference.rb
@@ -150,10 +150,19 @@ module RuboCop
           false
         end
 
+        # Enumerated in a single pass that stops at the first non-deprecated
+        # definition, since materializing every definition of a declaration
+        # that is almost never deprecated dominates the cop's cost.
         def deprecated?(declaration)
-          definitions = declaration.definitions.to_a
+          any = false
 
-          definitions.any? && definitions.all?(&:deprecated?)
+          declaration.definitions.each do |definition|
+            return false unless definition.deprecated?
+
+            any = true
+          end
+
+          any
         end
 
         # References from a definition that is itself documented as deprecated

--- a/spec/rubocop/cop/lint/deprecated_reference_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_reference_spec.rb
@@ -209,5 +209,90 @@ RSpec.describe RuboCop::Cop::Lint::DeprecatedReference, :config do
         RUBY
       end
     end
+
+    # A declaration reopened across files has one definition per site, and only
+    # counts as deprecated when every one of them is tagged. The bare
+    # `@deprecated` tags keep the message independent of which definition the
+    # index yields first.
+    context 'for declarations with multiple definitions' do
+      let(:current_source) do
+        <<~RUBY
+          class Client < Api
+            def call
+              old_method
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when every definition of a method is deprecated' do
+        cop.project_index = index_with_current(
+          'file:///lib/api_a.rb' => "class Api\n  # @deprecated\n  def old_method\n  end\nend\n",
+          'file:///lib/api_b.rb' => "class Api\n  # @deprecated\n  def old_method\n  end\nend\n"
+        )
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              old_method
+              ^^^^^^^^^^ Method `old_method` is deprecated.
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when a later definition of a method is not deprecated' do
+        cop.project_index = index_with_current(
+          'file:///lib/api_a.rb' => "class Api\n  # @deprecated\n  def old_method\n  end\nend\n",
+          'file:///lib/api_b.rb' => "class Api\n  def old_method\n  end\nend\n"
+        )
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              old_method
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when an earlier definition of a method is not deprecated' do
+        cop.project_index = index_with_current(
+          'file:///lib/api_a.rb' => "class Api\n  def old_method\n  end\nend\n",
+          'file:///lib/api_b.rb' => "class Api\n  # @deprecated\n  def old_method\n  end\nend\n"
+        )
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          class Client < Api
+            def call
+              old_method
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when every definition of a class is deprecated' do
+        cop.project_index = index_with_current(
+          'file:///lib/legacy_a.rb' => "# @deprecated\nclass Legacy\nend\n",
+          'file:///lib/legacy_b.rb' => "# @deprecated\nclass Legacy\nend\n"
+        )
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          Legacy.new
+          ^^^^^^ Constant `Legacy` is deprecated.
+        RUBY
+      end
+
+      it 'does not register an offense when only one definition of a class is deprecated' do
+        cop.project_index = index_with_current(
+          'file:///lib/legacy_a.rb' => "# @deprecated\nclass Legacy\nend\n",
+          'file:///lib/legacy_b.rb' => "class Legacy\nend\n"
+        )
+
+        expect_no_offenses(<<~RUBY, '/lib/current.rb')
+          Legacy.new
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
AI Disclosure: This was discovered by having Claude Code profile a lint run to look for performance issues, and then implemented using Claude. I have reviewed it manually and tested it to ensure it works.

`deprecated?` created an array of definitions and then materialized every definition. Most declarations are not deprecated, so this walked the entire collection and then failed on the first element checked. Instead, we can enumerate once and return early once we find the first non-deprecated definition.

Measured with `rake prof:run` over RuboCop's own 1737 files with `AllCops/UseProjectIndex` enabled:

    on_const     265 -> 105 samples (-60%), 1.4% -> 0.6% of total
    deprecated?  209 samples, 98% of which was `Enumerable#to_a`

**Method:** 1742 files (`lib`, `spec`, `tasks`). Project index build and parsing hoisted out of the timed region; both variants run in one process against the same index and same parsed sources, interleaved A/B, 9 rounds after warmup.

| Variant | Mean | Median | Stddev | Min |
|---|---|---|---|---|
| before — `.to_a` + `any?` + `all?` | 0.659s | 0.652s | 0.025s | 0.638s |
| after — single pass, early return | **0.461s** | **0.440s** | 0.061s | **0.431s** |
| **Change** | **−30.0% (1.43x)** | **−32.5% (1.48x)** | | **−32.4% (1.48x)** |

Per-round:

| Round | before | after | Speedup |
|---|---|---|---|
| 1 | 0.664s | 0.440s | 1.51x |
| 2 | 0.638s | 0.445s | 1.43x |
| 3 | 0.641s | 0.450s | 1.43x |
| 4 | 0.651s | 0.444s | 1.47x |
| 5 | 0.643s | 0.438s | 1.47x |
| 6 | 0.726s | 0.634s | 1.15x |
| 7 | 0.656s | 0.434s | 1.51x |
| 8 | 0.652s | 0.433s | 1.51x |
| 9 | 0.656s | 0.431s | 1.52x |

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
