### PR TITLE
Add new `Style/Eql` cop

### DIFF
--- a/changelog/new_add_new_style_eql_cop_20260820153104.md
+++ b/changelog/new_add_new_style_eql_cop_20260820153104.md
@@ -1,0 +1,1 @@
+* [#15583](https://github.com/rubocop/rubocop/pull/15583): Add new `Style/Eql` cop. ([@Starlexxx][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4223,6 +4223,13 @@ Style/EnvHome:
   Safe: false
   VersionAdded: '1.29'
 
+Style/Eql:
+  Description: 'Do not use `eql?` when using `==` will do.'
+  StyleGuide: '#eql'
+  Enabled: pending
+  SafeAutoCorrect: false
+  VersionAdded: '<<next>>'
+
 Style/EvalWithLocation:
   Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'
   Enabled: true

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -174,7 +174,7 @@ module RuboCop
         end
 
         def rackup_config_file?
-          File.basename(processed_source.file_path).eql?('config.ru')
+          File.basename(processed_source.file_path) == 'config.ru'
         end
 
         def allow_doxygen_comment?
@@ -190,7 +190,7 @@ module RuboCop
         end
 
         def gemfile?
-          File.basename(processed_source.file_path).eql?('Gemfile')
+          File.basename(processed_source.file_path) == 'Gemfile'
         end
 
         def ruby_comment_in_gemfile?(comment)

--- a/lib/rubocop/cop/style.rb
+++ b/lib/rubocop/cop/style.rb
@@ -79,6 +79,7 @@ module RuboCop
       register_cop :Encoding, "#{__dir__}/style/encoding"
       register_cop :EndBlock, "#{__dir__}/style/end_block"
       register_cop :EnvHome, "#{__dir__}/style/env_home"
+      register_cop :Eql, "#{__dir__}/style/eql"
       register_cop :EvalWithLocation, "#{__dir__}/style/eval_with_location"
       register_cop :EvenOdd, "#{__dir__}/style/even_odd"
       register_cop :ExactRegexpMatch, "#{__dir__}/style/exact_regexp_match"

--- a/lib/rubocop/cop/style/eql.rb
+++ b/lib/rubocop/cop/style/eql.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # Checks for uses of `eql?` when `==` will do.
+      # The stricter comparison semantics provided by `eql?` are rarely
+      # needed in practice.
+      #
+      # Calls without a receiver or without exactly one argument are not
+      # checked, and calls inside a definition of `eql?` are allowed, as
+      # delegating to another object's `eql?` is a common way to implement it.
+      #
+      # @safety
+      #   This cop is unsafe because `eql?` and `==` are not equivalent in
+      #   general: `eql?` never converts between numeric types, so
+      #   `1.eql?(1.0)` is `false` while `1 == 1.0` is `true`, and classes
+      #   may redefine either method independently. Additionally, safe
+      #   navigation calls are not autocorrected since `nil&.eql?(other)`
+      #   returns `nil` whereas `nil == other` returns `true` or `false`.
+      #
+      # @example
+      #   # bad
+      #   'ruby'.eql?(some_str)
+      #
+      #   # good
+      #   'ruby' == some_str
+      #
+      class Eql < Base
+        extend AutoCorrector
+
+        MSG = 'Use `==` instead of `eql?`.'
+        RESTRICT_ON_SEND = %i[eql?].freeze
+
+        INVALID_SYNTAX_ARG_TYPES = %i[splat forwarded_args forwarded_restarg block_pass].freeze
+
+        def on_send(node)
+          return unless node.receiver && node.arguments.one?
+          return if within_eql_definition?(node)
+
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node) if autocorrectable?(node)
+          end
+        end
+        alias on_csend on_send
+
+        private
+
+        def autocorrectable?(node)
+          return false if node.csend_type? || node.block_node
+
+          argument = node.first_argument
+          return false if INVALID_SYNTAX_ARG_TYPES.include?(argument.type)
+
+          !argument.hash_type? || argument.braces?
+        end
+
+        def autocorrect(corrector, node)
+          replacement = "#{node.receiver.source} == #{node.first_argument.source}"
+          replacement = "(#{replacement})" if requires_parentheses?(node)
+          corrector.replace(node, replacement)
+        end
+
+        def within_eql_definition?(node)
+          node.each_ancestor(:any_def).any? { |ancestor| ancestor.method?(:eql?) }
+        end
+
+        def requires_parentheses?(node)
+          parent = node.parent
+          return false unless parent&.call_type?
+
+          parent.receiver == node || parent.operator_method?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/formatter/pacman_formatter.rb
+++ b/lib/rubocop/formatter/pacman_formatter.rb
@@ -57,7 +57,7 @@ module RuboCop
 
       def update_progress_line
         return pacdots(@total_files) unless @total_files > cols
-        return pacdots(cols) unless (@total_files / cols).eql?(@repetitions)
+        return pacdots(cols) unless @total_files / cols == @repetitions
 
         pacdots(@total_files - (cols * @repetitions))
       end

--- a/spec/rubocop/cop/style/eql_spec.rb
+++ b/spec/rubocop/cop/style/eql_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Style::Eql, :config do
+  it 'registers an offense and corrects when using `eql?` with a parenthesized argument' do
+    expect_offense(<<~RUBY)
+      'ruby'.eql?(some_str)
+      ^^^^^^^^^^^^^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      'ruby' == some_str
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `eql?` without argument parentheses' do
+    expect_offense(<<~RUBY)
+      'ruby'.eql? some_str
+      ^^^^^^^^^^^^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      'ruby' == some_str
+    RUBY
+  end
+
+  it 'registers an offense and corrects with parentheses when `eql?` is a receiver of another call' do
+    expect_offense(<<~RUBY)
+      a.eql?(b).to_s
+      ^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (a == b).to_s
+    RUBY
+  end
+
+  it 'registers an offense and corrects with parentheses when `eql?` is negated' do
+    expect_offense(<<~RUBY)
+      !a.eql?(b)
+       ^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !(a == b)
+    RUBY
+  end
+
+  it 'registers an offense and corrects with parentheses when `eql?` is an operand of an operator' do
+    expect_offense(<<~RUBY)
+      c == a.eql?(b)
+           ^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      c == (a == b)
+    RUBY
+  end
+
+  it 'registers an offense and corrects without parentheses inside a condition' do
+    expect_offense(<<~RUBY)
+      if a.eql?(b) && c
+         ^^^^^^^^^ Use `==` instead of `eql?`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if a == b && c
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when the receiver is a method chain' do
+    expect_offense(<<~RUBY)
+      foo.bar.eql?(baz)
+      ^^^^^^^^^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo.bar == baz
+    RUBY
+  end
+
+  it 'registers an offense but does not correct when using safe navigation' do
+    expect_offense(<<~RUBY)
+      a&.eql?(b)
+      ^^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense but does not correct when the argument is a splat' do
+    expect_offense(<<~RUBY)
+      a.eql?(*b)
+      ^^^^^^^^^^ Use `==` instead of `eql?`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not register an offense when using `==`' do
+    expect_no_offenses(<<~RUBY)
+      'ruby' == some_str
+    RUBY
+  end
+
+  it 'does not register an offense when `eql?` has no receiver' do
+    expect_no_offenses(<<~RUBY)
+      eql?(other)
+    RUBY
+  end
+
+  it 'does not register an offense when `eql?` has no arguments' do
+    expect_no_offenses(<<~RUBY)
+      a.eql?
+    RUBY
+  end
+
+  it 'does not register an offense when `eql?` has multiple arguments' do
+    expect_no_offenses(<<~RUBY)
+      a.eql?(b, c)
+    RUBY
+  end
+
+  it 'does not register an offense when `eql?` is called inside a definition of `eql?`' do
+    expect_no_offenses(<<~RUBY)
+      def eql?(other)
+        id.eql?(other.id)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `&:eql?`' do
+    expect_no_offenses(<<~RUBY)
+      a.any?(&:eql?)
+    RUBY
+  end
+
+  it 'does not register an offense when using `method(:eql?)`' do
+    expect_no_offenses(<<~RUBY)
+      a.method(:eql?)
+    RUBY
+  end
+end


### PR DESCRIPTION
Adds a cop for the style guide rule https://rubystyle.guide/#eql ("Do not use `eql?` when using `==` will do").

```ruby
# bad
'ruby'.eql? some_str

# good
'ruby' == some_str
```

The cop is pending and marked `SafeAutoCorrect: false`: `eql?` never converts between numeric types (`1.eql?(1.0)` is `false` while `1 == 1.0` is `true`). Safe navigation calls are flagged but not autocorrected, and calls inside a definition of `eql?` are ignored (delegation pattern).

Ran the cop over rubocop's own code (3 hits, fixed in this PR) and over a corpus of 583 installed gems: 89 hits (aasm, actionpack, activerecord, addressable, dry-rb, parser, puma, selenium-webdriver, etc.), all genuine `receiver.eql?(arg)` calls where `==` suffices; no false positives from the exemptions. The only intentional-use hits were specs exercising an object's own `eql?` implementation, which is inherent to the rule.