### PR TITLE
Improve Lint/DuplicateMethods cross-file precision

### DIFF
--- a/changelog/change_add_allowed_cross_file_paths_option_to_lint_duplicate_methods_20260820173026.md
+++ b/changelog/change_add_allowed_cross_file_paths_option_to_lint_duplicate_methods_20260820173026.md
@@ -1,0 +1,1 @@
+* [#15585](https://github.com/rubocop/rubocop/pull/15585): Add `AllowedCrossFilePaths` option to `Lint/DuplicateMethods` to skip cross-file duplicates in configured paths. ([@bbatsov][])

--- a/changelog/fix_honor_active_support_redefinition_markers_in_lint_duplicate_methods_20260820173026.md
+++ b/changelog/fix_honor_active_support_redefinition_markers_in_lint_duplicate_methods_20260820173026.md
@@ -1,0 +1,1 @@
+* [#15585](https://github.com/rubocop/rubocop/pull/15585): Make `Lint/DuplicateMethods` honor `silence_redefinition_of_method` and `redefine_method` as intentional redefinitions. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1895,7 +1895,7 @@ Lint/DuplicateMethods:
   Description: 'Checks for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
-  VersionChanged: '1.89'
+  VersionChanged: '<<next>>'
   # Methods that define instance methods by delegation, in the style of
   # Active Support's `delegate` (`delegate :foo, :bar, to: :target`). Register
   # a project's own `delegate`-shaped macros here so the cop recognizes the
@@ -1903,6 +1903,14 @@ Lint/DuplicateMethods:
   # is `true`.
   DelegatingMethods:
     - delegate
+  # Cross-file duplicates (detected with `AllCops/UseProjectIndex`) whose other
+  # definition lives in a file matching one of these patterns are not reported.
+  # Useful for files that redefine application methods but are never loaded
+  # together with them, such as standalone scripts. Patterns follow the same
+  # glob (or regexp) semantics as `Exclude` and are matched against the other
+  # file's path relative to the directory of the config file; absolute patterns
+  # are matched against the absolute path.
+  AllowedCrossFilePaths: []
 
 Lint/DuplicateRegexpCharacterClassElement:
   Description: 'Checks for duplicate elements in Regexp character classes.'

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -21,6 +21,10 @@ module RuboCop
       # before redefining marks the redefinition as intentional and is respected
       # across files.
       #
+      # NOTE: Methods defined with `define_method` are not recorded in the project
+      # index, so a duplicate whose other definition uses `define_method` cannot
+      # be detected across files.
+      #
       # @example
       #
       #   # bad

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -27,6 +27,15 @@ module RuboCop
       # index, so a duplicate whose other definition uses `define_method` cannot
       # be detected across files.
       #
+      # Cross-file duplicates whose other definition lives in a file matching one
+      # of the `AllowedCrossFilePaths` patterns are not reported. This suits files
+      # that redefine application methods but are never loaded together with them,
+      # such as standalone scripts. Patterns are matched with the same glob (or
+      # regexp) semantics as `Exclude`, against the other file's path relative to
+      # the directory of the `.rubocop.yml` that configures the cop; absolute
+      # patterns are matched against the absolute path. Offenses inside such files
+      # themselves are best silenced with an ordinary per-cop `Exclude`.
+      #
       # @example
       #
       #   # bad
@@ -140,6 +149,17 @@ module RuboCop
       #   silence_redefinition_of_method :foo
       #   def foo
       #     1
+      #   end
+      #
+      # @example AllowedCrossFilePaths: ['script/**/*'] (default: [])
+      #   # Cross-file duplicates whose other definition lives in a file
+      #   # matching one of the patterns are not reported.
+      #
+      #   # good - assuming `AppHelper#format` is also defined in
+      #   # `script/backfill.rb`, which is never loaded with this file
+      #   class AppHelper
+      #     def format
+      #     end
       #   end
       #
       # @example DelegatingMethods: ['delegate', 'expose'] (default: ['delegate'])
@@ -470,11 +490,22 @@ module RuboCop
           if scope && !@scopes[scope].include?(key)
             @definitions[key] = node
             @scopes[scope] << key
-          elsif intentional_cross_file_redefinition?(node, method_name, key)
+          elsif intentional_cross_file_redefinition?(node, method_name, key) ||
+                allowed_cross_file_redefinition?(node, key)
             @definitions[key] = node
           else
             add_offense(location(node), message: message_for_dup(node, method_name, key))
           end
+        end
+
+        # `AllowedCrossFilePaths` also covers duplicates detected without the index,
+        # when the cop instance carries definitions over from an earlier file of the
+        # same run.
+        def allowed_cross_file_redefinition?(node, key)
+          other_path = @definitions[key].source_range.source_buffer.name
+          return false if other_path == node.source_range.source_buffer.name
+
+          allowed_cross_file_path?(other_path)
         end
 
         # The self-alias trick (`alias foo foo` or `alias_method :foo, :foo` right before
@@ -589,11 +620,25 @@ module RuboCop
 
           definitions = definitions_in_other_files(
             indexed_definitions(match[:owner], match[:separator], match[:name])
-          )
+          ).reject { |definition| allowed_cross_file_path?(definition.location.to_file_path) }
           return if definitions.empty? || cross_file_self_alias_trick?(definitions)
           return if cross_file_redefinition_marker?(definitions, match[:name])
 
           first_indexed_definition(definitions)
+        end
+
+        # Cross-file duplicates whose other definition site matches one of the
+        # `AllowedCrossFilePaths` patterns are skipped (e.g. standalone scripts that
+        # are never loaded together with the code they redefine). Patterns are
+        # matched like `Exclude` patterns, against the path relative to the
+        # directory of the config file that configures the cop; absolute patterns
+        # are matched against the absolute path.
+        def allowed_cross_file_path?(path)
+          patterns = cop_config.fetch('AllowedCrossFilePaths', [])
+          return false if patterns.empty?
+
+          relative = config.path_relative_to_config(path)
+          patterns.any? { |pattern| match_path?(pattern, relative) || match_path?(pattern, path) }
         end
 
         def indexed_definitions(owner, separator, name)

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -19,7 +19,9 @@ module RuboCop
       # file is wrapped in a conditional, so a platform-specific redefinition in
       # another file may still be reported. Aliasing the method to itself (see above)
       # before redefining marks the redefinition as intentional and is respected
-      # across files.
+      # across files. With `AllCops/ActiveSupportExtensionsEnabled: true`, Active
+      # Support's redefinition markers (`silence_redefinition_of_method` and
+      # `redefine_method`) are honored the same way.
       #
       # NOTE: Methods defined with `define_method` are not recorded in the project
       # index, so a duplicate whose other definition uses `define_method` cannot
@@ -133,6 +135,13 @@ module RuboCop
       #     delegate :foo, to: :bar
       #   end
       #
+      #   # good - Active Support's redefinition markers signal an intentional
+      #   # redefinition of a method defined in another file
+      #   silence_redefinition_of_method :foo
+      #   def foo
+      #     1
+      #   end
+      #
       # @example DelegatingMethods: ['delegate', 'expose'] (default: ['delegate'])
       #   # A project's own `delegate`-shaped macros can be registered so the
       #   # methods they define are recognized (with
@@ -164,13 +173,14 @@ module RuboCop
           super
           @definitions = {}
           @scopes = Hash.new { |hash, key| hash[key] = [] }
-          @self_aliased = Set.new
+          @intentionally_redefined = Set.new
         end
 
         def on_new_investigation
-          # The self-alias trick declares an intentional redefinition only within
-          # the file that uses it, so the tracked names do not carry over.
-          @self_aliased = Set.new
+          # The self-alias trick and Active Support's redefinition markers declare
+          # an intentional redefinition only within the file that uses them, so the
+          # tracked names do not carry over.
+          @intentionally_redefined = Set.new
           super
         end
 
@@ -203,7 +213,7 @@ module RuboCop
           return unless name && original_name
 
           if name == original_name
-            track_self_alias(node, name)
+            track_intentional_redefinition(node, name)
             return
           end
           return if node.ancestors.any?(&:if_type?)
@@ -245,6 +255,15 @@ module RuboCop
           )
         PATTERN
 
+        # Matches Active Support's markers of an intentional method redefinition:
+        # `silence_redefinition_of_method :name` suppresses Ruby's redefinition
+        # warning for a subsequent definition of `name`, and
+        # `redefine_method(:name) { ... }` both silences the warning and redefines.
+        # @!method active_support_redefinition_marker(node)
+        def_node_matcher :active_support_redefinition_marker, <<~PATTERN
+          (send nil? {:silence_redefinition_of_method :redefine_method} ({sym str} $_) ...)
+        PATTERN
+
         # @!method sym_name(node)
         def_node_matcher :sym_name, '(sym $_name)'
 
@@ -267,7 +286,7 @@ module RuboCop
 
           if name && original_name
             if name == original_name
-              track_self_alias(node, name)
+              track_intentional_redefinition(node, name)
               return
             end
             return if inside_condition?(node)
@@ -287,6 +306,12 @@ module RuboCop
             return if inside_condition?(node)
 
             names.each { |name| found_instance_method(node, name) }
+          elsif (name = active_support_redefinition_marker(node))
+            # `redefine_method` takes a block; scope resolution must start from the
+            # block node, since `parent_module_name` cannot see through a block
+            # ancestor that is not a module constructor.
+            track_intentional_redefinition(node.block_node || node, name) if
+              active_support_extensions_enabled?
           end
         end
 
@@ -454,18 +479,19 @@ module RuboCop
 
         # The self-alias trick (`alias foo foo` or `alias_method :foo, :foo` right before
         # a `def`) suppresses Ruby's method redefinition warning, signaling an intentional
-        # redefinition of a method defined in another file.
+        # redefinition of a method defined in another file. Active Support's redefinition
+        # markers (tracked when `ActiveSupportExtensionsEnabled` is on) signal the same.
         def intentional_cross_file_redefinition?(node, method_name, key)
-          @self_aliased.include?(method_name) &&
+          @intentionally_redefined.include?(method_name) &&
             @definitions[key].source_range.source_buffer.name !=
               node.source_range.source_buffer.name
         end
 
-        def track_self_alias(node, name)
+        def track_intentional_redefinition(node, name)
           scope = node.parent_module_name
           return unless scope
 
-          @self_aliased << "#{humanize_scope(scope)}#{name}"
+          @intentionally_redefined << "#{humanize_scope(scope)}#{name}"
         end
 
         def method_key(node, method_name)
@@ -548,7 +574,7 @@ module RuboCop
 
         def check_cross_file_duplicate(node, method_name)
           return unless project_index
-          return if @self_aliased.include?(method_name)
+          return if @intentionally_redefined.include?(method_name)
           return if node.each_ancestor(:any_def).any?
           return unless (prior = cross_file_prior_definition(method_name))
 
@@ -565,6 +591,7 @@ module RuboCop
             indexed_definitions(match[:owner], match[:separator], match[:name])
           )
           return if definitions.empty? || cross_file_self_alias_trick?(definitions)
+          return if cross_file_redefinition_marker?(definitions, match[:name])
 
           first_indexed_definition(definitions)
         end
@@ -603,6 +630,28 @@ module RuboCop
           alias_paths = aliases.map { |definition| definition.location.to_file_path }
 
           others.any? { |definition| alias_paths.include?(definition.location.to_file_path) }
+        end
+
+        # An Active Support redefinition marker alongside one of the definitions in
+        # another file marks the redefinition there as intentional, like the
+        # self-alias trick. The index does not record the marker's method-name
+        # argument, so the other file's source is searched for a marker naming
+        # the method.
+        def cross_file_redefinition_marker?(definitions, name)
+          return false unless active_support_extensions_enabled?
+
+          definitions.map { |definition| definition.location.to_file_path }.uniq.any? do |path|
+            redefinition_marker_in_file?(path, name)
+          end
+        end
+
+        def redefinition_marker_in_file?(path, name)
+          return false unless File.readable?(path)
+
+          escaped = Regexp.escape(name)
+          marker = /\b(?:silence_redefinition_of_method|redefine_method)\s*\(?\s*
+                    (?::#{escaped}|(["'])#{escaped}\1)(?![\w=!?])/x
+          File.read(path).scrub.match?(marker)
         end
 
         def first_indexed_definition(definitions)

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/a.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/a.rb
@@ -1,0 +1,5 @@
+class G
+  def marked
+    1
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/b.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/b.rb
@@ -1,0 +1,6 @@
+class G
+  silence_redefinition_of_method :marked
+  def marked
+    2
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/c.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/c.rb
@@ -1,0 +1,5 @@
+class H
+  def helper
+    1
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/d.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/d.rb
@@ -1,0 +1,6 @@
+class H
+  silence_redefinition_of_method :other_helper
+  def helper
+    2
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/e.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/e.rb
@@ -1,0 +1,5 @@
+class I
+  def gen
+    1
+  end
+end

--- a/spec/fixtures/cross_file_duplicate_methods_active_support/f.rb
+++ b/spec/fixtures/cross_file_duplicate_methods_active_support/f.rb
@@ -1,0 +1,9 @@
+class I
+  redefine_method(:gen) do
+    2
+  end
+
+  def gen
+    3
+  end
+end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1093,6 +1093,64 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
   end
   # rubocop:enable InternalAffairs/ExampleDescription
 
+  context 'with `AllowedCrossFilePaths`' do
+    let(:cop_config) { { 'AllowedCrossFilePaths' => ['scripts/**/*'] } }
+
+    it 'does not register an offense when the other definition site matches an allowed path' do
+      expect_no_offenses(<<~RUBY, 'scripts/import.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY, 'app/model.rb')
+        class A
+          def some_method
+            implement 2
+          end
+        end
+      RUBY
+    end
+
+    # rubocop:disable InternalAffairs/ExampleDescription -- `expect_no_offenses` is only the
+    # cross-file setup; the example asserts the offense in the second file.
+    it 'registers an offense when the other definition site does not match an allowed path' do
+      expect_no_offenses(<<~RUBY, 'app/model.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_offense(<<~RUBY, 'app/other.rb')
+        class A
+          def some_method
+          ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both app/model.rb:2 and app/other.rb:2.
+            implement 2
+          end
+        end
+      RUBY
+    end
+    # rubocop:enable InternalAffairs/ExampleDescription
+
+    it 'registers an offense for a same-file duplicate even in a file matching an allowed path' do
+      expect_offense(<<~RUBY, 'scripts/import.rb')
+        class A
+          def some_method
+            implement 1
+          end
+          def some_method
+          ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both scripts/import.rb:2 and scripts/import.rb:5.
+            implement 2
+          end
+        end
+      RUBY
+    end
+  end
+
   it_behaves_like('in scope', 'class', 'class A')
   it_behaves_like('in scope', 'module', 'module A')
   it_behaves_like('in scope', 'dynamic class', 'A = Class.new do')
@@ -2031,6 +2089,10 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
 
     def run_with_config(body)
       Dir.mktmpdir do |tmpdir|
+        # Resolve the `/var` -> `/private/var` macOS tmpdir symlink so that paths
+        # derived from the config location line up with the paths the index
+        # reports (`AllowedCrossFilePaths` matching relies on that).
+        tmpdir = File.realpath(tmpdir)
         stage_fixture(tmpdir)
         write_rubocop_config(tmpdir, body)
         cop_offenses(tmpdir)
@@ -2062,6 +2124,19 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       offenses = run_with_config('AllCops' => { 'UseProjectIndex' => false })
 
       expect(offenses).to be_empty
+    end
+
+    it 'does not report duplicates whose other definition site matches `AllowedCrossFilePaths`' do
+      offenses = run_with_config(
+        'AllCops' => { 'UseProjectIndex' => true },
+        'Lint/DuplicateMethods' => { 'AllowedCrossFilePaths' => ['b.rb', 'f*.rb', 'h.rb'] }
+      )
+
+      # The offense within an allowed file itself remains: its other definition
+      # site (`a.rb`/`e.rb`/`g.rb`) matches no allowed pattern. Silencing those
+      # is the job of an ordinary per-cop `Exclude`.
+      expect(offenses.map { |offense| File.basename(offense['path']) }.sort)
+        .to eq(%w[b.rb f.rb h.rb])
     end
 
     # The fixture contains:

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -963,6 +963,136 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  context 'with Active Support redefinition markers and `ActiveSupportExtensionsEnabled: true`' do
+    let(:config) do
+      RuboCop::Config.new('AllCops' => { 'ActiveSupportExtensionsEnabled' => true })
+    end
+
+    it 'does not register an offense when `silence_redefinition_of_method` marks ' \
+       'a redefinition of a method from another file' do
+      expect_no_offenses(<<~RUBY, 'first.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY, 'second.rb')
+        class A
+          silence_redefinition_of_method :some_method
+          def some_method
+            implement 2
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the marker uses a string method name' do
+      expect_no_offenses(<<~RUBY, 'first.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY, 'second.rb')
+        class A
+          silence_redefinition_of_method 'some_method'
+          def some_method
+            implement 2
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `redefine_method` marks ' \
+       'a redefinition of a method from another file' do
+      expect_no_offenses(<<~RUBY, 'first.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY, 'second.rb')
+        class A
+          redefine_method(:some_method) do
+            implement 2
+          end
+
+          def some_method
+            implement 3
+          end
+        end
+      RUBY
+    end
+
+    # rubocop:disable InternalAffairs/ExampleDescription -- `expect_no_offenses` is only the
+    # cross-file setup; the example asserts the offense in the second file.
+    it 'registers an offense when the marker names a different method' do
+      expect_no_offenses(<<~RUBY, 'first.rb')
+        class A
+          def some_method
+            implement 1
+          end
+        end
+      RUBY
+
+      expect_offense(<<~RUBY, 'second.rb')
+        class A
+          silence_redefinition_of_method :other_method
+          def some_method
+          ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both first.rb:2 and second.rb:3.
+            implement 2
+          end
+        end
+      RUBY
+    end
+    # rubocop:enable InternalAffairs/ExampleDescription
+
+    it 'registers an offense for a same-file duplicate even when the method is marked' do
+      expect_offense(<<~RUBY, 'test.rb')
+        class A
+          silence_redefinition_of_method :some_method
+          def some_method
+            implement 1
+          end
+          def some_method
+          ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both test.rb:3 and test.rb:6.
+            implement 2
+          end
+        end
+      RUBY
+    end
+  end
+
+  # rubocop:disable InternalAffairs/ExampleDescription -- `expect_no_offenses` is only the
+  # cross-file setup; the example asserts the offense in the second file.
+  it 'registers an offense despite `silence_redefinition_of_method` when ' \
+     '`ActiveSupportExtensionsEnabled` is disabled' do
+    expect_no_offenses(<<~RUBY, 'first.rb')
+      class A
+        def some_method
+          implement 1
+        end
+      end
+    RUBY
+
+    expect_offense(<<~RUBY, 'second.rb')
+      class A
+        silence_redefinition_of_method :some_method
+        def some_method
+        ^^^^^^^^^^^^^^^ Method `A#some_method` is defined at both first.rb:2 and second.rb:3.
+          implement 2
+        end
+      end
+    RUBY
+  end
+  # rubocop:enable InternalAffairs/ExampleDescription
+
   it_behaves_like('in scope', 'class', 'class A')
   it_behaves_like('in scope', 'module', 'module A')
   it_behaves_like('in scope', 'dynamic class', 'A = Class.new do')
@@ -1932,6 +2062,34 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       offenses = run_with_config('AllCops' => { 'UseProjectIndex' => false })
 
       expect(offenses).to be_empty
+    end
+
+    # The fixture contains:
+    # * `a.rb`/`b.rb` - `G#marked` redefined in `b.rb` with a preceding
+    #   `silence_redefinition_of_method :marked`
+    # * `c.rb`/`d.rb` - `H#helper` redefined in `d.rb`, whose marker names a
+    #   different method (`other_helper`)
+    # * `e.rb`/`f.rb` - `I#gen` redefined in `f.rb` with a `redefine_method(:gen)` marker
+    context 'with Active Support redefinition markers' do
+      let(:fixture_dir) do
+        File.expand_path('../../../fixtures/cross_file_duplicate_methods_active_support', __dir__)
+      end
+
+      it 'does not report redefinitions marked with Active Support markers when ' \
+         '`ActiveSupportExtensionsEnabled` is enabled' do
+        offenses = run_with_config(
+          'AllCops' => { 'UseProjectIndex' => true, 'ActiveSupportExtensionsEnabled' => true }
+        )
+
+        expect(offenses.map { |offense| File.basename(offense['path']) }.sort).to eq(%w[c.rb d.rb])
+      end
+
+      it 'reports marked redefinitions when `ActiveSupportExtensionsEnabled` is disabled' do
+        offenses = run_with_config('AllCops' => { 'UseProjectIndex' => true })
+
+        expect(offenses.map { |offense| File.basename(offense['path']) }.sort)
+          .to eq(%w[a.rb b.rb c.rb d.rb e.rb f.rb])
+      end
     end
   end
 end


### PR DESCRIPTION
Two precision improvements for the cross-file duplicate detection, both driven by running the cop over large real-world codebases (rails, discourse):

- `silence_redefinition_of_method` and `redefine_method` now mark a cross-file redefinition as intentional, the same way the self-alias trick already does (gated on `ActiveSupportExtensionsEnabled`, like the existing `delegate` handling). Rails' own `test_case.rb` monkey-patches trip the cop without this.
- New `AllowedCrossFilePaths` option to skip pairs whose other definition site matches configured path patterns - standalone scripts that are never co-loaded (think `script/import_scripts/*`) account for the bulk of offenses on app-shaped repos.

Also documents that `define_method`-defined methods are invisible to the index.