### PR TITLE
[Fix #11119] Preserve persistent cop instances across files

### DIFF
--- a/changelog/fix_preserve_persistent_cop_instances_across_files_20260802154039.md
+++ b/changelog/fix_preserve_persistent_cop_instances_across_files_20260802154039.md
@@ -1,0 +1,1 @@
+* [#11119](https://github.com/rubocop/rubocop/issues/11119): Preserve persistent cop instances across files. ([@Eljees][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -67,6 +67,8 @@ module RuboCop
     end
 
     def run(paths)
+      @inspection_team_by_config = {}.compare_by_identity
+
       # Compute the cache source checksum once to avoid potential
       # inconsistencies between workers.
       ResultCache.source_checksum
@@ -496,15 +498,8 @@ module RuboCop
 
     def mobilize_team(processed_source)
       config = @config_store.for_file(processed_source.path)
-      team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
-
-      if @project_index
-        team.cops.each do |cop|
-          cop.project_index = @project_index
-        end
-      end
-
-      team
+      @inspection_team_by_config ||= {}.compare_by_identity
+      @inspection_team_by_config[config] ||= assemble_team(config)
     end
 
     def mobilized_cop_classes(config)
@@ -650,18 +645,20 @@ module RuboCop
     # otherwise dormant team that can be used for config- and option-
     # level caching in ResultCache.
     def standby_team(config)
-      @team_by_config ||= {}.compare_by_identity
-      @team_by_config[config] ||= begin
-        team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+      @standby_team_by_config ||= {}.compare_by_identity
+      @standby_team_by_config[config] ||= assemble_team(config)
+    end
 
-        if @project_index
-          team.cops.each do |cop|
-            cop.project_index = @project_index
-          end
+    def assemble_team(config)
+      team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
+
+      if @project_index
+        team.cops.each do |cop|
+          cop.project_index = @project_index
         end
-
-        team
       end
+
+      team
     end
   end
 end

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -93,6 +93,34 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       end
     end
 
+    context 'with a cop supporting multiple sources', :restore_registry do
+      let(:source) { '' }
+      let!(:persisting_cop_class) do
+        stub_cop_class('Custom::Persisting') do
+          def self.support_multiple_source?
+            true
+          end
+        end
+      end
+      let(:options) do
+        super().merge(cache: 'false', only: ['Custom/Persisting'])
+      end
+
+      before do
+        create_empty_file('example2.rb')
+        create_file('.rubocop.yml', <<~YAML)
+          Custom/Persisting:
+            Enabled: true
+        YAML
+      end
+
+      it 'uses the same cop instance for every file' do
+        expect(persisting_cop_class).to receive(:new).once.and_call_original
+
+        expect(runner.run([])).to be true
+      end
+    end
+
     context 'if there is an offense in an inspected file' do
       let(:source) { <<~RUBY }
         # frozen_string_literal: true


### PR DESCRIPTION
Fixes #11119: cops that declare `support_multiple_source?` were still re-instantiated for every inspected file, so the flag had no observable effect.

`Runner#mobilize_team` built a brand-new `Cop::Team` for each `processed_source`, which meant a fresh set of cop instances per file no matter what the cop declared. But `Team` is already designed to be reused across sources: `Team#be_ready` maps `@standby_cops` through `Cop::Base#ready`, and `ready` returns `self` when `support_multiple_source?` is true and a fresh instance otherwise. The per-file/per-run decision therefore belongs to `ready` — rebuilding the team above it made that branch dead code.

This caches the inspection team by config identity, using the same `compare_by_identity` approach `standby_team` already used, so `be_ready` gets to make the decision:

* `mobilize_team` memoizes into `@inspection_team_by_config`, which is reset at the start of `run`.
* The team-building body shared by `mobilize_team` and `standby_team` is extracted into `assemble_team`, and `@team_by_config` is renamed `@standby_team_by_config` so the two caches stay clearly distinct.

Cops that do *not* declare `support_multiple_source?` are unaffected: `ready` still hands them a fresh instance per file, so no state leaks between files.

`spec/rubocop/runner_spec.rb` gains a case with a stubbed cop declaring `support_multiple_source? == true`, run over two files, asserting `.new` is called exactly once. It fails on master (one instance per file) and passes with this change.

AI-assisted (LLM used for drafting the patch, the test and this description); the analysis and the runs are mine.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code. — I ran `bundle exec rspec spec/rubocop/runner_spec.rb` (25 examples, 0 failures) and `bundle exec rubocop` over the diff (clean), but not the full `rake default`, so I am leaving this unticked rather than claiming it. Happy to run it and report back if you would like that before review.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/