### PR TITLE
[Fix #10449] Fix `Layout/ClassStructure` wrong reordering

### DIFF
--- a/changelog/fix_layout_class_structure_autocorrection_20260710175104.md
+++ b/changelog/fix_layout_class_structure_autocorrection_20260710175104.md
@@ -1,0 +1,1 @@
+* [#10449](https://github.com/rubocop/rubocop/issues/10449): Fix `Layout/ClassStructure` autocorrection producing a wrong order when an element cannot be moved, and make offenses report the category that actually blocks the expected order. ([@koic][])

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -190,33 +190,58 @@ module RuboCop
 
         # Validates code style on class declaration.
         # Add offense when find a node out of expected order.
+        # A node is out of order when its category is expected earlier than
+        # the highest-priority category seen so far, so that a low-priority element
+        # (even an unmovable one) cannot mask disorder among the elements that follow it.
+        # Consecutive elements of the same category are reported only once,
+        # on the first element of the group.
         def on_class(class_node)
-          previous = -1
-          walk_over_nested_class_definition(class_node) do |node, category|
-            index = expected_order.index(category)
-            if index < previous
-              message = format(MSG, category: category, previous: expected_order[previous])
-              add_offense(node, message: message) { |corrector| autocorrect(corrector, node) }
+          # Corrections are registered in reverse source order because an insertion at
+          # a given position lands before any insertion already made there;
+          # this keeps the source order of nodes moved before the same anchor.
+          out_of_order_elements(class_node).reverse_each do |node, category, previous|
+            message = format(MSG, category: category, previous: previous)
+
+            add_offense(node, message: message) do |corrector|
+              autocorrect(corrector, node)
             end
-            previous = index
           end
         end
         alias on_sclass on_class
 
         private
 
-        # Autocorrect by swapping between two nodes autocorrecting them
-        def autocorrect(corrector, node)
-          previous = node.left_siblings.reverse.find do |sibling|
-            !ignore_for_autocorrect?(node, sibling)
+        def out_of_order_elements(class_node)
+          out_of_order = []
+          max_index = -1
+          previous_category = nil
+          walk_over_nested_class_definition(class_node) do |node, category|
+            index = expected_order.index(category)
+            if index < max_index && category != previous_category
+              out_of_order << [node, category, expected_order[max_index]]
+            end
+            max_index = index if index > max_index
+            previous_category = category
           end
-          return unless previous
+          out_of_order
+        end
 
-          current_range = source_range_with_comment(node)
-          previous_range = source_range_with_comment(previous)
+        # Autocorrect by moving the node, together with the contiguous group of
+        # same-category elements that follows it, to its expected position.
+        def autocorrect(corrector, node)
+          return if dynamic_constant?(node)
 
-          corrector.insert_before(previous_range, current_range.source)
-          corrector.remove(current_range)
+          anchor = insertion_anchor(node)
+          return unless anchor
+
+          anchor_range = source_range_with_comment(anchor)
+          # Reversed for the same reason offenses are registered in reverse source order:
+          # the last insertion at a position comes first.
+          movable_group(node).reverse_each do |group_node|
+            current_range = source_range_with_comment(group_node)
+            corrector.insert_before(anchor_range, current_range.source)
+            corrector.remove(current_range)
+          end
         end
 
         # Classifies a node to match with something in the {expected_order}
@@ -302,15 +327,6 @@ module RuboCop
           end
         end
 
-        def ignore_for_autocorrect?(node, sibling)
-          classification = classify(node)
-          sibling_class = classify(sibling)
-
-          ignore?(sibling, sibling_class) ||
-            classification == sibling_class ||
-            dynamic_constant?(node)
-        end
-
         def humanize_node(node)
           if node.def_type?
             return :initializer if node.method?(:initialize)
@@ -326,6 +342,66 @@ module RuboCop
           expression = node.expression
           expression.send_type? &&
             !(expression.method?(:freeze) && expression.receiver&.recursive_basic_literal?)
+        end
+
+        # The expected position of the node: the first left sibling within its movable span
+        # whose category is expected to appear after the node's.
+        # Requiring a strictly later category keeps the order of elements sharing a category stable.
+        def insertion_anchor(node)
+          index = expected_order.index(classify(node))
+
+          movable_span(node).find do |sibling|
+            classification = classify(sibling)
+
+            !ignore?(sibling, classification) && expected_order.index(classification) > index
+          end
+        end
+
+        # The node together with the contiguous same-category right siblings,
+        # so that the whole group moves in a single pass while the offense is
+        # reported only on its first element.
+        def movable_group(node)
+          classification = classify(node)
+          group = [node]
+
+          node.right_siblings.each do |sibling|
+            break unless classify(sibling) == classification
+            break if ignore?(sibling, classification) || dynamic_constant?(sibling)
+
+            group << sibling
+          end
+
+          group
+        end
+
+        # Left siblings the node may be reordered with: those after the last barrier.
+        # Ignored elements within the span are simply jumped over.
+        def movable_span(node)
+          left_siblings = node.left_siblings
+          barrier_index = left_siblings.rindex { |sibling| barrier?(node, sibling) }
+
+          barrier_index ? left_siblings[(barrier_index + 1)..] : left_siblings
+        end
+
+        # A dynamic constant blocks every element: the cop does not move such constants,
+        # and letting other elements jump over one would change execution order just the same.
+        # A bare visibility modifier blocks only the elements whose meaning depends on
+        # the visibility section they appear in.
+        def barrier?(node, sibling)
+          dynamic_constant?(sibling) || (visibility_dependent?(node) && visibility_block?(sibling))
+        end
+
+        # Whether moving the node across a bare visibility modifier would change its meaning.
+        # This is the case for `def` nodes and for macros whose category is classified by visibility
+        # (e.g. `attr_accessor` when the expected order lists `private_attribute_macros`).
+        # Inline visibility (`private def foo`, `def self.foo`) travels with the node.
+        def visibility_dependent?(node)
+          return true if node.def_type?
+          return false if !node.send_type? || node.def_modifier?
+
+          key = find_category(node.method_name) || node.method_name.to_s
+
+          VISIBILITY_SCOPES.any? { |visibility| expected_order.include?("#{visibility}_#{key}") }
         end
 
         def private_constant?(node)

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -720,6 +720,185 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
     end
   end
 
+  context 'when misordered elements share their expected position' do
+    it 'corrects them in a single pass, preserving their relative order' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def do_something; end
+          include M
+          ^^^^^^^^^ `module_inclusion` is supposed to appear before `public_methods`.
+          CONST = 1
+          ^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY, loop: false)
+        class Foo
+          include M
+          CONST = 1
+          def do_something; end
+        end
+      RUBY
+    end
+
+    it 'reports the category blocking the expected order, not the adjacent element' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def self.do_something; end
+
+          def initialize; end
+
+          include M
+          ^^^^^^^^^ `module_inclusion` is supposed to appear before `initializer`.
+          CONST = 1
+          ^^^^^^^^^ `constants` is supposed to appear before `initializer`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY, loop: false)
+        class Foo
+          include M
+          CONST = 1
+          def self.do_something; end
+
+          def initialize; end
+
+        end
+      RUBY
+    end
+  end
+
+  context 'when consecutive elements of the same category are misordered' do
+    it 'registers an offense only on the first element and moves the whole group in a single pass' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def do_something; end
+          FIRST = 1
+          ^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          SECOND = 2
+        end
+      RUBY
+
+      expect_correction(<<~RUBY, loop: false)
+        class Foo
+          FIRST = 1
+          SECOND = 2
+          def do_something; end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a constant not assigned with a literal sits between misordered elements' do
+    it 'registers offenses but does not move elements across the constant' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def do_something; end
+          CONST = [*foo].freeze
+          ^^^^^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          include M
+          ^^^^^^^^^ `module_inclusion` is supposed to appear before `public_methods`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense for a misordered element that follows the constant' do
+      expect_offense(<<~RUBY)
+        class Foo
+          validates :name
+          CONST = do_something.freeze
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `constants` is supposed to appear before `macros`.
+          attr_reader :foo
+          ^^^^^^^^^^^^^^^^ `attribute_macros` is supposed to appear before `macros`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'moves only the part of a group that precedes the constant' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def do_something; end
+          FIRST = 1
+          ^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+          DYNAMIC = do_something.freeze
+          SECOND = 2
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          FIRST = 1
+          def do_something; end
+          DYNAMIC = do_something.freeze
+          SECOND = 2
+        end
+      RUBY
+    end
+  end
+
+  context 'when correcting would move an element across a bare visibility modifier' do
+    it 'registers an offense for a method but does not correct' do
+      expect_offense(<<~RUBY)
+        class Foo
+          private
+
+          def do_internal_work; end
+
+          public
+
+          def do_something; end
+          ^^^^^^^^^^^^^^^^^^^^^ `public_methods` is supposed to appear before `private_methods`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense for an attribute macro but does not correct' do
+      expect_offense(<<~RUBY)
+        class Foo
+          private
+
+          def do_internal_work; end
+
+          public
+
+          attr_reader :foo
+          ^^^^^^^^^^^^^^^^ `attribute_macros` is supposed to appear before `private_methods`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'corrects a misordered constant, which may cross the modifier' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def do_something; end
+
+          private
+
+          CONST = 1
+          ^^^^^^^^^ `constants` is supposed to appear before `public_methods`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          CONST = 1
+          def do_something; end
+
+          private
+
+        end
+      RUBY
+    end
+  end
+
   context 'when singleton class' do
     context 'simple example' do
       specify do


### PR DESCRIPTION
This commit fixes `Layout/ClassStructure` converging on a wrong order when autocorrecting a class that contains an element the cop refuses to move, and makes offenses point at the category that actually blocks the expected order.

Detection previously compared each element only with its immediate predecessor. A constant that is not assigned with a literal is never moved by the cop for execution-order safety, but its low-priority category reset the comparison, hiding any disorder among the elements that follow it. Detection now tracks the highest-priority category seen so far, so masked disorder is reported and the offense message names the true blocker, which also makes manual fixes guided by the messages land on a correct order. Consecutive elements of the same category are still reported only once, on the first element.

Autocorrection previously moved a flagged node one sibling up per pass, letting elements leapfrog an unmovable constant while others could not follow, which is how the mangled model in #10449 came about. Each flagged node, together with the contiguous group of same-category elements that follows it, is now moved directly to its expected position in a single pass.

Design decisions:

- A constant that the cop refuses to move also blocks other elements from being moved across it. Moving an element over such a constant changes execution order just the same as moving the constant itself, so both are refused for the same reason and the offense is left uncorrected.
- An element whose meaning depends on the visibility section it appears in (a `def`, or a macro whose category is classified by visibility such as `attr_accessor` with `private_attribute_macros` in `ExpectedOrder`) is no longer moved across a bare `private`, `protected`, or `public` modifier, since that would change its visibility. Previously such a move could silently make a public method private.

Fixes #10449 and #9738.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
