### PR TITLE
Allow json 3.x

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_dependency('json', '~> 2.3')
+  s.add_dependency('json', '>= 2.3')
   # NOTE: language_server-protocol gem doesn't use semantic versioning. Its versions follow x.y.z.t,
   # where x.y.z indicates the Language Server Protocol Specification, t is an incrementing number.
   s.add_dependency('language_server-protocol', '~> 3.17.0.2')


### PR DESCRIPTION
Ref: https://github.com/ruby/json/releases/tag/v3.0.0.rc1

I tried the test suite against 3.0.0.rc1, it's all green, no reason to prevent the upgrade.
