### PR TITLE
Fix cop crashes on binary string literals

### DIFF
--- a/changelog/fix_a_crash_in_lint_name_typo_and_lint_unused_private_method_on_binary_strings_20260820171101.md
+++ b/changelog/fix_a_crash_in_lint_name_typo_and_lint_unused_private_method_on_binary_strings_20260820171101.md
@@ -1,0 +1,1 @@
+* [#15584](https://github.com/rubocop/rubocop/pull/15584): Fix a crash in `Lint/NameTypo` and `Lint/UnusedPrivateMethod` on string literals with invalid encoding. ([@bbatsov][])

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -235,7 +235,10 @@ module RuboCop
               if literal.sym_type?
                 names << literal.value.to_s
               else
-                literal.value.scan(LITERAL_IDENTIFIER_PATTERN) { |token| names << token }
+                # `scan` raises on binary string literals with invalid byte sequences.
+                value = literal.value
+                value = value.scrub unless value.valid_encoding?
+                value.scan(LITERAL_IDENTIFIER_PATTERN) { |token| names << token }
               end
             end
         end

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -135,7 +135,10 @@ module RuboCop
               if literal.sym_type?
                 names << literal.value.to_s
               else
-                literal.value.scan(IDENTIFIER_PATTERN) { |token| names << token }
+                # `scan` raises on binary string literals with invalid byte sequences.
+                value = literal.value
+                value = value.scrub unless value.valid_encoding?
+                value.scan(IDENTIFIER_PATTERN) { |token| names << token }
               end
             end
         end

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -143,6 +143,14 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
         end
       end
 
+      it 'registers an offense when the file contains a binary string literal' do
+        expect_offense(<<~'RUBY')
+          DATA = "\xFF\xFE".b
+          Services::UserCraetor.new
+                    ^^^^^^^^^^^ Possible typo: `UserCraetor` is not defined in `Services`. Did you mean `UserCreator`?
+        RUBY
+      end
+
       context 'when CheckConstants is false' do
         let(:cop_config) { { 'CheckConstants' => false } }
 

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -175,6 +175,32 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
       expect_no_offenses(source, '/lib/current.rb')
     end
 
+    it 'registers an offense when the file contains a binary string literal' do
+      source = <<~'RUBY'
+        class Service
+          DATA = "\xFF\xFE".b
+
+          private
+
+          def helper
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_offense(<<~'RUBY', '/lib/current.rb')
+        class Service
+          DATA = "\xFF\xFE".b
+
+          private
+
+          def helper
+          ^^^^^^^^^^ Private method `helper` appears to be unused.
+          end
+        end
+      RUBY
+    end
+
     it 'does not register an offense when the method name appears inside a string literal' do
       source = <<~RUBY
         class Service


### PR DESCRIPTION
`Lint/NameTypo` and `Lint/UnusedPrivateMethod` scan the file's string literals for identifier-like tokens, and `String#scan` raises `ArgumentError` when a literal contains invalid byte sequences (e.g. `"\xFF\xFE"` in a test fixture). The cop errors out and the file's offenses are silently dropped - activesupport's test suite triggers this today. Scrub invalid encodings before scanning.