### PR TITLE
Preserve escape notation in `Style/StringConcatenation` autocorrect

### DIFF
--- a/changelog/fix_preserve_escape_notation_in_style_string_concatenation_autocorrect_20260806152836.md
+++ b/changelog/fix_preserve_escape_notation_in_style_string_concatenation_autocorrect_20260806152836.md
@@ -1,0 +1,1 @@
+* [#9543](https://github.com/rubocop/rubocop/issues/9543): Preserve escape notation in `Style/StringConcatenation` autocorrect. ([@bbatsov][])

--- a/lib/rubocop/cop/style/string_concatenation.rb
+++ b/lib/rubocop/cop/style/string_concatenation.rb
@@ -149,17 +149,26 @@ module RuboCop
         def adjust_str(part)
           case part.type
           when :str
-            if single_quoted?(part)
-              part.value.gsub(/(\\|"|#\{|#@|#\$)/, '\\\\\&')
-            else
-              part.value.inspect[1..-2]
-            end
+            adjust_str_literal(part)
           when :dstr, :begin
             part.children.map do |child|
               adjust_str(child)
             end.join
           else
             "\#{#{part.source}}"
+          end
+        end
+
+        def adjust_str_literal(part)
+          if single_quoted?(part)
+            part.value.gsub(/(\\|"|#\{|#@|#\$)/, '\\\\\&')
+          elsif double_quoted?(part)
+            # Reuse the source as written - rebuilding it from the value via
+            # `inspect` would rewrite the author's escape notation
+            # (e.g. `\x0a` into `\n`).
+            part.source[1..-2]
+          else
+            part.value.inspect[1..-2]
           end
         end
 
@@ -171,6 +180,10 @@ module RuboCop
 
         def single_quoted?(str_node)
           str_node.source.start_with?("'")
+        end
+
+        def double_quoted?(str_node)
+          str_node.source.start_with?('"')
         end
 
         def mode

--- a/spec/rubocop/cop/style/string_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/string_concatenation_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe RuboCop::Cop::Style::StringConcatenation, :config do
     RUBY
   end
 
+  it 'preserves the escape notation of double-quoted strings' do
+    expect_offense(<<~'RUBY')
+      "\x0a" + "test" + "A" + "\xff"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer string interpolation to string concatenation.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      "\x0atestA\xff"
+    RUBY
+  end
+
   it 'correctly handles nested concatenatable parts' do
     expect_offense(<<~RUBY)
       (user.vip? ? greeting + ', ' : '') + user.name + ' <' + user.email + '>'


### PR DESCRIPTION
The correction rebuilt double-quoted parts from the runtime value via `String#inspect`, which normalizes escapes - `"\x0a"` became `"\n"`, control characters turned into `\u` escapes, hex digits got upcased. Semantically identical output, but it rewrote notation the author chose deliberately, which is a real annoyance in byte-oriented codebases. Plain double-quoted literals now reuse their inner source verbatim; `%Q`, character literals and interpolated pieces keep the `inspect` fallback.

Fixes #9543

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/