### PR TITLE
[Fix #15554] Make `AllowForAlignment` stop at block boundaries

### DIFF
--- a/changelog/change_make_allow_for_alignment_stop_at_block_boundaries_20260809020531.md
+++ b/changelog/change_make_allow_for_alignment_stop_at_block_boundaries_20260809020531.md
@@ -1,0 +1,1 @@
+* [#15554](https://github.com/rubocop/rubocop/issues/15554): Change `AllowForAlignment` to no longer treat a same-indentation line beyond the enclosing block as an alignment anchor for `Layout/ExtraSpacing`, `Layout/SpaceAroundOperators`, and `Layout/SpaceBeforeFirstArg`. ([@koic][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -69,7 +69,15 @@ module RuboCop
           line = processed_source.lines[lineno]
           index = line =~ /\S/
           next unless index
-          next if indent && indent != index
+
+          if indent
+            # When searching for the nearest line with the same indentation,
+            # more deeply indented lines are nested content of the current group
+            # and are skipped, but a less deeply indented line ends the enclosing block:
+            # an alignment anchor beyond it would be coincidental.
+            break if index < indent
+            next if index > indent
+          end
 
           return yield(range, line, lineno + 1)
         end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -366,6 +366,60 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         end
       RUBY
     end
+
+    it 'registers an offense and corrects when the only vertically aligned line is in a preceding sibling block' do
+      expect_offense(<<~RUBY)
+        foo do
+          bar(:abcd) { it.qux }
+        end
+
+        foo do
+          bar(:b) {  it }
+                   ^ Unnecessary spacing detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo do
+          bar(:abcd) { it.qux }
+        end
+
+        foo do
+          bar(:b) { it }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects when an assignment is aligned only with one in a preceding sibling block' do
+      expect_offense(<<~RUBY)
+        if foo
+          aaa  = 1
+             ^ Unnecessary spacing detected.
+        end
+        if bar
+          bbb  = 1
+             ^ Unnecessary spacing detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        if foo
+          aaa = 1
+        end
+        if bar
+          bbb = 1
+        end
+      RUBY
+    end
+
+    it 'allows extra spacing when aligned with an assignment beyond a nested multiline entry' do
+      expect_no_offenses(<<~RUBY)
+        foo  = {
+                 a: 1
+               }
+        bar  = 2
+      RUBY
+    end
   end
 
   context 'when AllowForAlignment is false' do


### PR DESCRIPTION
When no aligned token is found on an adjacent line, the alignment check falls back to the nearest line with the same indentation. That search skipped every line whose indentation differs - including shallower ones such as `end` or the enclosing call - so it tunneled out of the enclosing block and a same-indent line in an unrelated sibling block could become an "alignment anchor":

```ruby
foo do
  bar(:abcd) { it.qux }
end

foo do
  bar(:b) {  it } # allowed: `it` "aligns" with `{` six lines up
end
```

The fallback now distinguishes the two directions of indentation change: more deeply indented lines are nested content of the current group and are still skipped (which keeps alignment across multiline entries working), but a shallower non-blank line ends the enclosing block and stops the search. This matches the scope rule the mixin's `relevant_assignment_lines` already applies to `=` alignment.

A distance threshold or token-type compatibility (also suggested in the issue) would be arbitrary or fuzzy by comparison; the block boundary is the unambiguous cutoff, and no configuration is added.

Resolves #15554.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
