### PR TITLE
Add todo comments for skipped unsafe corrections with `--disable-uncorrectable`

### DIFF
--- a/changelog/fix_add_todo_comments_for_skipped_unsafe_corrections_with_disable_uncorrectable_20260807173041.md
+++ b/changelog/fix_add_todo_comments_for_skipped_unsafe_corrections_with_disable_uncorrectable_20260807173041.md
@@ -1,0 +1,1 @@
+* [#7958](https://github.com/rubocop/rubocop/issues/7958): Add todo comments for skipped unsafe corrections with `--disable-uncorrectable`. ([@bbatsov][])

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -12,6 +12,14 @@ module RuboCop
         autocorrect_requested? && disable_uncorrectable? && autocorrect_enabled?
       end
 
+      # Whether a correction exists but is skipped because it is unsafe in a
+      # safe autocorrect run, while `--disable-uncorrectable` asks for a todo
+      # comment on everything this run cannot correct.
+      def skipped_unsafe_correction_with_disable_uncorrectable?
+        autocorrect_requested? && disable_uncorrectable? &&
+          @options.fetch(:safe_autocorrect, false) && !safe_autocorrect?
+      end
+
       def autocorrect_requested?
         @options.fetch(:autocorrect, false)
       end

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -447,6 +447,10 @@ module RuboCop
       def use_corrector(range, corrector)
         if autocorrect?
           attempt_correction(range, corrector)
+        elsif skipped_unsafe_correction_with_disable_uncorrectable?
+          # The unsafe correction will not run, so the offense is
+          # uncorrectable for this run and gets a todo comment.
+          attempt_correction(range, nil)
         elsif corrector && (always_autocorrect? || (contextual_autocorrect? && !LSP.enabled?))
           :uncorrected
         else

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -211,7 +211,7 @@ module RuboCop
         # run the other cops when no corrections are left
         on_duty = roundup_relevant_cops(processed_source)
 
-        autocorrect_cops, other_cops = on_duty.partition(&:autocorrect?)
+        autocorrect_cops, other_cops = partition_by_correcting(on_duty)
         report = investigate_partial(autocorrect_cops, processed_source,
                                      offset: offset, original: original)
 
@@ -251,6 +251,15 @@ module RuboCop
       end
 
       # @return [Array<cop>]
+      # A cop whose unsafe correction is skipped still inserts todo comments
+      # under `--disable-uncorrectable`, so it must run with the correcting
+      # cops - correctors of the later `other_cops` round are never applied.
+      def partition_by_correcting(cops)
+        cops.partition do |cop|
+          cop.autocorrect? || cop.skipped_unsafe_correction_with_disable_uncorrectable?
+        end
+      end
+
       def roundup_relevant_cops(processed_source)
         (cops + opted_in_standby_cops(processed_source)).select do |cop|
           next false if cop.excluded_file?(processed_source.file_path)

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -42,6 +42,43 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
       RUBY
     end
 
+    context 'with a cop whose autocorrect is unsafe' do
+      let(:cli_opts) { %w[--autocorrect --format simple --disable-uncorrectable] }
+
+      before do
+        create_file('example.rb', <<~RUBY)
+          # frozen_string_literal: true
+
+          require 'set'
+          require 'set'
+        RUBY
+      end
+
+      it 'adds a todo comment in a safe autocorrect run' do
+        expect(exit_code).to eq(0)
+        expect($stderr.string).to eq('')
+        expect(File.read('example.rb')).to eq(<<~RUBY)
+          # frozen_string_literal: true
+
+          require 'set'
+          require 'set' # rubocop:todo Lint/DuplicateRequire
+        RUBY
+      end
+
+      context 'when unsafe autocorrect is requested' do
+        let(:cli_opts) { %w[--autocorrect-all --format simple --disable-uncorrectable] }
+
+        it 'corrects instead of adding a todo comment' do
+          expect(exit_code).to eq(0)
+          expect(File.read('example.rb')).to eq(<<~RUBY)
+            # frozen_string_literal: true
+
+            require 'set'
+          RUBY
+        end
+      end
+    end
+
     context 'if one one-line disable statement fits' do
       it 'adds it' do
         setup_long_line


### PR DESCRIPTION
With safe autocorrect (`-a --disable-uncorrectable`), a cop whose correction exists but is unsafe fell into a gap: the correction wasn't applied and no `rubocop:todo` comment was inserted either, so the offense just stayed - defeating the flag's purpose of getting a codebase to a clean state. Such offenses now get the todo comment like anything else the run can't correct.

Two pieces: `Base#use_corrector` routes the skipped-unsafe case into the todo-insertion path, and `Team`'s cop partition treats these cops as correcting cops - correctors from the later round of non-correcting cops are silently dropped, which is why a naive fix reports "corrected" without actually touching the file. Unsafe autocorrect runs (`-A`) are unaffected and still correct normally.

Fixes #7958

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/