### PR TITLE
Add new `Style/DirectiveScope` cop

### DIFF
--- a/changelog/new_add_style_directive_scope_cop_20260810120001.md
+++ b/changelog/new_add_style_directive_scope_cop_20260810120001.md
@@ -1,0 +1,1 @@
+* [#15559](https://github.com/rubocop/rubocop/pull/15559): Add new `Style/DirectiveScope` cop to flag `disable`/`enable` pairs and disable-only `push`/`pop` scopes that wrap a single statement and can use `disable-next` instead. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -3973,6 +3973,14 @@ Style/DirEmpty:
   Enabled: pending
   VersionAdded: '1.48'
 
+Style/DirectiveScope:
+  Description: >-
+                 Checks for directive scopes that can be expressed with the
+                 tighter `disable-next` form.
+  Enabled: pending
+  SafeAutoCorrect: false
+  VersionAdded: '<<next>>'
+
 Style/DisableCopsWithinSourceCodeDirective:
   Description: >-
                  Forbids disabling/enabling cops within source code.

--- a/docs/modules/ROOT/pages/usage/source_code_directives.adoc
+++ b/docs/modules/ROOT/pages/usage/source_code_directives.adoc
@@ -300,3 +300,7 @@ as the code around it changes:
 
 `todo` and `todo-next` are aliases of `disable` and `disable-next` that mark
 a suppression you intend to revisit rather than a deliberate exception.
+
+The `Style/DirectiveScope` cop can enforce the tightest-form preference: it
+flags `disable`/`enable` pairs and disable-only `push`/`pop` scopes that
+wrap a single statement, and converts them to `disable-next`.

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -35,7 +35,7 @@ module RuboCop
     # @param args [Array<String>] command line arguments
     # @return [Integer] UNIX exit code
     #
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable-next Metrics/MethodLength, Metrics/AbcSize
     def run(args = ARGV)
       time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -80,11 +80,10 @@ module RuboCop
         puts "Finished in #{elapsed_time.round(5)} seconds"
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     private
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable-next Metrics/MethodLength, Metrics/AbcSize
     def profile_if_needed
       return yield unless @options[:profile]
 
@@ -116,7 +115,6 @@ module RuboCop
       end
       status
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def require_gem(name)
       require name

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -112,7 +112,7 @@ module RuboCop
       extras
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def analyze
       return {} if @no_directives
 
@@ -143,7 +143,6 @@ module RuboCop
         hash[cop_name] = cop_line_ranges(analysis)
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def resolve_push_cops(directive)
       directive.push_args.transform_values do |names|

--- a/lib/rubocop/comment_config/disable_next.rb
+++ b/lib/rubocop/comment_config/disable_next.rb
@@ -16,31 +16,36 @@ module RuboCop
         @detached_next_directives
       end
 
+      # The line range of the statement a `disable-next` directive on the
+      # given line scopes to (or would scope to), or `nil` when no statement
+      # is attached. A directive is only honored on a comment-only line.
+      # Stacked directives share the target, so the computation is memoized.
+      # @api private
+      def statement_scope_after(line)
+        return nil unless comment_only_line?(line)
+
+        code_line = attached_code_line(line)
+        return nil unless code_line
+
+        (@statement_bounds ||= {})[code_line] ||= statement_bounds_at(code_line)
+      end
+
       private
 
       def apply_disable_next(analyses, directive)
-        bounds = next_statement_bounds(directive)
+        bounds = statement_scope_after(directive.line_number)
         return @detached_next_directives << directive unless bounds
 
+        range = DirectiveRange.new(bounds.begin, bounds.end, directive)
         directive.cop_names.each do |cop_name|
-          cop_name = qualified_cop_name(cop_name)
-          analysis = analyses[cop_name]
-          range = DirectiveRange.new(bounds.begin, bounds.end, directive)
-          analyses[cop_name] = CopAnalysis.new(analysis.line_ranges + [range],
-                                               analysis.start_line_number, analysis.start_directive)
+          add_next_range(analyses, qualified_cop_name(cop_name), range)
         end
       end
 
-      # The directive scopes to the following statement, so it is only
-      # honored on a comment-only line with a statement attached below.
-      # Stacked directives share the target, so the computation is memoized.
-      def next_statement_bounds(directive)
-        return nil unless comment_only_line?(directive.line_number)
-
-        line = attached_code_line(directive.line_number)
-        return nil unless line
-
-        (@next_statement_bounds ||= {})[line] ||= statement_bounds_at(line)
+      def add_next_range(analyses, cop_name, range)
+        analysis = analyses[cop_name]
+        analyses[cop_name] = CopAnalysis.new(analysis.line_ranges + [range],
+                                             analysis.start_line_number, analysis.start_directive)
       end
 
       def attached_code_line(directive_line)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -2,7 +2,7 @@
 
 # FIXME: Moving Rails department code to RuboCop Rails will remove
 # the following rubocop:disable comment.
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable-next Metrics/ClassLength
 module RuboCop
   # This class represents the configuration of the RuboCop application
   # and all its cops. A Config is associated with a YAML configuration
@@ -27,7 +27,7 @@ module RuboCop
       config
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
     def initialize(hash = RuboCop::ConfigLoader.default_configuration, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
@@ -72,7 +72,6 @@ module RuboCop
       @badge_config_cache = {}.compare_by_identity
       @clusivity_config_exists_cache = {}
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def loaded_plugins
       @loaded_plugins ||= ConfigLoader.loaded_plugins
@@ -458,4 +457,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -49,7 +49,7 @@ module RuboCop
         FileFinder.root_level = nil
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable-next Metrics/AbcSize
       def load_file(file, check: true)
         path = file_path(file)
 
@@ -73,7 +73,6 @@ module RuboCop
 
         Config.create(hash, path, check: check)
       end
-      # rubocop:enable Metrics/AbcSize
 
       def load_yaml_configuration(absolute_path)
         file_contents = read_file(absolute_path)

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -115,7 +115,7 @@ module RuboCop
     # with the addition that any value that is a hash, and occurs in both
     # arguments, will also be merged. And so on.
     #
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable-next Metrics/AbcSize
     def merge(base_hash, derived_hash, **opts)
       result = base_hash.merge(derived_hash)
       keys_appearing_in_both = base_hash.keys & derived_hash.keys
@@ -132,7 +132,6 @@ module RuboCop
       end
       result
     end
-    # rubocop:enable Metrics/AbcSize
 
     # An `Enabled: true` setting in user configuration for a cop overrides an
     # `Enabled: false` setting for its department.

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -3,7 +3,7 @@
 module RuboCop
   # Handles validation of configuration, for example cop names, parameter
   # names, and Ruby versions.
-  # rubocop:disable Metrics/ClassLength
+  # rubocop:disable-next Metrics/ClassLength
   class ConfigValidator
     extend SimpleForwardable
 
@@ -324,5 +324,4 @@ module RuboCop
         "is supposed to be #{supposed_values} and #{Rainbow(value).yellow} is not."
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
+++ b/lib/rubocop/cop/internal_affairs/node_matcher_directive.rb
@@ -146,7 +146,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def formatted_message(offense_type, directive, actual_name, method_name)
           case offense_type
           when :wrong_name
@@ -166,7 +166,6 @@ module RuboCop
             format(MSG, method: method_name)
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def remove_receiver(current)
           current.delete_prefix('self.')

--- a/lib/rubocop/cop/internal_affairs/node_pattern_groups/ast_walker.rb
+++ b/lib/rubocop/cop/internal_affairs/node_pattern_groups/ast_walker.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module InternalAffairs
-      # rubocop:disable InternalAffairs/RedundantSourceRange -- node here is a `NodePattern::Node`
+      # rubocop:disable-next InternalAffairs/RedundantSourceRange -- node here is a `NodePattern::Node`
       class NodePatternGroups
         # Walks an AST that has been processed by `InternalAffairs::NodePatternGroups::Processor`
         # in order to find `node_type` and `node_sequence` nodes that can be replaced with a node
@@ -125,7 +125,6 @@ module RuboCop
           end
         end
       end
-      # rubocop:enable InternalAffairs/RedundantSourceRange
     end
   end
 end

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -281,7 +281,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def do_line_begins_inside_argument?(node, do_loc)
           line_begin_pos = do_loc.begin_pos - do_loc.column
           first_char_pos = line_begin_pos + (do_loc.source_line =~ /\S/)
@@ -292,7 +292,6 @@ module RuboCop
               first_char_pos < argument.source_range.end_pos
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         # The continuation line indentation is only an unmeaningful alignment target when
         # it is dictated by an opening delimiter, i.e. the line begins inside `(` or `[`.

--- a/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_guard_clause.rb
@@ -161,7 +161,7 @@ module RuboCop
           next_sibling.if_type? && contains_guard_clause?(next_sibling)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def last_heredoc_argument(node)
           n = last_heredoc_argument_node(node)
           n = n.children.first while n.respond_to?(:begin_type?) && n.begin_type?
@@ -176,7 +176,6 @@ module RuboCop
 
           last_heredoc_argument(n.receiver) if n.respond_to?(:receiver)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def last_heredoc_argument_node(node)
           return node unless node.respond_to?(:if_branch)

--- a/lib/rubocop/cop/layout/end_alignment.rb
+++ b/lib/rubocop/cop/layout/end_alignment.rb
@@ -123,7 +123,7 @@ module RuboCop
           AlignmentCorrector.align_end(corrector, processed_source, node, alignment_node(node))
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def check_assignment(node, rhs)
           # If there are method calls chained to the right hand side of the
           # assignment, we let rhs be the receiver of those method calls before
@@ -139,7 +139,6 @@ module RuboCop
 
           check_asgn_alignment(node, rhs)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check_asgn_alignment(outer_node, inner_node)
           align_with = {

--- a/lib/rubocop/cop/layout/line_continuation_spacing.rb
+++ b/lib/rubocop/cop/layout/line_continuation_spacing.rb
@@ -87,7 +87,7 @@ module RuboCop
           corrector.replace(range, correction)
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def ignored_literal_ranges(ast)
           # which lines start inside a string literal?
           return [] if ast.nil?
@@ -106,7 +106,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def comment_ranges(comments)
           comments.map(&:source_range)

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -328,7 +328,7 @@ module RuboCop
           [max - indentation_difference(line), 0].max
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_line(line, line_index)
           return if line_length(line) <= max
           return if allowed_line?(line, line_index)
@@ -348,7 +348,6 @@ module RuboCop
 
           register_offense(excess_range(nil, line, line_index), line, line_index)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def allowed_line?(line, line_index)
           matches_allowed_pattern?(line) ||

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -71,7 +71,7 @@ module RuboCop
 
         BLOCK_TYPES = %i[block numblock itblock].freeze
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_assignment(node, rhs)
           return if node.send_type? && node.loc.operator&.source != '='
           return unless rhs
@@ -80,7 +80,6 @@ module RuboCop
 
           check_by_enforced_style(node, rhs)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def check_by_enforced_style(node, rhs)
           case style

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -91,7 +91,7 @@ module RuboCop
           )
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
         def alignment_source(node, starting_loc)
           ending_loc =
             case node.type
@@ -111,7 +111,6 @@ module RuboCop
 
           range_between(starting_loc.begin_pos, ending_loc.end_pos).source
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         # We will use ancestor or wrapper with access modifier.
 

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -153,7 +153,7 @@ module RuboCop
           [token.line - 1, token.column - 1]
         end
 
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable-next Metrics/ParameterLists
         def issue_offenses(node, tokens, left, right, start_ok, end_ok)
           case style
           when :no_space
@@ -165,13 +165,12 @@ module RuboCop
             compact_offenses(node, tokens, left, right, start_ok, end_ok)
           end
         end
-        # rubocop:enable Metrics/ParameterLists
 
         def next_to_comment?(tokens, token)
           tokens[index_for(tokens, token) + 1].comment?
         end
 
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable-next Metrics/ParameterLists
         def compact_offenses(node, tokens, left, right, start_ok, end_ok)
           if qualifies_for_compact?(tokens, left, side: :left)
             compact_offense(node, left, side: :left)
@@ -185,7 +184,6 @@ module RuboCop
             space_offenses(node, nil, right, MSG, start_ok: true, end_ok: end_ok)
           end
         end
-        # rubocop:enable Metrics/ParameterLists
 
         def qualifies_for_compact?(tokens, token, side: :right)
           if side == :right

--- a/lib/rubocop/cop/lint/ambiguous_range.rb
+++ b/lib/rubocop/cop/lint/ambiguous_range.rb
@@ -83,14 +83,13 @@ module RuboCop
           yield range.end if range.end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def acceptable?(node)
           node.begin_type? ||
             node.literal? || rational_literal?(node) ||
             node.variable? || node.const_type? || node.self_type? ||
             (node.call_type? && acceptable_call?(node))
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def acceptable_call?(node)
           return true if node.unary_operation?

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -105,7 +105,7 @@ module RuboCop
             !processed_source.comment_config.comment_only_line?(directive_comment.line_number)
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def offense_message(directive_comment)
           comment = directive_comment.comment
           after_marker = comment.text.sub(DirectiveComment::DIRECTIVE_MARKER_REGEXP, '')
@@ -122,7 +122,6 @@ module RuboCop
 
           "#{COMMON_MSG} #{additional_msg}"
         end
-        # rubocop:enable Metrics/MethodLength
 
         def near_miss_keyword(comment)
           match = comment.text.match(NEAR_MISS_KEYWORD_REGEXP)

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -28,7 +28,7 @@ module RuboCop
         FOR_METHOD = ' Or, if they were intended to be separate method ' \
                      'arguments, separate them with a comma.'
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
         def on_dstr(node)
           each_bad_cons(node) do |lhs_node, rhs_node|
             range = lhs_node.source_range.join(rhs_node.source_range)
@@ -52,7 +52,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -80,7 +80,7 @@ module RuboCop
                       alternative: alternative)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def ineffective_modifier(node, ignored_methods = nil, modifier = nil, &block)
           node.each_child_node do |child|
             case child.type
@@ -97,7 +97,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def access_modifier?(node)
           node.bare_access_modifier? && !node.method?(:module_function)

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def check(node)
           return if node.parent&.regexp_type?
           return unless /(?<!\\)#\{.*\}/.match?(node.source)
@@ -51,7 +51,6 @@ module RuboCop
 
           add_offense(node) { |corrector| autocorrect(corrector, node) }
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def autocorrect(corrector, node)
           starting_token, ending_token = if node.source.include?('"')

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -88,7 +88,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_while_post(node)
           return if node.condition.source == 'true'
 
@@ -102,7 +102,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def on_until(node)
           return if node.condition.source == 'false'
@@ -118,7 +117,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_until_post(node)
           return if node.condition.source == 'false'
 
@@ -132,7 +131,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def on_case(case_node)
           if (cond = case_node.condition)
@@ -250,7 +248,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def correct_if_node(node, cond)
           result = condition_evaluation?(node, cond)
 
@@ -281,7 +279,6 @@ module RuboCop
             ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -24,7 +24,7 @@ module RuboCop
         MSG = 'Literal interpolation detected.'
         COMPOSITE = %i[array hash pair irange erange].freeze
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_interpolation(begin_node)
           final_node = begin_node.children.last
           return unless offending?(final_node)
@@ -50,7 +50,6 @@ module RuboCop
             corrector.replace(final_node.parent, replacement)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 
@@ -74,7 +73,7 @@ module RuboCop
           node.array_type? && grandparent.regexp_type?
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/MethodLength, Metrics/CyclomaticComplexity
         def autocorrected_value(node)
           case node.type
           when :int
@@ -95,7 +94,6 @@ module RuboCop
             node.source.gsub('"', '\"')
           end
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
         def handle_special_regexp_chars(begin_node, value)
           parent_node = begin_node.parent
@@ -155,7 +153,7 @@ module RuboCop
           "{#{hash_string}}"
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:disable-next Metrics/MethodLength, Metrics/AbcSize
         def autocorrected_value_in_hash(node)
           case node.type
           when :int
@@ -174,7 +172,6 @@ module RuboCop
             node.source.gsub('"', '\"')
           end
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         # Does node print its own source when converted to a string?
         def prints_as_self?(node)

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Lint
@@ -131,4 +131,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Lint/RedundantCopDisableDirective

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -2,7 +2,7 @@
 
 # The Lint/RedundantCopDisableDirective cop needs to be disabled so as
 # to be able to provide a (bad) example of a redundant disable.
-# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Lint
@@ -178,7 +178,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def each_already_disabled(cop, line_ranges)
           line_ranges.each_cons(2) do |previous_range, range|
             next if ignore_offense?(range)
@@ -206,7 +206,6 @@ module RuboCop
             yield comment, redundant if redundant
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def find_redundant_cop(cop, range)
           cop_offenses = offenses_to_check.select { |offense| offense.cop_name == cop }
@@ -423,4 +422,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Lint/RedundantCopDisableDirective

--- a/lib/rubocop/cop/lint/redundant_require_statement.rb
+++ b/lib/rubocop/cop/lint/redundant_require_statement.rb
@@ -63,7 +63,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def redundant_feature?(feature_name)
           feature_name == 'enumerator' ||
             (target_ruby_version >= 2.1 && feature_name == 'thread') ||
@@ -73,7 +73,6 @@ module RuboCop
             (target_ruby_version >= 3.2 && feature_name == 'set') ||
             (target_ruby_version >= 4.0 && feature_name == 'pathname')
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/lib/rubocop/cop/lint/redundant_safe_navigation.rb
+++ b/lib/rubocop/cop/lint/redundant_safe_navigation.rb
@@ -208,7 +208,7 @@ module RuboCop
           add_offense(range) { |corrector| corrector.replace(range, '.') }
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_or(node)
           conversion_with_default?(node) do |send_node|
             range = send_node.loc.dot.begin.join(node.source_range.end)
@@ -221,7 +221,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/lint/redundant_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/redundant_splat_expansion.rb
@@ -139,7 +139,7 @@ module RuboCop
           grandparent.array_type? && grandparent.children.size > 1
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def replacement_range_and_content(node)
           variable = node.children.first
           expression = node.source_range
@@ -157,7 +157,6 @@ module RuboCop
             [node.loc.operator, '']
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def array_splat?(node)
           node.children.first.array_type?

--- a/lib/rubocop/cop/lint/redundant_type_conversion.rb
+++ b/lib/rubocop/cop/lint/redundant_type_conversion.rb
@@ -192,7 +192,7 @@ module RuboCop
           (hash (pair (sym :exception) false))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity
         def on_send(node)
           return if node.arguments.any? || hash_or_set_with_block?(node)
 
@@ -208,7 +208,6 @@ module RuboCop
             corrector.remove(node.loc.dot.join(node.loc.end || node.loc.selector))
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
         alias on_csend on_send
 
         private

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -33,7 +33,7 @@ module RuboCop
         MSG_EACH_WITH_INDEX = 'Use `each` instead of `each_with_index`.'
         MSG_WITH_INDEX = 'Remove redundant `with_index`.'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_block(node)
           return unless node.receiver
           return if node.method?(:with_index) && !node.receiver.receiver
@@ -50,7 +50,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         alias on_numblock on_block
         alias on_itblock on_block

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -45,7 +45,7 @@ module RuboCop
           }
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
           return unless require_safe_navigation?(node)
 
@@ -63,7 +63,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -85,7 +85,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def find_consistent_parts(grouped_operands)
           csend_in_and, csend_in_or, send_in_and, send_in_or = most_left_indices(grouped_operands)
 
@@ -99,7 +99,6 @@ module RuboCop
             ['.', csend_in_or]
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def already_appropriate_call?(operand, dot_op)
           return true if operand.safe_navigation? && dot_op == '&.'
@@ -126,7 +125,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def most_left_indices(grouped_operands)
           indices = { csend_in_and: nil, csend_in_or: nil, send_in_and: nil, send_in_or: nil }
 
@@ -139,7 +138,6 @@ module RuboCop
 
           indices.values
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def operand_in_and?(node)
           return true if node.parent.and_type?

--- a/lib/rubocop/cop/lint/suppressed_exception_in_number_conversion.rb
+++ b/lib/rubocop/cop/lint/suppressed_exception_in_number_conversion.rb
@@ -78,7 +78,7 @@ module RuboCop
 
         minimum_target_ruby_version 2.6
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_rescue(node)
           if (method, exception_classes = begin_numeric_constructor_rescue_nil(node.parent))
             return unless expected_exception_classes_only?(exception_classes)
@@ -100,7 +100,6 @@ module RuboCop
             corrector.replace(node, prefer)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/lint/to_enum_arguments.rb
+++ b/lib/rubocop/cop/lint/to_enum_arguments.rb
@@ -135,7 +135,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         def argument_match?(send_arg, def_arg)
           def_arg_name = def_arg.children[0]
 
@@ -157,7 +157,6 @@ module RuboCop
             send_arg.forwarded_args_type?
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
         def keyword_hash_argument?(send_arg)
           send_arg.hash_type? && !send_arg.braces?

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -83,7 +83,7 @@ module RuboCop
           }
         PATTERN
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def flow_expression?(node)
           return report_on_flow_command?(node) if flow_command?(node)
 
@@ -102,7 +102,6 @@ module RuboCop
             false
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def check_if(node)
           if_branch = node.if_branch

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -210,7 +210,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_child_nodes(node, unused, cur_vis)
           node.child_nodes.each do |child|
             if child.send_type? && access_modifier?(child)
@@ -228,7 +228,6 @@ module RuboCop
 
           [cur_vis, unused]
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def check_send_node(node, cur_vis, unused)
           if node.bare_access_modifier?

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -173,7 +173,7 @@ module RuboCop
           node.receiver.nil? && !node.arguments?
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def autocorrect(corrector, assignment)
           if assignment.exception_assignment?
             remove_exception_assignment_part(corrector, assignment.node)
@@ -189,7 +189,6 @@ module RuboCop
             remove_local_variable_assignment_part(corrector, assignment.node)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def remove_exception_assignment_part(corrector, node)
           range = node.parent.children.first&.source_range || node.parent.location.keyword

--- a/lib/rubocop/cop/lint/useless_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_rescue.rb
@@ -56,7 +56,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity
         def only_reraising?(resbody_node)
           return false if use_exception_variable_in_ensure?(resbody_node)
 
@@ -70,7 +70,6 @@ module RuboCop
 
           exception_objects(resbody_node).include?(exception_name)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         def use_exception_variable_in_ensure?(resbody_node)
           return false unless (exception_variable = resbody_node.exception_variable)

--- a/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
+++ b/lib/rubocop/cop/lint/utils/nil_receiver_checker.rb
@@ -22,7 +22,7 @@ module RuboCop
 
           private
 
-          # rubocop:disable Metrics
+          # rubocop:disable-next Metrics
           def _cant_be_nil?(node, receiver)
             return false unless node
 
@@ -78,13 +78,12 @@ module RuboCop
               false
             end
           end
-          # rubocop:enable Metrics
 
           def non_nil_method?(method_name)
             !NIL_METHODS.include?(method_name) && !@additional_nil_methods.include?(method_name)
           end
 
-          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+          # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
           def sole_condition_of_parent_if?(node)
             child = node
             parent = node.parent
@@ -108,7 +107,6 @@ module RuboCop
 
             false
           end
-          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
           def non_nil_condition?(condition, node)
             return true if condition == node && same_binding_as_receiver?(condition)

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -153,7 +153,7 @@ module RuboCop
           check_expression(case_node.else_branch) if case_node.else_branch
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_void_op(node, &block)
           node = node.children.first while node&.begin_type?
           return unless node&.call_type? && OPERATORS.include?(node.method_name)
@@ -168,7 +168,6 @@ module RuboCop
             autocorrect_void_op(corrector, node)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def check_var(node)
           return unless node.variable? || node.const_type?

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def complexity_score_for(node)
           case node.type
           when :case
@@ -74,7 +74,6 @@ module RuboCop
             super
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def simple_in_pattern?(in_pattern_node)
           # `in_pattern_node.children[1]` is the guard (`if`/`unless`), or `nil`.

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -2,7 +2,7 @@
 
 # Lint/RedundantCopDisableDirective needs to be disabled so as
 # to be able to provide examples of rubocop:disable comments.
-# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective
 module RuboCop
   module Cop
     module Migration
@@ -85,4 +85,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Lint/RedundantCopDisableDirective

--- a/lib/rubocop/cop/mixin/comments_help.rb
+++ b/lib/rubocop/cop/mixin/comments_help.rb
@@ -64,7 +64,7 @@ module RuboCop
       # Returns the end line of a node, which might be a comment and not part of the AST
       # End line is considered either the line at which another node starts, or
       # the line at which the parent node ends.
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def find_end_line(node)
         if node.if_type?
           if node.else?
@@ -89,7 +89,6 @@ module RuboCop
           end
         end || node.loc.end.line
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     end
   end
 end

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -25,7 +25,7 @@ module RuboCop
       end
       private_constant :SYMBOL_TO_STRING_CACHE
 
-      # rubocop:disable Metrics
+      # rubocop:disable-next Metrics
       def style_detected(detected)
         return if no_acceptable_style?
 
@@ -51,7 +51,6 @@ module RuboCop
           config_to_allow_offenses[style_parameter_name] = updated_list.first
         end
       end
-      # rubocop:enable Metrics
 
       def no_acceptable_style?
         config_to_allow_offenses['Enabled'] == false

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -117,7 +117,7 @@ module RuboCop
           use_modifier_form_without_parenthesized_method_call?(method_dispatch_node)
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def def_node_that_require_parentheses(node)
         last_pair = node.parent.pairs.last
         return unless last_pair.key.source == last_pair.value.source
@@ -131,7 +131,6 @@ module RuboCop
 
         DefNode.new(def_node) unless def_node && def_node.arguments.empty?
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def find_ancestor_method_dispatch_node(node)
         return unless (ancestor = node.parent.parent)

--- a/lib/rubocop/cop/mixin/hash_subset.rb
+++ b/lib/rubocop/cop/mixin/hash_subset.rb
@@ -5,7 +5,7 @@ module RuboCop
     # Common functionality for Style/HashExcept and Style/HashSlice cops.
     # It registers an offense on methods with blocks that are equivalent
     # to Hash#except or Hash#slice.
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module HashSubset
       include RangeHelp
       extend NodePattern::Macros
@@ -206,6 +206,5 @@ module RuboCop
         range_between(node.loc.selector.begin_pos, node.parent.loc.end.end_pos)
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common functionality for checking whether an AST node/token is aligned
     # with something on a preceding or following line
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module PrecedingFollowingAlignment
       # Tokens that end with an `=`, as well as `<<`, that can be aligned together:
       # `=`, `==`, `===`, `!=`, `<=`, `>=`, `<<` and operator assignment (`+=`, etc).
@@ -214,6 +214,5 @@ module RuboCop
         asgn_tokens.reject { |t| eqls_to_ignore.include?(t.begin_pos) }
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -116,14 +116,13 @@ module RuboCop
         end
       end
 
-      # rubocop:disable Metrics/ParameterLists
+      # rubocop:disable-next Metrics/ParameterLists
       def final_pos(src, pos, increment, continuations, newlines, whitespace)
         pos = move_pos(src, pos, increment, true, /[ \t]/)
         pos = move_pos_str(src, pos, increment, continuations, "\\\n")
         pos = move_pos(src, pos, increment, newlines, /\n/)
         move_pos(src, pos, increment, whitespace, /\s/)
       end
-      # rubocop:enable Metrics/ParameterLists
 
       def move_pos(src, pos, step, condition, regexp)
         offset = step == -1 ? -1 : 0

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common methods shared by Style/TrailingCommaInArguments,
     # Style/TrailingCommaInArrayLiteral and Style/TrailingCommaInHashLiteral
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module TrailingComma
       include ConfigurableEnforcedStyle
       include RangeHelp
@@ -95,7 +95,7 @@ module RuboCop
         node.multiline? && !allowed_multiline_argument?(node)
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable-next Metrics/AbcSize
       def method_name_and_arguments_on_same_line?(node)
         return false if !node.call_type? || node.last_line != node.last_argument.last_line
         return true if node.last_argument.hash_type? && node.last_argument.braces?
@@ -104,7 +104,6 @@ module RuboCop
 
         line == node.last_argument.last_line
       end
-      # rubocop:enable Metrics/AbcSize
 
       # A single argument with the closing bracket on the same line as the end
       # of the argument is not considered multiline, even if the argument
@@ -223,6 +222,5 @@ module RuboCop
         false
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -167,7 +167,7 @@ module RuboCop
         PATTERN
 
         # rubocop:disable Metrics/AbcSize
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def on_or_asgn(node)
           lhs = node.lhs
           return unless lhs.ivasgn_type?
@@ -192,7 +192,6 @@ module RuboCop
             corrector.replace(lhs.loc.name, "@#{suggested_var}")
           end
         end
-        # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/AbcSize
 
         # @!method defined_memoized?(node, ivar)
@@ -203,7 +202,7 @@ module RuboCop
             $(ivasgn %1 _))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
         def on_defined?(node)
           arg = node.first_argument
           return false unless arg.ivar_type?
@@ -233,7 +232,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         private
 

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -209,7 +209,7 @@ module RuboCop
           forbidden_identifier?(name) || forbidden_pattern?(name)
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # rubocop:disable-next Metrics/MethodLength, Metrics/AbcSize
         def register_forbidden_name(node)
           if node.any_def_type?
             name_node = node.loc.name
@@ -227,7 +227,6 @@ module RuboCop
           message = format(MSG_FORBIDDEN, identifier: method_name)
           add_offense(name_node, message: message)
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         def attr_name(name_item)
           sym_name(name_item) || str_name(name_item)

--- a/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
+++ b/lib/rubocop/cop/naming/rescued_exceptions_variable_name.rb
@@ -118,7 +118,7 @@ module RuboCop
 
         # Returns the reassignment node once the exception variable is reassigned (a truthy
         # signal to stop correcting later references), or `nil` when no reassignment is found.
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def correct_node(corrector, node, offending_name, preferred_name)
           return unless node
 
@@ -141,7 +141,6 @@ module RuboCop
           end
           nil
         end
-        # rubocop:enable Metrics/MethodLength
 
         # If the exception variable is reassigned, that assignment needs to be corrected.
         # Further `lvar` nodes will not be corrected though since they now refer to a

--- a/lib/rubocop/cop/style.rb
+++ b/lib/rubocop/cop/style.rb
@@ -58,6 +58,7 @@ module RuboCop
       register_cop :DigChain, "#{__dir__}/style/dig_chain"
       register_cop :Dir, "#{__dir__}/style/dir"
       register_cop :DirEmpty, "#{__dir__}/style/dir_empty"
+      register_cop :DirectiveScope, "#{__dir__}/style/directive_scope"
       register_cop :DisableCopsWithinSourceCodeDirective, "#{__dir__}/style/disable_cops_within_source_code_directive"
       register_cop :DocumentationMethod, "#{__dir__}/style/documentation_method"
       register_cop :Documentation, "#{__dir__}/style/documentation"

--- a/lib/rubocop/cop/style/accessor_grouping.rb
+++ b/lib/rubocop/cop/style/accessor_grouping.rb
@@ -100,7 +100,7 @@ module RuboCop
           comment_line?(processed_source[node.first_line - 2])
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def groupable_accessor?(node)
           return true unless (previous_expression = node.left_siblings.last)
 
@@ -122,7 +122,6 @@ module RuboCop
             previous_expression.access_modifier? ||
             node.first_line - previous_expression.last_line > 1 # there is a space between nodes
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def class_send_elements(class_node)
           class_def = class_node.body

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -197,7 +197,7 @@ module RuboCop
           send_classifications.all? { |_, c, _, _| all_classifications.include?(c) }
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def add_forward_all_offenses(node, send_classifications, forwardable_args)
           rest_arg, kwrest_arg, block_arg = *forwardable_args
           registered_block_arg_offense = false
@@ -220,13 +220,12 @@ module RuboCop
 
           register_forward_all_offense(node, node.arguments, rest_arg || kwrest_arg)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def forward_all_first_argument(node)
           node.arguments.reverse_each.find(&:forwarded_restarg_type?)
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
         def add_post_ruby_32_offenses(def_node, send_classifications, forwardable_args)
           return unless use_anonymous_forwarding?
           return unless all_forwarding_offenses_correctable?(send_classifications)
@@ -250,7 +249,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         def non_splat_or_block_pass_lvar_references(body)
           body.each_descendant(:lvar, :lvasgn).filter_map do |lvar|
@@ -473,7 +471,7 @@ module RuboCop
 
           private
 
-          # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable-next Metrics/CyclomaticComplexity
           def can_forward_all?
             return false if any_arg_referenced?
             return false if ruby_30_or_lower_optarg?
@@ -483,7 +481,6 @@ module RuboCop
 
             no_additional_args? || (target_ruby_version >= 3.0 && no_post_splat_args?)
           end
-          # rubocop:enable Metrics/CyclomaticComplexity
 
           # def foo(a = 41, ...) is a syntax error in 3.0.
           def ruby_30_or_lower_optarg?

--- a/lib/rubocop/cop/style/array_first_last.rb
+++ b/lib/rubocop/cop/style/array_first_last.rb
@@ -31,7 +31,7 @@ module RuboCop
         MSG = 'Use `%<preferred>s`.'
         RESTRICT_ON_SEND = %i[[]].freeze
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
           return unless node.arguments.size == 1 && node.first_argument.int_type?
 
@@ -49,7 +49,6 @@ module RuboCop
             corrector.replace(offense_range, preferred_value(node, preferred))
           end
         end
-        # rubocop:enable Metrics/AbcSize
         alias on_csend on_send
 
         private

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -70,7 +70,7 @@ module RuboCop
             (send _ :& _))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
           return unless node.receiver&.begin_type?
           return unless (preferred_method = preferred_method(node))
@@ -88,7 +88,6 @@ module RuboCop
             corrector.replace(node, preferred)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable-next Metrics/ClassLength
 module RuboCop
   module Cop
     module Style
@@ -344,7 +344,7 @@ module RuboCop
           node.respond_to?(:block_node) && node.block_node
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def get_blocks(node, &block)
           case node.type
           when :block, :numblock, :itblock
@@ -368,9 +368,8 @@ module RuboCop
             node.each_child_node { |child| get_blocks(child, &block) }
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
-        # rubocop:disable Metrics/CyclomaticComplexity -- inlined special_method checks to avoid double evaluation
+        # rubocop:disable-next Metrics/CyclomaticComplexity -- inlined special_method checks to avoid double evaluation
         def proper_block_style?(node)
           return true if require_do_end?(node)
 
@@ -385,7 +384,6 @@ module RuboCop
           when :always_braces       then node.braces?
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def require_do_end?(node)
           return false if node.braces? || node.multiline?
@@ -507,4 +505,3 @@ module RuboCop
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -98,7 +98,7 @@ module RuboCop
             node.elsif_conditional? && min_branches_count?(node)
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def find_target(node)
           case node.type
           when :begin
@@ -116,7 +116,6 @@ module RuboCop
             find_target_in_send_node(node)
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def find_target_in_send_node(node)
           case node.method_name
@@ -181,7 +180,7 @@ module RuboCop
           conditions << condition if condition
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def condition_from_send_node(node, target)
           case node.method_name
           when :is_a?
@@ -196,7 +195,6 @@ module RuboCop
             condition_from_include_or_cover_node(node, target)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def condition_from_equality_node(node, target)
           condition = condition_from_binary_op(node.receiver, node.first_argument, target)

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -194,7 +194,7 @@ module RuboCop
             "#{node.body.children.first.const_name}"
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def remove_end(corrector, body)
           remove_begin_pos = if same_line?(body.loc.name, body.loc.end)
                                body.loc.name.end_pos
@@ -206,7 +206,6 @@ module RuboCop
 
           corrector.remove(range)
         end
-        # rubocop:enable Metrics/AbcSize
 
         def unindent(corrector, node)
           return unless node.body.children.last

--- a/lib/rubocop/cop/style/combinable_loops.rb
+++ b/lib/rubocop/cop/style/combinable_loops.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         MSG = 'Combine this loop with the previous loop.'
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def on_block(node)
           return unless node.parent&.begin_type?
           return unless collection_looping_method?(node)
@@ -77,7 +77,6 @@ module RuboCop
             combine_with_left_sibling(corrector, node)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         alias on_numblock on_block
         alias on_itblock on_block

--- a/lib/rubocop/cop/style/concat_array_literals.rb
+++ b/lib/rubocop/cop/style/concat_array_literals.rb
@@ -30,7 +30,7 @@ module RuboCop
           'Use `push` with elements as arguments without array brackets instead of `%<current>s`.'
         RESTRICT_ON_SEND = %i[concat].freeze
 
-        # rubocop:disable Metrics
+        # rubocop:disable-next Metrics
         def on_send(node)
           return if node.arguments.empty?
           return unless node.arguments.all?(&:array_type?)
@@ -68,7 +68,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics
         alias on_csend on_send
 
         private

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -448,7 +448,7 @@ module RuboCop
       # Helper module to provide common methods to ConditionalAssignment
       # correctors
       module ConditionalCorrectorHelper
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity
         def remove_whitespace_in_branches(corrector, branch, condition, column)
           branch.each_node do |child|
             next if child.source_range.nil?
@@ -468,7 +468,6 @@ module RuboCop
 
           corrector.remove_preceding(condition.loc.end, condition.loc.end.column - column)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         def same_line?(node1, node2)
           RuboCop::Cop::Util.same_line?(node1, node2)

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -82,7 +82,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def visibility_declaration?(node)
           node.parent.each_child_node(:send).any? do |child|
             next false unless (arguments = visibility_declaration_for(child))
@@ -98,7 +98,6 @@ module RuboCop
             constant_values.include?(node.name)
           end
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = 'Include a copyright notice matching /%<notice>s/ before any code.'
         AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in your RuboCop config'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_new_investigation
           return if notice.empty? || notice_found?(processed_source)
 
@@ -43,7 +43,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/style/directive_scope.rb
+++ b/lib/rubocop/cop/style/directive_scope.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Checks for directive scopes that can be expressed with the tighter
+      # `disable-next` form: a `disable`/`enable` pair wrapping exactly one
+      # statement, or a `push`/`pop` that only disables cops around exactly
+      # one statement. A statement-scoped directive cannot drift as the
+      # surrounding code changes and needs no closing boundary.
+      #
+      # @safety
+      #   The autocorrection is unsafe because the suppression scope shrinks
+      #   from the whole region to the statement: offenses of the suppressed
+      #   cops located on the directive lines themselves resurface.
+      #
+      # @example
+      #   # bad
+      #   # rubocop:disable Metrics/AbcSize
+      #   def foo
+      #   end
+      #   # rubocop:enable Metrics/AbcSize
+      #
+      #   # good
+      #   # rubocop:disable-next Metrics/AbcSize
+      #   def foo
+      #   end
+      #
+      #   # bad
+      #   # rubocop:push -Metrics/AbcSize
+      #   def foo
+      #   end
+      #   # rubocop:pop
+      #
+      #   # good
+      #   # rubocop:disable-next Metrics/AbcSize
+      #   def foo
+      #   end
+      #
+      #   # good - the region spans more than one statement
+      #   # rubocop:disable Metrics/AbcSize
+      #   def foo
+      #   end
+      #
+      #   def bar
+      #   end
+      #   # rubocop:enable Metrics/AbcSize
+      #
+      class DirectiveScope < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG_PAIR = 'Use `%<mode>s-next` instead of a `%<mode>s`/`enable` pair ' \
+                   'around a single statement.'
+        MSG_PUSH_POP = 'Use `disable-next` instead of `push`/`pop` around a single statement.'
+
+        def on_new_investigation
+          processed_source.comments.each do |comment|
+            directive = DirectiveComment.new(comment)
+            next unless comment_config.comment_only_line?(directive.line_number)
+
+            if plain_disable?(directive)
+              check_pair(directive)
+            elsif disable_only_push?(directive)
+              check_push_pop(directive)
+            end
+          end
+        end
+
+        private
+
+        def comment_config
+          processed_source.comment_config
+        end
+
+        def plain_disable?(directive)
+          directive.disabled? && !directive.disable_next?
+        end
+
+        def disable_only_push?(directive)
+          directive.push? && !directive.push_args.empty? && directive.push_args.keys == ['-']
+        end
+
+        def check_pair(directive)
+          enable = single_statement_closing_directive(directive)
+          return unless enable&.enabled?
+          return unless enable.raw_cop_names.sort == directive.raw_cop_names.sort
+
+          message = format(MSG_PAIR, mode: directive.mode)
+          add_offense(directive.comment, message: message) do |corrector|
+            convert_pair(corrector, directive, enable)
+          end
+        end
+
+        def convert_pair(corrector, directive, enable)
+          replacement = directive.comment.text.sub(/\b#{directive.mode}\b/,
+                                                   "#{directive.mode}-next")
+          corrector.replace(directive.comment, replacement)
+          remove_line(corrector, enable.comment)
+        end
+
+        def check_push_pop(directive)
+          pop = single_statement_closing_directive(directive)
+          return unless pop&.pop?
+
+          add_offense(directive.comment, message: MSG_PUSH_POP) do |corrector|
+            corrector.replace(directive.comment, disable_next_replacement(directive))
+            remove_line(corrector, pop.comment)
+          end
+        end
+
+        # The directive closing this one's scope, when that scope wraps
+        # exactly one statement - `nil` otherwise.
+        def single_statement_closing_directive(directive)
+          closing_line = single_closing_line(directive)
+          return nil unless closing_line
+
+          closing_comment = processed_source.comment_at_line(closing_line)
+          return nil unless closing_comment
+          return nil unless wraps_single_statement?(directive, closing_line)
+
+          DirectiveComment.new(closing_comment)
+        end
+
+        # The single line on which every disabled range opened by this
+        # directive ends, or `nil` when the ranges disagree or never close.
+        # For a `disable` that is the `enable` line; for a `push` it is the
+        # line before the `pop`.
+        def single_closing_line(directive)
+          ranges = ranges_opened_by(directive)
+          return nil if ranges.empty?
+
+          ends = ranges.map(&:end).uniq
+          return nil unless ends.size == 1 && ends.first.to_f.finite?
+
+          directive.push? ? ends.first + 1 : ends.first
+        end
+
+        def ranges_opened_by(directive)
+          comment_config.cop_disabled_line_ranges.each_value.flat_map do |ranges|
+            ranges.select do |range|
+              range.respond_to?(:directive) && range.directive.comment.equal?(directive.comment)
+            end
+          end
+        end
+
+        # The region wraps a single statement only when the directive sits
+        # immediately above it and the closing directive immediately below -
+        # any other line inside the region (a comment, a blank line) may
+        # carry offenses of the suppressed cops that the tighter scope
+        # would no longer cover.
+        def wraps_single_statement?(directive, closing_line)
+          scope = comment_config.statement_scope_after(directive.line_number)
+
+          !scope.nil? && scope.begin == directive.line_number + 1 && scope.end + 1 == closing_line
+        end
+
+        def disable_next_replacement(directive)
+          cops = directive.push_args['-'].join(', ')
+          reason = directive.reason
+          text = "# rubocop:disable-next #{cops}"
+          reason ? "#{text} -- #{reason}" : text
+        end
+
+        def remove_line(corrector, comment)
+          corrector.remove(range_by_whole_lines(comment.source_range, include_final_newline: true))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -42,7 +42,7 @@ module RuboCop
         MSG = 'Do not use empty `case` condition, instead use an `if` expression.'
         NOT_SUPPORTED_PARENT_TYPES = %i[return break next send csend yield super].freeze
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_case(case_node)
           if case_node.condition || NOT_SUPPORTED_PARENT_TYPES.include?(case_node.parent&.type)
             return
@@ -56,7 +56,6 @@ module RuboCop
 
           add_offense(case_node.loc.keyword) { |corrector| autocorrect(corrector, case_node) }
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -228,7 +228,7 @@ module RuboCop
           "Prefer #{message_text(style)} over #{message_text(detected_style)}."
         end
 
-        # rubocop:disable Style/FormatStringToken
+        # rubocop:disable-next Style/FormatStringToken
         def message_text(style)
           {
             annotated: 'annotated tokens (like `%<foo>s`)',
@@ -236,7 +236,6 @@ module RuboCop
             unannotated: 'unannotated tokens (like `%s`)'
           }[style]
         end
-        # rubocop:enable Style/FormatStringToken
 
         def tokens(str_node, &block)
           return if str_node.source == '__FILE__'

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -196,7 +196,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def autocorrect(corrector, node, condition, replacement, guard)
           corrector.replace(node.loc.keyword.join(condition.source_range), replacement)
 
@@ -217,7 +217,6 @@ module RuboCop
             corrector.remove(range_of_branch_to_remove(node, guard))
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def heredoc?(argument)
           argument.respond_to?(:heredoc?) && argument.heredoc?

--- a/lib/rubocop/cop/style/hash_each_methods.rb
+++ b/lib/rubocop/cop/style/hash_each_methods.rb
@@ -76,7 +76,7 @@ module RuboCop
         alias on_numblock on_block
         alias on_itblock on_block
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def check_unused_block_args(node, key, value)
           return if node.body.nil?
 
@@ -96,7 +96,6 @@ module RuboCop
             register_each_args_offense(node, message, 'each_value', unused_range)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def on_block_pass(node)
           kv_each_with_block_pass(node.parent) do |target, method|

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -217,7 +217,7 @@ module RuboCop
           acceptable_19_syntax_symbol?(pair.key.source)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def acceptable_19_syntax_symbol?(sym_name)
           sym_name.delete_prefix!(':')
 
@@ -237,7 +237,6 @@ module RuboCop
           (sym_name.start_with?("'") && sym_name.end_with?("'")) ||
             (sym_name.start_with?('"') && sym_name.end_with?('"'))
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check(pairs, delim, msg)
           pairs.each do |pair|

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -136,7 +136,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def check_branches(node, branches)
           # return if any branch is empty. An empty branch can be an `if`
           # without an `else` or a branch that contains only comments.
@@ -168,7 +168,6 @@ module RuboCop
 
           check_expressions(node, heads, :before_condition)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def duplicated_expressions?(node, expressions)
           unique_expressions = expressions.uniq
@@ -189,7 +188,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def check_expressions(node, expressions, insert_position)
           return if expressions.any?(&:nil?)
 
@@ -213,7 +212,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         def correct_assignment(corrector, node, expression, insert_position)
           indentation = indentation_of(node.parent)

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         MSG = 'Convert `if` nested inside `else` to `elsif`.'
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
           return if node.ternary? || node.unless?
 
@@ -81,7 +81,6 @@ module RuboCop
             ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -91,7 +91,7 @@ module RuboCop
           [Style::Next, Style::SoleNestedConditional]
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_if(node)
           return if endless_method?(node.body) || node.each_ancestor(:dstr).any?
 
@@ -109,7 +109,6 @@ module RuboCop
             ignore_node(node)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         MSG = 'Avoid modifier `%<keyword>s` after another conditional.'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_if(node)
           return unless node.modifier_form? && node.body.if_type?
 
@@ -37,7 +37,6 @@ module RuboCop
             corrector.remove(node.if_branch.source_range.end.join(node.condition.source_range.end))
           end
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/lib/rubocop/cop/style/map_to_hash.rb
+++ b/lib/rubocop/cop/style/map_to_hash.rb
@@ -67,7 +67,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def autocorrect(corrector, to_h, map)
           removal_range = range_between(to_h.loc.dot.begin_pos, to_h.loc.selector.end_pos)
 
@@ -83,7 +83,6 @@ module RuboCop
             corrector.replace(argument, argument.source[1..-2])
           end
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       class MethodCallWithArgsParentheses
         # Style omit_parentheses
-        # rubocop:disable Metrics/ModuleLength, Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/ModuleLength, Metrics/CyclomaticComplexity
         module OmitParentheses
           include RangeHelp
           include ReparsedEquivalence
@@ -150,7 +150,7 @@ module RuboCop
             node.parent&.class_type? && node.parent.single_line?
           end
 
-          # rubocop:disable Metrics/PerceivedComplexity
+          # rubocop:disable-next Metrics/PerceivedComplexity
           def call_with_ambiguous_arguments?(node)
             call_with_braced_block?(node) ||
               call_in_argument_with_block?(node) ||
@@ -163,7 +163,6 @@ module RuboCop
                   ambiguous_literal?(n) || logical_operator?(n)
               end
           end
-          # rubocop:enable Metrics/PerceivedComplexity
 
           def call_with_braced_block?(node)
             node.type?(:call, :super) && node.block_node&.braces?
@@ -269,7 +268,6 @@ module RuboCop
             last_argument.hash_type? && last_argument.children.any?(&:forwarded_kwrestarg_type?)
           end
         end
-        # rubocop:enable Metrics/ModuleLength, Metrics/CyclomaticComplexity
       end
     end
   end

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         MSG = 'Do not use parentheses for method calls with no arguments.'
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def on_send(node)
           return unless !node.arguments? && node.parenthesized?
           return if ineligible_node?(node)
@@ -44,7 +44,6 @@ module RuboCop
 
           register_offense(node)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
         alias on_csend on_send
 
         private

--- a/lib/rubocop/cop/style/multiline_method_signature.rb
+++ b/lib/rubocop/cop/style/multiline_method_signature.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def autocorrect(corrector, node, begin_of_arguments)
           arguments = node.arguments
           joined_arguments = arguments.map(&:source).join(', ')
@@ -62,7 +62,6 @@ module RuboCop
           corrector.remove(arguments_range)
           corrector.insert_after(begin_of_arguments, joined_arguments)
         end
-        # rubocop:enable Metrics/AbcSize
 
         def last_line_source_of_arguments(arguments)
           processed_source[arguments.last_line - 1].strip

--- a/lib/rubocop/cop/style/negated_if_else_condition.rb
+++ b/lib/rubocop/cop/style/negated_if_else_condition.rb
@@ -46,7 +46,7 @@ module RuboCop
           @corrected_nodes = nil
         end
 
-        # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/AbcSize,Metrics/CyclomaticComplexity
         def on_if(node)
           return unless if_else?(node)
           return unless (condition = unwrap_begin_nodes(node.condition))
@@ -64,7 +64,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize,Metrics/CyclomaticComplexity
 
         private
 

--- a/lib/rubocop/cop/style/negative_array_index.rb
+++ b/lib/rubocop/cop/style/negative_array_index.rb
@@ -91,7 +91,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def range_with_length_subtraction?(range_node, array_receiver)
           return false unless range_node&.range_type?
 
@@ -108,7 +108,6 @@ module RuboCop
 
           receivers_match_strict?(length_receiver, array_receiver)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def handle_range_pattern(receiver, range_node, index_arg)
           range_end = range_node.end
@@ -124,7 +123,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable-next Metrics/ParameterLists
         def build_range_offense_data(receiver, range_node, range_end, inner_end, negative_index,
                                      index_arg)
           range_op = range_node.erange_type? ? '...' : '..'
@@ -140,7 +139,6 @@ module RuboCop
 
           [message, replacement]
         end
-        # rubocop:enable Metrics/ParameterLists
 
         def format_range_message_parts(range_start, negative_index, index_arg)
           has_parentheses = index_arg.begin_type?

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -42,7 +42,7 @@ module RuboCop
         # @!method nil_check?(node)
         def_node_matcher :nil_check?, '(send _ :nil?)'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
           return unless node.receiver
 
@@ -61,7 +61,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rubocop/cop/style/operator_method_call.rb
+++ b/lib/rubocop/cop/style/operator_method_call.rb
@@ -26,7 +26,7 @@ module RuboCop
           splat kwsplat forwarded_args forwarded_restarg forwarded_kwrestarg block_pass
         ].freeze
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_send(node)
           return unless (dot = node.loc.dot)
           return if unary_method_no_operator?(node)
@@ -44,7 +44,6 @@ module RuboCop
             corrector.insert_after(selector, ' ') if insert_space_after?(node)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -184,9 +184,8 @@ module RuboCop
           def accesses?(rhs, lhs)
             if lhs.method?(:[]=)
               # FIXME: Workaround `rubocop:disable` comment for JRuby.
-              # rubocop:disable Performance/RedundantEqualityComparisonBlock
+              # rubocop:disable-next Performance/RedundantEqualityComparisonBlock
               matching_calls(rhs, lhs.receiver, :[]).any? { |args| args == lhs.arguments }
-              # rubocop:enable Performance/RedundantEqualityComparisonBlock
             else
               access_method = lhs.method_name.to_s.chop.to_sym
               matching_calls(rhs, lhs.receiver, access_method).any?

--- a/lib/rubocop/cop/style/redundant_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_assignment.rb
@@ -57,7 +57,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def check_branch(node)
           return unless node
 
@@ -72,7 +72,6 @@ module RuboCop
             check_begin_node(node)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check_case_node(node)
           node.when_branches.each { |when_node| check_branch(when_node.body) }

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -180,7 +180,7 @@ module RuboCop
             !use_hash_key_access?(if_branch)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def if_branch_is_true_type_and_else_is_not?(node)
           return false unless node.ternary? || node.if?
 
@@ -190,7 +190,6 @@ module RuboCop
 
           node.if_branch&.true_type? && node.else_branch && !node.else_branch.true_type?
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def branches_have_assignment?(node)
           _condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
@@ -240,7 +239,7 @@ module RuboCop
           "#{method.source}(#{arguments.source})"
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def if_source(if_branch, arithmetic_operation)
           if branches_have_method?(if_branch.parent) && if_branch.parenthesized?
             if_branch.source.delete_suffix(')')
@@ -257,7 +256,6 @@ module RuboCop
             if_branch.source
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def else_source(else_branch, arithmetic_operation) # rubocop:disable Metrics/AbcSize
           if arithmetic_operation

--- a/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
+++ b/lib/rubocop/cop/style/redundant_double_splat_hash_braces.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = 'Remove the redundant double splat and braces, use keyword arguments directly.'
         MERGE_METHODS = %i[merge merge!].freeze
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_hash(node)
           return if node.pairs.empty? || node.pairs.any?(&:hash_rocket?)
           return unless (parent = node.parent)
@@ -38,7 +38,6 @@ module RuboCop
             autocorrect(corrector, node, kwsplat)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 

--- a/lib/rubocop/cop/style/redundant_each.rb
+++ b/lib/rubocop/cop/style/redundant_each.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def redundant_each_method(node)
           return if node.last_argument&.block_pass_type?
 
@@ -81,7 +81,6 @@ module RuboCop
 
           prev_method if detected || prev_method.method?(:reverse_each)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def range(node)
           return node.selector unless node.method?(:each)

--- a/lib/rubocop/cop/style/redundant_format.rb
+++ b/lib/rubocop/cop/style/redundant_format.rb
@@ -155,7 +155,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def all_fields_literal?(string, arguments)
           count = 0
           sequences = RuboCop::Cop::Utils::FormatString.new(string).format_sequences
@@ -175,7 +175,6 @@ module RuboCop
 
           sequences.size == count
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         # If the sequence has a variable (`*`) width, it cannot be autocorrected
         # if the width is not given as a numeric literal argument
@@ -186,7 +185,7 @@ module RuboCop
           argument.nil? || !numeric?(argument)
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def find_argument(sequence, arguments, hash)
           if hash && (sequence.annotated? || sequence.template?)
             find_hash_value_node(hash, sequence.name.to_sym).first
@@ -200,7 +199,6 @@ module RuboCop
             arguments.shift
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def matching_argument?(sequence, argument)
           # Template specifiers don't give a type, any acceptable literal type is ok.

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -152,7 +152,7 @@ module RuboCop
           check_send(begin_node, node) if call_node?(node)
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def find_offense_message(begin_node, node)
           return 'a keyword' if keyword_with_redundant_parentheses?(node)
           return 'a literal' if node.literal? && disallowed_literal?(begin_node, node)
@@ -189,7 +189,6 @@ module RuboCop
             'a comparison expression'
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         # @!method interpolation?(node)
         def_node_matcher :interpolation?, '[^begin ^^dstr]'
@@ -305,7 +304,7 @@ module RuboCop
           parent.begin_type? && parent.children.one?
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def body_range?(begin_node, node)
           return false if begin_node.chained?
           return false unless node.range_type?
@@ -315,7 +314,6 @@ module RuboCop
           (node.begin.nil? && begin_node == parent.children.first) ||
             (node.end.nil? && begin_node == parent.children.last)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def disallowed_one_line_pattern_matching?(begin_node, node)
           if (parent = begin_node.parent)

--- a/lib/rubocop/cop/style/redundant_regexp_argument.rb
+++ b/lib/rubocop/cop/style/redundant_regexp_argument.rb
@@ -66,7 +66,7 @@ module RuboCop
           DETERMINISTIC_REGEX.match?(regexp_node.source)
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable-next Metrics/MethodLength
         def preferred_argument(regexp_node)
           new_argument = replacement(regexp_node)
 
@@ -92,7 +92,6 @@ module RuboCop
 
           "#{quote}#{new_argument}#{quote}"
         end
-        # rubocop:enable Metrics/MethodLength
 
         def replacement(regexp_node)
           regexp_content = regexp_node.content

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -108,7 +108,7 @@ module RuboCop
           corrector.insert_after(node.children.last, '}')
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def check_branch(node)
           return unless node
 
@@ -124,7 +124,6 @@ module RuboCop
             check_begin_node(node)
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def check_return_node(node)
           return if cop_config['AllowMultipleReturnValues'] && node.children.size > 1

--- a/lib/rubocop/cop/style/redundant_self_assignment.rb
+++ b/lib/rubocop/cop/style/redundant_self_assignment.rb
@@ -55,7 +55,7 @@ module RuboCop
               ...))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_lvasgn(node)
           return unless (rhs = node.rhs)
           return unless rhs.type?(:any_block, :call) && method_returning_self?(rhs.method_name)
@@ -69,7 +69,6 @@ module RuboCop
             corrector.replace(node, rhs.source)
           end
         end
-        # rubocop:enable Metrics/AbcSize
         alias on_ivasgn on_lvasgn
         alias on_cvasgn on_lvasgn
         alias on_gvasgn on_lvasgn

--- a/lib/rubocop/cop/style/redundant_string_escape.rb
+++ b/lib/rubocop/cop/style/redundant_string_escape.rb
@@ -75,7 +75,7 @@ module RuboCop
           node.loc.to_hash.key?(:begin) && !node.loc.begin.nil?
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def allowed_escape?(node, range)
           escaped = range.source[(1..-1)]
 
@@ -95,7 +95,6 @@ module RuboCop
 
           false
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def interpolation_not_enabled?(node)
           single_quoted?(node) ||

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -67,7 +67,7 @@ module RuboCop
           node.parent && parentheses?(node.parent)
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def correct_rescue_block(corrector, node, parenthesized)
           operation = node.body
 
@@ -83,7 +83,6 @@ module RuboCop
             #{node_offset}end
           RESCUE_CLAUSE
         end
-        # rubocop:enable Metrics/AbcSize
 
         def indentation_and_offset(node, parenthesized)
           node_indentation = indentation(node)

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -152,7 +152,7 @@ module RuboCop
         # @!method strip_begin(node)
         def_node_matcher :strip_begin, '{ (begin $!begin) $!(begin) }'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_if(node)
           return if allowed_if_condition?(node)
 
@@ -170,7 +170,6 @@ module RuboCop
             corrector.insert_before(method_call.loc.dot, '&') unless method_call.safe_navigation?
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def on_and(node) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
           collect_and_clauses(node).each do |(lhs, lhs_operator_range), (rhs, _rhs_operator_range)|

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -92,7 +92,7 @@ module RuboCop
           second.int_type? ? second.to_a.first : :unknown
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def range_size(range_node)
           vals = range_node.to_a
           return :unknown unless vals.all? { |val| val.nil? || val.int_type? }
@@ -107,7 +107,6 @@ module RuboCop
             (low..high).size
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def source_range(shuffle_node, node)
           shuffle_node.loc.selector.join(node.source_range.end)

--- a/lib/rubocop/cop/style/select_by_regexp.rb
+++ b/lib/rubocop/cop/style/select_by_regexp.rb
@@ -97,7 +97,7 @@ module RuboCop
           }
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_send(node)
           return if target_ruby_version < 2.6 && node.method?(:filter)
           return unless (block_node = node.block_node)
@@ -113,7 +113,6 @@ module RuboCop
 
           register_offense(node, block_node, regexp, replacement)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         alias on_csend on_send
 
         private

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -83,7 +83,7 @@ module RuboCop
           processed_source.tokens.group_by(&:line)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def semicolon_position(tokens)
           if tokens.last.semicolon?
             -1
@@ -100,7 +100,6 @@ module RuboCop
             -4
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def exist_semicolon_before_right_curly_brace?(tokens)
           tokens[-2]&.right_curly_brace? && tokens[-3]&.semicolon?
@@ -122,7 +121,7 @@ module RuboCop
           tokens[1]&.type == :tSTRING_DBEG && tokens[2]&.semicolon?
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
         def register_semicolon(line, column, after_expression, token_before_semicolon = nil)
           range = source_range(processed_source.buffer, line, column)
 
@@ -146,7 +145,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         def replace_semicolon_with_line_break(corrector, range)
           # Replacing the semicolon with a newline would move the rest of the

--- a/lib/rubocop/cop/style/single_line_do_end_block.rb
+++ b/lib/rubocop/cop/style/single_line_do_end_block.rb
@@ -36,7 +36,7 @@ module RuboCop
 
         MSG = 'Prefer multiline `do`...`end` block.'
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def on_block(node)
           return if node.multiline? || node.braces?
           return if single_line_blocks_preferred? && suitable_as_single_line?(node)
@@ -55,7 +55,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize
         alias on_numblock on_block
         alias on_itblock on_block
 

--- a/lib/rubocop/cop/style/sole_nested_conditional.rb
+++ b/lib/rubocop/cop/style/sole_nested_conditional.rb
@@ -148,7 +148,7 @@ module RuboCop
           corrector.remove(range_with_surrounding_space(range, newlines: false))
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def correct_for_basic_condition_style(corrector, node, if_branch)
           range = range_between(
             node.condition.source_range.end_pos, if_branch.condition.source_range.begin_pos
@@ -164,7 +164,6 @@ module RuboCop
                       end
           corrector.remove(end_range)
         end
-        # rubocop:enable Metrics/AbcSize
 
         def autocorrect_outer_condition_modify_form(corrector, node, if_branch)
           correct_node(corrector, if_branch)

--- a/lib/rubocop/cop/style/super_arguments.rb
+++ b/lib/rubocop/cop/style/super_arguments.rb
@@ -103,7 +103,7 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def arguments_identical?(def_node, super_node, def_args, super_args)
           return false if argument_list_size_differs?(def_args, super_args, super_node)
 
@@ -120,7 +120,6 @@ module RuboCop
 
           true
         end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def argument_list_size_differs?(def_args, super_args, super_node)
           # If the def node has a block argument and the super node has an explicit block,

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -167,7 +167,7 @@ module RuboCop
           [Layout::SpaceBeforeBlockBraces]
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_block(node)
           symbol_proc?(node) do |dispatch_node, arguments_node, method_name|
             if active_support_extensions_enabled?
@@ -184,7 +184,6 @@ module RuboCop
             register_offense(node, method_name, dispatch_node.method_name)
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         alias on_numblock on_block
         alias on_itblock on_block
 

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -122,7 +122,7 @@ module RuboCop
           node.comparison_method? && !noncommutative_operator?(node)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def valid_yoda?(node)
           return true unless (rhs = node.first_argument)
 
@@ -133,7 +133,6 @@ module RuboCop
 
           enforce_yoda? ? constant_portion?(lhs) : constant_portion?(rhs)
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def message(node)
           format(MSG, source: node.source)

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -9,7 +9,7 @@ module RuboCop
     # For performance reasons, Team will first dispatch cops & forces in two groups,
     # first the ones needed for autocorrection (if any), then the rest
     # (unless autocorrections happened).
-    # rubocop:disable Metrics/ClassLength
+    # rubocop:disable-next Metrics/ClassLength
     class Team
       InvestigationResult = Struct.new(:report, :corrector)
       private_constant :InvestigationResult
@@ -404,6 +404,5 @@ module RuboCop
         end
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     # This module contains a collection of useful utility methods.
-    # rubocop:disable Metrics/ModuleLength
+    # rubocop:disable-next Metrics/ModuleLength
     module Util
       include PathUtil
 
@@ -35,7 +35,7 @@ module RuboCop
         node.loc_is?(:end, ')')
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
       def add_parentheses(node, corrector)
         if node.args_type?
           arguments_range = node.source_range
@@ -55,7 +55,6 @@ module RuboCop
           corrector.insert_after(args_end(node), ')')
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def any_descendant?(node, *types)
         if block_given?
@@ -210,6 +209,5 @@ module RuboCop
         source == target || (source.is_a?(Array) && source.include?(target))
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -47,7 +47,7 @@ module RuboCop
           !@references.empty?
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def reference!(node)
           reference = Reference.new(node, @scope)
           @references << reference
@@ -72,7 +72,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def in_modifier_conditional?(assignment, reference_node)
           conditional = modifier_conditional_of(assignment.node)

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -137,7 +137,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     "NOTE: Requires Ruby version #{requirement}\n\n"
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable-next Metrics/MethodLength
   def properties(cop)
     header = [
       'Enabled by default', 'Safe', 'Supports autocorrection', 'Version Added',
@@ -160,7 +160,6 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     ]]
     "#{to_table(header, content)}\n"
   end
-  # rubocop:enable Metrics/MethodLength
 
   def cop_header(cop)
     content = +"\n"
@@ -217,7 +216,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     "xref:#{filename}#allowmultilinefinalelement[AllowMultilineFinalElement]"
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength
+  # rubocop:disable-next Metrics/CyclomaticComplexity,Metrics/MethodLength
   def configurable_values(cop_config, name)
     case name
     when /^Enforced/
@@ -244,7 +243,6 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
       end
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity,Metrics/MethodLength
 
   def to_table(header, content)
     table = ['|===', "| #{header.join(' | ')}\n\n"].join("\n")
@@ -303,7 +301,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     "\ninclude::../partials/#{filename}[]\n"
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable-next Metrics/MethodLength
   def print_cops_of_department(department)
     selected_cops = cops_of_department(department)
     content = +<<~HEADER
@@ -323,7 +321,6 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
       file.write("#{content.strip}\n")
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def print_cop_with_doc(cop) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
     cop_config = config.for_cop(cop)

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -74,11 +74,10 @@ module RuboCop
         end
 
         # Make Kernel#binding public.
-        # rubocop:disable Lint/UselessMethodDefinition
+        # rubocop:disable-next Lint/UselessMethodDefinition
         def binding
           super
         end
-        # rubocop:enable Lint/UselessMethodDefinition
 
         def decorated_message(offense)
           offense.message.gsub(/`(.+?)`/) { "<code>#{escape(Regexp.last_match(1))}</code>" }
@@ -144,11 +143,10 @@ module RuboCop
         }.freeze
 
         # Make Kernel#binding public.
-        # rubocop:disable Lint/UselessMethodDefinition
+        # rubocop:disable-next Lint/UselessMethodDefinition
         def binding
           super
         end
-        # rubocop:enable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -47,7 +47,7 @@ module RuboCop
         end
       end
 
-      # rubocop:disable Layout/LineLength,Metrics/AbcSize,Metrics/MethodLength
+      # rubocop:disable-next Layout/LineLength,Metrics/AbcSize,Metrics/MethodLength
       def finished(_inspected_files)
         output.puts %(<?xml version='1.0'?>)
         output.puts %(<testsuites>)
@@ -70,7 +70,6 @@ module RuboCop
         output.puts %(  </testsuite>)
         output.puts %(</testsuites>)
       end
-      # rubocop:enable Layout/LineLength,Metrics/AbcSize,Metrics/MethodLength
 
       private
 

--- a/lib/rubocop/formatter/offense_count_formatter.rb
+++ b/lib/rubocop/formatter/offense_count_formatter.rb
@@ -52,7 +52,7 @@ module RuboCop
         report_summary(@offense_counts, @offending_files_count)
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable-next Metrics/AbcSize
       def report_summary(offense_counts, offending_files_count)
         per_cop_counts = ordered_offense_counts(offense_counts)
         total_count = total_offense_count(offense_counts)
@@ -68,7 +68,6 @@ module RuboCop
 
         output.puts
       end
-      # rubocop:enable Metrics/AbcSize
 
       def ordered_offense_counts(offense_counts)
         offense_counts.sort_by { |k, v| [-v, k] }.to_h

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -106,7 +106,7 @@ module RuboCop
         include Colorizable
         include TextUtil
 
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable-next Metrics/ParameterLists
         def initialize(
           file_count, offense_count, correction_count, correctable_count, rainbow,
           safe_autocorrect: false
@@ -118,7 +118,6 @@ module RuboCop
           @rainbow = rainbow
           @safe_autocorrect = safe_autocorrect
         end
-        # rubocop:enable Metrics/ParameterLists
 
         def summary
           if @correction_count.positive?

--- a/lib/rubocop/formatter/worst_offenders_formatter.rb
+++ b/lib/rubocop/formatter/worst_offenders_formatter.rb
@@ -32,7 +32,7 @@ module RuboCop
         report_summary(@offense_counts)
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable-next Metrics/AbcSize
       def report_summary(offense_counts)
         per_file_counts = ordered_offense_counts(offense_counts)
         total_count = total_offense_count(offense_counts)
@@ -50,7 +50,6 @@ module RuboCop
 
         output.puts
       end
-      # rubocop:enable Metrics/AbcSize
 
       def ordered_offense_counts(offense_counts)
         offense_counts.sort_by { |k, v| [-v, k] }.to_h

--- a/lib/rubocop/lsp/diagnostic.rb
+++ b/lib/rubocop/lsp/diagnostic.rb
@@ -35,7 +35,7 @@ module RuboCop
         code_actions
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength
       def to_lsp_diagnostic(config)
         highlighted = @offense.highlighted_area
 
@@ -61,7 +61,6 @@ module RuboCop
           }
         )
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       private
 
@@ -82,7 +81,7 @@ module RuboCop
         LanguageServer::Protocol::Interface::CodeDescription.new(href: doc_url)
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable-next Metrics/MethodLength
       def autocorrect_action
         LanguageServer::Protocol::Interface::CodeAction.new(
           title: "Autocorrect #{@offense.cop_name}",
@@ -101,9 +100,8 @@ module RuboCop
           is_preferred: true
         )
       end
-      # rubocop:enable Metrics/MethodLength
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable-next Metrics/MethodLength
       def offense_replacements
         @offense.corrector.as_replacements.map do |range, replacement|
           LanguageServer::Protocol::Interface::TextEdit.new(
@@ -121,9 +119,8 @@ module RuboCop
           )
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable-next Metrics/MethodLength
       def disable_line_action
         LanguageServer::Protocol::Interface::CodeAction.new(
           title: "Disable #{@offense.cop_name} for this line",
@@ -141,7 +138,6 @@ module RuboCop
           )
         )
       end
-      # rubocop:enable Metrics/MethodLength
 
       def line_disable_comment
         DisableCommentEdits.new(

--- a/lib/rubocop/mcp/server.rb
+++ b/lib/rubocop/mcp/server.rb
@@ -156,7 +156,7 @@ module RuboCop
         summary
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+      # rubocop:disable-next Metrics/MethodLength, Metrics/ParameterLists
       def build_tool(
         name:, description:,
         title:, destructive_hint:, idempotent_hint:, read_only_hint:, safety_required:
@@ -194,7 +194,6 @@ module RuboCop
           ::MCP::Tool::Response.new([{ type: 'text', text: e.message }], error: true)
         end
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
     end
   end
 end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -51,7 +51,7 @@ module RuboCop
 
     private
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable-next Metrics/AbcSize
     def define_options
       OptionParser.new do |opts|
         opts.banner = rainbow.wrap('Usage: rubocop [options] [file1, file2, ...]').bright
@@ -71,7 +71,6 @@ module RuboCop
         add_profile_options(opts) if RUBY_ENGINE == 'ruby' && !Platform.windows?
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     def add_check_options(opts) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       section(opts, 'Basic Options') do # rubocop:disable Metrics/BlockLength
@@ -385,7 +384,7 @@ module RuboCop
       %i[only except].each { |opt| OptionsValidator.validate_cop_list(@options[opt]) }
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable-next Metrics/AbcSize
     def validate_compatibility # rubocop:disable Metrics/MethodLength
       if only_includes_redundant_disable?
         raise OptionArgumentError, 'Lint/RedundantCopDisableDirective cannot be used with --only.'
@@ -408,7 +407,6 @@ module RuboCop
 
       raise OptionArgumentError, "Incompatible cli options: #{incompatible_options.inspect}"
     end
-    # rubocop:enable Metrics/AbcSize
 
     def validate_auto_gen_config
       return if @options.key?(:auto_gen_config)
@@ -530,7 +528,7 @@ module RuboCop
 
   # This module contains help texts for command line options.
   # @api private
-  # rubocop:disable Metrics/ModuleLength
+  # rubocop:disable-next Metrics/ModuleLength
   module OptionsHelp
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
     FORMATTER_OPTION_LIST = RuboCop::Formatter::FormatterSet::BUILTIN_FORMATTERS_FOR_KEYS.keys
@@ -696,5 +694,4 @@ module RuboCop
       memory:                           'Profile rubocop memory usage.'
     }.freeze
   end
-  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -63,7 +63,7 @@ module RuboCop
         end
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable-next Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def match_path?(pattern, path)
       case pattern
       when String
@@ -89,7 +89,6 @@ module RuboCop
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)

--- a/lib/rubocop/plugin/configuration_integrator.rb
+++ b/lib/rubocop/plugin/configuration_integrator.rb
@@ -88,7 +88,7 @@ module RuboCop
           result
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def load_plugin_rubocop_config(plugin, runner_context)
           rules = plugin.rules(runner_context)
 
@@ -105,7 +105,6 @@ module RuboCop
             raise "Plugin `#{plugin_name}' failed to load with error: #{error_message}"
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         # This is how we ensure "first-in wins": plugins can override AllCops settings that are
         # set by RuboCop's default configuration, but once a plugin sets an AllCop setting, they

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -74,7 +74,7 @@ module RuboCop
 
     def setup_subtasks(name, *args, &task_block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace(name) do
-        # rubocop:todo Naming/InclusiveLanguage
+        # rubocop:todo-next Naming/InclusiveLanguage
         task(:auto_correct, *args) do |_, task_args|
           require 'rainbow'
           warn Rainbow(
@@ -86,7 +86,6 @@ module RuboCop
             perform('--autocorrect')
           end
         end
-        # rubocop:enable Naming/InclusiveLanguage
 
         desc "Autocorrect RuboCop offenses (only when it's safe)."
         task(:autocorrect, *args) do |_, task_args|

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -117,7 +117,7 @@ module RuboCop
         source
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable-next Metrics/AbcSize
       def expect_offense(source, file = nil, severity: nil, chomp: false, **replacements)
         expected_annotations = parse_annotations(source, **replacements)
         source = expected_annotations.plain_source
@@ -138,9 +138,8 @@ module RuboCop
 
         @offenses
       end
-      # rubocop:enable Metrics/AbcSize
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+      # rubocop:disable-next Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       def expect_correction(correction, loop: true, source: nil)
         if source
           expected_annotations = parse_annotations(source, raise_error: false)
@@ -177,7 +176,6 @@ module RuboCop
         expect(new_source).to eq(correction)
         expect(@processed_source).to be_valid_syntax, 'Expected correction to be valid syntax'
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
       def expect_no_corrections
         raise '`expect_no_corrections` must follow `expect_offense`' unless @processed_source

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 # or stubbing Dir.pwd get a fresh value.
 RSpec.configure { |c| c.before { RuboCop::PathUtil.reset_pwd } }
 
-# rubocop:disable Metrics/BlockLength
+# rubocop:disable-next Metrics/BlockLength
 RSpec.shared_context 'isolated environment' do
   around do |example|
     Dir.mktmpdir do |tmpdir|
@@ -69,7 +69,6 @@ RSpec.shared_context 'isolated environment' do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength
 
 # Workaround for https://github.com/rubocop/rubocop/issues/12978,
 # there should already be no gemfile in the temp directory

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -616,7 +616,7 @@ module RuboCop
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable-next Metrics/MethodLength
     def get_processed_source(file, prism_result, source: nil)
       config = @config_store.for_file(file)
       ruby_version = config.target_ruby_version
@@ -650,7 +650,6 @@ module RuboCop
       processed_source.registry = mobilized_cop_classes(config)
       processed_source
     end
-    # rubocop:enable Metrics/MethodLength
 
     # A Cop::Team instance is stateful and may change when inspecting.
     # The "standby" team for a given config is an initialized but

--- a/lib/rubocop/server/cache.rb
+++ b/lib/rubocop/server/cache.rb
@@ -45,7 +45,7 @@ module RuboCop
           @project_dir_cache_key ||= project_dir[1..].tr('/', '+')
         end
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize
         def restart_key(args_config_file_path: nil)
           lockfile_path = LOCKFILE_NAMES.map do |lockfile_name|
             Pathname(project_dir).join(lockfile_name)
@@ -61,7 +61,6 @@ module RuboCop
 
           Digest::SHA1.hexdigest(version_data + config_data + inherit_from_data + require_data)
         end
-        # rubocop:enable Metrics/AbcSize
 
         def dir
           dir_path.tap do |d|

--- a/lib/rubocop/server/cli.rb
+++ b/lib/rubocop/server/cli.rb
@@ -55,7 +55,7 @@ module RuboCop
 
       private
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       def process_arguments(argv)
         server_arguments = delete_server_argument_from(argv)
 
@@ -84,9 +84,8 @@ module RuboCop
 
         STATUS_SUCCESS
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:disable-next Metrics/CyclomaticComplexity, Metrics/MethodLength
       def run_command(server_command, detach:)
         case server_command
         when '--server'
@@ -107,7 +106,6 @@ module RuboCop
           Server::ClientCommand::Status.new.run
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def fetch_cache_root_path_from(arguments)
         cache_root = arguments.detect { |argument| argument.start_with?('--cache-root') }

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -23,7 +23,7 @@ module RuboCop
 
     # NOTE: Marked as private but used by gems like standard.
     # @api private
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable-next Metrics/MethodLength
     def self.version(debug: false, env: nil)
       if debug
         target_ruby_version = target_ruby_version(env)
@@ -48,7 +48,6 @@ module RuboCop
         STRING
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # @api private
     def self.verbose(env: nil)
@@ -72,7 +71,7 @@ module RuboCop
     end
 
     # @api private
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def self.extension_versions(env)
       plugins = config_for_pwd(env).loaded_plugins
       plugin_versions = plugins.filter_map do |plugin|
@@ -108,7 +107,6 @@ module RuboCop
 
       plugin_versions + feature_versions
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     # @api private
     def self.target_ruby_version(env)

--- a/lib/ruby_lsp/rubocop/addon.rb
+++ b/lib/ruby_lsp/rubocop/addon.rb
@@ -41,7 +41,7 @@ module RubyLsp
         @runtime_adapter = nil
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable-next Metrics/MethodLength
       def register_additional_file_watchers(global_state, message_queue)
         return unless global_state.supports_watching_files
 
@@ -66,7 +66,6 @@ module RubyLsp
           )
         )
       end
-      # rubocop:enable Metrics/MethodLength
 
       def workspace_did_change_watched_files(changes)
         if (changed_config_file = changed_config_file(changes))

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'RuboCop Project', type: :feature do
       configuration_keys.each_with_index { |key, idx| expect(key).to eq expected[idx] }
     end
 
-    # rubocop:disable RSpec/NoExpectationExample
+    # rubocop:disable-next RSpec/NoExpectationExample
     it 'has a SupportedStyles for all EnforcedStyle and EnforcedStyle is valid' do
       errors = []
       cop_names.each do |name|
@@ -107,9 +107,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
 
       raise errors.join("\n") unless errors.empty?
     end
-    # rubocop:enable RSpec/NoExpectationExample
 
-    # rubocop:disable RSpec/NoExpectationExample
+    # rubocop:disable-next RSpec/NoExpectationExample
     it 'does not have any duplication' do
       fname = File.expand_path('../config/default.yml', __dir__)
       content = File.read(fname)
@@ -118,7 +117,6 @@ RSpec.describe 'RuboCop Project', type: :feature do
               "on line #{key1.start_line} and line #{key2.start_line}"
       end
     end
-    # rubocop:enable RSpec/NoExpectationExample
 
     %w[Safe SafeAutoCorrect AutoCorrect].each do |metadata|
       it "does not include `#{metadata}: true`" do
@@ -291,9 +289,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
     let(:path) { File.expand_path('../CHANGELOG.md', __dir__) }
     let(:entries) { lines.grep(/^\*/).map(&:chomp) }
 
-    # rubocop:disable RSpec/IncludeExamples
+    # rubocop:disable-next RSpec/IncludeExamples
     include_examples 'has Changelog format'
-    # rubocop:enable RSpec/IncludeExamples
 
     context 'future entries' do
       let(:allowed_cop_names) do
@@ -321,9 +318,8 @@ RSpec.describe 'RuboCop Project', type: :feature do
         context "For #{path}" do
           let(:path) { path }
 
-          # rubocop:disable RSpec/IncludeExamples
+          # rubocop:disable-next RSpec/IncludeExamples
           include_examples 'has Changelog format'
-          # rubocop:enable RSpec/IncludeExamples
 
           it 'has a link to the issue or pull request address at the beginning' do
             repo = 'rubocop/rubocop'

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1124,7 +1124,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
             EnforcedStyle: #{style}
         YAML
         expect(cli.run(['--autocorrect-all'])).to eq(0)
-        # rubocop:disable Style/HashLikeCase
+        # rubocop:disable-next Style/HashLikeCase
         corrected = case style
                     when :semantic
                       <<~RUBY
@@ -1160,7 +1160,6 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
                         end.baz
                       RUBY
                     end
-        # rubocop:enable Style/HashLikeCase
         expect($stderr.string).to eq('')
         expect(File.read('example.rb')).to eq(corrected)
       end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1771,7 +1771,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         end
       end
 
-      # rubocop:disable Layout/LineContinuationLeadingSpace
+      # rubocop:disable-next Layout/LineContinuationLeadingSpace
       context 'when clang format is specified' do
         it 'outputs with clang format' do
           create_file('example1.rb', ['x= 0 ', '#' * 130, 'y ', 'puts x'])
@@ -1866,7 +1866,6 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           ].join("\n"))
         end
       end
-      # rubocop:enable Layout/LineContinuationLeadingSpace
 
       context 'when emacs format is specified' do
         it 'outputs with emacs format' do

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::CommentConfig do
 
   describe '#cop_enabled_at_line?' do
     let(:source) do
-      # rubocop:disable Lint/EmptyExpression, Lint/EmptyInterpolation
+      # rubocop:disable-next Lint/EmptyExpression, Lint/EmptyInterpolation
       <<~RUBY
         # rubocop:disable Metrics/MethodLength with a comment why
         def some_method
@@ -61,7 +61,6 @@ RSpec.describe RuboCop::CommentConfig do
         it { is_expected.to have_http_status 200 }                          # 52
         # rubocop:enable RSpec/Rails/HttpStatus
       RUBY
-      # rubocop:enable Lint/EmptyExpression, Lint/EmptyInterpolation
     end
 
     def disabled_lines_of_cop(cop)

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/NumericLiteralPrefix
+# rubocop:disable-next Style/NumericLiteralPrefix
 RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
   subject(:cop) { described_class.new(config, options) }
 
@@ -113,4 +113,3 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
     end
   end
 end
-# rubocop:enable Style/NumericLiteralPrefix

--- a/spec/rubocop/cop/style/directive_scope_spec.rb
+++ b/spec/rubocop/cop/style/directive_scope_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::DirectiveScope, :config do
+  it 'registers an offense and corrects a `disable`/`enable` pair around one statement' do
+    expect_offense(<<~RUBY)
+      # rubocop:disable Metrics/AbcSize
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `disable-next` instead of a `disable`/`enable` pair around a single statement.
+      def foo
+        bar
+      end
+      # rubocop:enable Metrics/AbcSize
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable-next Metrics/AbcSize
+      def foo
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects a `todo`/`enable` pair, keeping the reason' do
+    expect_offense(<<~RUBY)
+      # rubocop:todo Metrics/AbcSize, Metrics/MethodLength -- legacy method
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `todo-next` instead of a `todo`/`enable` pair around a single statement.
+      def foo
+        bar
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:todo-next Metrics/AbcSize, Metrics/MethodLength -- legacy method
+      def foo
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects a disable-only `push`/`pop` around one statement' do
+    expect_offense(<<~RUBY)
+      # rubocop:push -Metrics/AbcSize -- special case
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `disable-next` instead of `push`/`pop` around a single statement.
+      def foo
+        bar
+      end
+      # rubocop:pop
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # rubocop:disable-next Metrics/AbcSize -- special case
+      def foo
+        bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the pair wraps several statements' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Metrics/AbcSize
+      def foo
+      end
+
+      def bar
+      end
+      # rubocop:enable Metrics/AbcSize
+    RUBY
+  end
+
+  it 'does not register an offense when the `enable` closes only some of the cops' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def foo
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
+    RUBY
+  end
+
+  it 'does not register an offense for an end-of-line disable' do
+    expect_no_offenses(<<~RUBY)
+      foo # rubocop:disable Metrics/AbcSize
+    RUBY
+  end
+
+  it 'does not register an offense for an unclosed disable' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Metrics/AbcSize
+      def foo
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a `push` that also enables cops' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:push -Metrics/AbcSize +Style/For
+      def foo
+      end
+      # rubocop:pop
+    RUBY
+  end
+
+  it 'does not register an offense for a bare `push`' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:push
+      # rubocop:disable Metrics/AbcSize
+      def foo
+      end
+      # rubocop:pop
+    RUBY
+  end
+
+  it 'does not register an offense for an already tight `disable-next`' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable-next Metrics/AbcSize
+      def foo
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when other lines sit inside the region' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Metrics/AbcSize
+      def foo
+        bar
+      end
+
+      # rubocop:enable Metrics/AbcSize
+    RUBY
+  end
+
+  it 'does not register an offense when a comment sits between the directive and the statement' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Layout/LineLength
+      # some comment the pair may be protecting
+      def foo
+        bar
+      end
+      # rubocop:enable Layout/LineLength
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/style/redundant_format_spec.rb
+++ b/spec/rubocop/cop/style/redundant_format_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
       end
 
       context 'with literal arguments' do
-        # rubocop:disable Metrics/ParameterLists
+        # rubocop:disable-next Metrics/ParameterLists
         shared_examples 'offending format specifier' do |specifier, value, result, start_delim = "'", end_delim = "'", **metadata|
           it 'registers an offense and corrects', **metadata do
             options = {
@@ -127,7 +127,6 @@ RSpec.describe RuboCop::Cop::Style::RedundantFormat, :config do
             RUBY
           end
         end
-        # rubocop:enable Metrics/ParameterLists
 
         shared_examples 'non-offending format specifier' do |specifier, value|
           it 'does not register an offense' do

--- a/spec/rubocop/cop/style/redundant_string_escape_spec.rb
+++ b/spec/rubocop/cop/style/redundant_string_escape_spec.rb
@@ -113,9 +113,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
   end
 
   RSpec.shared_examples 'a literal with interpolation' do |l, r|
-    # rubocop:disable RSpec/IncludeExamples
+    # rubocop:disable-next RSpec/IncludeExamples
     include_examples 'common no offenses', l, r
-    # rubocop:enable RSpec/IncludeExamples
 
     it 'registers an offense and corrects an escaped # before interpolation' do
       expect_offense(<<~'RUBY', l: l, r: r)
@@ -209,9 +208,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
   end
 
   RSpec.shared_examples 'a literal without interpolation' do |l, r|
-    # rubocop:disable RSpec/IncludeExamples
+    # rubocop:disable-next RSpec/IncludeExamples
     include_examples 'common no offenses', l, r
-    # rubocop:enable RSpec/IncludeExamples
 
     it 'does not register an offense for an escaped # with following {' do
       expect_no_offenses(wrap('\#{my_lvar}'))
@@ -346,9 +344,8 @@ RSpec.describe RuboCop::Cop::Style::RedundantStringEscape, :config do
   end
 
   context 'with an interpolation-enabled HEREDOC' do
-    # rubocop:disable RSpec/IncludeExamples
+    # rubocop:disable-next RSpec/IncludeExamples
     include_examples 'common no offenses', "<<~MYHEREDOC\n", "\nMYHEREDOC"
-    # rubocop:enable RSpec/IncludeExamples
 
     it 'does not register an offense for a heredoc interpolating a string with an allowed escape' do
       expect_no_offenses(<<~'RUBY')

--- a/spec/rubocop/ext/regexp_node_spec.rb
+++ b/spec/rubocop/ext/regexp_node_spec.rb
@@ -97,9 +97,8 @@ RSpec.describe RuboCop::Ext::RegexpNode do
         nodes = node.parsed_tree.each_expression.map { |exp, _index| exp }
 
         # `Parser::Source::Map` does not have `source_range` method.
-        # rubocop:disable InternalAffairs/LocationExpression
+        # rubocop:disable-next InternalAffairs/LocationExpression
         sources = nodes.map { |n| n.loc.expression.source }
-        # rubocop:enable InternalAffairs/LocationExpression
 
         expect(sources).to eq %w{([a-z]+) [a-z]+ a-z a z \d* \s? (?:foo) foo}
 

--- a/spec/rubocop/file_patterns_spec.rb
+++ b/spec/rubocop/file_patterns_spec.rb
@@ -3,7 +3,7 @@
 # `be_match` here calls `FilePatterns#match?(path)`, which is unrelated to the
 # RSpec-builtin `match` matcher (regex/pattern), so the predicate matcher is
 # not redundant in this file.
-# rubocop:disable RSpec/RedundantPredicateMatcher
+# rubocop:disable-next RSpec/RedundantPredicateMatcher
 RSpec.describe RuboCop::FilePatterns do
   describe '#match?' do
     let(:patterns) { ['lib/**/*.rb', 'README.md'] }
@@ -57,4 +57,3 @@ RSpec.describe RuboCop::FilePatterns do
     end
   end
 end
-# rubocop:enable RSpec/RedundantPredicateMatcher

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -1725,11 +1725,10 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
 
     it 'decodes URI-encoded paths for file system operations' do
-      # rubocop:disable RSpec/AnyInstance
+      # rubocop:disable-next RSpec/AnyInstance
       expect_any_instance_of(RuboCop::Runner).to receive(:run).with(
         ['/path/with spaces/file.rb']
       ).and_call_original
-      # rubocop:enable RSpec/AnyInstance
 
       result
     end
@@ -1745,9 +1744,8 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
 
     it 'refreshes the project index' do
-      # rubocop:disable RSpec/AnyInstance
+      # rubocop:disable-next RSpec/AnyInstance
       expect_any_instance_of(RuboCop::Lsp::StdinRunner).to receive(:reset_project_index)
-      # rubocop:enable RSpec/AnyInstance
 
       result
     end
@@ -1763,9 +1761,8 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
 
     it 'refreshes the project index' do
-      # rubocop:disable RSpec/AnyInstance
+      # rubocop:disable-next RSpec/AnyInstance
       expect_any_instance_of(RuboCop::Lsp::StdinRunner).to receive(:reset_project_index)
-      # rubocop:enable RSpec/AnyInstance
 
       result
     end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         expect { options.parse ['--help'] }.to exit_with_code(0)
       end
 
-      # rubocop:disable RSpec/ExampleLength
+      # rubocop:disable-next RSpec/ExampleLength
       it 'shows help text' do
         begin
           options.parse(['--help'])
         rescue SystemExit # rubocop:disable Lint/SuppressedException
         end
 
-        # rubocop:todo Naming/InclusiveLanguage
+        # rubocop:todo-next Naming/InclusiveLanguage
         expected_help = <<~OUTPUT
           Usage: rubocop [options] [file1, file2, ...]
 
@@ -237,7 +237,6 @@ RSpec.describe RuboCop::Options, :isolated_environment do
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
         OUTPUT
-        # rubocop:enable Naming/InclusiveLanguage
 
         if RUBY_ENGINE == 'ruby' && !RuboCop::Platform.windows?
           expected_help += <<~OUTPUT
@@ -250,7 +249,6 @@ RSpec.describe RuboCop::Options, :isolated_environment do
 
         expect($stdout.string).to eq(expected_help)
       end
-      # rubocop:enable RSpec/ExampleLength
 
       it 'lists all builtin formatters' do
         begin
@@ -668,7 +666,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
-    # rubocop:todo Naming/InclusiveLanguage
+    # rubocop:todo-next Naming/InclusiveLanguage
     describe 'deprecated options' do
       describe '--auto-correct' do
         it 'emits a warning and sets the correct options instead' do
@@ -698,7 +696,6 @@ RSpec.describe RuboCop::Options, :isolated_environment do
         end
       end
     end
-    # rubocop:enable Naming/InclusiveLanguage
 
     def expect_autocorrect_options_for_fix_layout
       options_keys = options.instance_variable_get(:@options).keys

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       end
 
       context 'when the extractor matches' do
-        # rubocop:disable Layout/LineLength
+        # rubocop:disable-next Layout/LineLength
         let(:custom_ruby_extractor) do
           lambda do |_processed_source|
             [
@@ -156,7 +156,6 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
             ]
           end
         end
-        # rubocop:enable Layout/LineLength
 
         let(:source) do
           <<~RUBY

--- a/spec/ruby_lsp/rubocop/addon_spec.rb
+++ b/spec/ruby_lsp/rubocop/addon_spec.rb
@@ -332,7 +332,7 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
 
   private
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable-next Metrics/MethodLength
   def create_server(source, uri)
     server = RubyLsp::Server.new(test_mode: true)
     server.global_state.formatter = 'rubocop'
@@ -358,7 +358,6 @@ describe 'RubyLSP::RuboCop::Addon', :isolated_environment, :lsp do
     server.load_addons
     server
   end
-  # rubocop:enable Metrics/MethodLength
 
   def process_message(method, **params)
     server.process_message(id: request_id.next, method: method, params: params)

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -3,7 +3,7 @@
 require 'fileutils'
 
 module FileHelper
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable-next Metrics/MethodLength
   def create_file(file_path, content, retain_line_terminators: false)
     file_path = File.expand_path(file_path)
 
@@ -31,13 +31,11 @@ module FileHelper
 
     file_path
   end
-  # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable InternalAffairs/CreateEmptyFile
+  # rubocop:disable-next InternalAffairs/CreateEmptyFile
   def create_empty_file(file_path)
     create_file(file_path, '')
   end
-  # rubocop:enable InternalAffairs/CreateEmptyFile
 
   def create_link(link_path, target_path)
     link_path = File.expand_path(link_path)


### PR DESCRIPTION
Flags directive scopes that can be expressed with the tighter `disable-next` form: a `disable`/`enable` pair sitting immediately around a single statement, or a `push`/`pop` that only disables cops around one. Statement-scoped directives cannot drift as the surrounding code changes and need no closing boundary. The autocorrect preserves `--` reasons, maps `todo` pairs to `todo-next`, and is marked unsafe since the suppression scope shrinks from the region to the statement.

Dogfooding shaped the design: a first draft only required the region to contain one statement, and applying it to this very repo resurfaced three `Naming/InclusiveLanguage` offenses in `options.rb` - that pair was also protecting comment lines inside the region. The rule is therefore strict adjacency (directive directly above the statement, closing directive directly below), which by construction cannot un-cover any line. Under that rule the second commit converts the 184 qualifying sites in this codebase, with the full suite and self-lint green on the result - drop that commit if you'd rather keep the old form here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/