### PR TITLE
[Fix #15541] Fix a false negative for `Lint/OutOfRangeRegexpRef`

### DIFF
--- a/changelog/fix_a_false_negative_for_lint_out_of_range_regexp_ref_20260807183855.md
+++ b/changelog/fix_a_false_negative_for_lint_out_of_range_regexp_ref_20260807183855.md
@@ -1,0 +1,1 @@
+* [#15541](https://github.com/rubocop/rubocop/issues/15541): Fix a false negative for `Lint/OutOfRangeRegexpRef` when a preceding element access with a non-string literal argument (e.g. `hash[:key]`) discarded the tracked capture count. ([@koic][])

--- a/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
+++ b/lib/rubocop/cop/lint/out_of_range_regexp_ref.rb
@@ -53,6 +53,8 @@ module RuboCop
         end
 
         def after_send(node)
+          return if backrefs_unaffected?(node)
+
           @valid_ref = nil
 
           if regexp_first_argument?(node)
@@ -109,6 +111,19 @@ module RuboCop
                        else
                          node.each_capture(named: false).count
                        end
+        end
+
+        # A call such as `hash[:key]` or `array[0]` cannot involve a regexp match:
+        # a non-string literal cannot act as a pattern (whereas `sub`, `gsub`,
+        # and `match` treat a string one as a pattern and do set backreferences),
+        # and `$~` is frame-local, so a user-defined method cannot change
+        # the caller's backreferences either.
+        def backrefs_unaffected?(send_node)
+          first_argument = send_node.first_argument
+          return false unless first_argument&.basic_literal?
+          return false if first_argument.str_type?
+
+          !regexp_receiver?(send_node)
         end
 
         def regexp_first_argument?(send_node)

--- a/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
+++ b/spec/rubocop/cop/lint/out_of_range_regexp_ref_spec.rb
@@ -138,6 +138,47 @@ RSpec.describe RuboCop::Cop::Lint::OutOfRangeRegexpRef, :config do
     RUBY
   end
 
+  it 'registers an offense for a reference following `match?` on an element access with a symbol key' do
+    expect_offense(<<~RUBY)
+      foo[:bar].match?(/(baz)/) && $1
+                                   ^^ $1 is out of range (no regexp capture groups detected).
+    RUBY
+  end
+
+  it 'registers an offense when an element access with a symbol key follows a regexp match' do
+    expect_offense(<<~RUBY)
+      /(foo)/ =~ bar
+      baz[:qux]
+      puts $2
+           ^^ $2 is out of range (1 regexp capture group detected).
+    RUBY
+  end
+
+  it 'registers an offense when an element access with an integer index follows a regexp match' do
+    expect_offense(<<~RUBY)
+      /(foo)/ =~ bar
+      baz[0]
+      puts $2
+           ^^ $2 is out of range (1 regexp capture group detected).
+    RUBY
+  end
+
+  it 'does not register an offense when an element access with a non-literal argument follows a regexp match' do
+    expect_no_offenses(<<~RUBY)
+      /(foo)/ =~ bar
+      baz[qux]
+      puts $2
+    RUBY
+  end
+
+  it 'does not register an offense when an element access with a string argument follows a regexp match' do
+    expect_no_offenses(<<~RUBY)
+      /(foo)/ =~ bar
+      baz['qux']
+      puts $2
+    RUBY
+  end
+
   it 'does not register an offense when in range references are used inside a when clause' do
     expect_no_offenses(<<~RUBY)
       case "foobar"


### PR DESCRIPTION
The cop tracks the capture count of the last matched regexp in `@valid_ref` and resets it to nil (unknown) for every call to a method that can take a regexp, because such a call may change the backreferences. `[]` is on that list for `String#[/regexp/]`, so a plain element access like `hash[:key]` or `array[0]` also discarded the tracked state, and references after it were never checked:

```ruby
foo[:bar].match?(/(b)/) && $1 # no offense, while the same code without `[:bar]` reports `$1`
```

A call whose first argument is a non-string literal cannot involve a regexp match, so it now keeps the tracked state. This is decided by the argument alone because `$~` is frame-local in Ruby: a user-defined `[]` that matches internally cannot change the caller's backreferences.
String literals remain conservative since `sub`, `gsub`, and `match` treat a string argument as a pattern and do set `$~`. A regexp receiver still resets the state (`/(x)/ === :sym` sets `$~` for symbols).

Fixes #15541.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
