### PR TITLE
Don't autocorrect away directives for unknown cops

### DIFF
--- a/changelog/fix_don_t_autocorrect_away_directives_for_unknown_cops_20260807141540.md
+++ b/changelog/fix_don_t_autocorrect_away_directives_for_unknown_cops_20260807141540.md
@@ -1,0 +1,1 @@
+* [#8349](https://github.com/rubocop/rubocop/issues/8349): Don't autocorrect away directives for unknown cops. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -248,14 +248,23 @@ module RuboCop
           location = DirectiveComment.new(comment).range
           cop_names = cops.sort.map { |c| describe(c) }.join(', ')
 
-          add_offense(location, message: message(cop_names)) do |corrector|
-            range = comment_range_with_surrounding_space(location, comment.source_range)
+          # An unknown cop may just not be loaded in this run (e.g. a custom
+          # cop whose configuration failed to load) - removing its directive
+          # would destroy something that cannot be restored, so only report.
+          return add_offense(location, message: message(cop_names)) if any_unknown_cop?(cops)
 
-            if leave_free_comment?(comment, range)
-              corrector.replace(range, ' # ')
-            else
-              corrector.remove(range)
-            end
+          add_offense(location, message: message(cop_names)) do |corrector|
+            remove_entire_comment(corrector, location, comment)
+          end
+        end
+
+        def remove_entire_comment(corrector, location, comment)
+          range = comment_range_with_surrounding_space(location, comment.source_range)
+
+          if leave_free_comment?(comment, range)
+            corrector.replace(range, ' # ')
+          else
+            corrector.remove(range)
           end
         end
 
@@ -265,12 +274,27 @@ module RuboCop
           ranges = cop_ranges.map { |_, r| r }
 
           cop_ranges.each do |cop, range|
-            cop_name = describe(cop)
-            add_offense(range, message: message(cop_name)) do |corrector|
-              range = directive_range_in_list(range, ranges)
-              corrector.remove(range)
-            end
+            add_offense_for_cop_in_list(cop, range, ranges)
           end
+        end
+
+        def add_offense_for_cop_in_list(cop, range, ranges)
+          cop_name = describe(cop)
+          return add_offense(range, message: message(cop_name)) if unknown_cop?(cop)
+
+          add_offense(range, message: message(cop_name)) do |corrector|
+            corrector.remove(directive_range_in_list(range, ranges))
+          end
+        end
+
+        def any_unknown_cop?(cops)
+          cops.any? { |cop| unknown_cop?(cop) }
+        end
+
+        def unknown_cop?(cop)
+          return false if cop == 'all' || department_marker?(cop)
+
+          !all_cop_names.include?(cop)
         end
 
         def leave_free_comment?(comment, range)

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -97,13 +97,34 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           end
 
           context 'an unknown cop' do
-            it 'returns an offense' do
+            it 'returns an offense without removing the directive' do
               expect_offense(<<~RUBY)
                 # rubocop:disable UnknownCop
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `UnknownCop` (unknown cop).
               RUBY
 
-              expect_correction('')
+              expect_no_corrections
+            end
+          end
+
+          context 'an unknown cop alongside a cop with offenses' do
+            let(:offenses) do
+              [
+                RuboCop::Cop::Offense.new(:convention,
+                                          FakeLocation.new(line: 2, column: 0),
+                                          'Method has too many lines.',
+                                          'Metrics/MethodLength')
+              ]
+            end
+
+            it 'returns an offense without removing the unknown cop from the directive' do
+              expect_offense(<<~RUBY)
+                # rubocop:disable UnknownCop, Metrics/MethodLength
+                                  ^^^^^^^^^^ Unnecessary disabling of `UnknownCop` (unknown cop).
+                def m; end
+              RUBY
+
+              expect_no_corrections
             end
           end
 
@@ -314,7 +335,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
               RUBY
 
-              expect_correction('')
+              expect_no_corrections
             end
 
             context 'when the department starts with a lowercase letter' do
@@ -324,7 +345,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `lint/SelfAssignment` (did you mean `Lint/SelfAssignment`?).
                 RUBY
 
-                expect_correction('')
+                expect_no_corrections
               end
             end
 
@@ -335,7 +356,7 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Lint/selfAssignment` (did you mean `Lint/SelfAssignment`?).
                 RUBY
 
-                expect_correction('')
+                expect_no_corrections
               end
             end
           end


### PR DESCRIPTION
`Lint/RedundantCopDisableDirective` deleted any directive whose cop it couldn't resolve - including directives for custom or extension cops whose configuration simply failed to load in that invocation, with editor integrations as the classic trigger. That silently destroys something the tool cannot restore. The offense stays (with its did-you-mean hint for typos), but a directive naming a cop that isn't in the registry is no longer removed by autocorrect. Directives for known cops are corrected exactly as before, including mixed lists where only the known names get removed.

Fixes #8349

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/