### PR TITLE
Don't flag disables of pending cops as redundant

### DIFF
--- a/changelog/fix_don_t_flag_disables_of_pending_cops_as_redundant_20260807141045.md
+++ b/changelog/fix_don_t_flag_disables_of_pending_cops_as_redundant_20260807141045.md
@@ -1,0 +1,1 @@
+* [#7894](https://github.com/rubocop/rubocop/issues/7894): Don't flag disables of pending cops as redundant. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -105,9 +105,20 @@ module RuboCop
 
         def each_redundant_disable(&block)
           cop_disabled_line_ranges.each do |cop, line_ranges|
+            # A pending cop that is not enabled in this run produces no
+            # offenses, so its directives cannot be judged - they typically
+            # prepare the code for the moment the cop gets enabled.
+            next if pending_cop_not_run?(cop)
+
             each_already_disabled(cop, line_ranges, &block)
             each_line_range(cop, line_ranges, &block)
           end
+        end
+
+        def pending_cop_not_run?(cop)
+          cop_cfg = config.for_cop(cop)
+          cop_cfg['Enabled'] == 'pending' &&
+            !processed_source.registry.enabled_pending_cop?(cop_cfg, config, cop)
         end
 
         def each_line_range(cop, line_ranges)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -61,6 +61,34 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
             end
           end
 
+          context 'a cop that is pending in the config' do
+            let(:other_cops) { { 'Metrics/MethodLength' => { 'Enabled' => 'pending' } } }
+
+            it 'returns no offense when the pending cop does not run' do
+              expect_no_offenses(<<~RUBY)
+                # rubocop:disable Metrics/MethodLength
+                foo
+              RUBY
+            end
+
+            context 'when pending cops are enabled via `NewCops: enable`' do
+              let(:other_cops) do
+                {
+                  'AllCops' => { 'NewCops' => 'enable' },
+                  'Metrics/MethodLength' => { 'Enabled' => 'pending' }
+                }
+              end
+
+              it 'returns an offense' do
+                expect_offense(<<~RUBY)
+                  # rubocop:disable Metrics/MethodLength
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
+                  foo
+                RUBY
+              end
+            end
+          end
+
           context 'a department that is disabled in the config' do
             let(:config) do
               RuboCop::Config.new('Metrics' => { 'Enabled' => false })


### PR DESCRIPTION
A pending cop that isn't enabled in the current run produces no offenses, so `Lint/RedundantCopDisableDirective` judged its directives unnecessary - punishing exactly the teams that add disables ahead of enabling a new cop. Cops that are pending and not running are now skipped; once the cop is enabled (`NewCops: enable`, `--enable-pending-cops`), redundancy is judged as before. Config-disabled (`Enabled: false`) cops keep their existing handling.

Fixes #7894

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/