### PR TITLE
Suppress multi-line offenses with a directive on any of their lines

### DIFF
--- a/changelog/fix_suppress_multi_line_offenses_with_a_directive_on_any_of_their_lines_20260807105450.md
+++ b/changelog/fix_suppress_multi_line_offenses_with_a_directive_on_any_of_their_lines_20260807105450.md
@@ -1,0 +1,1 @@
+* [#14379](https://github.com/rubocop/rubocop/issues/14379): Suppress multi-line offenses with a directive on any of their lines. ([@bbatsov][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -45,6 +45,20 @@ module RuboCop
       disabled_line_ranges.none? { |range| range.include?(line_number) }
     end
 
+    # Whether the cop is enabled for all of the given line span. The cop
+    # counts as disabled for the span when any of its disabled ranges
+    # overlaps it, so that a directive on any line of a multi-line offense
+    # suppresses the offense.
+    def cop_enabled_at_lines?(cop, first_line, last_line)
+      cop = cop.cop_name if cop.respond_to?(:cop_name)
+      disabled_line_ranges = cop_disabled_line_ranges[cop]
+      return true unless disabled_line_ranges
+
+      disabled_line_ranges.none? do |range|
+        range.end >= first_line && range.begin <= last_line
+      end
+    end
+
     def cop_opted_in?(cop)
       opt_in_cops.include?(cop.cop_name)
     end

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -208,7 +208,7 @@ module RuboCop
         severity = find_severity(range_to_pass, severity)
         message = find_message(range_to_pass, message)
 
-        status, corrector = enabled_line?(range.line) ? correct(range, &block) : :disabled
+        status, corrector = enabled_lines?(range) ? correct(range, &block) : :disabled
 
         # Since this range may be generated from Ruby code embedded in some
         # template file, we convert it to location info in the original file.
@@ -522,6 +522,16 @@ module RuboCop
         return true if @options[:ignore_disable_comments] || !@processed_source
 
         @processed_source.comment_config.cop_enabled_at_line?(self, line_number)
+      end
+
+      # A multi-line offense is suppressed by a directive on any line of its
+      # range, not only its first line, matching the intuition that the
+      # directive is attached to the offending code.
+      def enabled_lines?(range)
+        return true if @options[:ignore_disable_comments] || !@processed_source
+
+        comment_config = @processed_source.comment_config
+        comment_config.cop_enabled_at_lines?(self, range.first_line, range.last_line)
       end
 
       def find_severity(_range, severity)

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -198,7 +198,11 @@ module RuboCop
         end
 
         def range_with_offense?(range, offenses = offenses_to_check)
-          offenses.none? { |offense| range.cover?(offense.line) }
+          # An offense is covered when the disabled range overlaps any line of
+          # its span, mirroring how offenses are suppressed.
+          offenses.none? do |offense|
+            offense.line <= range.end && offense.location.last_line >= range.begin
+          end
         end
 
         def all_disabled?(comment)

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -195,6 +195,28 @@ RSpec.describe RuboCop::CommentConfig do
     end
   end
 
+  describe '#cop_enabled_at_lines?' do
+    let(:source) do
+      <<~RUBY
+        def foo(a,
+                b) # rubocop:disable Metrics/ParameterLists
+        end
+      RUBY
+    end
+
+    it 'returns false when a disabled range overlaps any line of the span' do
+      expect(comment_config).not_to be_cop_enabled_at_lines('Metrics/ParameterLists', 1, 2)
+    end
+
+    it 'returns true when no disabled range overlaps the span' do
+      expect(comment_config).to be_cop_enabled_at_lines('Metrics/ParameterLists', 3, 3)
+    end
+
+    it 'returns true for a cop without directives' do
+      expect(comment_config).to be_cop_enabled_at_lines('Style/ClassVars', 1, 3)
+    end
+  end
+
   describe '#extra_enabled_comments' do
     subject(:extra) { comment_config.extra_enabled_comments }
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
 
     before do
-      allow(processed_source.comment_config).to receive(:cop_enabled_at_line?).and_return(false)
+      allow(processed_source.comment_config).to receive(:cop_enabled_at_lines?).and_return(false)
     end
 
     context 'ignore_disable_comments is false' do

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -366,6 +366,35 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
         end
       end
 
+      context 'and there is a multi-line offense' do
+        let(:offenses) do
+          [
+            RuboCop::Cop::Offense.new(:convention,
+                                      FakeLocation.new(line: 1, column: 8, last_line: 2),
+                                      'Avoid parameter lists longer than 5 parameters.',
+                                      'Metrics/ParameterLists')
+          ]
+        end
+
+        it 'returns no offense for a directive on a later line of the offense' do
+          expect_no_offenses(<<~RUBY)
+            def foo(a:, b:, c:,
+                    d:, e:, f:) # rubocop:disable Metrics/ParameterLists
+            end
+          RUBY
+        end
+
+        it 'returns an offense for a directive on a line past the offense' do
+          expect_offense(<<~RUBY)
+            def foo(a:, b:, c:,
+                    d:, e:, f:)
+              do_something # rubocop:disable Metrics/ParameterLists
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ParameterLists`.
+            end
+          RUBY
+        end
+      end
+
       context 'and there are two offenses' do
         let(:message) { 'Replace class var @@class_var with a class instance var.' }
         let(:cop_name) { 'Style/ClassVars' }

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe RuboCop::Cop::Metrics::ParameterLists, :config do
     RUBY
   end
 
+  it 'accepts a multi-line parameter list with a disable directive on its last line' do
+    expect_no_offenses(<<~RUBY)
+      def meth(a, b, c,
+               d, e) # rubocop:disable Metrics/ParameterLists
+      end
+    RUBY
+  end
+
   it 'accepts a proc with more than 4 parameters' do
     expect_no_offenses(<<~RUBY)
       proc { |a, b, c, d, e| }

--- a/spec/support/fake_location.rb
+++ b/spec/support/fake_location.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 # Tests may use this to fake out a location structure in an Offense.
-FakeLocation = Struct.new(:line, :column, keyword_init: true)
+FakeLocation = Struct.new(:line, :column, :last_line, keyword_init: true) do
+  alias_method :first_line, :line
+
+  def initialize(line:, column:, last_line: nil)
+    super(line: line, column: column, last_line: last_line || line)
+  end
+end


### PR DESCRIPTION
An offense was only checked against its first line when consulting `rubocop:disable` directives, so a trailing disable on a later line of a multi-line offense - like the closing line of a multi-line `def` with too many parameters - didn't suppress it, and `Lint/RedundantCopDisableDirective` then flagged the directive as unnecessary on top. The suppression check and the redundancy analysis now both intersect the offense's whole line span with the disabled ranges, which is the generic fix suggested when the per-cop approach was rejected in #14380.

This is a deliberate behavior change: a directive on any line an offense spans now suppresses it, matching the intuition that the comment is attached to the offending code. Directives that don't touch any line of an offense behave exactly as before.

Fixes #14379

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/