### PR TITLE
[Fix #13022] Fix `Exclude` of a top level directory with a relative path

### DIFF
--- a/changelog/fix_exclude_of_top_level_directories_when_the_path_is_relative_20260807163231.md
+++ b/changelog/fix_exclude_of_top_level_directories_when_the_path_is_relative_20260807163231.md
@@ -1,0 +1,1 @@
+* [#13022](https://github.com/rubocop/rubocop/issues/13022): Fix `Exclude` of a top level directory being ignored when RuboCop is invoked with a relative path. ([@Eljees][])

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -116,8 +116,13 @@ module RuboCop
 
     def combined_exclude_glob_patterns(base_dir)
       exclude = @config_store.for(base_dir).for_all_cops['Exclude'] || []
+      # `Exclude` patterns coming from the configuration are always absolute, while `base_dir`
+      # can be relative (e.g. `rubocop .`). Strip the absolute prefix, but keep the resulting
+      # pattern anchored at `base_dir` so that it matches the directories yielded by
+      # `Dir.glob(File.join(base_dir, '*/'))`, which are relative when `base_dir` is.
+      absolute_base_dir = File.expand_path(base_dir)
       patterns = exclude.select { |pattern| pattern.is_a?(String) && pattern.end_with?('/**/*') }
-                        .map { |pattern| pattern.sub("#{base_dir}/", '') }
+                        .map { |pattern| pattern.sub("#{absolute_base_dir}/", '') }
       "#{base_dir}/{#{patterns.join(',')}}"
     end
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -439,6 +439,20 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).to include('ruby3.rb')
     end
 
+    context 'when the base dir is relative' do
+      let(:base_dir) { '.' }
+
+      it 'does not search excluded top level directories' do
+        config = instance_double(RuboCop::Config)
+        exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
+        allow(config).to receive(:for_all_cops).and_return(exclude_property)
+        allow(config_store).to receive(:for).and_return(config)
+
+        expect(found_basenames).not_to include('ruby1.rb')
+        expect(found_basenames).to include('ruby3.rb')
+      end
+    end
+
     it 'works also if a folder is named ","' do
       create_empty_file(',/ruby4.rb')
 


### PR DESCRIPTION
Fixes #13022.

`combined_exclude_glob_patterns` strips `base_dir` from each `Exclude` pattern:

```ruby
patterns = exclude.select { |pattern| pattern.is_a?(String) && pattern.end_with?('/**/*') }
                  .map { |pattern| pattern.sub("#{base_dir}/", '') }
```

`Exclude` patterns from the configuration are always absolute, but `base_dir` is whatever was passed on the command line. With `rubocop .` the substitution finds nothing to strip, so the pattern stays absolute, the resulting glob never matches the relative directories that `Dir.glob(File.join(base_dir, '*/'))` yields, and the excluded top level directory is walked anyway.

The prefix that gets stripped is now `File.expand_path(base_dir)`, so it matches the absolute form the patterns actually have, while the glob stays anchored at `base_dir` and keeps working for absolute invocations.

@koic asked on #13028 for a regression test, so there is one: a `base_dir` of `.` with an absolute `Exclude`, asserting that the excluded directory's file is not found and a sibling still is. It fails on current `master` and passes with the change; the rest of `target_finder_spec.rb` stays green (66 examples, 0 failures), and `bundle exec rubocop` on both touched files reports no offenses.

AI-assisted (LLM used for drafting); the runs above are mine.
