### PR TITLE
Stop honoring wrongly-namespaced disable directives

### DIFF
--- a/changelog/change_stop_honoring_wrongly_namespaced_disable_directives_20260807150005.md
+++ b/changelog/change_stop_honoring_wrongly_namespaced_disable_directives_20260807150005.md
@@ -1,0 +1,1 @@
+* [#12219](https://github.com/rubocop/rubocop/issues/12219): Stop honoring wrongly-namespaced disable directives. ([@bbatsov][])

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -240,7 +240,12 @@ module RuboCop
     end
 
     def qualified_cop_name(cop_name)
-      Cop::Registry.qualified_cop_name(cop_name.strip, processed_source.file_path)
+      # A directive naming a cop under the wrong department is not honored -
+      # the mistake is surfaced by `Lint/RedundantCopDisableDirective` (with a
+      # did-you-mean hint) instead of a stderr warning that is easy to miss
+      # and disappears entirely on cached runs.
+      Cop::Registry.qualified_cop_name(cop_name.strip, processed_source.file_path,
+                                       correct_namespace: false)
     end
 
     # `Style/DisableCopsWithinSourceCodeDirective` cannot be disabled via

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -80,17 +80,22 @@ module RuboCop
           # This has to remain a strict inequality to handle
           # the case when max_range is Float::INFINITY
           return true if line_range.max - line_range.min < max_range + 2
+          # A name that is not registered as written (e.g. a wrongly-namespaced
+          # cop) suppresses nothing; `Lint/RedundantCopDisableDirective` reports
+          # it, so demanding its re-enablement would only add noise.
+          return true unless Registry.global.names.include?(cop)
+
+          expected_open_range?(cop, line_range)
+        end
+
+        def expected_open_range?(cop, line_range)
           # This cop is disabled in the config, it is not expected to be re-enabled
           return true if line_range.min == CommentConfig::CONFIG_DISABLED_LINE_RANGE_MIN
 
-          cop_class = RuboCop::Cop::Registry.global.find_by_cop_name cop
-          if cop_class &&
+          cop_class = RuboCop::Cop::Registry.global.find_by_cop_name(cop)
+          !!(cop_class &&
              !processed_source.registry.enabled?(cop_class, config) &&
-             line_range.max == Float::INFINITY
-            return true
-          end
-
-          false
+             line_range.max == Float::INFINITY)
         end
 
         def max_range

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -116,6 +116,11 @@ module RuboCop
         end
 
         def pending_cop_not_run?(cop)
+          # `Config#for_cop` corrects wrongly-namespaced names, but a name that
+          # is not registered as written never suppresses anything, so it is
+          # reported as unknown rather than exempted via the corrected cop.
+          return false unless all_cop_names.include?(cop)
+
           cop_cfg = config.for_cop(cop)
           cop_cfg['Enabled'] == 'pending' &&
             !processed_source.registry.enabled_pending_cop?(cop_cfg, config, cop)
@@ -342,7 +347,13 @@ module RuboCop
 
         SIMILAR_COP_NAMES_CACHE = Hash.new do |hash, cop_name|
           hash[:all_cop_names] = Registry.global.names unless hash.key?(:all_cop_names)
-          hash[cop_name] = NameSimilarity.find_similar_name(cop_name, hash[:all_cop_names])
+          # A registered cop with the same base name is a better suggestion
+          # than anything spelling similarity can find - the most common
+          # mistake is qualifying a cop with the wrong department.
+          basename = "/#{cop_name.split('/').last}"
+          same_basename = hash[:all_cop_names].find { |name| name.end_with?(basename) }
+          hash[cop_name] =
+            same_basename || NameSimilarity.find_similar_name(cop_name, hash[:all_cop_names])
         end
         private_constant :SIMILAR_COP_NAMES_CACHE
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -23,8 +23,8 @@ module RuboCop
         global.without_department(:Test).cops
       end
 
-      def self.qualified_cop_name(name, origin, warn: true)
-        global.qualified_cop_name(name, origin, warn: warn)
+      def self.qualified_cop_name(name, origin, warn: true, correct_namespace: true)
+        global.qualified_cop_name(name, origin, warn: warn, correct_namespace: correct_namespace)
       end
 
       # Changes momentarily the global registry
@@ -171,11 +171,19 @@ module RuboCop
       # @note Emits a warning if the provided name has an incorrect namespace
       #
       # @return [String] Qualified cop name
-      def qualified_cop_name(name, path, warn: true)
+      def qualified_cop_name(name, path, warn: true, correct_namespace: true)
         badge = Badge.parse(name)
         print_department_missing_warning(name, path) if warn && department_missing?(badge, name)
         return name if registered?(badge)
+        # A name qualified with the wrong department is returned as is when
+        # namespace correction is not wanted, so the caller can surface the
+        # mistake instead of silently acting on the corrected name.
+        return name if badge.qualified? && !correct_namespace
 
+        resolve_cop_name(badge, name, path, warn)
+      end
+
+      def resolve_cop_name(badge, name, path, warn)
         potential_badges = qualify_badge(badge)
 
         case potential_badges.size

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -546,13 +546,13 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
                    '  # rubocop: enable Style/NumericLiterals',
                    'end'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
-      expect($stderr.string)
-        .to eq(['example.rb: Warning: Style/LineLength has the wrong ' \
-                'namespace - replace it with Layout/LineLength',
-                ''].join("\n"))
-      # 2 real cops were disabled, and 1 that was incorrect
-      # 2 real cops was enabled, but only 1 had been disabled correctly
+      expect($stderr.string).to be_empty
+      # 2 real cops were disabled; the wrongly-namespaced `Style/LineLength` is
+      # not honored and gets reported with a suggestion instead.
+      # 2 real cops were enabled, but only 1 had been disabled correctly.
       expect($stdout.string).to eq(<<~RESULT)
+        #{abs('example.rb')}:3:19: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/LineLength` (did you mean `Layout/LineLength`?).
+        #{abs('example.rb')}:4:121: C: Layout/LineLength: Line is too long. [130/120]
         #{abs('example.rb')}:8:21: W: [Correctable] Lint/RedundantCopEnableDirective: Unnecessary enabling of Layout/LineLength.
         #{abs('example.rb')}:9:121: C: Layout/LineLength: Line is too long. [132/120]
         #{abs('example.rb')}:11:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -195,6 +195,22 @@ RSpec.describe RuboCop::CommentConfig do
     end
   end
 
+  describe 'a directive with a wrongly-namespaced cop name' do
+    let(:source) do
+      <<~RUBY
+        x = 1 # rubocop:disable Style/Void
+      RUBY
+    end
+
+    it 'does not disable the correctly-namespaced cop' do
+      expect(comment_config).to be_cop_enabled_at_line('Lint/Void', 1)
+    end
+
+    it 'tracks the range under the name as written' do
+      expect(comment_config.cop_disabled_line_ranges).to eq({ 'Style/Void' => [1..1] })
+    end
+  end
+
   describe '#cop_enabled_at_lines?' do
     let(:source) do
       <<~RUBY

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -352,6 +352,17 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
             end
           end
 
+          context 'a cop qualified with the wrong department' do
+            it 'returns an offense suggesting the correctly-namespaced cop' do
+              expect_offense(<<~RUBY)
+                # rubocop:disable Style/Void
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Style/Void` (did you mean `Lint/Void`?).
+              RUBY
+
+              expect_no_corrections
+            end
+          end
+
           context 'misspelled cops' do
             it 'returns an offense' do
               message = 'Unnecessary disabling of `KlassLength` (unknown ' \

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -166,6 +166,30 @@ RSpec.describe RuboCop::Cop::Registry do
       expect(qualified).to eql('Metrics/MethodLength')
     end
 
+    context 'when namespace correction is not wanted' do
+      it 'returns a wrongly-namespaced name as is, without a warning' do
+        qualified = nil
+
+        expect do
+          qualified = registry.qualified_cop_name('Style/MethodLength', origin,
+                                                  correct_namespace: false)
+        end.not_to output.to_stderr
+
+        expect(qualified).to eql('Style/MethodLength')
+      end
+
+      it 'still qualifies names without a namespace' do
+        warning = "/app/.rubocop.yml: Warning: no department given for MethodLength.\n"
+        qualified = nil
+
+        expect do
+          qualified = registry.qualified_cop_name('MethodLength', origin, correct_namespace: false)
+        end.to output(warning).to_stderr
+
+        expect(qualified).to eql('Metrics/MethodLength')
+      end
+    end
+
     context 'when cops share the same class name' do
       let(:cops) do
         [


### PR DESCRIPTION
A directive like `# rubocop:disable Style/Void` (the cop lives in `Lint`) was silently corrected and worked, with only an easy-to-miss stderr warning that exits 0 - and on cached runs the warning disappeared entirely, so CI looked clean while the mistake spread. The mistake now surfaces through the normal offense machinery: the directive is inert, the real cop's offenses appear, and `Lint/RedundantCopDisableDirective` flags the directive with a suggestion pointing at the correctly-namespaced cop (same-base-name matches now beat spelling similarity, so `Style/Void` suggests `Lint/Void` rather than `Style/Not`). `Lint/MissingCopEnableDirective` skips names that aren't registered as written, so one mistake produces one clear signal. Unqualified names (`# rubocop:disable LineLength`) still resolve exactly as before.

This is a deliberate behavior change: wrongly-namespaced directives that used to suppress offenses no longer do. Since offenses cache correctly (unlike stderr warnings), this also resolves the directive-related manifestation of #10822.

Fixes #12219

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/