### PR TITLE
Fix `Lint/RedundantSafeNavigation` FP for shadowed block variables

### DIFF
--- a/changelog/fix_lint_redundant_safe_navigation_false_positive_for_shadowed_block_variables_20260806123242.md
+++ b/changelog/fix_lint_redundant_safe_navigation_false_positive_for_shadowed_block_variables_20260806123242.md
@@ -1,0 +1,1 @@
+* [#15517](https://github.com/rubocop/rubocop/issues/15517): Fix `Lint/RedundantSafeNavigation` false positive for shadowed block variables. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -12,6 +12,7 @@ module RuboCop
             @receiver = receiver
             @additional_nil_methods = additional_nil_methods
             @checked_nodes = {}.compare_by_identity
+            @receiver_scope_block = find_receiver_scope_block
           end
 
           def cant_be_nil?
@@ -60,6 +61,11 @@ module RuboCop
               return true if _cant_be_nil?(node.expression, receiver)
             end
 
+            # Nodes are compared structurally, so a same-named variable beyond the
+            # block that binds the receiver would match even though it is a
+            # different variable - stop before crossing that block.
+            return false if @receiver_scope_block.equal?(node.parent)
+
             if sequentially_reached?(node)
               node.left_siblings.reverse_each do |sibling|
                 next unless sibling.is_a?(AST::Node)
@@ -76,21 +82,41 @@ module RuboCop
           end
           # rubocop:enable Metrics
 
+          # The innermost block whose parameters bind the receiver - an explicit
+          # or shadowed parameter, `it`, or a numbered parameter. Nodes outside
+          # that block's body can only refer to a different, same-named variable.
+          def find_receiver_scope_block
+            return unless @receiver.lvar_type?
+
+            name = @receiver.children.first
+            child = @receiver
+            @receiver.each_ancestor do |ancestor|
+              return nil if ancestor.type?(:any_def, :sclass)
+              return ancestor if rebinds_name?(ancestor, child, name)
+
+              child = ancestor
+            end
+
+            nil
+          end
+
+          def rebinds_name?(ancestor, child, name)
+            ancestor.any_block_type? && ancestor.body.equal?(child) &&
+              ancestor.argument_list.any? { |argument| argument.name == name }
+          end
+
           def non_nil_method?(method_name)
             !NIL_METHODS.include?(method_name) && !@additional_nil_methods.include?(method_name)
           end
 
-          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           def sole_condition_of_parent_if?(node)
             child = node
             parent = node.parent
 
-            while parent
+            while parent && !parent.equal?(@receiver_scope_block)
               if parent.if_type?
-                unless parent.unless?
-                  condition = parent.condition
-                  return true if !child.equal?(condition) && non_nil_condition?(condition, node)
-                end
+                return true if non_nil_if_condition?(parent, child, node)
 
                 parent = find_top_if(parent) if parent.elsif?
               elsif else_branch?(parent)
@@ -104,7 +130,14 @@ module RuboCop
 
             false
           end
-          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+          def non_nil_if_condition?(if_node, child, node)
+            return false if if_node.unless?
+
+            condition = if_node.condition
+            !child.equal?(condition) && non_nil_condition?(condition, node)
+          end
 
           def non_nil_condition?(condition, node)
             return true if condition == node

--- a/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_safe_navigation_spec.rb
@@ -1023,6 +1023,57 @@ RSpec.describe RuboCop::Cop::Lint::RedundantSafeNavigation, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense when the receiver is `it` shadowing an outer `it`', :ruby34 do
+      expect_no_offenses(<<~RUBY)
+        p(values.map { it.map { it&.upcase } })
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is a block parameter shadowing an outer one' do
+      expect_no_offenses(<<~RUBY)
+        p(values.map { |val| val.map { |val| val&.upcase } })
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver shadows a variable used as a parent `if` condition' do
+      expect_no_offenses(<<~RUBY)
+        val = f
+        if val
+          arr.map { |val| val&.foo }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when method is called on a block parameter in the same block' do
+      expect_offense(<<~RUBY)
+        values.map do |val|
+          val.bar
+          val&.baz
+             ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        values.map do |val|
+          val.bar
+          val.baz
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when method is called on an unshadowed variable before the block' do
+      expect_offense(<<~RUBY)
+        foo.bar
+        arr.each { foo&.baz }
+                      ^^ Redundant safe navigation on non-nil receiver (detected by analyzing previous code/method invocations).
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo.bar
+        arr.each { foo.baz }
+      RUBY
+    end
   end
 
   it 'registers an offense when `&.` is used for `to_s`' do


### PR DESCRIPTION
With `InferNonNilReceiver` on, the nil-receiver checker compares nodes structurally, so a plain call on an outer `it` (or any same-named block parameter) counted as proof that a shadowing inner variable can't be nil - and the autocorrect turned `values.map { it.map { it&.upcase } }` into code that raises `NoMethodError`. The checker now stops its search at the block that binds the receiver, since anything beyond it refers to a different variable. Explicit parameters, shadowed ones, `it`, and numbered parameters are all covered.

Fixes #15517

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/