### PR TITLE
Fix Lint/UnusedPrivateMethod retaining stale info

### DIFF
--- a/changelog/fix_lint_unused_private_method_retaining_stale_project_index_20260809135237.md
+++ b/changelog/fix_lint_unused_private_method_retaining_stale_project_index_20260809135237.md
@@ -1,0 +1,1 @@
+* [#15556](https://github.com/rubocop/rubocop/pull/15556): Fix `Lint/UnusedPrivateMethod` retaining every past `project_index` object it has seen (and the index graph reachable from each), rather than only the most recent one. This caused unbounded memory growth in long-lived processes such as `rubocop --server`. ([@bquorning][])

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -62,11 +62,11 @@ module RuboCop
                                         marshal_dump marshal_load].to_set.freeze
 
         class << self
-          # The reference-name set is derived once per index and shared by the
-          # per-file cop instances.
-          def reference_names_cache
-            @reference_names_cache ||= {}.compare_by_identity
-          end
+          # The reference-name set is a property of the index, not of the cop
+          # instance, so all per-file instances share one computation. A
+          # single-entry cache (instead of a hash keyed by index) avoids
+          # retaining stale graphs in long-lived processes.
+          attr_accessor :cached_reference_names
         end
 
         def on_new_investigation
@@ -111,9 +111,17 @@ module RuboCop
         end
 
         def referenced_names
-          self.class.reference_names_cache[project_index] ||=
-            project_index.method_references
-                         .to_set { |reference| reference.name.delete_suffix('()') }
+          index, names = self.class.cached_reference_names
+          return names if index.equal?(project_index)
+
+          compute_referenced_names.tap do |computed|
+            self.class.cached_reference_names = [project_index, computed]
+          end
+        end
+
+        def compute_referenced_names
+          project_index.method_references
+                       .to_set { |reference| reference.name.delete_suffix('()') }
         end
 
         # Symbol literals and identifier-like tokens inside string literals in the

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -212,5 +212,45 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
         end
       RUBY
     end
+
+    describe 'the reference-name cache' do
+      it 'is computed once per index and shared across cop instances' do
+        index = index_with_current
+
+        first_cop = cop
+        first_cop.project_index = index
+        first_cop_names = first_cop.send(:referenced_names)
+
+        second_cop = described_class.new
+        second_cop.project_index = index
+        second_cop_names = second_cop.send(:referenced_names)
+
+        expect(second_cop_names).to be(first_cop_names)
+      end
+
+      it 'replaces the cached entry when the index changes, rather than accumulating it' do
+        other_source = <<~RUBY
+          class Other
+            def go(service)
+              service.helper
+            end
+          end
+        RUBY
+
+        first_cop = cop
+        first_cop.project_index = index_with_current('file:///lib/other.rb' => other_source)
+        first_cop_names = first_cop.send(:referenced_names)
+
+        second_cop = described_class.new
+        second_cop.project_index = index_with_current
+        second_cop_names = second_cop.send(:referenced_names)
+
+        expect(second_cop_names).not_to eq(first_cop_names)
+
+        index, cached = described_class.cached_reference_names
+        expect(index).to be(second_cop.project_index)
+        expect(cached).to be(second_cop_names)
+      end
+    end
   end
 end


### PR DESCRIPTION
`.reference_names_cache` stored the reference-name Set in a class-level Hash keyed by the `project_index`. In long-lived processes such as `rubocop --server`, a new index object is created per run, so the hash grew by one entry per run and older entries were never released to be GC'ed.

Replace it with a single-entry cache: an `[index, value]` pair that is overwritten whenever `project_index` changes, matching the pattern already used by `ProjectIndexHelp#project_index_signature`.

Added specs to assert the cache is shared across instances for the same index, and recomputed (replacing, not accumulating) when the index changes.

We hit this while working on a similar cache in rubocop-rspec’s `RSpec/LetSetup`, which was modeled on this cop and inherited the same leaky pattern.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
