### PR TITLE
Fix an error for LSP `workspace/executeCommand` without arguments

### DIFF
--- a/changelog/fix_an_error_for_lsp_execute_command_without_arguments_20260813145234.md
+++ b/changelog/fix_an_error_for_lsp_execute_command_without_arguments_20260813145234.md
@@ -1,0 +1,1 @@
+* [#15569](https://github.com/rubocop/rubocop/pull/15569): Fix an error for the built-in language server when a `workspace/executeCommand` request has no document URI in its arguments. ([@koic][])

--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -151,25 +151,13 @@ module RuboCop
           return
         end
 
-        uri = request[:params][:arguments][0][:uri]
-        formatted = nil
-
-        # The `workspace/executeCommand` is an LSP method triggered by intentional user actions,
-        # so the user's intention for autocorrection is respected.
-        LSP.disable { formatted = format_file(uri, command: command) }
-
-        @server.write(
-          id: request[:id],
-          method: 'workspace/applyEdit',
-          params: {
-            label: label,
-            edit: {
-              changes: {
-                uri => formatted
-              }
-            }
-          }
-        )
+        # Clients such as Eglot can invoke a command without arguments, so respond with
+        # an error instead of letting the server crash on a missing URI.
+        if (uri = document_uri_from(request))
+          write_formatting_edits(request, uri: uri, command: command, label: label)
+        else
+          write_invalid_arguments_error(request, command)
+        end
       end
 
       handle 'textDocument/willSave' do |_request|
@@ -217,6 +205,47 @@ module RuboCop
           lint_mode: request.dig(:params, :initializationOptions, :lintMode) == true,
           layout_mode: request.dig(:params, :initializationOptions, :layoutMode) == true
         }
+      end
+
+      def document_uri_from(request)
+        argument = request.dig(:params, :arguments, 0)
+
+        argument[:uri] if argument.is_a?(Hash)
+      end
+
+      def write_formatting_edits(request, uri:, command:, label:)
+        formatted = nil
+
+        # The `workspace/executeCommand` is an LSP method triggered by intentional user actions,
+        # so the user's intention for autocorrection is respected.
+        LSP.disable { formatted = format_file(uri, command: command) }
+
+        @server.write(
+          id: request[:id],
+          method: 'workspace/applyEdit',
+          params: {
+            label: label,
+            edit: {
+              changes: {
+                uri => formatted
+              }
+            }
+          }
+        )
+      end
+
+      def write_invalid_arguments_error(request, command)
+        message = "Missing document URI in arguments for #{command}"
+
+        @server.write(
+          id: request[:id],
+          error: LanguageServer::Protocol::Interface::ResponseError.new(
+            code: LanguageServer::Protocol::Constant::ErrorCodes::INVALID_PARAMS,
+            message: message
+          )
+        )
+
+        Logger.log(message)
       end
 
       def format_file(file_uri, command: nil)

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -1459,6 +1459,61 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
     end
   end
 
+  describe 'execute command without arguments' do
+    let(:requests) do
+      [{
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'workspace/executeCommand',
+        params: {
+          command: 'rubocop.formatAutocorrects'
+        }
+      }]
+    end
+
+    it 'handles requests' do
+      expect(stderr.chomp).to eq(
+        '[server] Missing document URI in arguments for rubocop.formatAutocorrects'
+      )
+      expect(messages.last).to eq(
+        jsonrpc: '2.0',
+        id: 99,
+        error: {
+          code: -32_602,
+          message: 'Missing document URI in arguments for rubocop.formatAutocorrects'
+        }
+      )
+    end
+  end
+
+  describe 'execute command with empty arguments' do
+    let(:requests) do
+      [{
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'workspace/executeCommand',
+        params: {
+          command: 'rubocop.formatAutocorrectsAll',
+          arguments: []
+        }
+      }]
+    end
+
+    it 'handles requests' do
+      expect(stderr.chomp).to eq(
+        '[server] Missing document URI in arguments for rubocop.formatAutocorrectsAll'
+      )
+      expect(messages.last).to eq(
+        jsonrpc: '2.0',
+        id: 99,
+        error: {
+          code: -32_602,
+          message: 'Missing document URI in arguments for rubocop.formatAutocorrectsAll'
+        }
+      )
+    end
+  end
+
   describe 'did open on ignored path' do
     let(:requests) do
       [{


### PR DESCRIPTION
The `workspace/executeCommand` handler assumed a request always carries `arguments` with a document URI and crashed the language server when it did not. The LSP specification makes command arguments optional, and clients such as Eglot allow users to invoke an advertised command without any arguments, since RuboCop 1.89 started advertising its commands via `executeCommandProvider`.

Respond with an invalid params error instead so the client receives a proper reply and the server keeps running.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
