### PR TITLE
Fix loss of plugin-declared AllCops keys with multiple plugins

### DIFF
--- a/changelog/fix_plugin_all_cops_key_loss.md
+++ b/changelog/fix_plugin_all_cops_key_loss.md
@@ -1,0 +1,1 @@
+* [#15574](https://github.com/rubocop/rubocop/pull/15574): Fix an incorrect warning such as `AllCops does not support TargetRailsVersion parameter` when a plugin declares a custom `AllCops` key with a nil value and another plugin is loaded after it. ([@koic][])

--- a/docs/modules/ROOT/pages/plugins.adoc
+++ b/docs/modules/ROOT/pages/plugins.adoc
@@ -68,6 +68,33 @@ If a path containing `-` is given, it will be used as is, but if we
 cannot find the file to load, we will replace `-` with `/` and try it
 again as when Bundler loads gems.
 
+== Custom `AllCops` Settings
+
+A plugin can introduce its own settings under `AllCops` (for example, `rubocop-rails` provides `AllCops: TargetRailsVersion`)
+by declaring the key with a nil value in the `AllCops` section of its own configuration file, shown here for a hypothetical
+`TargetFrameworkVersion` setting:
+
+[source,yaml]
+----
+# config/default.yml in the plugin gem.
+AllCops:
+  TargetFrameworkVersion: ~
+----
+
+When the plugin is loaded, its `AllCops` keys are merged into the default configuration, so users of the plugin can set
+the key in their project's configuration and pass configuration validation without
+"AllCops does not support X parameter" warnings:
+
+[source,yaml]
+----
+# A project's .rubocop.yml.
+plugins:
+  - rubocop-framework # The plugin declaring `TargetFrameworkVersion`
+
+AllCops:
+  TargetFrameworkVersion: 7.1
+----
+
 == Plugin Suggestions
 
 Depending on what gems you have in your bundle, RuboCop might suggest plugins

--- a/lib/rubocop/plugin/configuration_integrator.rb
+++ b/lib/rubocop/plugin/configuration_integrator.rb
@@ -59,7 +59,11 @@ module RuboCop
 
               plugin_config.make_excludes_absolute
 
-              ConfigLoader.merge_with_default(plugin_config, plugin_config_path)
+              # `unset_nil: false` keeps `AllCops` keys declared with a nil value by a plugin
+              # (e.g. `TargetRailsVersion: ~` of rubocop-rails); `merge_all_cop_settings` above
+              # carries such keys into each subsequent plugin's config, where `unset_nil: true`
+              # would delete them from the combined configuration.
+              ConfigLoader.merge_with_default(plugin_config, plugin_config_path, unset_nil: false)
             end
           end
         end

--- a/spec/rubocop/plugin/configuration_integrator_spec.rb
+++ b/spec/rubocop/plugin/configuration_integrator_spec.rb
@@ -62,6 +62,73 @@ RSpec.describe RuboCop::Plugin::ConfigurationIntegrator, :isolated_environment d
       end
     end
 
+    context 'when a plugin declares a custom `AllCops` key alongside another plugin' do
+      let(:rubocop_config) { RuboCop::Config.new }
+      let(:declaring_plugin) do
+        Class.new(LintRoller::Plugin) do
+          def rules(_context)
+            LintRoller::Rules.new(
+              type: :path, config_format: :rubocop, value: 'declaring_default.yml'
+            )
+          end
+        end
+      end
+      let(:other_plugin) do
+        Class.new(LintRoller::Plugin) do
+          def rules(_context)
+            LintRoller::Rules.new(type: :path, config_format: :rubocop, value: 'other_default.yml')
+          end
+        end
+      end
+
+      before do
+        create_file('declaring_default.yml', <<~YAML)
+          AllCops:
+            TargetFrameworkVersion: ~
+        YAML
+        create_file('other_default.yml', <<~YAML)
+          AllCops:
+            Exclude:
+              - db/*schema.rb
+        YAML
+      end
+
+      after do
+        RuboCop::ConfigLoader.default_configuration = nil
+      end
+
+      shared_examples 'keeps the declared key' do
+        it 'keeps the key in the default configuration' do
+          integrated_config
+
+          default_all_cops = RuboCop::ConfigLoader.default_configuration['AllCops']
+          expect(default_all_cops).to have_key('TargetFrameworkVersion')
+        end
+
+        it 'recognizes the key when validating a user configuration' do
+          integrated_config
+
+          expect do
+            RuboCop::Config.create(
+              { 'AllCops' => { 'TargetFrameworkVersion' => 7.1 } }, '.rubocop.yml', check: true
+            )
+          end.not_to output(/AllCops does not support TargetFrameworkVersion parameter/).to_stderr
+        end
+      end
+
+      context 'when the other plugin is loaded after the declaring plugin' do
+        let(:plugins) { [declaring_plugin.new, other_plugin.new] }
+
+        it_behaves_like 'keeps the declared key'
+      end
+
+      context 'when the declaring plugin is loaded after the other plugin' do
+        let(:plugins) { [other_plugin.new, declaring_plugin.new] }
+
+        it_behaves_like 'keeps the declared key'
+      end
+    end
+
     context 'when using a plugin with `Plugin` type is `:object`' do
       let(:rubocop_config) do
         RuboCop::Config.new('Style/FrozenStringLiteralComment' => { 'Exclude' => %w[**/*.arb] })


### PR DESCRIPTION
A plugin can declare a custom `AllCops` key in its default configuration (e.g. `TargetRailsVersion: ~` of rubocop-rails) so that user configurations setting the key pass validation. However, when another plugin was loaded after that plugin, the key was lost from the combined default configuration and users got an incorrect warning such as "AllCops does not support TargetRailsVersion parameter" (rubocop/rubocop-rails#1442, worked around there by patching the private `ConfigValidator::COMMON_PARAMS` constant).

The cause is an interaction inside the plugin configuration integrator: `merge_all_cop_settings` carries the combined `AllCops` (including the nil-valued key) into each subsequent plugin's config, and `ConfigLoader.merge_with_default` then applies the user-configuration semantics of `unset_nil: true`, which deletes a key that appears on both sides with a nil derived value. Plugin configurations are default configuration material, not user overrides, so nil values there must declare a key rather than unset it. Passing `unset_nil: false` for the plugin merge preserves the key regardless of plugin order.

This makes declaring the key in a plugin's default configuration a reliable mechanism, which is also documented now, so extensions no longer need private-constant hacks to suppress the warning.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
