### PR TITLE
[Fix #15067] Fix an incorrect autocorrect for Style/CollectionQuerying

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_collection_querying_20260819134047.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_collection_querying_20260819134047.md
@@ -1,0 +1,1 @@
+* [#15067](https://github.com/rubocop/rubocop/issues/15067): Fix an incorrect autocorrect for `Style/CollectionQuerying` when `count` is used without a block. ([@Starlexxx][])

--- a/lib/rubocop/cop/style/collection_querying.rb
+++ b/lib/rubocop/cop/style/collection_querying.rb
@@ -15,31 +15,18 @@ module RuboCop
       # would yield false positives. For example, `String` implements `length`
       # and `size`, but it doesn't include `Enumerable`.
       #
+      # When `count` is used without a block, it measures the collection's
+      # size, so the offense is corrected to `empty?` or `!empty?`. The
+      # predicate methods `any?`, `none?` and `one?` test element truthiness
+      # instead and would return different results for collections with falsey
+      # elements (e.g. `[false].count.zero?` is `false`, but `[false].none?`
+      # is `true`). For the same reason, `count == 1` and `count > 1` without
+      # a block are not flagged.
+      #
       # @safety
       #   The cop is unsafe because receiver might not include `Enumerable`, or
       #   it has nonstandard implementation of `count` or any replacement
       #   methods.
-      #
-      #   It's also unsafe because for collections with falsey values, expressions
-      #   with `count` without a block return a different result than methods `any?`,
-      #   `none?` and `one?`:
-      #
-      #   [source,ruby]
-      #   ----
-      #   [nil, false].count.positive?
-      #   [nil].count == 1
-      #   # => true
-      #
-      #   [nil, false].any?
-      #   [nil].one?
-      #   # => false
-      #
-      #   [nil].count == 0
-      #   # => false
-      #
-      #   [nil].none?
-      #   # => true
-      #   ----
       #
       #   Autocorrection is unsafe when replacement methods don't iterate over
       #   every element in collection and the given block runs side effects:
@@ -60,12 +47,14 @@ module RuboCop
       #   x.count > 0
       #   x.count != 0
       #
+      #   # good
+      #   !x.empty?
+      #
+      #   # bad
       #   x.count(&:foo?).positive?
       #   x.count { |item| item.foo? }.positive?
       #
       #   # good
-      #   x.any?
-      #
       #   x.any?(&:foo?)
       #   x.any? { |item| item.foo? }
       #
@@ -74,24 +63,33 @@ module RuboCop
       #   x.count == 0
       #
       #   # good
-      #   x.none?
+      #   x.empty?
       #
       #   # bad
-      #   x.count == 1
-      #   x.one?
+      #   x.count(&:foo?).zero?
+      #   x.count(&:foo?) == 0
+      #
+      #   # good
+      #   x.none?(&:foo?)
+      #
+      #   # bad
+      #   x.count(&:foo?) == 1
+      #
+      #   # good
+      #   x.one?(&:foo?)
       #
       # @example AllCops:ActiveSupportExtensionsEnabled: false (default)
       #
       #   # good
-      #   x.count > 1
+      #   x.count(&:foo?) > 1
       #
       # @example AllCops:ActiveSupportExtensionsEnabled: true
       #
       #   # bad
-      #   x.count > 1
+      #   x.count(&:foo?) > 1
       #
       #   # good
-      #   x.many?
+      #   x.many?(&:foo?)
       #
       class CollectionQuerying < Base
         include RangeHelp
@@ -102,13 +100,21 @@ module RuboCop
         RESTRICT_ON_SEND = %i[positive? > != zero? ==].freeze
 
         REPLACEMENTS = {
-          [:positive?, nil] => :any?,
-          [:>, 0] => :any?,
-          [:!=, 0] => :any?,
-          [:zero?, nil] => :none?,
-          [:==, 0] => :none?,
-          [:==, 1] => :one?,
-          [:>, 1] => :many?
+          [:positive?, nil] => 'any?',
+          [:>, 0] => 'any?',
+          [:!=, 0] => 'any?',
+          [:zero?, nil] => 'none?',
+          [:==, 0] => 'none?',
+          [:==, 1] => 'one?',
+          [:>, 1] => 'many?'
+        }.freeze
+
+        NO_BLOCK_REPLACEMENTS = {
+          [:positive?, nil] => '!empty?',
+          [:>, 0] => '!empty?',
+          [:!=, 0] => '!empty?',
+          [:zero?, nil] => 'empty?',
+          [:==, 0] => 'empty?'
         }.freeze
 
         # @!method count_predicate(node)
@@ -132,28 +138,50 @@ module RuboCop
         def on_send(node)
           return unless (count_node = count_predicate(node))
 
-          replacement_method = replacement_method(node)
+          replacement = replacement_method(node, count_node)
 
-          return unless replacement_supported?(replacement_method)
+          return unless replacement_supported?(node, replacement)
 
           offense_range = count_node.loc.selector.join(node.source_range.end)
           add_offense(offense_range,
-                      message: format(MSG, prefer: replacement_method)) do |corrector|
-            corrector.replace(count_node.loc.selector, replacement_method)
-            corrector.remove(removal_range(node))
+                      message: format(MSG, prefer: replacement)) do |corrector|
+            autocorrect(corrector, node, count_node, replacement)
           end
         end
 
         private
 
-        def replacement_method(node)
-          REPLACEMENTS.fetch([node.method_name, node.first_argument&.value])
+        def autocorrect(corrector, node, count_node, replacement)
+          if replacement.start_with?('!')
+            corrector.insert_before(count_node, '!')
+            corrector.replace(count_node.loc.selector, 'empty?')
+          else
+            corrector.replace(count_node.loc.selector, replacement)
+          end
+
+          corrector.remove(removal_range(node))
         end
 
-        def replacement_supported?(method_name)
-          return true if active_support_extensions_enabled?
+        def replacement_method(node, count_node)
+          key = [node.method_name, node.first_argument&.value]
+          return REPLACEMENTS.fetch(key) if block_given_to_count?(count_node)
 
-          method_name != :many?
+          NO_BLOCK_REPLACEMENTS[key]
+        end
+
+        def block_given_to_count?(count_node)
+          count_node.parent&.any_block_type? || count_node.last_argument&.block_pass_type?
+        end
+
+        def replacement_supported?(node, replacement)
+          return false unless replacement
+          return false if replacement == 'many?' && !active_support_extensions_enabled?
+
+          !(replacement.start_with?('!') && receiver_of_call?(node))
+        end
+
+        def receiver_of_call?(node)
+          node.parent&.call_type? && node.parent.receiver == node
         end
 
         def removal_range(node)

--- a/spec/rubocop/cop/style/collection_querying_spec.rb
+++ b/spec/rubocop/cop/style/collection_querying_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
   it 'registers an offense for `.count.positive?`' do
     expect_offense(<<~RUBY)
       x.count.positive?
-        ^^^^^^^^^^^^^^^ Use `any?` instead.
+        ^^^^^^^^^^^^^^^ Use `!empty?` instead.
     RUBY
 
     expect_correction(<<~RUBY)
-      x.any?
+      !x.empty?
     RUBY
   end
 
@@ -16,13 +16,86 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
     expect_offense(<<~RUBY)
       x
         .count
-         ^^^^^ Use `any?` instead.
+         ^^^^^ Use `!empty?` instead.
         .positive?
     RUBY
 
     expect_correction(<<~RUBY)
-      x
-        .any?
+      !x
+        .empty?
+    RUBY
+  end
+
+  it 'registers an offense for `.count > 0`' do
+    expect_offense(<<~RUBY)
+      x.count > 0
+        ^^^^^^^^^ Use `!empty?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !x.empty?
+    RUBY
+  end
+
+  it 'registers an offense for `.count != 0`' do
+    expect_offense(<<~RUBY)
+      x.count != 0
+        ^^^^^^^^^^ Use `!empty?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !x.empty?
+    RUBY
+  end
+
+  it 'registers an offense for `.count.zero?`' do
+    expect_offense(<<~RUBY)
+      x.count.zero?
+        ^^^^^^^^^^^ Use `empty?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.empty?
+    RUBY
+  end
+
+  it 'registers an offense for `.count == 0`' do
+    expect_offense(<<~RUBY)
+      x.count == 0
+        ^^^^^^^^^^ Use `empty?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      x.empty?
+    RUBY
+  end
+
+  it 'registers an offense for parenthesized `.count > 0` with a further call' do
+    expect_offense(<<~RUBY)
+      (x.count > 0).to_s
+         ^^^^^^^^^ Use `!empty?` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (!x.empty?).to_s
+    RUBY
+  end
+
+  it 'does not register an offense for `.count == 1`' do
+    expect_no_offenses(<<~RUBY)
+      x.count == 1
+    RUBY
+  end
+
+  it 'does not register an offense for `.count.positive?` used as a receiver' do
+    expect_no_offenses(<<~RUBY)
+      x.count.positive?.to_s
+    RUBY
+  end
+
+  it 'does not register an offense for negated `.count.positive?`' do
+    expect_no_offenses(<<~RUBY)
+      !x.count.positive?
     RUBY
   end
 
@@ -84,11 +157,11 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
   it 'registers an offense for `&.count.positive?`' do
     expect_offense(<<~RUBY)
       x&.count.positive?
-         ^^^^^^^^^^^^^^^ Use `any?` instead.
+         ^^^^^^^^^^^^^^^ Use `!empty?` instead.
     RUBY
 
     expect_correction(<<~RUBY)
-      x&.any?
+      !x&.empty?
     RUBY
   end
 
@@ -160,6 +233,12 @@ RSpec.describe RuboCop::Cop::Style::CollectionQuerying, :config do
 
       expect_correction(<<~RUBY)
         x.many?(&:foo?)
+      RUBY
+    end
+
+    it 'does not register an offense for `.count > 1` without a block' do
+      expect_no_offenses(<<~RUBY)
+        x.count > 1
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #15067. Supersedes #15076 (credit to @wwenrr for the original approach).

Without a block `count` measures size, so `count.zero?` now corrects to `empty?` and `count.positive?`/`> 0`/`!= 0` to `!empty?` — `none?`/`any?` test element truthiness and disagree for collections with falsey elements. Blockless `count == 1`/`count > 1` are no longer flagged, and no offense is registered when the predicate is the receiver of a further call, so `x.count.positive?.to_s` doesn't autocorrect to `!x.empty?.to_s`.