### PR TITLE
Remove a directive's `--` reason along with the directive

### DIFF
--- a/changelog/fix_remove_a_directive_s_reason_along_with_the_directive.md
+++ b/changelog/fix_remove_a_directive_s_reason_along_with_the_directive.md
@@ -1,0 +1,1 @@
+* [#15561](https://github.com/rubocop/rubocop/pull/15561): Fix `Lint/RedundantCopDisableDirective` and `Lint/RedundantCopEnableDirective` leaving a directive's `--` reason behind when removing the directive. ([@corsonknowles][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -293,12 +293,14 @@ module RuboCop
           end
 
           add_offense(location, message: message(cop_names)) do |corrector|
-            remove_entire_comment(corrector, location, comment)
+            remove_entire_comment(corrector, comment)
           end
         end
 
-        def remove_entire_comment(corrector, location, comment)
-          range = comment_range_with_surrounding_space(location, comment.source_range)
+        def remove_entire_comment(corrector, comment)
+          # Take the `--` reason with the directive; `leave_free_comment?` keeps anything else.
+          directive_range = DirectiveComment.new(comment).range_with_reason
+          range = comment_range_with_surrounding_space(directive_range, comment.source_range)
 
           if leave_free_comment?(comment, range)
             corrector.replace(range, ' # ')

--- a/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_enable_directive.rb
@@ -89,12 +89,18 @@ module RuboCop
               range_of_offense(comment, name),
               message: format(MSG, cop: all_or_name(name))
             ) do |corrector|
-              if directive.match?(cop_names)
-                corrector.remove(range_with_surrounding_space(directive.range, side: :right))
-              else
-                corrector.remove(range_with_comma(comment, name))
-              end
+              corrector.remove(removal_range(directive, comment, cop_names, name))
             end
+          end
+        end
+
+        # When every cop on the directive is redundant the whole comment goes, `--` reason
+        # included; otherwise just the one cop is spliced out of the list.
+        def removal_range(directive, comment, cop_names, name)
+          if directive.match?(cop_names)
+            range_with_surrounding_space(directive.range_with_reason, side: :right)
+          else
+            range_with_comma(comment, name)
           end
         end
 

--- a/lib/rubocop/directive_comment.rb
+++ b/lib/rubocop/directive_comment.rb
@@ -114,6 +114,19 @@ module RuboCop
       )
     end
 
+    # `#range` stops at the cop list, so a `--` reason sits outside it. The reason documents the
+    # directive and means nothing once the directive is gone, so removal has to cover both. Any
+    # other trailing text is an ordinary comment and is left alone.
+    def range_with_reason
+      directive_range = range
+      trailing = Parser::Source::Range.new(
+        comment.source_range.source_buffer, directive_range.end_pos, comment.source_range.end_pos
+      )
+      return directive_range unless trailing.source.lstrip.start_with?(TRAILING_COMMENT_MARKER)
+
+      directive_range.with(end_pos: comment.source_range.end_pos)
+    end
+
     # Returns match captures to directive comment pattern
     def match_captures
       @match_captures ||= @match_data && begin

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
               expect_correction('')
             end
 
+            it 'removes a standalone directive together with its `--` reason' do
+              expect_offense(<<~RUBY)
+                # rubocop:disable Metrics/MethodLength -- kept for documentation purposes
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/MethodLength`.
+              RUBY
+
+              expect_correction('')
+            end
+
             describe 'when that cop was previously enabled' do
               it 'returns no offense' do
                 expect_no_offenses(<<~RUBY)
@@ -891,6 +900,23 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
           # rubocop:disable Metrics
           def bar
             do_something # rubocop:disable Metrics/ClassLength
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something
+          end
+        RUBY
+      end
+
+      it 'removes cop duplicated by department and the `--` reason with it' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Metrics
+          def bar
+            do_something # rubocop:disable Metrics/ClassLength -- the reason
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unnecessary disabling of `Metrics/ClassLength`.
           end
         RUBY

--- a/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_enable_directive_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopEnableDirective, :config do
     RUBY
   end
 
+  # Without taking the reason along, the `#` is removed but its text is not, leaving bare
+  # words behind that do not parse.
+  it 'registers an offense and removes the `--` reason with the directive' do
+    expect_offense(<<~RUBY)
+      foo
+      # rubocop:enable Layout/LineLength -- no longer needed
+                       ^^^^^^^^^^^^^^^^^ Unnecessary enabling of Layout/LineLength.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo
+    RUBY
+  end
+
   it 'registers an offense and corrects when the first cop is unnecessarily enabled' do
     expect_offense(<<~RUBY)
       # rubocop:disable Layout/LineLength

--- a/spec/rubocop/directive_comment_spec.rb
+++ b/spec/rubocop/directive_comment_spec.rb
@@ -181,6 +181,47 @@ RSpec.describe RuboCop::DirectiveComment do
     end
   end
 
+  describe '#range_with_reason' do
+    # Needs real source ranges, so build an actual comment rather than a double.
+    subject(:covered) { described_class.new(real_comment).range_with_reason.source }
+
+    let(:real_comment) do
+      RuboCop::ProcessedSource.new(source, RUBY_VERSION.to_f).comments.first
+    end
+
+    context 'when the directive carries a `--` reason' do
+      let(:source) { "x = 1 # rubocop:disable Style/StringLiterals -- a good reason\n" }
+
+      it 'covers the directive and the reason' do
+        expect(covered).to eq('# rubocop:disable Style/StringLiterals -- a good reason')
+      end
+    end
+
+    context 'when the marker has no text after it' do
+      let(:source) { "x = 1 # rubocop:disable Style/StringLiterals --\n" }
+
+      it 'still covers the marker, which is meaningless on its own' do
+        expect(covered).to eq('# rubocop:disable Style/StringLiterals --')
+      end
+    end
+
+    context 'when the trailing text is an ordinary comment' do
+      let(:source) { "x = 1 # rubocop:disable Style/StringLiterals - just a note\n" }
+
+      it 'covers only the directive' do
+        expect(covered).to eq('# rubocop:disable Style/StringLiterals')
+      end
+    end
+
+    context 'when there is no trailing text' do
+      let(:source) { "x = 1 # rubocop:disable Style/StringLiterals\n" }
+
+      it 'covers only the directive' do
+        expect(covered).to eq('# rubocop:disable Style/StringLiterals')
+      end
+    end
+  end
+
   describe '#single_line?' do
     subject { directive_comment.single_line? }
 


### PR DESCRIPTION
`DirectiveComment#range` stops at the cop list, so a `--` reason sits outside the range that the redundant-directive cops remove. The reason documents the directive and means nothing once the directive is gone, but it survived autocorrection:

```console
$ cat sample.rb
a = 1 # rubocop:disable Style/StringLiterals -- a good reason

$ rubocop -a sample.rb >/dev/null; cat sample.rb
a = 1 # -- a good reason
```

It can also weld the leftover onto the preceding line. Given a directive with no reason followed by a standalone one that has a reason, the two lines merge:

```ruby
# before
d = 4 # rubocop:disable Style/StringLiterals
# rubocop:disable Style/StringLiterals -- standalone with reason
e = 5
# after `rubocop -a`
d = 4 # -- standalone with reason
e = 5
```

`Lint/RedundantCopEnableDirective` fares worse, because it removes the whole comment including the leading `#`. The leftover reason is then not a comment at all and the file stops parsing:

```console
$ cat enable.rb
a = 1
# rubocop:enable Layout/LineLength -- no longer needed
puts a

$ rubocop -a enable.rb >/dev/null; cat enable.rb
a = 1
-- no longer needed
puts a

$ ruby -c enable.rb
enable.rb:2: syntax error found ... unexpected local variable or method
```

## The change

`DirectiveComment#range_with_reason` extends the range over the reason when the trailing text starts with `TRAILING_COMMENT_MARKER`, and both cops use it for their removal range.

Two notes on the shape:

- It keys off the **marker**, not `#reason`. `#reason` is `nil` for a bare `--` with nothing after it, and that is precisely a case where the enable cop would still leave unparseable output behind.
- Only the reported **correction** range grows. The offence range is unchanged, so highlighting still covers just `# rubocop:disable Foo` and no existing expectations shift.

Trailing text that does not use the marker is not a reason, so it is left exactly as it was — `Lint/RedundantCopDisableDirective` still preserves it as a free comment:

```ruby
b = 2 # rubocop:disable Style/StringLiterals - a single dash note
# stays
b = 2 # - a single dash note
```

The existing `removes cop duplicated by department and leaves free text as a comment` example covers that and is untouched.

## Adjacent bug, deliberately not fixed here

`Lint/RedundantCopEnableDirective` also mishandles *non*-marker trailing text, for the same reason it mishandled the marker case — it takes the `#` but leaves the text:

```ruby
# rubocop:enable Layout/LineLength - single dash note   ->   - single dash note
```

That still produces unparseable output after this PR. It is a separate defect needing the free-comment preservation that the disable cop has, and it is not about `--` at all, so I left it out to keep this PR to one subject. Happy to follow up, or fold it in if you would rather see them together.

## Testing

Seven new examples, all of which fail on `master` and pass with the change: four unit examples on `#range_with_reason` (marker with text, bare marker, non-marker trailing text, no trailing text) and three correction examples across the two cops. `bundle exec rake` is green — full suite plus `internal_investigation` over 1741 files.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder][2] named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded: "<<next>>"` in `config/default.yml`.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/rubocop/rubocop/blob/master/changelog/
