### PR TITLE
Merge department and cop-level `Exclude` settings

### DIFF
--- a/changelog/fix_merge_department_and_cop_level_exclude_settings_20260806112312.md
+++ b/changelog/fix_merge_department_and_cop_level_exclude_settings_20260806112312.md
@@ -1,0 +1,1 @@
+* [#11148](https://github.com/rubocop/rubocop/issues/11148): Merge department and cop-level `Exclude` settings. ([@bbatsov][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -168,7 +168,11 @@ module RuboCop
         department_config = self[badge.department_name]
         cop_config = for_cop(badge.to_s)
         if department_config
-          department_config.merge(cop_config)
+          merged_config = department_config.merge(cop_config)
+          if department_config['Exclude'] && cop_config['Exclude']
+            merged_config['Exclude'] = department_config['Exclude'] | cop_config['Exclude']
+          end
+          merged_config
         else
           cop_config
         end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -855,6 +855,39 @@ RSpec.describe RuboCop::Config do
           'Bar' => 43 }
       )
     end
+
+    context 'when both the department and the cop define `Exclude`' do
+      let(:hash) do
+        {
+          'Style' => { 'Exclude' => ['foo.rb'] },
+          'Style/Alias' => { 'Exclude' => ['bar.rb'] }
+        }
+      end
+
+      it 'merges the two `Exclude` lists' do
+        expect(configuration.for_badge(RuboCop::Cop::Style::Alias.badge)).to eq(
+          { 'Enabled' => true,
+            'Exclude' => ['foo.rb', 'bar.rb'] }
+        )
+      end
+    end
+
+    context 'when only the cop defines `Exclude`' do
+      let(:hash) do
+        {
+          'Style' => { 'Foo' => 42 },
+          'Style/Alias' => { 'Exclude' => ['bar.rb'] }
+        }
+      end
+
+      it 'keeps the cop `Exclude`' do
+        expect(configuration.for_badge(RuboCop::Cop::Style::Alias.badge)).to eq(
+          { 'Enabled' => true,
+            'Foo' => 42,
+            'Exclude' => ['bar.rb'] }
+        )
+      end
+    end
   end
 
   describe '#for_enabled_cop' do


### PR DESCRIPTION
Excluding a file at the department level (e.g. `Style: Exclude:`) silently failed for cops that ship their own default `Exclude`, like `Style/Documentation` - the cop-level list replaced the department one in `Config#for_badge` instead of being combined with it. Now the two lists are unioned, so a department-wide exclusion actually covers every cop in the department. `Include` is deliberately untouched, since unioning it would widen which files a cop runs on.

Fixes #11148

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/