### PR TITLE
Harden `push`/`pop` directive handling

### DIFF
--- a/changelog/fix_suggest_rubocop_pop_for_an_unclosed_push_directive_20260807150001.md
+++ b/changelog/fix_suggest_rubocop_pop_for_an_unclosed_push_directive_20260807150001.md
@@ -1,0 +1,1 @@
+* [#15547](https://github.com/rubocop/rubocop/pull/15547): Make `Lint/MissingCopEnableDirective` suggest `# rubocop:pop` instead of `# rubocop:enable` for an unclosed `# rubocop:push`. ([@bbatsov][])

--- a/changelog/new_flag_rubocop_pop_without_a_matching_push_20260807150002.md
+++ b/changelog/new_flag_rubocop_pop_without_a_matching_push_20260807150002.md
@@ -1,0 +1,1 @@
+* [#15547](https://github.com/rubocop/rubocop/pull/15547): Make `Lint/RedundantCopEnableDirective` flag `# rubocop:pop` directives without a matching `# rubocop:push`. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2141,7 +2141,7 @@ Lint/MissingCopEnableDirective:
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`.'
   Enabled: true
   VersionAdded: '0.52'
-  VersionChanged: '1.88'
+  VersionChanged: '<<next>>'
   # Maximum number of consecutive lines the cop can be disabled for.
   # 0 allows only single-line disables
   # 1 would mean the maximum allowed is the following:
@@ -2324,6 +2324,7 @@ Lint/RedundantCopEnableDirective:
   Description: Checks for rubocop:enable comments that can be removed.
   Enabled: true
   VersionAdded: '0.76'
+  VersionChanged: '<<next>>'
 
 Lint/RedundantDirGlobSort:
   Description: 'Checks for redundant `sort` method to `Dir.glob` and `Dir[]`.'

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -105,8 +105,8 @@ module RuboCop
           end
 
           if max_range == Float::INFINITY
-            # A range opened by `# rubocop:push` is closed by `# rubocop:pop`,
-            # not by `# rubocop:enable`.
+            # A range opened by `rubocop:push` is closed by `rubocop:pop`,
+            # not by `rubocop:enable`.
             enabling_directive = directive.push? ? '# rubocop:pop' : '# rubocop:enable'
             format(MSG, cop: cop, type: type, directive: enabling_directive)
           else

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -55,7 +55,7 @@ module RuboCop
       class MissingCopEnableDirective < Base
         include RangeHelp
 
-        MSG = 'Re-enable %<cop>s %<type>s with `# rubocop:enable` after disabling it.'
+        MSG = 'Re-enable %<cop>s %<type>s with `%<directive>s` after disabling it.'
         MSG_BOUND = 'Re-enable %<cop>s %<type>s within %<max_range>s lines after disabling it.'
 
         def on_new_investigation
@@ -98,13 +98,17 @@ module RuboCop
         end
 
         def message(cop, comment, type = 'cop')
+          directive = DirectiveComment.new(comment)
           if department_enabled?(cop, comment)
             type = 'department'
             cop = cop.split('/').first
           end
 
           if max_range == Float::INFINITY
-            format(MSG, cop: cop, type: type)
+            # A range opened by `# rubocop:push` is closed by `# rubocop:pop`,
+            # not by `# rubocop:enable`.
+            enabling_directive = directive.push? ? '# rubocop:pop' : '# rubocop:enable'
+            format(MSG, cop: cop, type: type, directive: enabling_directive)
           else
             format(MSG_BOUND, cop: cop, type: type, max_range: max_range)
           end

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -30,21 +30,55 @@ module RuboCop
       #   foo = "1"
       #   # rubocop:enable all
       #   baz
+      #
+      #   # bad
+      #   foo = 1
+      #   # rubocop:pop
+      #
+      #   # good
+      #   # rubocop:push -Style/StringLiterals
+      #   foo = "1"
+      #   # rubocop:pop
       class RedundantCopEnableDirective < Base
         include RangeHelp
         include SurroundingSpace
         extend AutoCorrector
 
         MSG = 'Unnecessary enabling of %<cop>s.'
+        MSG_ORPHAN_POP = 'Unnecessary `rubocop:pop` without a matching `rubocop:push`.'
 
         def on_new_investigation
-          return if processed_source.blank? || !processed_source.raw_source.include?('enable')
+          return if processed_source.blank?
 
+          source = processed_source.raw_source
+          check_extra_enables if source.include?('enable')
+          check_orphan_pops if source.include?('pop')
+        end
+
+        private
+
+        def check_extra_enables
           offenses = processed_source.comment_config.extra_enabled_comments
           offenses.each { |comment, cop_names| register_offense(comment, cop_names) }
         end
 
-        private
+        def check_orphan_pops
+          push_depth = 0
+          processed_source.comments.each do |comment|
+            directive = DirectiveComment.new(comment)
+            if directive.push?
+              push_depth += 1
+            elsif directive.pop?
+              push_depth.zero? ? register_orphan_pop(directive) : push_depth -= 1
+            end
+          end
+        end
+
+        def register_orphan_pop(directive)
+          add_offense(directive.range, message: MSG_ORPHAN_POP) do |corrector|
+            corrector.remove(range_with_surrounding_space(directive.range, side: :right))
+          end
+        end
 
         def register_offense(comment, cop_names)
           directive = DirectiveComment.new(comment)

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
         x =   0
       RUBY
     end
+
+    it 'suggests `# rubocop:pop` when a `push` with inline args has no matching `pop`' do
+      expect_offense(<<~RUBY)
+        # rubocop:push -Layout/SpaceAroundOperators
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:pop` after disabling it.
+        x =   0
+      RUBY
+    end
   end
 
   context 'when the cop is disabled in the config' do

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -378,4 +378,42 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
       RUBY
     end
   end
+
+  context 'with `rubocop:pop` directives' do
+    it 'registers an offense and corrects a `pop` without a matching `push`' do
+      expect_offense(<<~RUBY)
+        foo = 1
+        # rubocop:pop
+        ^^^^^^^^^^^^^ Unnecessary `rubocop:pop` without a matching `rubocop:push`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo = 1
+      RUBY
+    end
+
+    it 'registers an offense for a second `pop` after a matched pair' do
+      expect_offense(<<~RUBY)
+        # rubocop:push -Style/StringLiterals
+        foo = "1"
+        # rubocop:pop
+        # rubocop:pop
+        ^^^^^^^^^^^^^ Unnecessary `rubocop:pop` without a matching `rubocop:push`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:push -Style/StringLiterals
+        foo = "1"
+        # rubocop:pop
+      RUBY
+    end
+
+    it 'does not register an offense for a matched `push` / `pop` pair' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:push -Style/StringLiterals
+        foo = "1"
+        # rubocop:pop
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Two rough edges from the push/pop directives introduced in 1.84:

An orphan `# rubocop:pop` (no matching `push`) was silently ignored - almost always a mistake, like a deleted `push` leaving its `pop` behind. `Lint/RedundantCopEnableDirective` now flags and removes it.

And `Lint/MissingCopEnableDirective` told users to close an unclosed `# rubocop:push -Cop` with `# rubocop:enable`, but the directive that closes a push is `# rubocop:pop` - the message now says so.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/