### PR TITLE
Fix `Lint/NameTypo` false positives in reopened gem namespaces

### DIFF
--- a/changelog/fix_lint_name_typo_false_positives_in_gem_namespaces_20260814150028.md
+++ b/changelog/fix_lint_name_typo_false_positives_in_gem_namespaces_20260814150028.md
@@ -1,0 +1,1 @@
+* [#15568](https://github.com/rubocop/rubocop/pull/15568): Fix `Lint/NameTypo` registering false positives for names provided by a gem whose namespace the project reopens, and for constants read from a namespace with an unresolved ancestor. ([@HoneyryderChuck][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -355,6 +355,14 @@ module RuboCop
       @gem_versions_in_target ||= read_gem_versions_from_target_lockfile
     end
 
+    # Returns the names of the target's gems that are sourced from a local path
+    # (i.e. `path:` dependencies and the project's own gem when the `Gemfile`
+    # uses `gemspec`), whose code therefore lives in the project itself.
+    # @returns [Array<String>, nil] The gem names, or nil without a lockfile.
+    def path_sourced_gems_in_target
+      @path_sourced_gems_in_target ||= read_path_sourced_gems_from_target_lockfile
+    end
+
     def inspect # :nodoc:
       "#<#{self.class.name}:#{object_id} @loaded_path=#{loaded_path}>"
     end
@@ -397,6 +405,14 @@ module RuboCop
       return nil unless lockfile_path
 
       Lockfile.new(lockfile_path).gem_versions
+    end
+
+    # @returns [Array<String>, nil] The names of the gems sourced from a local path.
+    def read_path_sourced_gems_from_target_lockfile
+      lockfile_path = bundler_lock_file_path
+      return nil unless lockfile_path
+
+      Lockfile.new(lockfile_path).path_sourced_gem_names
     end
 
     def enable_cop?(qualified_cop_name, cop_options)

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -27,6 +27,13 @@ module RuboCop
       # alone is not reported, since the index does not see gems or the
       # standard library.
       #
+      # For the same reason, a namespace whose root segment names a gem in the
+      # bundle (`Flipper` for the `flipper` gem) is left alone: a project that
+      # reopens it (`module Flipper; module Adapters; ...`) makes it resolve in
+      # the index, while the members the gem itself defines stay invisible and
+      # would look like typos. Enabling `AllCops/ProjectIndexIncludesGems`
+      # indexes those sources and restores the check.
+      #
       # Names that appear as symbols or inside string literals in the same
       # file are never reported, since they usually belong to runtime
       # definitions the index cannot see (`stub_const`, `const_set`,
@@ -132,11 +139,47 @@ module RuboCop
           namespace = resolve_constant_in_index(node.namespace)
           return nil unless namespace.is_a?(Rubydex::Namespace)
           return nil if namespace.find_member(node.short_name.to_s)
+          return nil unless complete_index_members?(namespace)
           return nil if literal_names.include?(node.short_name.to_s)
 
           spell_check(node.short_name, constant_member_names(namespace))
         rescue StandardError
           nil
+        end
+
+        # Whether the index can be trusted to list everything the namespace
+        # defines. A name missing from an incomplete member list is not
+        # evidence of a typo, so both gaps have to be ruled out first:
+        # an ancestor that does not resolve may contribute the name, and so
+        # may a gem that reopens the namespace.
+        def complete_index_members?(declaration)
+          fully_resolved_index_ancestry?(declaration) && !gem_owned_namespace?(declaration)
+        end
+
+        # Whether the namespace's root segment names a gem in the bundle,
+        # which is then free to define members the index never sees: gem
+        # sources are only indexed when `AllCops/ProjectIndexIncludesGems`
+        # is enabled. A project that reopens such a namespace to add its own
+        # members (`module Flipper; module Adapters; ...`) makes it resolve
+        # in the index while most of what it holds stays invisible.
+        def gem_owned_namespace?(declaration)
+          return false if config.for_all_cops['ProjectIndexIncludesGems']
+
+          root = declaration.name.to_s.split('::').first.to_s
+          bundled_gem_namespaces.include?(root.downcase)
+        end
+
+        # Gem names normalized towards the constant they conventionally
+        # provide: `flipper` for `Flipper`, `activerecord` for `ActiveRecord`.
+        def bundled_gem_namespaces
+          @bundled_gem_namespaces ||= bundled_gem_names.to_set { |name| name.delete('-_').downcase }
+        end
+
+        # The bundle's gems except those sourced from a local path, whose code
+        # lives in the project and is indexed like the rest of it — among them
+        # the project's own gem, which its lockfile lists in the `PATH` section.
+        def bundled_gem_names
+          (config.gem_versions_in_target || {}).keys - (config.path_sourced_gems_in_target || [])
         end
 
         # Writers are indexed under the reader's name, so setter calls are
@@ -155,13 +198,15 @@ module RuboCop
           nil
         end
 
-        # The receiver's declaration when it resolves in the index, its whole
-        # ancestry is resolved, and the method is not found — nil otherwise.
+        # The receiver's declaration when it resolves in the index, everything
+        # it can inherit or be reopened with is visible there, and the method
+        # is not found — nil otherwise.
         def unknown_method_owner(node, base)
           declaration = resolve_constant_in_index(node.receiver)
           return nil unless declaration.is_a?(Rubydex::Namespace)
           return nil if responds_in_index?(declaration, node.method_name.to_s, base)
           return nil unless fully_resolved_index_ancestry?(declaration)
+          return nil if gem_owned_namespace?(declaration)
 
           declaration
         end

--- a/lib/rubocop/lockfile.rb
+++ b/lib/rubocop/lockfile.rb
@@ -59,6 +59,18 @@ module RuboCop
       end
     end
 
+    # Names of gems sourced from a local path, i.e. `path:` dependencies and the
+    # project's own gem when the `Gemfile` uses `gemspec`. Git sources are not
+    # included: their code lives outside the project, like a released gem's.
+    # @return [Array<String>]
+    def path_sourced_gem_names
+      return [] unless parser
+
+      parser.specs.filter_map do |spec|
+        spec.name if path_source?(spec.source)
+      end
+    end
+
     # Whether this lockfile includes the named gem, directly or indirectly.
     # @param [String] name
     # @return [Boolean]
@@ -67,6 +79,12 @@ module RuboCop
     end
 
     private
+
+    # `Bundler::Source::Git` is a subclass of `Bundler::Source::Path`, but a git
+    # source is a remote one.
+    def path_source?(source)
+      source.is_a?(::Bundler::Source::Path) && !source.is_a?(::Bundler::Source::Git)
+    end
 
     # @return [Bundler::LockfileParser, nil]
     def parser

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -135,6 +135,8 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
 
   let(:gem_versions) { {} }
 
+  let(:path_sourced_gems) { [] }
+
   ### Utilities
 
   def source_range(range, buffer: source_buffer)
@@ -179,6 +181,7 @@ RSpec.shared_context 'config' do # rubocop:disable Metrics/BlockLength
         **gem_versions.transform_values { |value| Gem::Version.new(value) }
       }
     )
+    allow(config).to receive(:path_sourced_gems_in_target).and_return(path_sourced_gems)
 
     config
   end

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -81,6 +81,68 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
         RUBY
       end
 
+      context 'when the namespace names a gem in the bundle' do
+        let(:gem_versions) { { 'services' => '1.0.0' } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Services::UserCraetor.new
+          RUBY
+        end
+
+        context 'when the gem name is underscored' do
+          let(:gem_versions) { { 'ser_vices' => '1.0.0' } }
+
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              Services::UserCraetor.new
+            RUBY
+          end
+        end
+
+        context 'when the gem is sourced from a local path' do
+          let(:path_sourced_gems) { ['services'] }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              Services::UserCraetor.new
+                        ^^^^^^^^^^^ Possible typo: `UserCraetor` is not defined in `Services`. Did you mean `UserCreator`?
+            RUBY
+          end
+        end
+
+        context 'when gem sources are indexed' do
+          let(:all_cops_config) { super().merge('ProjectIndexIncludesGems' => true) }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              Services::UserCraetor.new
+                        ^^^^^^^^^^^ Possible typo: `UserCraetor` is not defined in `Services`. Did you mean `UserCreator`?
+            RUBY
+          end
+        end
+      end
+
+      context 'when the ancestry is not fully resolved' do
+        before do
+          cop.project_index = build_index(
+            'file:///services.rb' => <<~RUBY
+              class Services < External::Base
+                class UserCreator; end
+
+                class UserDeleter; end
+              end
+            RUBY
+          )
+        end
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Services::UserCraetor.new
+          RUBY
+        end
+      end
+
       context 'when CheckConstants is false' do
         let(:cop_config) { { 'CheckConstants' => false } }
 
@@ -226,6 +288,27 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
           expect_no_offenses(<<~RUBY)
             Report.generate_sumary
           RUBY
+        end
+      end
+
+      context 'when the receiver names a gem in the bundle' do
+        let(:gem_versions) { { 'report' => '1.0.0' } }
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            Report.generate_sumary
+          RUBY
+        end
+
+        context 'when the gem is sourced from a local path' do
+          let(:path_sourced_gems) { ['report'] }
+
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              Report.generate_sumary
+                     ^^^^^^^^^^^^^^^ Possible typo: `Report` does not respond to `generate_sumary`. Did you mean `generate_summary`?
+            RUBY
+          end
         end
       end
 

--- a/spec/rubocop/lockfile_spec.rb
+++ b/spec/rubocop/lockfile_spec.rb
@@ -104,6 +104,51 @@ RSpec.describe RuboCop::Lockfile, :isolated_environment do
     end
   end
 
+  describe '#path_sourced_gem_names' do
+    subject { super().path_sourced_gem_names }
+
+    it_behaves_like 'error states'
+
+    it { is_expected.to eq([]) }
+
+    context 'when gems are sourced from a path or a git repository' do
+      let(:lockfile) do
+        create_file('Gemfile.lock', <<~LOCKFILE)
+          PATH
+            remote: .
+            specs:
+              my_gem (1.0.0)
+
+          PATH
+            remote: vendor/other_gem
+            specs:
+              other_gem (1.0.0)
+
+          GIT
+            remote: https://github.com/rubocop/rubocop.git
+            revision: 0000000000000000000000000000000000000000
+            specs:
+              rubocop (1.0.0)
+
+          GEM
+            specs:
+              rake (13.0.1)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            my_gem!
+            other_gem!
+            rake (~> 13.0)
+            rubocop!
+        LOCKFILE
+      end
+
+      it { is_expected.to contain_exactly('my_gem', 'other_gem') }
+    end
+  end
+
   describe '#includes_gem?' do
     subject { super().includes_gem?(name) }
 


### PR DESCRIPTION
The cop treated any namespace that resolves in the project index as having a complete member list. That does not hold for a namespace a project reopens to add its own members (`module Flipper; module Adapters; ...`): it resolves, but everything the gem itself defines is invisible unless `AllCops/ProjectIndexIncludesGems` is on, so `Flipper::Adapter` was reported as a typo for `Flipper::Adapters`.

Skip constant and method checks when the namespace's root segment names a gem in the bundle, and apply the existing ancestry-completeness guard to constants as well as methods.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ x Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
