### PR TITLE
Add `--display-suppressed` to report directive-suppressed offenses

### DIFF
--- a/changelog/new_add_display_suppressed_option_20260807170001.md
+++ b/changelog/new_add_display_suppressed_option_20260807170001.md
@@ -1,0 +1,1 @@
+* [#15550](https://github.com/rubocop/rubocop/pull/15550): Add `--display-suppressed` option to also report offenses suppressed by directive comments, including their `--` justification in the JSON formatter. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -72,6 +72,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--display-only-safe-correctable`
 | Only output safe correctable offense messages.
 
+| `--display-suppressed`
+| Also output offenses suppressed by directive comments, tagged `[Suppressed]` (with their `--` justification in the JSON formatter). Suppressed offenses do not affect the exit code.
+
 | `--enable-all-cops`
 | Run with all cops enabled, including those disabled by default. Overrides `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files.
 

--- a/docs/modules/ROOT/pages/usage/source_code_directives.adoc
+++ b/docs/modules/ROOT/pages/usage/source_code_directives.adoc
@@ -74,6 +74,12 @@ You can add a comment to the disabling/enabling directive by prefixing it with `
 
 The syntax of directives can be checked using the cop `Lint/CopDirectiveSyntax`.
 
+To see what the directives in a codebase actually suppress, run with
+`--display-suppressed`: suppressed offenses are reported tagged `[Suppressed]`
+(including their `--` justification in the JSON formatter) without affecting
+the exit code. Relatedly, `--ignore-disable-comments` runs cops as if no
+directives existed at all.
+
 == Temporarily Enabling Cops in Source Code
 
 In a similar way to disabling cops within source code, you can also temporarily enable specific

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -209,12 +209,14 @@ module RuboCop
         message = find_message(range_to_pass, message)
 
         status, corrector = enabled_lines?(range) ? correct(range, &block) : :disabled
+        justification = suppression_reason(range) if status == :disabled
 
         # Since this range may be generated from Ruby code embedded in some
         # template file, we convert it to location info in the original file.
         range = range_for_original(range)
 
-        current_offenses << Offense.new(severity, range, message, name, status, corrector)
+        current_offenses << Offense.new(severity, range, message, name, status, corrector,
+                                        justification: justification)
       end
 
       # This method should be overridden when a cop's behavior depends
@@ -532,6 +534,23 @@ module RuboCop
 
         comment_config = @processed_source.comment_config
         comment_config.cop_enabled_at_lines?(self, range.first_line, range.last_line)
+      end
+
+      # The `--` reason on the directive that suppresses offenses on this
+      # range, or `nil` when the directive carries none.
+      def suppression_reason(range)
+        covering = covering_disabled_range(range)
+        return unless covering && !covering.begin.to_f.infinite?
+
+        comment = @processed_source.comment_at_line(covering.begin)
+        comment && DirectiveComment.new(comment).reason
+      end
+
+      def covering_disabled_range(range)
+        disabled_ranges = @processed_source.comment_config.cop_disabled_line_ranges[cop_name]
+        disabled_ranges&.find do |disabled_range|
+          disabled_range.end >= range.first_line && disabled_range.begin <= range.last_line
+        end
       end
 
       def find_severity(_range, severity)

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -86,9 +86,19 @@ module RuboCop
 
       NO_LOCATION = PseudoSourceRange.new(1, 0, '', 0, 0).freeze
 
+      # @api public
+      #
+      # @!attribute [r] justification
+      #
+      # @return [String, nil]
+      #   the reason given on the directive that suppressed this offense
+      #   (the text after `--`), or `nil` when the offense is not suppressed
+      #   or the directive carries no reason
+      attr_reader :justification
+
       # @api private
       def initialize(severity, location, message, cop_name, # rubocop:disable Metrics/ParameterLists
-                     status = :uncorrected, corrector = nil)
+                     status = :uncorrected, corrector = nil, justification: nil)
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
 
@@ -101,15 +111,16 @@ module RuboCop
         @cop_name = cop_name.freeze
         @status = status
         @corrector = corrector
+        @justification = justification.freeze
         freeze
       end
 
       def marshal_dump
-        [@severity, @location, @message, @cop_name, @status]
+        [@severity, @location, @message, @cop_name, @status, @justification]
       end
 
       def marshal_load(array)
-        @severity, @location, @message, @cop_name, @status = array
+        @severity, @location, @message, @cop_name, @status, @justification = array
         @line = @location.line
         @column = @location.column
       end
@@ -121,8 +132,10 @@ module RuboCop
       # @return [Boolean]
       #   whether this offense can be automatically corrected via autocorrect.
       #   This includes todo comments, for example when requested with `--disable-uncorrectable`.
+      #   An offense suppressed by a directive comment is not correctable -
+      #   autocorrect will not touch it.
       def correctable?
-        @status != :unsupported
+        @status != :unsupported && @status != :disabled
       end
 
       # @api public

--- a/lib/rubocop/formatter/emacs_style_formatter.rb
+++ b/lib/rubocop/formatter/emacs_style_formatter.rb
@@ -23,7 +23,9 @@ module RuboCop
 
       def message(offense)
         message =
-          if offense.corrected_with_todo?
+          if offense.disabled?
+            "[Suppressed] #{offense.message}"
+          elsif offense.corrected_with_todo?
             "[Todo] #{offense.message}"
           elsif offense.corrected?
             "[Corrected] #{offense.message}"

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -47,7 +47,7 @@ module RuboCop
       end
 
       def hash_for_offense(offense)
-        {
+        hash = {
           severity:    offense.severity.name,
           message:     offense.message,
           cop_name:    offense.cop_name,
@@ -55,6 +55,15 @@ module RuboCop
           correctable: offense.correctable?,
           location:    hash_for_location(offense)
         }
+
+        # Suppressed offenses appear only under `--display-suppressed`, so
+        # these keys are additive for existing consumers.
+        if offense.disabled?
+          hash[:suppressed] = true
+          hash[:justification] = offense.justification
+        end
+
+        hash
       end
 
       # TODO: Consider better solution for Offense#real_column.

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -86,7 +86,9 @@ module RuboCop
 
       def message(offense)
         message =
-          if offense.corrected_with_todo?
+          if offense.disabled?
+            magenta('[Suppressed] ')
+          elsif offense.corrected_with_todo?
             green('[Todo] ')
           elsif offense.corrected?
             green('[Corrected] ')

--- a/lib/rubocop/formatter/tap_formatter.rb
+++ b/lib/rubocop/formatter/tap_formatter.rb
@@ -68,7 +68,9 @@ module RuboCop
 
       def message(offense)
         message =
-          if offense.corrected_with_todo?
+          if offense.disabled?
+            '[Suppressed] '
+          elsif offense.corrected_with_todo?
             '[Todo] '
           elsif offense.corrected?
             '[Corrected] '

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -132,6 +132,7 @@ module RuboCop
         option(opts, '--display-only-fail-level-offenses')
         option(opts, '--display-only-correctable')
         option(opts, '--display-only-safe-correctable')
+        option(opts, '--display-suppressed')
       end
     end
 
@@ -611,6 +612,8 @@ module RuboCop
       display_only_correctable:         ['Only output correctable offense messages.'],
       display_only_safe_correctable:    ['Only output safe-correctable offense messages',
                                          'when combined with --display-only-correctable.'],
+      display_suppressed:               ['Also output offenses suppressed by directive',
+                                         'comments. They do not affect the exit code.'],
       show_cops:                        ['Show the given cops, or all cops by',
                                          'default, and their configurations for the',
                                          'current directory.',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -264,7 +264,8 @@ module RuboCop
       file_offense_cache(file) do
         source, offenses = do_inspection_loop(file)
         offenses = add_redundant_disables(file, offenses.compact.sort, source)
-        offenses.sort.reject(&:disabled?).freeze
+        offenses = offenses.reject(&:disabled?) unless @options[:display_suppressed]
+        offenses.sort.freeze
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -559,6 +559,21 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       RESULT
     end
 
+    it 'reports suppressed offenses with `--display-suppressed` without affecting the exit code' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        x = 1 # rubocop:disable Lint/UselessAssignment -- demo data
+      RUBY
+      expect(cli.run(['--format', 'emacs', '--display-suppressed', 'example.rb'])).to eq(0)
+      expect($stdout.string)
+        .to include('[Suppressed] Lint/UselessAssignment: Useless assignment to variable - `x`')
+
+      $stdout.string.clear
+      expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
+      expect($stdout.string).not_to include('Suppressed')
+    end
+
     it 'can disable all cops on a single line' do
       create_file('example.rb', 'y("123", 123456) # rubocop:disable all')
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -236,4 +236,27 @@ RSpec.describe RuboCop::Cop::Offense do
       expect(offense.highlighted_area.length).to eq 0
     end
   end
+
+  context 'when the offense is suppressed by a directive' do
+    subject(:offense) do
+      described_class.new(:convention, location, 'message', 'CopName', :disabled, nil,
+                          justification: 'a good reason')
+    end
+
+    it 'exposes the directive justification' do
+      expect(offense.justification).to eq('a good reason')
+    end
+
+    it 'is not correctable' do
+      expect(offense).not_to be_correctable
+    end
+
+    it 'round-trips the justification through marshalling' do
+      expect(Marshal.load(Marshal.dump(offense)).justification).to eq('a good reason')
+    end
+  end
+
+  it 'defaults justification to nil' do
+    expect(offense.justification).to be_nil
+  end
 end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -128,6 +128,23 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
       expect(hash[:corrected]).to be(true)
     end
 
+    it 'does not include suppression keys for a regular offense' do
+      expect(hash).not_to have_key(:suppressed)
+      expect(hash).not_to have_key(:justification)
+    end
+
+    context 'for an offense suppressed by a directive' do
+      let(:offense) do
+        RuboCop::Cop::Offense.new(:convention, location, 'This is message', 'CopName', :disabled,
+                                  nil, justification: 'a fine reason')
+      end
+
+      it 'includes the suppression keys' do
+        expect(hash[:suppressed]).to be(true)
+        expect(hash[:justification]).to eq('a fine reason')
+      end
+    end
+
     it 'sets value of #hash_for_location for :location key' do
       location_hash = {
         start_line: 2,

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -173,6 +173,8 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --display-only-safe-correctable
                                                Only output safe-correctable offense messages
                                                when combined with --display-only-correctable.
+                  --display-suppressed         Also output offenses suppressed by directive
+                                               comments. They do not affect the exit code.
 
           Autocorrection:
               -a, --autocorrect                Autocorrect offenses (only when it's safe).


### PR DESCRIPTION
Offenses suppressed by `rubocop:disable` directives are fully materialized during inspection and then silently discarded, so there has been no way to see what a codebase's directives actually hide. `--display-suppressed` reports them tagged `[Suppressed]` in the text-based formatters, with the directive's `--` justification carried into the JSON formatter as a `justification` field alongside `"suppressed": true`. Suppressed offenses never affect the exit code, and they no longer count as autocorrectable (`-a` won't touch them, so advertising them in that count was misleading).

The result cache keys on options, so runs with and without the flag don't contaminate each other, and the JSON keys only appear on suppressed entries - existing consumers see no schema change unless they opt in.

This is the suppression-visibility counterpart of ESLint's `suppressedMessages`: combined with `Lint/RedundantCopDisableDirective` it makes directives auditable - what does this suppression hide, and is it still load-bearing?

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/