### PR TITLE
Add job timeouts to the CI workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# `timeout-minutes` on each job is a guard against intermittent CI hangs:
+# a job hitting its limit is hung, not slow. A normal run finishes in about
+# 1-2 minutes on ubuntu, 4-5 minutes on Windows, and 15 minutes on JRuby.
 jobs:
   spec-ubuntu:
     name: Spec - ubuntu ${{ matrix.ruby }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +45,7 @@ jobs:
   spec-jruby:
     name: Spec - JRuby
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
@@ -54,6 +59,7 @@ jobs:
     needs: spec-ubuntu # Don't spend CI resources on slow Windows specs if CI won't pass anyway.
     name: Spec - windows ${{ matrix.ruby }}
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +84,7 @@ jobs:
   ascii_spec:
     name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -101,6 +108,7 @@ jobs:
   documentation_check:
     name: Documentation Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
@@ -113,6 +121,7 @@ jobs:
   prism:
     runs-on: ubuntu-latest
     name: Prism
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
CI runs intermittently hang: a random ubuntu spec job stops producing output right after "Starting test-queue master"
and sits until GitHub Actions' default 360-minute job limit cancels it.

A normal job finishes in about 1-2 minutes on ubuntu, 4-5 minutes on Windows, and about 14 minutes on JRuby, so cap the JRuby job at 30 minutes and every other job at 20 minutes. This does not fix the hang itself, but it cuts the feedback delay for a hung job from 6 hours to at most 30 minutes.

I'll investigate the underlying issue separately.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
