### PR TITLE
Fix frozen registry pollution from lazily loaded plugin cops

### DIFF
--- a/changelog/fix_frozen_registry_pollution_from_lazy_loaded_cops.md
+++ b/changelog/fix_frozen_registry_pollution_from_lazy_loaded_cops.md
@@ -1,0 +1,1 @@
+* [#15572](https://github.com/rubocop/rubocop/pull/15572): Fix `RuboCop::Cop::Registry#freeze` to freeze its internal collections, so that registering a lazily loaded cop after the freeze fails fast at the registration site instead of corrupting the registry. ([@koic][])

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -333,10 +333,33 @@ module RuboCop
         cop ? [cop] : cops_for_department(directive)
       end
 
+      # Loads all cops that are registered for lazy loading. Useful when lazily registered cops
+      # must not outlive the current global registry, e.g. before a temporary global registry is
+      # discarded in tests.
+      #
+      # @api private
+      def load_all_lazy_cops
+        # Take a snapshot because loading a cop can load (and thereby register)
+        # another lazy-loaded cop, e.g. its superclass.
+        badges = @cops_by_badge.keys
+
+        badges.each do |badge|
+          load_lazy_cop(badge) if @cops_by_badge[badge].is_a?(String)
+        end
+      end
+
       def freeze
         clear_enrollment_queue
         load_all_lazy_cops
         unqualified_cop_names # build cache
+
+        # Freeze the structural collections as well, so that a cop class defined after
+        # the freeze fails fast at its `enlist`/`lazy_load` call site instead of corrupting
+        # the registry and failing much later.
+        @cops_by_badge.freeze
+        @departments.freeze
+        @enrollment_queue.freeze
+
         super
       end
 
@@ -404,13 +427,6 @@ module RuboCop
         else
           cop_enabled
         end
-      end
-
-      def load_all_lazy_cops
-        # Take a snapshot because loading a cop can load (and thereby register)
-        # another lazy-loaded cop, e.g. its superclass.
-        badges = @cops_by_badge.keys
-        badges.each { |badge| load_lazy_cop(badge) if @cops_by_badge[badge].is_a?(String) }
       end
 
       # @return [Class, nil] the loaded cop class, or nil if the cop excluded

--- a/spec/rubocop/config_obsoletion_spec.rb
+++ b/spec/rubocop/config_obsoletion_spec.rb
@@ -320,6 +320,12 @@ RSpec.describe RuboCop::ConfigObsoletion do
     context 'when the extensions are loaded via inherit_gem', :restore_registry do
       include_context 'mock console output'
 
+      # Resolving the inherited gem config requires `rubocop-performance` in-process,
+      # which may only lazily register its cops (rubocop-performance 1.27+). Load them while
+      # the temporary global registry is still in place, so that their deferred class definitions
+      # cannot fire later and enlist into the frozen global registry.
+      after { RuboCop::Cop::Registry.global.load_all_lazy_cops }
+
       let(:resolver) { RuboCop::ConfigLoaderResolver.new }
       let(:gem_root) { File.expand_path('gems') }
 

--- a/spec/rubocop/version_spec.rb
+++ b/spec/rubocop/version_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe RuboCop::Version do
 
     before { RuboCop::ConfigLoader.clear_options }
 
+    # Requiring an extension may only lazily register its cops (e.g. rubocop-performance 1.27+).
+    # Load them while the temporary global registry is still in place, so that their deferred class
+    # definitions cannot fire later and enlist into the frozen global registry.
+    after { RuboCop::Cop::Registry.global.load_all_lazy_cops }
+
     context 'when no extensions are required' do
       before do
         create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
Since rubocop-performance 1.27 (999e328b5 in the dev bundle), random spec workers on CI
intermittently reported hundreds of cascading failures with:

```
can't modify frozen RuboCop::Cop::Registry (registry.rb:385)
```

e.g. run https://github.com/rubocop/rubocop/actions/runs/31928204133, where all 246 failures were in one worker.

Root cause: `spec_helper.rb` freezes the global registry at suite start as a pollution guard. rubocop-performance 1.27 switched to lazy cop registration (`register_cop` + `autoload`), so when a spec requires the gem in-process inside its `:restore_registry` window, only the autoloads (process-global state) are installed while the cop registrations go to the temporary global registry and are discarded with it. The gem also prepends `autocorrect_incompatible_with` onto `Lint/UnusedMethodArgument` and `Naming/BlockForwarding`, referencing `Performance::BlockGivenWithExplicitBlock`. When a later spec in the same process runs autocorrect with one of those cops, the autoload fires outside any temporary-registry window, `Base.inherited` enlists the class into the frozen global registry (the queue array itself was not frozen, so the push succeeded silently), and the next `Registry#departments` call died reassigning `@enrollment_queue` in `clear_enrollment_queue`. The queue could never be flushed afterwards, so every subsequent registry-touching spec in that process failed. The flake needed the requiring spec and an autocorrect spec in the same process in that order, hence the random appearance. With 1.26, requiring the gem defined all cop classes inside the isolation window, which is why this never happened before.

Two specs require the gem in-process: the `RuboCop::Version.extension_versions` specs, and the "when the extensions are loaded via inherit_gem" context in config_obsoletion_spec, which resolves a mocked gem config whose `.rubocop.yml` contains `require: [rubocop-performance]`. The latter caused the Windows job failures of run https://github.com/rubocop/rubocop/actions/runs/31932295449 on the two `Naming/BlockForwarding` autocorrect specs: in a serial run (Windows, JRuby) both specs always share one process, so only the example order decides whether it reproduces. Reproduced locally with the failing job's seed (`bundle exec rspec --seed 39703`) and bisected to the minimal pair:

```
bundle exec rspec './spec/rubocop/config_obsoletion_spec.rb[1:1:3]' \
  spec/rubocop/cli/autocorrect_spec.rb:613 --order defined
```

The fix is two-layered:

- Both requiring spec groups now call `Registry#load_all_lazy_cops` (made public as `@api private`) in an `after` hook, which runs inside the `:restore_registry` window. Lazily registered plugin cops are resolved while the temporary registry is still the global one, so no armed autoload survives the window,  restoring the pre-1.27 behavior. The hook is deliberately per-spec rather than generalized  into the 'maintain registry' shared context (even with `prepend_after`, a shared-context hook empirically runs after spec-defined `after` hooks, so lazy_loader_spec's temp cop file is already deleted when the load would run). lazy_loader_spec itself needs no hook because its autoload is armed on a `stub_const`-ed module that mock teardown removes along with the autoload.
- `Registry#freeze` now also freezes `@cops_by_badge`, `@departments`, and `@enrollment_queue`, so any future post-freeze registration raises at the `enlist`/`lazy_load` call site, in the spec that triggers the class definition, instead of silently corrupting the registry and cascading into unrelated specs. The memoization caches stay unfrozen since they are written during normal operation. Production code never freezes the global registry, so runtime behavior is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
