### PR TITLE
Add `RequiredBlankLines` option to `Layout/EmptyLineAfterMagicComment`

### DIFF
--- a/changelog/new_add_number_of_empty_lines_option_to_layout_empty_line_after_magic_comment.md
+++ b/changelog/new_add_number_of_empty_lines_option_to_layout_empty_line_after_magic_comment.md
@@ -1,0 +1,1 @@
+* [#15111](https://github.com/rubocop/rubocop/issues/15111): Add `NumberOfEmptyLines` option to `Layout/EmptyLineAfterMagicComment` to configure the minimum number of empty lines required after magic comments. ([@alejofraga][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -618,6 +618,12 @@ Layout/EmptyLineAfterMagicComment:
   StyleGuide: '#separate-magic-comments-from-code'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '<<next>>'
+  # The minimum number of empty lines required after the last magic comment. Set this
+  # to `2` when using YARD, which otherwise treats the magic comments as documentation
+  # for the first module or class in the file. `Layout/EmptyLines` has to be disabled
+  # for values greater than `1`.
+  NumberOfEmptyLines: 1
 
 Layout/EmptyLineAfterMultilineCondition:
   Description: 'Enforces empty line after multiline condition.'

--- a/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/layout/empty_line_after_magic_comment.rb
@@ -5,6 +5,14 @@ module RuboCop
     module Layout
       # Checks for a newline after the final magic comment.
       #
+      # `NumberOfEmptyLines` configures the minimum number of empty lines required. Set it
+      # to `2` when using YARD, which otherwise treats the magic comments as documentation
+      # for the first module or class in the file.
+      #
+      # NOTE: `Layout/EmptyLines` has to be disabled for values greater than `1`, as it
+      # removes the extra empty lines this cop adds, and autocorrecting with both enabled
+      # loops between them.
+      #
       # @example
       #   # good
       #   # frozen_string_literal: true
@@ -20,28 +28,78 @@ module RuboCop
       #   class Person
       #     # Some code
       #   end
+      #
+      # @example NumberOfEmptyLines: 1 (default)
+      #   # good
+      #   # frozen_string_literal: true
+      #
+      #   class Person
+      #   end
+      #
+      # @example NumberOfEmptyLines: 2
+      #   # bad
+      #   # frozen_string_literal: true
+      #
+      #   class Person
+      #   end
+      #
+      #   # good
+      #   # frozen_string_literal: true
+      #
+      #
+      #   class Person
+      #   end
       class EmptyLineAfterMagicComment < Base
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Add an empty line after magic comments.'
+        MSG = 'Expected at least %<expected>d empty %<lines>s after magic comments; found ' \
+              '%<actual>d.'
+
+        def validate_config
+          return if number_of_empty_lines.is_a?(Integer) && number_of_empty_lines.positive?
+
+          raise ValidationError,
+                'The `Layout/EmptyLineAfterMagicComment` cop only accepts a positive ' \
+                'integer for its `NumberOfEmptyLines` configuration parameter, but ' \
+                "`#{number_of_empty_lines.inspect}` was given."
+        end
 
         def on_new_investigation
           return unless (last_magic_comment = last_magic_comment(processed_source))
-          return unless (next_line = processed_source[last_magic_comment.loc.line])
-          return if next_line.strip.empty?
+
+          actual = empty_lines_after(last_magic_comment)
+          # Trailing empty lines are `Layout/TrailingEmptyLines`' responsibility.
+          return unless processed_source[last_magic_comment.loc.line + actual]
+          return if actual >= number_of_empty_lines
 
           offending_range = offending_range(last_magic_comment)
 
-          add_offense(offending_range) do |corrector|
-            corrector.insert_before(offending_range, "\n")
+          add_offense(offending_range, message: message(actual)) do |corrector|
+            corrector.insert_before(offending_range, "\n" * (number_of_empty_lines - actual))
           end
         end
 
         private
 
+        def message(actual)
+          format(MSG, expected: number_of_empty_lines, actual: actual,
+                      lines: number_of_empty_lines == 1 ? 'line' : 'lines')
+        end
+
+        def empty_lines_after(last_magic_comment)
+          first_line = last_magic_comment.loc.line
+          count = 0
+          count += 1 while (line = processed_source[first_line + count]) && line.strip.empty?
+          count
+        end
+
         def offending_range(last_magic_comment)
           source_range(processed_source.buffer, last_magic_comment.loc.line + 1, 0)
+        end
+
+        def number_of_empty_lines
+          cop_config.fetch('NumberOfEmptyLines', 1)
         end
 
         # Find the last magic comment in the source file.

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1222,7 +1222,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     expect($stdout.string).to eq(<<~RESULT)
       == example.rb ==
       C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-      C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+      C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
       C:  3:  1: Style/Documentation: Missing top-level documentation comment for class A.
       W:  4:  3: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/MethodLength.
       C:  5:  3: [Corrected] Layout/IndentationWidth: Use 2 (not 6) spaces for indentation.

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         == example.rb ==
         C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
         C:  1:  7: [Corrected] Layout/SpaceAroundOperators: Surrounding space missing for operator ==.
-        C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+        C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 
         1 file inspected, 3 offenses detected, 3 offenses corrected
       OUTPUT
@@ -88,7 +88,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
           C:  1:  4: [Todo] Style/IpAddresses: Do not hardcode IP addresses.
-          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 
           1 file inspected, 3 offenses detected, 3 offenses corrected
         OUTPUT
@@ -117,7 +117,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
           W:  1: 21: [Corrected] Lint/UnusedMethodArgument: Unused method argument - some_arg. If it's necessary, use _ or _some_arg as an argument name to indicate that it won't be used. If it's unnecessary, remove it. You can also write as ordinary_method(*) if you want the method to accept any arguments but don't care about them.
-          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
           W:  5: 29: [Todo] Lint/UnusedMethodArgument: Unused method argument - some_keyword_arg. You can also write as method_with_keyword_arg(*) if you want the method to accept any arguments but don't care about them.
 
           1 file inspected, 4 offenses detected, 4 offenses corrected
@@ -197,7 +197,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  1:  4: [Todo] Style/IpAddresses: Do not hardcode IP addresses.
             C:  1: 15: [Todo] Style/IpAddresses: Do not hardcode IP addresses.
-            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 
             1 file inspected, 4 offenses detected, 4 offenses corrected
           OUTPUT
@@ -243,7 +243,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
             C:  3:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
             C:  3:  3: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
             C:  3:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
@@ -295,7 +295,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
           C:  1:  4: [Todo] Style/IpAddresses: Do not hardcode IP addresses.
-          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+          C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 
           1 file inspected, 3 offenses detected, 3 offenses corrected
         OUTPUT
@@ -456,7 +456,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             == example.rb ==
             C:  1:  1: [Todo] Metrics/MethodLength: Method has too many lines. [3/2]
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+            C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 
             1 file inspected, 3 offenses detected, 3 offenses corrected
           OUTPUT

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # rbs_inline: enabled
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # rbs_inline: disabled
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # typed: true
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       # Documentation for Foo
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
       class Foo; end
     RUBY
 
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
       # encoding: utf-8
       # frozen_string_literal: true
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -174,7 +174,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
       # frozen_string_literal: true
       # shareable_constant_value: none
       class Foo; end
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
       # Hello!
-      ^ Add an empty line after magic comments.
+      ^ Expected at least 1 empty line after magic comments; found 0.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -213,5 +213,94 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
 
   it 'accepts a source file with only a magic comment' do
     expect_no_offenses('# frozen_string_literal: true')
+  end
+
+  it 'accepts a magic comment followed only by empty lines' do
+    expect_no_offenses("# frozen_string_literal: true\n\n  \n\n")
+  end
+
+  it 'accepts more empty lines than required' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+
+
+      class Foo; end
+    RUBY
+  end
+
+  context 'when `NumberOfEmptyLines: 2`' do
+    let(:cop_config) { { 'NumberOfEmptyLines' => 2 } }
+
+    it 'registers an offense for code that immediately follows the comment' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: true
+        class Foo; end
+        ^ Expected at least 2 empty lines after magic comments; found 0.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # frozen_string_literal: true
+
+
+        class Foo; end
+      RUBY
+    end
+
+    it 'registers an offense when only one empty line follows the comment' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: true
+
+        ^{} Expected at least 2 empty lines after magic comments; found 1.
+        class Foo; end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # frozen_string_literal: true
+
+
+        class Foo; end
+      RUBY
+    end
+
+    it 'accepts code separated from the comment by two empty lines' do
+      expect_no_offenses(<<~RUBY)
+        # frozen_string_literal: true
+
+
+        class Foo; end
+      RUBY
+    end
+
+    it 'accepts more empty lines than required' do
+      expect_no_offenses(<<~RUBY)
+        # frozen_string_literal: true
+
+
+
+        class Foo; end
+      RUBY
+    end
+
+    it 'accepts a source file with only a magic comment' do
+      expect_no_offenses('# frozen_string_literal: true')
+    end
+  end
+
+  describe 'invalid `NumberOfEmptyLines` configuration' do
+    shared_examples 'invalid value' do |value|
+      context "when `NumberOfEmptyLines: #{value.inspect}`" do
+        let(:cop_config) { { 'NumberOfEmptyLines' => value } }
+
+        it 'raises a validation error' do
+          expect { expect_no_offenses('# frozen_string_literal: true') }
+            .to raise_error(RuboCop::ValidationError, /only accepts a positive integer/)
+        end
+      end
+    end
+
+    it_behaves_like 'invalid value', 0
+    it_behaves_like 'invalid value', -1
+    it_behaves_like 'invalid value', 1.5
+    it_behaves_like 'invalid value', 'two'
   end
 end


### PR DESCRIPTION
Fixes #15111

## Summary

Adds a `RequiredBlankLines` option to `Layout/EmptyLineAfterMagicComment` to configure how many empty lines are required after the last magic comment.

The default of `1` preserves the current behavior exactly — all pre-existing specs pass unchanged. Setting it to `2` addresses the motivating case from the issue: YARD treats magic comments as documentation for the first module or class in the file unless two blank lines separate them ([yard#1657](https://github.com/lsegal/yard/issues/1657)).

```yaml
Layout/EmptyLineAfterMagicComment:
  RequiredBlankLines: 2
```

The cop now counts the blank lines following the last magic comment and corrects in either direction — inserting when there are too few, removing the surplus when there are too many.

Follows the approach proposed by @hammadxcm in #15111.

## Questions for reviewers

- **Option name.** I went with `RequiredBlankLines`; `BlankLineCount` was suggested on the issue. Happy to rename.
- **Message wording with `RequiredBlankLines: 0`.** The message reads `Add 0 empty lines after magic comments.`, which is awkward for what is really a removal. Suggestions welcome.

## Notes

- Trailing blank lines at the end of a file are left to `Layout/TrailingEmptyLines`; the cop only checks when actual content follows the magic comment.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder][2] named `{change_type}_{change_description}.md` if the new code introduces user-observable changes.
* [x] The PR passes `bundle exec rake default`

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/rubocop/rubocop/blob/master/changelog/