### PR TITLE
Don't let modifier cops create lines past `Layout/LineLength` `Max`

### DIFF
--- a/changelog/fix_modifier_cops_creating_lines_past_line_length_max_20260806122345.md
+++ b/changelog/fix_modifier_cops_creating_lines_past_line_length_max_20260806122345.md
@@ -1,0 +1,1 @@
+* [#15531](https://github.com/rubocop/rubocop/issues/15531): Fix a regression in RuboCop 1.89 where the modifier cops could produce lines longer than `Layout/LineLength` `Max` when exemptions like `AllowedPatterns` matched the result. ([@bbatsov][])

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -35,8 +35,14 @@ module RuboCop
         condition.each_node.any?(&:lvasgn_type?)
       end
 
+      # The rendered modifier form is compared against the bare maximum, not
+      # `acceptable_line_length?`: `Layout/LineLength`'s exemptions describe
+      # long lines the user tolerates, not permission to manufacture new ones,
+      # so collapsing to modifier form must never push a line past the maximum.
       def modifier_fits_on_single_line?(node)
-        acceptable_line_length?(line_in_modifier_form(node), node.first_line)
+        return true unless max_line_length
+
+        line_length(line_in_modifier_form(node)) <= max_line_length
       end
 
       def line_in_modifier_form(node)
@@ -46,12 +52,12 @@ module RuboCop
         "#{code_before}#{to_modifier_form(node)}#{code_after(node)}"
       end
 
-      # Rather than comparing the rendered modifier form against the bare
-      # maximum, ask the question `Layout/LineLength` would: a line the user's
-      # configuration exempts (`Layout/LineLength` disabled at that line, an
-      # allowed pattern, an allowed cop directive, an allowed URI) fits by
-      # definition. This keeps every modifier cop consistent with
-      # `Layout/LineLength` instead of each reimplementing part of its policy.
+      # Whether an existing line is acceptable to `Layout/LineLength`,
+      # exemptions (the cop disabled at that line, an allowed pattern, an
+      # allowed cop directive, an allowed URI) included. Only for judging
+      # lines already in the source as too long - see
+      # `modifier_fits_on_single_line?` for why the exemptions must not apply
+      # when deciding whether a modifier line may be created.
       def acceptable_line_length?(line, line_number)
         return true unless max_line_length
         return true if line_length(line) <= max_line_length

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -28,16 +28,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     let(:long_url) { 'https://some.example.com/with/a/rather?long&and=very&complicated=path' }
 
     context 'when the excess is an allowed URI' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
+      it 'accepts' do
+        expect_no_offenses(<<~RUBY)
           if url == '#{long_url}'
-          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
             puts 1
           end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          puts 1 if url == '#{long_url}'
         RUBY
       end
 
@@ -67,16 +62,11 @@ RSpec.describe RuboCop::Cop::Style::IfUnlessModifier, :config do
     context 'when the modifier form matches an allowed pattern' do
       let(:line_length_config) { super().merge('AllowedPatterns' => ['^\s*puts']) }
 
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
+      it 'accepts' do
+        expect_no_offenses(<<~RUBY)
           if condition_with_a_rather_long_name_taking_up_space
-          ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
             puts 'a long message that would not fit within the configured maximum'
           end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          puts 'a long message that would not fit within the configured maximum' if condition_with_a_rather_long_name_taking_up_space
         RUBY
       end
     end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -138,16 +138,11 @@ RSpec.describe RuboCop::Cop::Style::WhileUntilModifier, :config do
     let(:long_url) { 'https://example.com/a/rather/long/path?with=query' }
 
     context 'when the excess is an allowed URI' do
-      it 'registers an offense and corrects to modifier form' do
-        expect_offense(<<~RUBY)
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
           while url == '#{long_url}'
-          ^^^^^ Favor modifier `while` usage when having a single-line body.
             step
           end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          step while url == '#{long_url}'
         RUBY
       end
     end


### PR DESCRIPTION
1.89's unified fit predicate applied `Layout/LineLength`'s exemption ladder in both directions, so an `AllowedPatterns` match (or a disable directive) let `Style/IfUnlessModifier` and friends collapse multiline conditionals into lines far past `Max` - Homebrew hit this with 179-char lines against a Max of 118. The exemptions describe long lines the user tolerates, not permission to create new ones, so the fits direction is back to the bare maximum comparison while the too-long direction keeps the exemptions (an existing exempted modifier line still won't be forced back to multiline).

Fixes #15531

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/