### PR TITLE
[Fix #15576] Fix an incorrect autocorrect for `Style/Sample`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_sample_20260819094651.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_sample_20260819094651.md
@@ -1,0 +1,1 @@
+* [#15576](https://github.com/rubocop/rubocop/issues/15576): Fix an incorrect autocorrect for `Style/Sample` when `shuffle` is given a `random:` argument; the offense is still reported but no longer autocorrected, since `shuffle` and `sample` consume a seeded generator differently and would select different elements. ([@koic][])

--- a/lib/rubocop/cop/style/sample.rb
+++ b/lib/rubocop/cop/style/sample.rb
@@ -7,6 +7,10 @@ module RuboCop
       # `shuffle.last`, and `shuffle[]` and change them to use
       # `sample` instead.
       #
+      # NOTE: An offense involving a `random:` argument is registered but not autocorrected:
+      # `shuffle` and `sample` consume the given generator differently, so for a seeded generator
+      # the correction would select different elements.
+      #
       # @example
       #   # bad
       #   [1, 2, 3].shuffle.first
@@ -45,10 +49,12 @@ module RuboCop
             range = source_range(shuffle_node, node)
             message = message(shuffle_arg, method, method_args, range)
 
-            add_offense(range, message: message) do |corrector|
-              corrector.replace(
-                source_range(shuffle_node, node), correction(shuffle_arg, method, method_args)
-              )
+            if shuffle_arg.empty?
+              add_offense(range, message: message) do |corrector|
+                corrector.replace(range, correction(shuffle_arg, method, method_args))
+              end
+            else
+              add_offense(range, message: message)
             end
           end
         end

--- a/spec/rubocop/cop/style/sample_spec.rb
+++ b/spec/rubocop/cop/style/sample_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
     end
   end
 
+  # `shuffle` and `sample` consume a given generator differently, so for a seeded generator
+  # the correction would select different elements and is not applied.
+  shared_examples 'offense without autocorrection' do |wrong, right|
+    it "registers an offense without autocorrection for #{wrong}" do
+      expect_offense(<<~RUBY, wrong: wrong)
+        [1, 2, 3].%{wrong}
+                  ^{wrong} Use `#{right}` instead of `#{wrong}`.
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
   shared_examples 'accepts' do |acceptable|
     it "accepts #{acceptable}" do
       expect_no_offenses("[1, 2, 3].#{acceptable}")
@@ -55,11 +68,16 @@ RSpec.describe RuboCop::Cop::Style::Sample, :config do
   it_behaves_like('offense', 'shuffle.slice(0, 3)', 'sample(3)')
   it_behaves_like('offense', 'shuffle.slice(0..3)', 'sample(4)')
   it_behaves_like('offense', 'shuffle.slice(0...3)', 'sample(3)')
-  it_behaves_like('offense', 'shuffle(random: Random.new).first', 'sample(random: Random.new)')
-  it_behaves_like('offense', 'shuffle(random: Random.new).first(2)',
-                  'sample(2, random: Random.new)')
-  it_behaves_like('offense', 'shuffle(random: foo).last(bar)', 'sample(bar, random: foo)')
-  it_behaves_like('offense', 'shuffle(random: Random.new)[0..3]', 'sample(4, random: Random.new)')
+  it_behaves_like('offense without autocorrection',
+                  'shuffle(random: Random.new).first', 'sample(random: Random.new)')
+  it_behaves_like('offense without autocorrection',
+                  'shuffle(random: Random.new).first(2)', 'sample(2, random: Random.new)')
+  it_behaves_like('offense without autocorrection',
+                  'shuffle(random: foo).last(bar)', 'sample(bar, random: foo)')
+  it_behaves_like('offense without autocorrection',
+                  'shuffle(random: Random.new)[0..3]', 'sample(4, random: Random.new)')
+  it_behaves_like('offense without autocorrection',
+                  'shuffle(random: Random.new(123)).first(5)', 'sample(5, random: Random.new(123))')
 
   it_behaves_like('accepts', 'sample')
   it_behaves_like('accepts', 'shuffle')


### PR DESCRIPTION
The cop's autocorrection rewrote `shuffle(random: rng).first(n)` into `sample(n, random: rng)`, but `shuffle` and `sample` consume the given generator differently, so for a seeded generator the two expressions select different elements:

```ruby
items = (1..20).to_a
items.shuffle(random: Random.new(123_456)).first(5) # => [20, 14, 13, 10, 6]
items.sample(5, random: Random.new(123_456))        # => [2, 12, 20, 14, 19]
```

Passing a seeded generator is the common way to make sampling reproducible, so the correction, which is classified safe, silently changed which elements deterministic samplers return.

An offense involving a `random:` argument is now registered without autocorrection: the two forms are equivalent in distribution but not in sequence, and only the author knows whether the exact sequence matters. This covers seeded literals and generators arriving in variables alike, and follows the register-without-correcting pattern the code base already uses where a mechanical rewrite cannot preserve behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
