### PR TITLE
Reuse cop teams across files of the same config

### DIFF
--- a/changelog/fix_reuse_cop_teams_across_files_of_the_same_config_20260810143019.md
+++ b/changelog/fix_reuse_cop_teams_across_files_of_the_same_config_20260810143019.md
@@ -1,0 +1,1 @@
+* [#11119](https://github.com/rubocop/rubocop/issues/11119): Reuse cop teams across files of the same config. ([@bbatsov][])

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -127,6 +127,8 @@ module RuboCop
       # in the `on_new_investigation` callback.
       # If your cop does autocorrections, be aware that your instance may be called
       # multiple times with the same `processed_source.path` but different content.
+      # Note that under `--parallel` each worker process has its own cop
+      # instances, so state persists only within a worker's share of the files.
       def self.support_multiple_source?
         false
       end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -501,17 +501,31 @@ module RuboCop
       end
     end
 
+    # Teams are reused across files (and autocorrect iterations) of the same
+    # config: `Team#investigate` refreshes every non-persistent cop through
+    # `be_ready`, while cops that opt in via `support_multiple_source?` keep
+    # their instance and can accumulate cross-file state. Note that under
+    # `--parallel` each worker process has its own teams, so persistence is
+    # scoped to a worker.
     def mobilize_team(processed_source)
       config = @config_store.for_file(processed_source.path)
-      team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
-
-      if @project_index
-        team.cops.each do |cop|
-          cop.project_index = @project_index
-        end
+      # A long-lived runner (the LSP's `StdinRunner`) swaps `@options` between
+      # runs - teams built with the old options must not be reused then.
+      unless @mobilized_teams_options.equal?(@options)
+        @mobilized_teams_options = @options
+        @mobilized_teams = {}.compare_by_identity
       end
+      @mobilized_teams[config] ||= begin
+        team = Cop::Team.mobilize(mobilized_cop_classes(config), config, @options)
 
-      team
+        if @project_index
+          team.cops.each do |cop|
+            cop.project_index = @project_index
+          end
+        end
+
+        team
+      end
     end
 
     def mobilized_cop_classes(config)

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -439,6 +439,54 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
     end
   end
 
+  describe '#run with a cop that supports multiple sources', :restore_registry do
+    subject(:runner) { described_class.new(options, RuboCop::ConfigStore.new) }
+
+    let(:options) { { formatters: [['progress', formatter_output_path]] } }
+
+    before do
+      create_file('multi_source_cop.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        module RuboCop
+          module Cop
+            module MultiTest
+              class InstanceTracker < Base
+                class << self
+                  attr_accessor :instance_ids
+                end
+                self.instance_ids = []
+
+                def self.support_multiple_source?
+                  true
+                end
+
+                def on_new_investigation
+                  self.class.instance_ids << object_id
+                end
+              end
+            end
+          end
+        end
+      RUBY
+      create_file('.rubocop.yml', <<~YAML)
+        require: ./multi_source_cop.rb
+        MultiTest/InstanceTracker:
+          Enabled: true
+      YAML
+      create_file('file1.rb', "# frozen_string_literal: true\n\nputs 1\n")
+      create_file('file2.rb', "# frozen_string_literal: true\n\nputs 2\n")
+    end
+
+    it 'reuses the same cop instance across files' do
+      runner.run(%w[file1.rb file2.rb])
+
+      ids = RuboCop::Cop::MultiTest::InstanceTracker.instance_ids
+      expect(ids.size).to eq(2)
+      expect(ids.uniq.size).to eq(1)
+    end
+  end
+
   describe '#run with cops autocorrecting each-other' do
     include_context 'mock console output'
 


### PR DESCRIPTION
`Runner#mobilize_team` built a fresh team (and fresh cop instances) for every file, which meant cops opting into `support_multiple_source?` never actually saw more than one file outside `--stdin`. Teams are now memoized per config, so cop instances persist across all files sharing a config — `Team#investigate` already refreshes non-persistent cops via `be_ready`, so regular cops are unaffected.

The memo is invalidated when the runner's options object changes, since the LSP's `StdinRunner` is a long-lived runner that swaps options between requests.

Fixes #11119