### PR TITLE
Add new `Style/TimeNow` cop

### DIFF
--- a/changelog/new_add_new_style_time_now_cop_20260819173521.md
+++ b/changelog/new_add_new_style_time_now_cop_20260819173521.md
@@ -1,0 +1,1 @@
+* [#15581](https://github.com/rubocop/rubocop/pull/15581): Add new `Style/TimeNow` cop. ([@Starlexxx][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -6052,6 +6052,12 @@ Style/TernaryParentheses:
     - require_parentheses_when_complex
   AllowSafeAssignment: true
 
+Style/TimeNow:
+  Description: 'Prefer `Time.now` over `Time.new` when retrieving the current system time.'
+  StyleGuide: '#time-now'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Style/TopLevelMethodDefinition:
   Description: 'Looks for top-level method definitions.'
   StyleGuide: '#top-level-methods'

--- a/lib/rubocop/cop/style.rb
+++ b/lib/rubocop/cop/style.rb
@@ -283,6 +283,7 @@ module RuboCop
       register_cop :SymbolProc, "#{__dir__}/style/symbol_proc"
       register_cop :TallyMethod, "#{__dir__}/style/tally_method"
       register_cop :TernaryParentheses, "#{__dir__}/style/ternary_parentheses"
+      register_cop :TimeNow, "#{__dir__}/style/time_now"
       register_cop :TopLevelMethodDefinition, "#{__dir__}/style/top_level_method_definition"
       register_cop :TrailingBodyOnClass, "#{__dir__}/style/trailing_body_on_class"
       register_cop :TrailingBodyOnMethodDefinition, "#{__dir__}/style/trailing_body_on_method_definition"

--- a/lib/rubocop/cop/style/time_now.rb
+++ b/lib/rubocop/cop/style/time_now.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Checks for `Time.new` without arguments, which is an implicit way
+      # to retrieve the current system time. Prefer the more explicit `Time.now`.
+      #
+      # @example
+      #   # bad
+      #   Time.new
+      #
+      #   # good
+      #   Time.now
+      #
+      #   # good - `Time.new` with arguments constructs a specific time
+      #   Time.new(2026, 8, 19)
+      #
+      class TimeNow < Base
+        extend AutoCorrector
+
+        MSG = 'Prefer `Time.now` over `Time.new` to retrieve the current time.'
+        RESTRICT_ON_SEND = %i[new].freeze
+
+        # @!method time_new?(node)
+        def_node_matcher :time_new?, <<~PATTERN
+          (call (const {nil? cbase} :Time) :new)
+        PATTERN
+
+        def on_send(node)
+          return unless time_new?(node)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node.loc.selector.join(node.source_range.end), 'now')
+          end
+        end
+        alias on_csend on_send
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/style/time_now_spec.rb
+++ b/spec/rubocop/cop/style/time_now_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::TimeNow, :config do
+  it 'registers an offense when using `Time.new` without arguments' do
+    expect_offense(<<~RUBY)
+      Time.new
+      ^^^^^^^^ Prefer `Time.now` over `Time.new` to retrieve the current time.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time.now
+    RUBY
+  end
+
+  it 'registers an offense when using `Time.new` with parentheses and no arguments' do
+    expect_offense(<<~RUBY)
+      Time.new()
+      ^^^^^^^^^^ Prefer `Time.now` over `Time.new` to retrieve the current time.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time.now
+    RUBY
+  end
+
+  it 'registers an offense when using `::Time.new`' do
+    expect_offense(<<~RUBY)
+      ::Time.new
+      ^^^^^^^^^^ Prefer `Time.now` over `Time.new` to retrieve the current time.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ::Time.now
+    RUBY
+  end
+
+  it 'registers an offense when using `Time&.new`' do
+    expect_offense(<<~RUBY)
+      Time&.new
+      ^^^^^^^^^ Prefer `Time.now` over `Time.new` to retrieve the current time.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time&.now
+    RUBY
+  end
+
+  it 'registers an offense when `Time.new` is a receiver' do
+    expect_offense(<<~RUBY)
+      Time.new.year
+      ^^^^^^^^ Prefer `Time.now` over `Time.new` to retrieve the current time.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Time.now.year
+    RUBY
+  end
+
+  it 'does not register an offense when using `Time.now`' do
+    expect_no_offenses(<<~RUBY)
+      Time.now
+    RUBY
+  end
+
+  it 'does not register an offense when using `Time.new` with arguments' do
+    expect_no_offenses(<<~RUBY)
+      Time.new(2026, 8, 19)
+    RUBY
+  end
+
+  it 'does not register an offense when using `Time.new` with a keyword argument' do
+    expect_no_offenses(<<~RUBY)
+      Time.new(in: '+09:00')
+    RUBY
+  end
+
+  it 'does not register an offense when calling `new` on a namespaced `Time` constant' do
+    expect_no_offenses(<<~RUBY)
+      Foo::Time.new
+    RUBY
+  end
+
+  it 'does not register an offense when calling `new` on another constant' do
+    expect_no_offenses(<<~RUBY)
+      Date.new
+    RUBY
+  end
+
+  it 'does not register an offense when calling `new` without a receiver' do
+    expect_no_offenses(<<~RUBY)
+      new
+    RUBY
+  end
+end


### PR DESCRIPTION
Adds a new `Style/TimeNow` cop for the [`#time-now`](https://rubystyle.guide/#time-now) style guide rule: prefer `Time.now` over `Time.new` when retrieving the current system time.

```ruby
# bad
Time.new

# good
Time.now
```

Only zero-argument `Time.new` is flagged, so constructing specific times like `Time.new(2026, 8, 19)` or `Time.new(in: '+09:00')` is untouched. The autocorrect is safe since both calls return the current time.

Ran the cop over ~400 published gems: 4 hits (activesupport, byebug, capybara, faker), all true positives, no false positives.