### PR TITLE
[Fix #15562] Make `Layout/SpaceAroundOperators` aware of endless method definitions

### DIFF
--- a/changelog/change_make_layout_space_around_operators_aware_of_endless_method_definitions_20260811232625.md
+++ b/changelog/change_make_layout_space_around_operators_aware_of_endless_method_definitions_20260811232625.md
@@ -1,0 +1,1 @@
+* [#15562](https://github.com/rubocop/rubocop/issues/15562): Make `Layout/SpaceAroundOperators` aware of endless method definitions. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1416,6 +1416,7 @@ Layout/SpaceAroundOperators:
   StyleGuide: '#spaces-operators'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '<<next>>'
   # When `true`, allows most uses of extra spacing if the intent is to align
   # with an operator on the previous or next line, not counting empty lines
   # or comment lines.

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -129,6 +129,12 @@ module RuboCop
           check_operator(:class, node.loc.operator, rhs)
         end
 
+        def on_def(node)
+          return unless node.endless?
+
+          check_operator(:assignment, node.loc.assignment, node.body)
+        end
+
         def on_binary(node)
           rhs = node.rhs
 
@@ -170,6 +176,7 @@ module RuboCop
         alias on_or_asgn  on_assignment
         alias on_and_asgn on_assignment
         alias on_op_asgn  on_assignment
+        alias on_defs     on_def
 
         private
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -377,6 +377,98 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
         "" => foo
       RUBY
     end
+
+    context 'with endless method definitions' do
+      it 'registers an offense for a parameterless definition without space after `=`' do
+        expect_offense(<<~RUBY)
+          def foo =1
+                  ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo = 1
+        RUBY
+      end
+
+      it 'registers an offense for a parenthesized definition without space around `=`' do
+        expect_offense(<<~RUBY)
+          def foo()=1
+                   ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo() = 1
+        RUBY
+      end
+
+      it 'registers an offense for a parenthesized definition without space after `=`' do
+        expect_offense(<<~RUBY)
+          def foo() =1
+                    ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo() = 1
+        RUBY
+      end
+
+      it 'registers an offense for a parenthesized definition without space before `=`' do
+        expect_offense(<<~RUBY)
+          def foo()= 1
+                   ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo() = 1
+        RUBY
+      end
+
+      it 'registers an offense for a definition with parameters without space around `=`' do
+        expect_offense(<<~RUBY)
+          def foo(a, b)=a + b
+                       ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo(a, b) = a + b
+        RUBY
+      end
+
+      it 'registers an offense for a singleton definition without space after `=`' do
+        expect_offense(<<~RUBY)
+          def self.foo =1
+                       ^ Surrounding space missing for operator `=`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def self.foo = 1
+        RUBY
+      end
+
+      it 'does not register an offense for a correctly spaced definition' do
+        expect_no_offenses(<<~RUBY)
+          def foo = 1
+          def bar() = 2
+          def self.baz = 3
+        RUBY
+      end
+
+      it 'does not register an offense when the body is on the next line after `=`' do
+        expect_no_offenses(<<~RUBY)
+          def foo() =
+            1
+        RUBY
+      end
+
+      # An operator at the beginning of a continuation line is ignored by this cop as a whole,
+      # not just for endless method definitions.
+      it 'does not register an offense when `=` is at the beginning of a continuation line' do
+        expect_no_offenses(<<~RUBY)
+          def foo()
+            =1
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyleForExponentOperator is space' do


### PR DESCRIPTION
The `=` of an endless method definition was not checked by any cop, so `def hello ='hello world'` reported no offense.

The check routes `node.loc.assignment` through the cop's standard `check_operator` machinery rather than handling the `=` by hand. This covers the parenless form (`def hello =1`), reuses the standard message and autocorrect, and inherits the cop-wide policies: `=` at the end of a line counts as spaced (like `x =` before a wrapped right-hand side), and an operator at the beginning of a continuation line is ignored.

The correction is safe by construction: `def hello=...` with no space before the `=` lexes as a setter name and endless setter definitions are a syntax error, so in any endless definition that parses, the method name is already delimited before the `=` and inserting spaces cannot change it.

Resolves #15562.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
