### PR TITLE
Fix false positives in `Lint/ConstantReassignment` with compact namespaces

### DIFF
--- a/changelog/fix_false_positives_in_lint_constant_reassignment_with_compact_namespaces.md
+++ b/changelog/fix_false_positives_in_lint_constant_reassignment_with_compact_namespaces.md
@@ -1,0 +1,1 @@
+* [#15538](https://github.com/rubocop/rubocop/pull/15538): Fix false positives in `Lint/ConstantReassignment` when a constant is assigned in compact-style namespaces (e.g. `module A::B`). ([@alex-tan][])

--- a/lib/rubocop/cop/lint/constant_reassignment.rb
+++ b/lib/rubocop/cop/lint/constant_reassignment.rb
@@ -175,10 +175,19 @@ module RuboCop
         end
 
         def ancestor_namespaces(node)
-          node
-            .each_ancestor(:class, :module)
-            .map { |ancestor| ancestor.identifier.short_name }
-            .reverse
+          ancestors = node.each_ancestor(:class, :module).reverse_each
+
+          ancestors.with_object([]) do |ancestor, namespaces|
+            append_namespaces(namespaces, ancestor.identifier)
+          end
+        end
+
+        # Compact definitions (e.g. `module A::B`) contribute every path segment,
+        # and an absolute one (e.g. `module ::A::B`) discards the enclosing namespaces.
+        def append_namespaces(namespaces, identifier)
+          namespaces.clear if identifier.absolute?
+          namespaces.concat(identifier_namespaces(identifier))
+          namespaces << identifier.short_name
         end
 
         def unconditional_definition?(node)
@@ -188,14 +197,11 @@ module RuboCop
         end
 
         def definition_name(node)
-          identifier = node.identifier
+          namespaces = ancestor_namespaces(node)
+          append_namespaces(namespaces, node.identifier)
+          constant = namespaces.pop
 
-          if identifier.namespace&.cbase_type?
-            fully_qualified_name_for([], identifier.short_name)
-          else
-            namespaces = ancestor_namespaces(node) + identifier_namespaces(identifier)
-            fully_qualified_name_for(namespaces, identifier.short_name)
-          end
+          fully_qualified_name_for(namespaces, constant)
         end
 
         def identifier_namespaces(identifier)

--- a/spec/rubocop/cop/lint/constant_reassignment_spec.rb
+++ b/spec/rubocop/cop/lint/constant_reassignment_spec.rb
@@ -479,6 +479,81 @@ RSpec.describe RuboCop::Cop::Lint::ConstantReassignment, :config do
     RUBY
   end
 
+  it 'does not register an offense for the same constant in a compact and a top-level namespace' do
+    expect_no_offenses(<<~RUBY)
+      module Matcher
+        FOO = :bar
+      end
+
+      module Documentation::Matcher
+        FOO = :baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same constant in two compact namespaces' do
+    expect_no_offenses(<<~RUBY)
+      module A::Matcher
+        FOO = :bar
+      end
+
+      module B::Matcher
+        FOO = :baz
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for the same constant in a compact class and a top-level class' do
+    expect_no_offenses(<<~RUBY)
+      class Matcher
+        FOO = :bar
+      end
+
+      class Documentation::Matcher
+        FOO = :baz
+      end
+    RUBY
+  end
+
+  it 'registers an offense when reassigning a constant inside a compact namespace' do
+    expect_offense(<<~RUBY)
+      module A::B
+        FOO = :bar
+        FOO = :baz
+        ^^^^^^^^^^ Constant `FOO` is already assigned in this namespace.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a compact namespace reopens a nested namespace' do
+    expect_offense(<<~RUBY)
+      module A
+        module B
+          FOO = :bar
+        end
+      end
+
+      module A::B
+        FOO = :baz
+        ^^^^^^^^^^ Constant `FOO` is already assigned in this namespace.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when an absolute compact namespace escapes the enclosing namespace' do
+    expect_no_offenses(<<~RUBY)
+      module Outer
+        FOO = :bar
+      end
+
+      module Outer
+        module ::Other::Outer
+          FOO = :baz
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when class keyword reopens after constant assignment' do
     expect_no_offenses(<<~RUBY)
       FooError = Class.new(StandardError)


### PR DESCRIPTION
`Lint/ConstantReassignment` reports a constant as already assigned when the same constant name is used in a compact-style namespace (`module A::B`) and in an unrelated namespace that happens to share the last segment.

Given two unrelated modules:

```ruby
# knowledge_base_matcher.rb
module KnowledgeBaseMatcher
  DEFAULT_NUMBER_OF_RESULTS = 10
end

# documentation/knowledge_base_matcher.rb
module Documentation::KnowledgeBaseMatcher
  DEFAULT_NUMBER_OF_RESULTS = 20 # => Constant `DEFAULT_NUMBER_OF_RESULTS` is already assigned ...
end
```

`Documentation::KnowledgeBaseMatcher::DEFAULT_NUMBER_OF_RESULTS` and `KnowledgeBaseMatcher::DEFAULT_NUMBER_OF_RESULTS` are distinct constants, and Ruby emits no `already initialized constant` warning here, so the offense is a false positive. It reproduces both within a single file and across files via the project index.

The cause is `ancestor_namespaces`, which collapsed each enclosing `class`/`module` to its `identifier.short_name`:

```ruby
node
  .each_ancestor(:class, :module)
  .map { |ancestor| ancestor.identifier.short_name }
  .reverse
```

For `module Documentation::KnowledgeBaseMatcher` that yields `KnowledgeBaseMatcher`, dropping the `Documentation` prefix, so the namespace is tracked as `::KnowledgeBaseMatcher` and collides with the top-level module.

This builds the namespace from every path segment instead, clearing the accumulated namespaces when a definition is absolute (`module ::A::B`) since that escapes its lexical parent. `definition_name` already handled compact identifiers via `identifier_namespaces`, so it now shares the same helper rather than duplicating a subset of the logic.

That sharing also fixes the inverse false negative, where a compact definition reopening a nested namespace was not detected:

```ruby
module A
  module B
    FOO = :bar
  end
end

module A::B
  FOO = :baz # not previously reported; now correctly flagged
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

There is no existing issue for this, so the commit message has no `[Fix #issue-number]` prefix. `bundle exec rake default` passes: 32454 examples, 0 failures (3 pending), and RuboCop reports no offenses across all 1737 inspected files.
