### PR TITLE
Keep `justification` when an offense is loaded from the result cache

### DIFF
--- a/changelog/fix_keep_justification_when_an_offense_is_loaded_from_the_result_cache.md
+++ b/changelog/fix_keep_justification_when_an_offense_is_loaded_from_the_result_cache.md
@@ -1,0 +1,1 @@
+* [#15558](https://github.com/rubocop/rubocop/pull/15558): Fix `--display-suppressed` reporting a `nil` `justification` when the offense is loaded from the result cache. ([@corsonknowles][])

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -22,7 +22,7 @@ module RuboCop
 
     def serialize_offense(offense)
       status = :uncorrected if %i[corrected corrected_with_todo].include?(offense.status)
-      {
+      hash = {
         # Calling #to_s here ensures that the serialization works when using
         # other json serializers such as Oj. Some of these gems do not call
         # #to_s implicitly.
@@ -35,6 +35,10 @@ module RuboCop
         cop_name: offense.cop_name,
         status:   status || offense.status
       }
+      # Only offenses suppressed by a directive can carry one, so keep the key out of the
+      # common case rather than writing a null for every cached offense.
+      hash[:justification] = offense.justification if offense.justification
+      hash
     end
 
     def message(offense)
@@ -47,7 +51,8 @@ module RuboCop
     def deserialize_offenses(offenses)
       offenses.map! do |o|
         location = location_from_source_buffer(o)
-        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym)
+        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym,
+                         justification: o['justification'])
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -584,6 +584,24 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       expect($stdout.string).to include('"justification":"kept for documentation purposes"')
     end
 
+    it 'keeps the justification when the offense is served from the result cache' do
+      create_file('example.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        # rubocop:disable-next Lint/UselessAssignment -- kept for documentation purposes
+        useless = 1
+      RUBY
+      args = ['--format', 'json', '--display-suppressed', '--cache', 'true',
+              '--cache-root', '.cache', 'example.rb']
+
+      expect(cli.run(args)).to eq(0)
+      expect($stdout.string).to include('"justification":"kept for documentation purposes"')
+
+      $stdout.string.clear
+      expect(cli.run(args)).to eq(0)
+      expect($stdout.string).to include('"justification":"kept for documentation purposes"')
+    end
+
     it 'reports a detached `disable-next` even when no cop is disabled in the config' do
       create_file('.rubocop.yml', <<~YAML)
         AllCops:

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -116,6 +116,27 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         end
       end
 
+      context 'an offense suppressed by a directive carrying a justification' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(
+            :warning, location, 'unused var', 'Lint/UselessAssignment', :disabled,
+            justification: 'kept for the vendored payload'
+          )
+        end
+
+        it 'serializes them with the justification' do
+          cache.save([offense])
+          expect(cache.load[0].justification).to eq('kept for the vendored payload')
+        end
+      end
+
+      context 'an offense that carries no justification' do
+        it 'serializes them with a nil justification' do
+          cache.save(offenses)
+          expect(cache.load[0].justification).to be_nil
+        end
+      end
+
       context 'a global offense' do
         let(:no_location) { RuboCop::Cop::Offense::NO_LOCATION }
         let(:global_offense) do


### PR DESCRIPTION
`--display-suppressed` reports the directive's `--` reason as the offense's `justification`, but `CachedData` never serialized it. `serialize_offense` writes only severity/location/message/cop_name/status, and `deserialize_offenses` rebuilds the offense without the keyword, so it comes back `nil`.

The result is that the field silently reads as absent for anyone with caching on — which is the default. A cold run returns the reason, the identical warm run returns `nil`:

```console
$ cat sample.rb
a = "justified" # rubocop:disable Style/StringLiterals -- vendor payload stays double quoted
puts a

$ rm -rf ~/.cache/rubocop_cache
$ rubocop --display-suppressed --format json sample.rb | jq -c '.files[].offenses[] | {cop_name, justification}'
{"cop_name":"Style/StringLiterals","justification":"vendor payload stays double quoted"}

$ rubocop --display-suppressed --format json sample.rb | jq -c '.files[].offenses[] | {cop_name, justification}'
{"cop_name":"Style/StringLiterals","justification":null}
```

`Offense#marshal_dump`/`#marshal_load` already carry the field, so `--parallel` was unaffected — the worker IPC path round-trips it correctly and only the result cache dropped it. Nor is `--cache false` a workaround, since it cannot be combined with `--parallel`.

Two notes on the shape of the fix:

- The key is written only when a justification is present, so cache entries for the overwhelmingly common unsuppressed offense are byte-for-byte unchanged, and old cache files deserialize fine (`o['justification']` is simply `nil`).
- `display_suppressed` is not in `ResultCache::NON_CHANGING`, so runs with and without the flag already use distinct cache entries. I verified a cache warmed *without* the flag is correctly not reused by a run *with* it, so this was the only gap.

Both new specs fail on `master` and pass with the change — the CLI one runs twice against a real `--cache-root` to confirm the second run is genuinely served from cache rather than passing vacuously.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder][2] named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded: "<<next>>"` in `config/default.yml`.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/rubocop/rubocop/blob/master/changelog/