### PR TITLE
Add `RESTRICT_ON_SEND` constants to `Naming/MethodName` and `Style/StabbyLambdaParentheses`

### DIFF
--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -105,6 +105,10 @@ module RuboCop
 
         MSG = 'Use %<style>s for method names.'
         MSG_FORBIDDEN = '`%<identifier>s` is forbidden, use another method name instead.'
+        RESTRICT_ON_SEND = %i[
+          define_method define_singleton_method new define alias_method
+          attr attr_reader attr_writer attr_accessor
+        ].freeze
 
         OPERATOR_METHODS = %i[| ^ & <=> == === =~ > >= < <= << >> + - * /
                               % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `].to_set.freeze

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -25,6 +25,8 @@ module RuboCop
 
         MSG_REQUIRE = 'Wrap stabby lambda arguments with parentheses.'
         MSG_NO_REQUIRE = 'Do not wrap stabby lambda arguments with parentheses.'
+        RESTRICT_ON_SEND = %i[lambda].freeze
+
         def on_send(node)
           return unless stabby_lambda_with_args?(node)
           return unless redundant_parentheses?(node) || missing_parentheses?(node)


### PR DESCRIPTION
`Naming/MethodName` and `Style/StabbyLambdaParentheses` only handle fixed method names, but their `on_send` callbacks currently receive every send node. This adds `RESTRICT_ON_SEND` constants so the commissioner skips unrelated calls.

Both callbacks predate #8365. The bulk migrations in #8640 and #8644 missed these files; #15020 recently made the same `lambda` optimization in `Layout/SpaceInLambdaLiteral`. There is no behavior change.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.