### PR TITLE
Prune excluded directories for relative directory arguments

### DIFF
--- a/changelog/fix_prune_excluded_directories_when_a_relative_path_is_passed_20260806123923.md
+++ b/changelog/fix_prune_excluded_directories_when_a_relative_path_is_passed_20260806123923.md
@@ -1,0 +1,1 @@
+* [#13022](https://github.com/rubocop/rubocop/issues/13022): Fix `rubocop .` (and other relative directory arguments) needlessly traversing directories excluded by the configuration, which made it much slower than `rubocop` in projects with large ignored trees. ([@bbatsov][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -21,7 +21,10 @@ module RuboCop
 
       args.uniq.each do |arg|
         files += if File.directory?(arg)
-                   target_files_in_dir(arg.chomp(File::SEPARATOR))
+                   # Expand the directory so that the traversal can prune directories the
+                   # config excludes - the exclude patterns are absolute paths, and glued
+                   # onto a relative base (`rubocop .`) they never match anything.
+                   target_files_in_dir(File.expand_path(arg.chomp(File::SEPARATOR)))
                  else
                    process_explicit_path(arg, mode)
                  end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -217,6 +217,30 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when a relative directory path is passed and the configuration excludes a directory' do
+      let(:args) { ['.'] }
+
+      before do
+        create_empty_file('excluded/ruby5.rb')
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            Exclude:
+              - 'excluded/**/*'
+        YAML
+      end
+
+      it 'prunes the excluded directory instead of traversing it' do
+        globbed_patterns = []
+        allow(Dir).to receive(:glob).and_wrap_original do |original, *glob_args, &block|
+          globbed_patterns.concat(Array(glob_args.first))
+          original.call(*glob_args, &block)
+        end
+
+        expect(found_files).not_to include(a_string_including('excluded'))
+        expect(globbed_patterns).not_to include(a_string_including('excluded'))
+      end
+    end
+
     context 'when a hidden directory path is passed' do
       let(:args) { ['.hidden'] }
 


### PR DESCRIPTION
`rubocop .` produced exactly the same results as `rubocop`, just slower - sometimes much slower. The config's `Exclude` patterns are absolutized, so glued onto a relative base dir they formed a glob that never matched anything and the target finder's directory pruning was silently defeated, traversing every excluded tree (`node_modules`, `tmp`, ...). Directory arguments are now expanded before traversal, which also covers `rubocop lib`-style invocations.

Fixes #13022

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/