### PR TITLE
[Fix #9963] Fix false negatives for Layout/ExtraSpacing

### DIFF
--- a/changelog/fix_false_negatives_for_layout_extra_spacing_20260813135746.md
+++ b/changelog/fix_false_negatives_for_layout_extra_spacing_20260813135746.md
@@ -1,0 +1,1 @@
+* [#9963](https://github.com/rubocop/rubocop/issues/9963): Fix false negatives for `Layout/ExtraSpacing`. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -41,6 +41,7 @@ module RuboCop
 
           @aligned_comments = aligned_locations(processed_source.comments.map(&:loc))
           @corrected = Set.new if force_equal_sign_alignment?
+          prepare_alignment_data
 
           processed_source.tokens.each_cons(2) do |token1, token2|
             check_tokens(processed_source.ast, token1, token2)
@@ -95,17 +96,118 @@ module RuboCop
           end_pos = token2.begin_pos - 1
           return if end_pos <= start_pos
 
-          return if allow_for_alignment? && aligned_tok?(token2)
+          return if allow_for_alignment? && aligned_tok?(token1, token2)
 
           yield range_between(start_pos, end_pos)
         end
 
-        def aligned_tok?(token)
+        def aligned_tok?(previous_token, token)
           if token.comment?
             @aligned_comments.include?(token.line)
           else
-            aligned_with_something?(token.pos)
+            aligned_with_something?(token.pos) &&
+              (ASSIGNMENT_OR_COMPARISON_TOKENS.include?(token.type) ||
+               spacing_varies?(previous_token, token))
           end
+        end
+
+        def spacing_varies?(previous_token, token)
+          by_column, typed = group_profile(token.line)
+          column = token.pos.column
+          lines, spacings = typed[[column, token.type]]
+          entries = by_column[column]
+
+          if lines.size > 1
+            uniform_alignment_allowed?(token, lines, spacings)
+          elsif entries.size > 1
+            distinct_spacings(entries).size > 1
+          else
+            nearest_spacing_varies?(previous_token, token)
+          end
+        end
+
+        def uniform_alignment_allowed?(token, lines, spacings)
+          return @alignment_verdicts[lines] if @alignment_verdicts.key?(lines)
+
+          @alignment_verdicts[lines] =
+            spacings.uniq.size > 1 || aligned_on_other_column?(token, lines)
+        end
+
+        def aligned_on_other_column?(token, lines)
+          line_set = Set.new(lines)
+          by_column, = group_profile(token.line)
+
+          by_column.any? do |column, entries|
+            next false if column == token.pos.column
+
+            shared = entries.filter_map { |line, spacing| spacing if line_set.include?(line) }
+            shared.uniq.size > 1
+          end
+        end
+
+        def distinct_spacings(entries)
+          entries.map(&:last).uniq
+        end
+
+        def group_profile(line_number)
+          group = alignment_lines(line_number)
+
+          @group_profiles[group] ||= build_group_profile(group)
+        end
+
+        def build_group_profile(group)
+          by_column = Hash.new { |hash, key| hash[key] = [] }
+          typed = Hash.new { |hash, key| hash[key] = [[], []] }
+
+          group.each { |line| record_line_spacings(by_column, typed, line) }
+
+          [by_column, typed]
+        end
+
+        def record_line_spacings(by_column, typed, line)
+          @tokens_by_line[line]&.each_cons(2) do |previous_token, token|
+            spacing = token.begin_pos - previous_token.end_pos
+            by_column[token.pos.column] << [line, spacing]
+            lines, spacings = typed[[token.pos.column, token.type]]
+            lines << line
+            spacings << spacing
+          end
+        end
+
+        def nearest_spacing_varies?(previous_token, token)
+          spacing = token.begin_pos - previous_token.end_pos
+          line_ranges = [(token.line - 1).downto(1),
+                         (token.line + 1).upto(processed_source.lines.length)]
+
+          line_ranges.any? do |line_numbers|
+            nearest_spacing_differs?(line_numbers, token, spacing)
+          end
+        end
+
+        def nearest_spacing_differs?(line_numbers, token, spacing)
+          line_numbers.each do |line|
+            break if definition_boundary_lines.include?(line)
+            next if aligned_comment_lines.include?(line)
+
+            other_spacing = spacing_before_token_at(line, token.pos.column)
+            return other_spacing != spacing if other_spacing
+          end
+
+          false
+        end
+
+        def spacing_before_token_at(line_number, column)
+          tokens = @tokens_by_line[line_number]
+          index = tokens&.index { |token| token.pos.column == column }
+          return unless index&.positive?
+
+          tokens[index].begin_pos - tokens[index - 1].end_pos
+        end
+
+        def prepare_alignment_data
+          @group_profiles = {}.compare_by_identity
+          @alignment_verdicts = {}.compare_by_identity
+          @tokens_by_line = processed_source.tokens.group_by(&:line)
         end
 
         def ignored_range?(ast, start_pos)

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -182,20 +182,58 @@ module RuboCop
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
       def relevant_assignment_lines(line_range)
+        relevant_lines(line_range) { |line_number| assignment_lines.include?(line_number) }
+      end
+
+      def alignment_lines(line_number)
+        @alignment_lines_by_line ||= {}
+        return @alignment_lines_by_line[line_number] if @alignment_lines_by_line.key?(line_number)
+
+        lines = alignment_line_ranges(line_number).flatten.uniq.sort.freeze
+
+        lines.each { |line| @alignment_lines_by_line[line] = lines }
+      end
+
+      def alignment_line_ranges(line_number)
+        last_line = processed_source.lines.length
+
+        [
+          relevant_lines(line_number.downto(1), definition_boundary_lines) do |line|
+            !aligned_comment_lines.include?(line)
+          end,
+          relevant_lines(line_number.upto(last_line), definition_boundary_lines) do |line|
+            !aligned_comment_lines.include?(line)
+          end
+        ]
+      end
+
+      def definition_boundary_lines
+        @definition_boundary_lines ||= begin
+          nodes = processed_source.ast&.each_node(:any_def) || []
+
+          nodes.each_with_object(Set.new) do |node, lines|
+            lines << node.first_line << node.last_line
+          end
+        end
+      end
+
+      def relevant_lines(line_range, boundary_lines = [])
         result                        = []
-        original_line_indent          = processed_source.line_indentation(line_range.first)
+        original_line                 = line_range.first
+        original_line_indent          = processed_source.line_indentation(original_line)
         relevant_line_indent_at_level = true
 
         line_range.each do |line_number|
           current_line_indent = processed_source.line_indentation(line_number)
           blank_line          = processed_source.lines[line_number - 1].blank?
 
-          if (current_line_indent < original_line_indent && !blank_line) ||
+          if (line_number != original_line && boundary_lines.include?(line_number)) ||
+             (current_line_indent < original_line_indent && !blank_line) ||
              (relevant_line_indent_at_level && blank_line)
             break
           end
 
-          result << line_number if assignment_lines.include?(line_number) &&
+          result << line_number if yield(line_number) &&
                                    current_line_indent == original_line_indent
 
           unless blank_line

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -367,6 +367,110 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       RUBY
     end
 
+    it 'registers offenses and corrects repeated extra spacing' do
+      expect_offense(<<~RUBY)
+        RSpec.describe 'Test' do
+          let(:low_group)   { create(:low_group) }
+                         ^^ Unnecessary spacing detected.
+          let(:medium_group)   { create(:medium_group) }
+                            ^^ Unnecessary spacing detected.
+          let(:normal_group)   { create(:normal_group) }
+                            ^^ Unnecessary spacing detected.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe 'Test' do
+          let(:low_group) { create(:low_group) }
+          let(:medium_group) { create(:medium_group) }
+          let(:normal_group) { create(:normal_group) }
+        end
+      RUBY
+    end
+
+    it 'accepts extra spacing that aligns repeated tokens' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe 'Test' do
+          let(:low_group)      { create(:low_group) }
+          let(:medium_group)   { create(:medium_group) }
+          let(:normal_group)   { create(:normal_group) }
+        end
+      RUBY
+    end
+
+    it 'registers offenses when a differently spaced token is beyond a blank line' do
+      expect_offense(<<~RUBY)
+        foo(:a)   { bar }
+               ^^ Unnecessary spacing detected.
+        foo(:b)   { bar }
+               ^^ Unnecessary spacing detected.
+
+        foo(:abc) { bar }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(:a) { bar }
+        foo(:b) { bar }
+
+        foo(:abc) { bar }
+      RUBY
+    end
+
+    it 'registers offenses when a differently spaced token is beyond a method definition' do
+      expect_offense(<<~RUBY)
+        foo(:a)   { bar }
+               ^^ Unnecessary spacing detected.
+        foo(:b)   { bar }
+               ^^ Unnecessary spacing detected.
+        def unrelated
+          bar
+        end
+        foo(:abc) { bar }
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(:a) { bar }
+        foo(:b) { bar }
+        def unrelated
+          bar
+        end
+        foo(:abc) { bar }
+      RUBY
+    end
+
+    it 'registers offenses when unrelated aligned code follows repeated extra spacing' do
+      expect_offense(<<~RUBY)
+        foo(:a)   { bar }
+               ^^ Unnecessary spacing detected.
+        foo(:b)   { bar }
+               ^^ Unnecessary spacing detected.
+        xy    = 1
+        abcde = 2
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo(:a) { bar }
+        foo(:b) { bar }
+        xy    = 1
+        abcde = 2
+      RUBY
+    end
+
+    it 'accepts uniformly padded tokens when another column on the same lines varies' do
+      expect_no_offenses(<<~RUBY)
+        it_behaves_like 'foo', 'var = if',     'test',  'end'
+        it_behaves_like 'foo', 'var = unless', 'test',  'end'
+      RUBY
+    end
+
+    it 'accepts extra spacing that aligns tokens of different kinds' do
+      expect_no_offenses(<<~RUBY)
+        register(:a,    1)
+        register(:bb,   :s)
+        register(:ccc,  2)
+      RUBY
+    end
+
     it 'registers an offense and corrects when the only vertically aligned line is in a preceding sibling block' do
       expect_offense(<<~RUBY)
         foo do


### PR DESCRIPTION
`Layout/ExtraSpacing` treated repeated identical gaps as alignment whenever the following tokens happened to share a column. As a result, it reported only the first line in the example from #9963.

This change requires spacing to vary within the relevant alignment group before accepting it as intentional alignment. Existing handling for assignment and comparison operators and aligned comments remains unchanged. The added examples cover both repeated unnecessary spacing and genuine alignment of repeated tokens.

Fixes #9963.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
