### PR TITLE
Make JUnit formatter output only enabled cops

### DIFF
--- a/changelog/change_make_junit_formatter_output_only_enabled_cops_20260710162847.md
+++ b/changelog/change_make_junit_formatter_output_only_enabled_cops_20260710162847.md
@@ -1,0 +1,1 @@
+* [#15582](https://github.com/rubocop/rubocop/pull/15582): Make JUnit formatter output `<testcase>` elements only for cops enabled for each inspected file, instead of all cops. ([@koic][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -322,9 +322,8 @@ results. A typical invocation in this type of scenario might look like:
 $ rubocop --format junit --out test-reports/junit.xml
 ----
 
-Since there is one XML node for each cop for each file, the size of the resulting
-XML can get quite large. If it is too large for you, you can restrict the output
-to just failures by adding the `--display-only-failed` option.
+Since there is one XML node for each enabled cop for each file, the size of the resulting XML can get quite large.
+If it is too large for you, you can restrict the output to just failures by adding the `--display-only-failed` option.
 
 == Offense Count Formatter
 

--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -25,21 +25,21 @@ module RuboCop
         super
 
         @test_case_elements = []
+        @config_store = nil
 
         reset_count
       end
 
+      def file_started(_file, options)
+        @config_store = options[:config_store]
+      end
+
       def file_finished(file, offenses)
         @inspected_file_count += 1
+        @offense_count += offenses.count
 
-        # TODO: Returns all cops with the same behavior as
-        # the original rubocop-junit-formatter.
-        # https://github.com/mikian/rubocop-junit-formatter/blob/v0.1.4/lib/rubocop/formatter/junit_formatter.rb#L9
-        #
-        # In the future, it would be preferable to return only enabled cops.
-        Cop::Registry.all.each do |cop|
+        cops_for(file).each do |cop|
           target_offenses = offenses_for_cop(offenses, cop)
-          @offense_count += target_offenses.count
 
           next unless relevant_for_output?(options, target_offenses)
 
@@ -73,6 +73,14 @@ module RuboCop
 
       private
 
+      def cops_for(file)
+        # `file_started` is not called when this formatter is used directly through the API,
+        # in which case all cops are returned for compatibility.
+        return Cop::Registry.all if @config_store.nil?
+
+        registry.enabled(@config_store.for_file(file))
+      end
+
       def relevant_for_output?(options, target_offenses)
         !options[:display_only_failed] || target_offenses.any?
       end
@@ -87,6 +95,16 @@ module RuboCop
           name: cop.cop_name
         ).tap do |test_case_element|
           add_failure_to(test_case_element, target_offenses, cop.cop_name)
+        end
+      end
+
+      # Filtering by badge keeps lazy-loaded cops unloaded; `Registry#enabled` then loads only
+      # the enabled cops, the same set the runner mobilizes.
+      def registry
+        @registry ||= Cop::Registry.global.filter_by_badge(options) do |badge|
+          next false if badge.department == :Test || badge.match_name?(options[:except])
+
+          options[:only].nil? || badge.match_name?(options[:only])
         end
       end
 

--- a/spec/rubocop/formatter/junit_formatter_spec.rb
+++ b/spec/rubocop/formatter/junit_formatter_spec.rb
@@ -10,36 +10,36 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
   before { cop.send(:begin_investigation, processed_source) }
 
   describe '#file_finished' do
-    before do
+    let(:offenses) do
       cop.add_offense(Parser::Source::Range.new(source_buffer, 0, 1), message: 'message 1')
-      offenses = cop.add_offense(
-        Parser::Source::Range.new(source_buffer, 9, 10),
-        message: 'message 2'
-      )
-
-      formatter.file_finished('test_1', offenses)
-      formatter.file_finished('test_2', offenses)
-
-      formatter.finished(nil)
+      cop.add_offense(Parser::Source::Range.new(source_buffer, 9, 10), message: 'message 2')
     end
 
-    it 'displays start of parsable text' do
-      expect(output.string).to start_with(<<~XML)
-        <?xml version='1.0'?>
-        <testsuites>
-          <testsuite name='rubocop' tests='2' failures='4'>
-      XML
-    end
+    context 'when `file_started` has not been called' do
+      before do
+        formatter.file_finished('test_1', offenses)
+        formatter.file_finished('test_2', offenses)
 
-    it 'displays end of parsable text' do
-      expect(output.string).to end_with(<<~XML)
-          </testsuite>
-        </testsuites>
-      XML
-    end
+        formatter.finished(nil)
+      end
 
-    it "displays an offense for `classname='test_1'` in parsable text" do
-      expect(output.string).to include(<<-XML)
+      it 'displays start of parsable text' do
+        expect(output.string).to start_with(<<~XML)
+          <?xml version='1.0'?>
+          <testsuites>
+            <testsuite name='rubocop' tests='2' failures='4'>
+        XML
+      end
+
+      it 'displays end of parsable text' do
+        expect(output.string).to end_with(<<~XML)
+            </testsuite>
+          </testsuites>
+        XML
+      end
+
+      it "displays an offense for `classname='test_1'` in parsable text" do
+        expect(output.string).to include(<<-XML)
     <testcase classname='test_1' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
         test:1:1
@@ -48,11 +48,11 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
         test:3:2
       </failure>
     </testcase>
-      XML
-    end
+        XML
+      end
 
-    it "displays an offense for `classname='test_2'` in parsable text" do
-      expect(output.string).to include(<<-XML)
+      it "displays an offense for `classname='test_2'` in parsable text" do
+        expect(output.string).to include(<<-XML)
     <testcase classname='test_2' name='Layout/SpaceInsideBlockBraces'>
       <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
         test:1:1
@@ -61,13 +61,83 @@ RSpec.describe RuboCop::Formatter::JUnitFormatter, :config do
         test:3:2
       </failure>
     </testcase>
-      XML
+        XML
+      end
+
+      it 'displays a non-offense element in parsable text' do
+        expect(output.string).to include(<<~XML)
+          <testcase classname='test_1' name='Style/Alias'/>
+        XML
+      end
     end
 
-    it 'displays a non-offense element in parsable text' do
-      expect(output.string).to include(<<~XML)
-        <testcase classname='test_1' name='Style/Alias'/>
-      XML
+    context 'when `file_started` is called with a config store' do
+      let(:junit_config) do
+        RuboCop::ConfigLoader.merge_with_default(
+          RuboCop::Config.new('Style/Alias' => { 'Enabled' => false }), ''
+        )
+      end
+      let(:config_store) { instance_double(RuboCop::ConfigStore, for_file: junit_config) }
+
+      before do
+        %w[test_1 test_2].each do |file|
+          formatter.file_started(file, config_store: config_store)
+          formatter.file_finished(file, offenses)
+        end
+
+        formatter.finished(nil)
+      end
+
+      it 'displays start of parsable text' do
+        expect(output.string).to start_with(<<~XML)
+          <?xml version='1.0'?>
+          <testsuites>
+            <testsuite name='rubocop' tests='2' failures='4'>
+        XML
+      end
+
+      it "displays an offense for `classname='test_1'` in parsable text" do
+        expect(output.string).to include(<<-XML)
+    <testcase classname='test_1' name='Layout/SpaceInsideBlockBraces'>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 1'>
+        test:1:1
+      </failure>
+      <failure type='Layout/SpaceInsideBlockBraces' message='message 2'>
+        test:3:2
+      </failure>
+    </testcase>
+        XML
+      end
+
+      it 'displays a non-offense element for an enabled cop in parsable text' do
+        expect(output.string).to include(<<~XML)
+          <testcase classname='test_1' name='Style/AndOr'/>
+        XML
+      end
+
+      it 'does not display an element for a disabled cop' do
+        expect(output.string).not_to include("name='Style/Alias'")
+      end
+
+      context 'and the `only` option is given' do
+        subject(:formatter) { described_class.new(output, only: ['Layout']) }
+
+        it 'displays elements only for cops in the given department' do
+          expect(output.string).to include("name='Layout/SpaceInsideBlockBraces'")
+          expect(output.string).not_to include("name='Style/")
+        end
+      end
+
+      context 'and the `except` option is given' do
+        subject(:formatter) { described_class.new(output, except: ['Style/AndOr']) }
+
+        it 'does not display an element for the excepted cop' do
+          expect(output.string).to include(<<~XML)
+            <testcase classname='test_1' name='Style/YodaCondition'/>
+          XML
+          expect(output.string).not_to include("name='Style/AndOr'")
+        end
+      end
     end
   end
 end

--- a/spec/rubocop/lazy_loading_spec.rb
+++ b/spec/rubocop/lazy_loading_spec.rb
@@ -106,4 +106,33 @@ RSpec.describe 'cop lazy loading' do # rubocop:disable RSpec/DescribeClass
     expect(values['alias_loaded']).to eq('true')
     expect(values['copyright_loaded']).to eq('false')
   end
+
+  it 'does not load cops disabled in the config when using the junit formatter' do
+    output = run_script(<<~RUBY)
+      require 'rubocop'
+      require 'tmpdir'
+
+      xml = nil
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, 'example.rb')
+        File.write(file, "# frozen_string_literal: true\\n")
+        out = File.join(dir, 'junit.xml')
+        RuboCop::CLI.new.run([
+          '--force-default-config', '--cache', 'false', '--format', 'junit', '--out', out, file
+        ])
+
+        xml = File.read(out)
+      end
+
+      loaded = $LOADED_FEATURES.grep(#{cop_file_pattern})
+      puts "copyright_loaded=\#{loaded.any? { |file| file.end_with?('style/copyright.rb') }}"
+      puts "copyright_testcase=\#{xml.include?("name='Style/Copyright'")}"
+      puts "enabled_testcase=\#{xml.include?("name='Style/Alias'")}"
+    RUBY
+
+    values = output.scan(/^(\w+)=(.+)$/).to_h
+    expect(values['copyright_loaded']).to eq('false')
+    expect(values['copyright_testcase']).to eq('false')
+    expect(values['enabled_testcase']).to eq('true')
+  end
 end


### PR DESCRIPTION
The JUnit formatter emitted a `<testcase>` element for every cop in the registry for every inspected file, matching the behavior of the original rubocop-junit-formatter gem. This resolves the TODO left when the formatter was imported: the XML now contains elements only for cops enabled for each inspected file, which keeps the report focused on cops that can actually report offenses and greatly reduces the output size.

Design decisions:

- Cop selection mirrors the Runner's `mobilize_cop_badge?`: the global registry is filtered by badge for `--only`/`--except` (including department names) and the `Test` department, and the filtered copy carries the CLI options so that `Registry#enabled` honors `--safe`, pending cop flags, and `--only` force-enables. Filtering by badge keeps lazy-loaded cops unloaded, so a junit run loads only the cops the runner mobilizes anyway and the testcase list matches the cops that actually ran.
- The per-file config is obtained from the config store passed to `file_started`. When the formatter is used directly through the API without `file_started`, all cops are returned as before, so the previous output is preserved for programmatic users.
- The offense count is now accumulated per file rather than per cop, so it cannot drop offenses whose cop is not in the emitted list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
