### PR TITLE
Add `AllowTrailingComment` option to `Style/DisableCopsWithinSourceCodeDirective`

### DIFF
--- a/changelog/new_add_allow_trailing_comment_option_to_20260807162705.md
+++ b/changelog/new_add_allow_trailing_comment_option_to_20260807162705.md
@@ -1,0 +1,1 @@
+* [#15073](https://github.com/rubocop/rubocop/issues/15073): Add `AllowTrailingComment` option to `Style/DisableCopsWithinSourceCodeDirective`. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3977,9 +3977,10 @@ Style/DisableCopsWithinSourceCodeDirective:
                  Forbids disabling/enabling cops within source code.
   Enabled: false
   VersionAdded: '0.82'
-  VersionChanged: '1.89'
+  VersionChanged: '<<next>>'
   AllowedCops: []
   DisallowedCops: []
+  AllowTrailingComment: false
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -19,6 +19,12 @@ module RuboCop
       # allowlisting all other cops. `AllowedCops` and `DisallowedCops` should not
       # both be set at the same time; if `DisallowedCops` is set, it takes precedence.
       #
+      # With `AllowTrailingComment` set to `true`, a disable directive carrying
+      # a `--` trailing justification comment is allowed, so a team can require
+      # every disable to be documented instead of banning them outright. Enable
+      # directives are not checked in this mode, since they end a suppression
+      # rather than start one.
+      #
       # This cop cannot be disabled via directive comments when it is explicitly
       # enabled with `Enabled: true`. This prevents users from bypassing the cop
       # with `# rubocop:disable Style/DisableCopsWithinSourceCodeDirective`.
@@ -52,16 +58,28 @@ module RuboCop
       #   foo
       #   # rubocop:enable Metrics/AbcSize
       #
+      # @example AllowTrailingComment: true
+      #   # bad
+      #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
+      #
+      #   # good
+      #   x = 0 # rubocop:disable Layout/SpaceAroundOperators -- would misalign the table
+      #
       class DisableCopsWithinSourceCodeDirective < Base
         extend AutoCorrector
 
         # rubocop:enable Lint/RedundantCopDisableDirective
         MSG = 'RuboCop disable/enable directives are not permitted.'
         MSG_FOR_COPS = 'RuboCop disable/enable directives for %<cops>s are not permitted.'
+        MSG_MISSING_REASON = 'RuboCop disable directives without a `--` justification ' \
+                             'comment are not permitted.'
 
         def on_new_investigation
           processed_source.comments.each do |comment|
-            directive_cops = directive_cops(comment)
+            directive = DirectiveComment.new(comment)
+            next if allow_trailing_comment? && (directive.reason || directive.enabled?)
+
+            directive_cops = directive_cops(directive)
             disallowed_cops = compute_disallowed_cops(directive_cops)
 
             next unless disallowed_cops.any?
@@ -85,13 +103,7 @@ module RuboCop
         end
 
         def register_offense(comment, directive_cops, disallowed_cops)
-          message = if any_cops_allowed? || disallowed_cops_config.any?
-                      format(MSG_FOR_COPS, cops: "`#{disallowed_cops.join('`, `')}`")
-                    else
-                      MSG
-                    end
-
-          add_offense(comment, message: message) do |corrector|
+          add_offense(comment, message: offense_message(disallowed_cops)) do |corrector|
             replacement = ''
 
             if directive_cops.length != disallowed_cops.length
@@ -103,9 +115,23 @@ module RuboCop
           end
         end
 
-        def directive_cops(comment)
-          match_captures = DirectiveComment.new(comment).match_captures
+        def offense_message(disallowed_cops)
+          if allow_trailing_comment?
+            MSG_MISSING_REASON
+          elsif any_cops_allowed? || disallowed_cops_config.any?
+            format(MSG_FOR_COPS, cops: "`#{disallowed_cops.join('`, `')}`")
+          else
+            MSG
+          end
+        end
+
+        def directive_cops(directive)
+          match_captures = directive.match_captures
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
+        end
+
+        def allow_trailing_comment?
+          cop_config['AllowTrailingComment']
         end
 
         def allowed_cops

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -80,6 +80,18 @@ module RuboCop
       MALFORMED_DIRECTIVE_WITHOUT_COP_NAME_REGEXP.match?(comment.text)
     end
 
+    # The text of the directive's optional `--` trailing comment, or `nil`
+    # when there is none.
+    def reason
+      return unless @match_data
+
+      tail = @match_data.post_match.lstrip
+      return unless tail.start_with?(TRAILING_COMMENT_MARKER)
+
+      reason = tail.delete_prefix(TRAILING_COMMENT_MARKER).strip
+      reason unless reason.empty?
+    end
+
     # Checks if this directive relates to single line
     def single_line?
       !comment.text.start_with?(DIRECTIVE_COMMENT_REGEXP)

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -270,4 +270,64 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       RUBY
     end
   end
+
+  context 'when AllowTrailingComment is true' do
+    let(:cop_config) { { 'AllowTrailingComment' => true } }
+
+    it 'registers an offense for a disable directive without a justification' do
+      expect_offense(<<~RUBY)
+        x = 0 # rubocop:disable Layout/SpaceAroundOperators
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = 0#{trailing_whitespace}
+      RUBY
+    end
+
+    it 'does not register an offense for a disable directive with a justification' do
+      expect_no_offenses(<<~RUBY)
+        x = 0 # rubocop:disable Layout/SpaceAroundOperators -- aligning with the table below
+      RUBY
+    end
+
+    it 'does not register an offense for an enable directive closing a justified disable' do
+      expect_no_offenses(<<~RUBY)
+        # rubocop:disable Metrics/AbcSize -- legacy method, tracked in JIRA-123
+        def foo
+        end
+        # rubocop:enable Metrics/AbcSize
+      RUBY
+    end
+
+    it 'registers an offense for a `todo` directive without a justification' do
+      expect_offense(<<~RUBY)
+        x = 0 # rubocop:todo Layout/SpaceAroundOperators
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+      RUBY
+    end
+
+    context 'combined with AllowedCops' do
+      let(:cop_config) do
+        { 'AllowTrailingComment' => true, 'AllowedCops' => ['Metrics/AbcSize'] }
+      end
+
+      it 'does not register an offense for an allowed cop without a justification' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:disable Metrics/AbcSize
+          def foo
+          end
+          # rubocop:enable Metrics/AbcSize
+        RUBY
+      end
+
+      it 'registers an offense for a non-allowed cop without a justification' do
+        expect_offense(<<~RUBY)
+          def foo # rubocop:disable Metrics/CyclomaticComplexity
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -115,6 +115,40 @@ RSpec.describe RuboCop::DirectiveComment do
     end
   end
 
+  describe '#reason' do
+    subject { directive_comment.reason }
+
+    context 'when there is a trailing comment' do
+      let(:text) { '# rubocop:disable Metrics/AbcSize -- this is a good reason' }
+
+      it { is_expected.to eq('this is a good reason') }
+    end
+
+    context 'when there is a trailing comment on an EOL directive' do
+      let(:text) { '# rubocop:todo Metrics/AbcSize, Lint/Void -- see #1234' }
+
+      it { is_expected.to eq('see #1234') }
+    end
+
+    context 'when there is no trailing comment' do
+      let(:text) { '# rubocop:disable Metrics/AbcSize' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the trailing comment marker has no text after it' do
+      let(:text) { '# rubocop:disable Metrics/AbcSize --' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when trailing text does not start with the marker' do
+      let(:text) { '# rubocop:disable Metrics/AbcSize because reasons' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#single_line?' do
     subject { directive_comment.single_line? }
 


### PR DESCRIPTION
Lets a team require every disable directive to carry a `--` justification comment instead of banning directives outright: with `AllowTrailingComment: true`, justified disables pass and bare ones are flagged with a message asking for the reason. Enable directives aren't checked in this mode - they end a suppression rather than start one, and flagging them would break the pairing of a justified disable.

Under the hood this also gives `DirectiveComment` a `#reason` accessor for the `--` trailing comment. The parser has recognized that syntax for years but the text was inaccessible - this is the first step toward surfacing justifications in output.

Fixes #15073

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/