### PR TITLE
Add autocorrection to Lint/CopDirectiveSyntax

### DIFF
--- a/changelog/change_add_autocorrection_to_lint_cop_directive_syntax_20260819120000.md
+++ b/changelog/change_add_autocorrection_to_lint_cop_directive_syntax_20260819120000.md
@@ -1,0 +1,1 @@
+* [#15578](https://github.com/rubocop/rubocop/pull/15578): Add unsafe autocorrection to `Lint/CopDirectiveSyntax` for directives that omit the commas between cop names, and for trailing comments marked with `#` instead of `--`. ([@corsonknowles][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1802,6 +1802,7 @@ Lint/ConstantResolution:
 Lint/CopDirectiveSyntax:
   Description: 'Checks that `# rubocop:` directives are strictly formatted.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '1.72'
   VersionChanged: '1.91'
 

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -8,6 +8,13 @@ module RuboCop
       #
       # A comment can be added to the directive by prefixing it with `--`.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because inserting the missing comma
+      #   changes which cops a directive suppresses. A `rubocop:disable` listing
+      #   `Layout/LineLength Style/Encoding` disables only the first cop today;
+      #   once the comma is added it disables both, so offenses that were being
+      #   reported quietly stop being reported.
+      #
       # @example
       #   # bad
       #   # rubocop:disable Layout/LineLength Style/Encoding
@@ -70,6 +77,14 @@ module RuboCop
         INVALID_KEYWORD_MSG = 'The directive keyword must be `rubocop`, not `%<keyword>s`.'
         UNKNOWN_COP_MSG = 'Unknown cop name `%<name>s`%<suggestion>s.'
 
+        MALFORMED_MSG = {
+          missing_mode_name: MISSING_MODE_NAME_MSG,
+          invalid_mode_name: INVALID_MODE_NAME_MSG,
+          missing_cop_name: MISSING_COP_NAME_MSG,
+          invalid_signed_args: INVALID_SIGNED_ARGS_MSG,
+          malformed_cop_names: MALFORMED_COP_NAMES_MSG
+        }.freeze
+
         # A comment that looks like an attempted directive: any keyword
         # followed by a colon and a valid mode name.
         NEAR_MISS_KEYWORD_REGEXP = /
@@ -97,7 +112,9 @@ module RuboCop
               merge_directives(corrector, comment, directives)
             end
           elsif directive_comment.malformed?
-            add_offense(comment, message: offense_message(directive_comment))
+            add_offense(comment, message: offense_message(directive_comment)) do |corrector|
+              autocorrect_cop_names(corrector, directive_comment)
+            end
           elsif misplaced_next_directive?(directive_comment)
             add_offense(comment, message: NEXT_DIRECTIVE_AT_EOL_MSG)
           elsif (name = unknown_cop_name(directive_comment))
@@ -171,24 +188,77 @@ module RuboCop
             directive_comment.next?
         end
 
-        # rubocop:disable-next Metrics/MethodLength
         def offense_message(directive_comment)
+          "#{COMMON_MSG} #{MALFORMED_MSG.fetch(malformed_kind(directive_comment))}"
+        end
+
+        # The shape of the malformation, as a symbol, so that the message and the
+        # corrector agree on it without either depending on the message wording.
+        def malformed_kind(directive_comment)
           comment = directive_comment.comment
           after_marker = comment.text.sub(DirectiveComment::DIRECTIVE_MARKER_REGEXP, '')
           mode = after_marker.split(' ', 2).first
-          additional_msg = if mode.nil?
-                             MISSING_MODE_NAME_MSG
-                           elsif !DirectiveComment::AVAILABLE_MODES.include?(mode)
-                             INVALID_MODE_NAME_MSG
-                           elsif directive_comment.missing_cop_name?
-                             MISSING_COP_NAME_MSG
-                           elsif directive_comment.invalid_signed_args?
-                             INVALID_SIGNED_ARGS_MSG
-                           else
-                             MALFORMED_COP_NAMES_MSG
-                           end
+          if mode.nil?
+            :missing_mode_name
+          elsif !DirectiveComment::AVAILABLE_MODES.include?(mode)
+            :invalid_mode_name
+          elsif directive_comment.missing_cop_name?
+            :missing_cop_name
+          elsif directive_comment.invalid_signed_args?
+            :invalid_signed_args
+          else
+            :malformed_cop_names
+          end
+        end
 
-          "#{COMMON_MSG} #{additional_msg}"
+        # Two shapes are mechanical, and nothing else is corrected: either every
+        # trailing token is a known cop name (a comma was left out), or the trailing
+        # text is marked as a comment with `#` (the wrong marker was used). Text that
+        # mixes the two cannot be split without guessing where the names end, and a
+        # wrong guess would disable a cop the author never named.
+        def autocorrect_cop_names(corrector, directive_comment)
+          return unless malformed_kind(directive_comment) == :malformed_cop_names
+
+          comment = directive_comment.comment
+          return unless (match = comment.text.match(DirectiveComment::DIRECTIVE_COMMENT_REGEXP))
+
+          trailing = match.post_match
+          # A second directive belongs on its own line. Marking it as a comment would
+          # be a silent change of meaning, and merging is `MULTIPLE_DIRECTIVES_MSG`.
+          return if DirectiveComment::DIRECTIVE_MARKER_REGEXP.match?(trailing)
+
+          if (names = omitted_cop_names(trailing, directive_comment))
+            corrector.replace(comment, "#{match[0]}, #{names.join(', ')}")
+          elsif (reason = marked_as_comment(trailing))
+            corrector.replace(
+              comment, "#{match[0]} #{DirectiveComment::TRAILING_COMMENT_MARKER} #{reason}"
+            )
+          end
+        end
+
+        # Only when *every* token is a cop name or department, so that rebuilding the
+        # list as comma-separated drops nothing but the separators themselves. A single
+        # unrecognized token means the tail is prose, and prose is left alone.
+        def omitted_cop_names(trailing, directive_comment)
+          names = trailing.strip.split(/[\s,]+/)
+          return if names.empty?
+
+          registry = directive_comment.cop_registry
+          names if names.all? { |name| known_cop_name?(registry, name) }
+        end
+
+        # Sliced from the source rather than tokenized, so commas and other
+        # punctuation the author typed survive the correction verbatim.
+        def marked_as_comment(trailing)
+          match = trailing.match(/\A\s*\#+\s*(?<reason>\S.*?)\s*\z/)
+          match[:reason] if match
+        end
+
+        def known_cop_name?(registry, name)
+          return false unless /\A#{DirectiveComment::COP_NAME_PATTERN_NC}\z/o.match?(name)
+          return true if registry.department?(name)
+
+          registry.contains_cop_matching?([registry.qualified_cop_name(name, nil, warn: false)])
         end
 
         def near_miss_keyword(comment)

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -1,6 +1,139 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
+  describe 'autocorrection' do
+    it 'inserts the missing comma between two cop names' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength Style/Encoding
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style/Encoding
+      RUBY
+    end
+
+    it 'inserts the missing commas between three cop names' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength Style/Encoding Lint/Void
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style/Encoding, Lint/Void
+      RUBY
+    end
+
+    it 'inserts the missing comma before a department name' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength Style
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style
+      RUBY
+    end
+
+    it 'inserts the missing comma when only some commas are present' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style/Encoding Lint/Void
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength, Style/Encoding, Lint/Void
+      RUBY
+    end
+
+    it 'replaces a `#` comment marker with `--`' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength # this is why
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength -- this is why
+      RUBY
+    end
+
+    it 'keeps punctuation in a `#` comment verbatim' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength # the URL below is long, sadly
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # rubocop:disable Layout/LineLength -- the URL below is long, sadly
+      RUBY
+    end
+
+    # Correcting these would mean guessing where the cop names end, and a wrong
+    # guess would disable a cop the author never named.
+    it 'does not correct an unmarked trailing comment' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength this is why
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct a comment whose first word is a department name' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Metrics/AbcSize Metrics are noisy in this file
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct a comment that mixes a department name into prose' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength Style choice, leave it
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct cop names followed by a comment' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength Style/Encoding this is why
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct a stray trailing comma' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct stray trailing punctuation' do
+      expect_offense(<<~RUBY)
+        # rubocop:disable Layout/LineLength:
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed directive comment detected. Cop names must be separated by commas. Comment in the directive must start with `--`.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not correct a directive with a missing mode name' do
+      expect_offense(<<~RUBY)
+        # rubocop:
+        ^^^^^^^^^^ Malformed directive comment detected. The mode name is missing.
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
   it 'does not register an offense for a single cop name' do
     expect_no_offenses(<<~RUBY)
       # rubocop:disable Layout/LineLength


### PR DESCRIPTION
`Lint/CopDirectiveSyntax` has no autocorrection today, so every malformed directive has to be fixed by hand. This adds correction for the one offence shape that has an unambiguous fix.

I ran into this on a large codebase with **164 malformed directives across 108 files**. Every one had to be repaired manually, and the shapes were repetitive enough that it was cleanly mechanisable.

### Why it is correctable

`MALFORMED_COP_NAMES_MSG` covers two different mistakes:

> Cop names must be separated by commas. Comment in the directive must start with `--`.

Telling them apart is what makes correction possible, and the cop already has the means: a word following the cop list is **another cop name if the registry knows it**, and prose otherwise. `unknown_cop_name` already uses `cop_registry` the same way.

```ruby
# before
# rubocop:disable Layout/LineLength Style/Encoding
# after
# rubocop:disable Layout/LineLength, Style/Encoding

# before
# rubocop:disable Layout/LineLength this is why
# after
# rubocop:disable Layout/LineLength -- this is why
```

Both mistakes at once are handled — `A B some words` becomes `A, B -- some words`. Department names work too, since the registry recognises them.

Two smaller shapes are also corrected, because both showed up repeatedly in real code:

- a `#` used as the separator becomes `--`, so `# rubocop:disable A # legacy note` → `# rubocop:disable A -- legacy note`
- punctuation left dangling after the cop names is dropped rather than turned into a comment, so `# rubocop:disable A,` and `# rubocop:disable A:` both become `# rubocop:disable A`

### Deliberately not corrected

**A second directive in the same comment**, e.g. `# rubocop:disable A # rubocop:disable B`. Marking the second one as a comment would silently stop disabling its cops, and relocating it to its own line is not a change this cop should make unprompted. It still registers an offence, with no correction.

**Anything with a missing or invalid mode, or a missing cop name** — there is nothing to infer, so no correction is offered.

### Also in this change

`offense_message` is split into itself plus `additional_message`, so the corrector can ask which shape an offence is rather than re-deriving it. That has the side effect of bringing the method under `Metrics/MethodLength`, so its `# rubocop:disable-next Metrics/MethodLength` directive is no longer needed and is removed.

### Verified

- `bundle exec rspec spec/rubocop/cop/lint/cop_directive_syntax_spec.rb` — 37 examples, 0 failures (8 new)
- `bundle exec rspec spec/project_spec.rb` — 688 examples, 0 failures
- `bundle exec rubocop` clean on the changed files and the changelog entry
- Exercised end to end with `exe/rubocop --only Lint/CopDirectiveSyntax -a` on a scratch file covering every shape above, confirming the duplicate-directive case is left alone

One thing worth noting for reviewers: while testing I found that `# rubocop:disable Lint some words` is not reported at all, because `Lint` disables the whole department — including `Lint/CopDirectiveSyntax` itself — for that line. That is pre-existing behaviour and out of scope here, but it is the same family as #14598, so I mention it in case it is of interest.