### PR TITLE
Fix `Lint/UselessMethodDefinition` FP for methods with `**kwargs`

### DIFF
--- a/changelog/fix_lint_useless_method_definition_false_positive_for_methods_with_kwargs_20260806152259.md
+++ b/changelog/fix_lint_useless_method_definition_false_positive_for_methods_with_kwargs_20260806152259.md
@@ -1,0 +1,1 @@
+* [#10046](https://github.com/rubocop/rubocop/issues/10046): Fix `Lint/UselessMethodDefinition` false positive for methods with `**kwargs`. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/useless_method_definition.rb
+++ b/lib/rubocop/cop/lint/useless_method_definition.rb
@@ -59,7 +59,7 @@ module RuboCop
         end
 
         def use_rest_or_optional_args?(node)
-          node.arguments.any? { |arg| arg.type?(:restarg, :optarg, :kwoptarg) }
+          node.arguments.any? { |arg| arg.type?(:restarg, :optarg, :kwoptarg, :kwrestarg) }
         end
 
         def delegating?(node, def_node)

--- a/spec/rubocop/cop/lint/useless_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/useless_method_definition_spec.rb
@@ -214,6 +214,14 @@ RSpec.describe RuboCop::Cop::Lint::UselessMethodDefinition, :config do
     RUBY
   end
 
+  it 'does not register an offense when method definition contains rest keyword arguments' do
+    expect_no_offenses(<<~RUBY)
+      def method(**options)
+        super
+      end
+    RUBY
+  end
+
   it 'does not register an offense when method definition with generic method macro containing only `super` call' do
     expect_no_offenses(<<~RUBY)
       do_something def method


### PR DESCRIPTION
A `def method(**options); super; end` delegator isn't useless - when the parent's signature differs it changes which call shapes the method accepts, so removing it alters behavior. The cop already skips `*args`, optional and defaulted-keyword signatures for exactly this reason; `**kwargs` was just missing from the list.

Fixes #10046

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/