### PR TITLE
[Fix #13941] Fix false positives for Lint/UselessConstantScoping with class-like assignments

### DIFF
--- a/changelog/fix_false_positives_for_lint_useless_constant_scoping_with_class_new.md
+++ b/changelog/fix_false_positives_for_lint_useless_constant_scoping_with_class_new.md
@@ -1,0 +1,1 @@
+* [#13941](https://github.com/rubocop/rubocop/issues/13941): Fix false positives for `Lint/UselessConstantScoping` when assigning with `Class.new`, `Module.new`, `Struct.new`, or `Data.define` after `private`. ([@pdobb][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2718,6 +2718,7 @@ Lint/UselessConstantScoping:
   Description: 'Checks for useless constant scoping.'
   Enabled: pending
   VersionAdded: '1.72'
+  VersionChanged: '<<next>>'
 
 Lint/UselessDefaultValueArgument:
   Description: 'Checks for usage of `fetch` or `Array.new` with default value argument and block.'

--- a/lib/rubocop/cop/lint/useless_constant_scoping.rb
+++ b/lib/rubocop/cop/lint/useless_constant_scoping.rb
@@ -10,6 +10,11 @@ module RuboCop
       # It does not support autocorrection due to behavior change and multiple ways to fix it.
       # Or a public constant may be intended.
       #
+      # Constant assignments that define classes or modules via `Class.new`, `Module.new`,
+      # `Struct.new`, or `Data.define` are allowed. Those forms are class and module definitions
+      # written with assignment syntax, and match the common practice of placing nested
+      # `class` / `module` bodies after `private` without intending private constant visibility.
+      #
       # @example
       #
       #   # bad
@@ -29,6 +34,19 @@ module RuboCop
       #     PUBLIC_CONST = 42 # If private scope is not intended.
       #   end
       #
+      #   # good - class/module definitions via assignment, same as nested `class`/`module`
+      #   class Foo
+      #     private
+      #
+      #     def some_private_method
+      #     end
+      #
+      #     MyClass = Class.new
+      #     MyModule = Module.new
+      #     MyStruct = Struct.new(:name)
+      #     MyData = Data.define(:name)
+      #   end
+      #
       class UselessConstantScoping < Base
         MSG = 'Useless `private` access modifier for constant scope.'
 
@@ -37,9 +55,27 @@ module RuboCop
           (send nil? :private_constant $...)
         PATTERN
 
+        # Matches class/module-like constant assignments. Nested `class` / `module`
+        # keyword definitions are not visited by this cop; these assignment forms are
+        # the equivalent syntax and should be treated the same way.
+        # @!method class_or_module_definition_assignment?(node)
+        def_node_matcher :class_or_module_definition_assignment?, <<~PATTERN
+          {
+            (send (const {nil? cbase} {:Class :Module :Struct}) :new ...)
+            (send (const {nil? cbase} :Data) :define ...)
+            (any_block
+              {
+                (send (const {nil? cbase} {:Class :Module :Struct}) :new ...)
+                (send (const {nil? cbase} :Data) :define ...)
+              }
+              ...)
+          }
+        PATTERN
+
         def on_casgn(node)
           return unless after_private_modifier?(node.left_siblings)
           return if private_constantize?(node.right_siblings, node.name)
+          return if class_or_module_definition_assignment?(node.expression)
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
+++ b/spec/rubocop/cop/lint/useless_constant_scoping_spec.rb
@@ -172,4 +172,161 @@ RSpec.describe RuboCop::Cop::Lint::UselessConstantScoping, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for `Class.new` after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Class.new
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Class.new` with a superclass after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Class.new(Parent)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Class.new` with a block after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Class.new do
+          def baz
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `::Class.new` after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = ::Class.new
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Module.new` after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Module.new
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Module.new` with a block after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Module.new do
+          def baz
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Struct.new` after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Struct.new(:name)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Struct.new` with a block after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Struct.new(:name) do
+          def baz
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Data.define` after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Data.define(:name)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `Data.define` with a block after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        Bar = Data.define(:name) do
+          def baz
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for class-like constants mixed with private methods after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        attr_reader :name
+
+        def some_private_method
+        end
+
+        MySubClass = Class.new
+        MyStruct = Struct.new(:attr1, :attr2)
+        MyData = Data.define(:attr1, :attr2)
+      end
+    RUBY
+  end
+
+  it 'still registers an offense for a non class-like constant after `private` methods' do
+    expect_offense(<<~RUBY)
+      class Foo
+        private
+
+        def some_private_method
+        end
+
+        CONST = 42
+        ^^^^^^^^^^ Useless `private` access modifier for constant scope.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for nested class and module keyword definitions after `private`' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        private
+
+        class Bar
+        end
+
+        module Baz
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes https://github.com/rubocop/rubocop/issues/13941

### Summary

`Lint/UselessConstantScoping` currently flags constant assignments after `private`, including class-like definitions such as:

```ruby
class MyBaseClass
  private

  attr_reader :name

  MySubClass = Class.new          # offense today
  MyStruct = Struct.new(:name)    # offense today
  MyData = Data.define(:name)     # offense today
end
```

Nested `class` / `module` keyword definitions in the same position are not flagged. That inconsistency is what led to this issue.

After discussion on the issue and on the earlier PR (#13944), the direction settled on **allowing** these assignment forms for practical symmetry with keyword-based class/module definitions, rather than expanding the cop to flag keyword definitions as well. See [koic's comment](https://github.com/rubocop/rubocop/pull/13944#issuecomment-2752108428).

### Changes

- Skip offenses when the constant's RHS is a class/module-like definition:
  - `Class.new` / `::Class.new` (with optional superclass and/or block)
  - `Module.new` / `::Module.new` (with optional block)
  - `Struct.new` / `::Struct.new` (with optional block)
  - `Data.define` / `::Data.define` (with optional block)
- Block variants cover `block`, `numblock`, and `itblock` via `any_block`.
- Plain constants such as `CONST = 42` after `private` are still flagged.
- Docs and tests updated; changelog entry added.

### Example after this change

```ruby
class MyBaseClass
  private

  attr_reader :name

  class MySubClass
  end

  MySubClass2 = Class.new           # no offense
  MyStruct = Struct.new(:attr1)     # no offense
  MyData = Data.define(:attr1)      # no offense
  CONST = 42                        # still an offense
end
```

### Note on a possible follow-up

@bbatsov also suggested a configuration option to allow a general mixture of methods and plain constants after `private` (for cases like `CONST = 1` used by private methods without `private_constant`). This PR intentionally stays focused on the class-like assignment false positives from #13941; a separate option could still be added later if desired.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran focused specs for this cop (`bundle exec rspec spec/rubocop/cop/lint/useless_constant_scoping_spec.rb`).
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.