### PR TITLE
Make `Lint/CopDirectiveSyntax` catch keyword typos and unknown cop names

### DIFF
--- a/changelog/change_make_lint_cop_directive_syntax_catch_keyword_typos_and_unknown_cop_names_20260807131710.md
+++ b/changelog/change_make_lint_cop_directive_syntax_catch_keyword_typos_and_unknown_cop_names_20260807131710.md
@@ -1,0 +1,1 @@
+* [#14673](https://github.com/rubocop/rubocop/issues/14673): Make `Lint/CopDirectiveSyntax` catch keyword typos and unknown cop names. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1734,6 +1734,7 @@ Lint/CopDirectiveSyntax:
   Description: 'Checks that `# rubocop:` directives are strictly formatted.'
   Enabled: pending
   VersionAdded: '1.72'
+  VersionChanged: '<<next>>'
 
 Lint/DataDefineOverride:
   Description: 'Disallow overriding the `Data` built-in methods via `Data.define`.'

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -42,6 +42,18 @@ module RuboCop
       #   # good
       #   # rubocop:disable Layout/LineLength -- comment
       #
+      #   # bad
+      #   # rucocop:disable Layout/LineLength
+      #
+      #   # good
+      #   # rubocop:disable Layout/LineLength
+      #
+      #   # bad
+      #   # rubocop:disable Layout/LineLenght
+      #
+      #   # good
+      #   # rubocop:disable Layout/LineLength
+      #
       class CopDirectiveSyntax < Base
         COMMON_MSG = 'Malformed directive comment detected.'
 
@@ -50,19 +62,37 @@ module RuboCop
         MISSING_COP_NAME_MSG = 'The cop name is missing.'
         MALFORMED_COP_NAMES_MSG = 'Cop names must be separated by commas. ' \
                                   'Comment in the directive must start with `--`.'
+        INVALID_KEYWORD_MSG = 'The directive keyword must be `rubocop`, not `%<keyword>s`.'
+        UNKNOWN_COP_MSG = 'Unknown cop name `%<name>s`%<suggestion>s.'
+
+        # A comment that looks like an attempted directive: any keyword
+        # followed by a colon and a valid mode name.
+        NEAR_MISS_KEYWORD_REGEXP = /
+          \A\#+\s*(?<keyword>[A-Za-z][\w-]*)\s*:\s*
+          (?:#{DirectiveComment::AVAILABLE_MODES.join('|')})\b
+        /x.freeze
 
         def on_new_investigation
           processed_source.comments.each do |comment|
             directive_comment = DirectiveComment.new(comment)
-            next unless directive_comment.start_with_marker?
-            next unless directive_comment.malformed?
-
-            message = offense_message(directive_comment)
-            add_offense(comment, message: message)
+            if directive_comment.start_with_marker?
+              check_directive(comment, directive_comment)
+            elsif (keyword = near_miss_keyword(comment))
+              message = format("#{COMMON_MSG} #{INVALID_KEYWORD_MSG}", keyword: keyword)
+              add_offense(comment, message: message)
+            end
           end
         end
 
         private
+
+        def check_directive(comment, directive_comment)
+          if directive_comment.malformed?
+            add_offense(comment, message: offense_message(directive_comment))
+          elsif (name = unknown_cop_name(directive_comment))
+            add_offense(comment, message: unknown_cop_message(directive_comment, name))
+          end
+        end
 
         # rubocop:disable Metrics/MethodLength
         def offense_message(directive_comment)
@@ -82,6 +112,42 @@ module RuboCop
           "#{COMMON_MSG} #{additional_msg}"
         end
         # rubocop:enable Metrics/MethodLength
+
+        def near_miss_keyword(comment)
+          match = comment.text.match(NEAR_MISS_KEYWORD_REGEXP)
+          return unless match
+
+          keyword = match[:keyword]
+          return if keyword == 'rubocop'
+
+          keyword if similar_to_rubocop?(keyword)
+        end
+
+        def similar_to_rubocop?(keyword)
+          return true if keyword.casecmp?('rubocop')
+          # `DidYouMean` is not always available - see `NameSimilarity`.
+          return false unless defined?(DidYouMean::Levenshtein)
+
+          DidYouMean::Levenshtein.distance(keyword.downcase, 'rubocop') <= 2
+        end
+
+        def unknown_cop_name(directive_comment)
+          return if directive_comment.push? || directive_comment.pop? || directive_comment.all_cops?
+
+          registry = directive_comment.cop_registry
+          directive_comment.raw_cop_names.find do |name|
+            next false if registry.department?(name)
+
+            qualified = registry.qualified_cop_name(name, nil, warn: false)
+            !registry.contains_cop_matching?([qualified])
+          end
+        end
+
+        def unknown_cop_message(directive_comment, name)
+          similar = NameSimilarity.find_similar_name(name, directive_comment.cop_registry.names)
+          suggestion = similar ? " (did you mean `#{similar}`?)" : ''
+          format(UNKNOWN_COP_MSG, name: name, suggestion: suggestion)
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -102,4 +102,68 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
     RUBY
   end
+
+  context 'with a near-miss directive keyword' do
+    it 'registers an offense for a typo in the keyword' do
+      expect_offense(<<~RUBY)
+        # rucocop:disable Layout/LineLength
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The directive keyword must be `rubocop`, not `rucocop`.
+      RUBY
+    end
+
+    it 'registers an offense for a wrongly-cased keyword' do
+      expect_offense(<<~RUBY)
+        # RuboCop:disable Layout/LineLength
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The directive keyword must be `rubocop`, not `RuboCop`.
+      RUBY
+    end
+
+    it 'registers an offense for a trailing near-miss directive' do
+      expect_offense(<<~RUBY)
+        a = 1 # robocop:disable Layout/LineLength
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. The directive keyword must be `rubocop`, not `robocop`.
+      RUBY
+    end
+
+    it 'does not register an offense for other tools directives' do
+      expect_no_offenses(<<~RUBY)
+        # pylint: disable=foo
+      RUBY
+    end
+
+    it 'does not register an offense for prose mentioning a mode name after a colon' do
+      expect_no_offenses(<<~RUBY)
+        # TODO: disable the cop here eventually
+      RUBY
+    end
+  end
+
+  context 'with an unknown cop name' do
+    it 'registers an offense with a suggestion for a misspelled cop name' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLenght
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown cop name `Layout/LineLenght` (did you mean `Layout/LineLength`?).
+      RUBY
+    end
+
+    it 'registers an offense in a list of cop names' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style/Encodingg
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown cop name `Style/Encodingg` (did you mean `Style/Encoding`?).
+      RUBY
+    end
+
+    it 'registers an offense for an unknown cop name in an enable directive' do
+      expect_offense(<<~RUBY)
+        # rubocop:enable Layout/LineLenght
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown cop name `Layout/LineLenght` (did you mean `Layout/LineLength`?).
+      RUBY
+    end
+
+    it 'does not register an offense for an unqualified cop name that resolves' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable LineLength
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Directive near-misses are completely silent today: `# rucocop:disable Foo` (or a wrongly-cased `# RuboCop:disable`) isn't a directive at all and quietly does nothing, and a misspelled cop name in an otherwise valid directive suppresses nothing while looking like it works. The cop now flags both - keywords within a small edit distance of `rubocop`, and cop names that resolve to neither a registered cop nor a department, with a did-you-mean suggestion. Deliberately conservative on the keyword side (colon + valid mode name required, small edit distance) so other tools' directives (`# pylint: disable=...`) and prose like `# TODO: disable this` stay untouched; a clean self-lint run over the whole repo backs that up.

Part of a larger effort to make directives either work exactly as written or fail loudly. Refs #14673, #14794.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/