### PR TITLE
Fix Style/InverseMethods class hierarchy guard for non-literal operands

### DIFF
--- a/changelog/fix_class_hierarchy_guard_for_non_literal_operands_in_style_inverse_methods_20260820000000.md
+++ b/changelog/fix_class_hierarchy_guard_for_non_literal_operands_in_style_inverse_methods_20260820000000.md
@@ -1,0 +1,1 @@
+* [#15577](https://github.com/rubocop/rubocop/issues/15577): Fix `Style/InverseMethods` to not autocorrect class hierarchy comparisons (`<=`, `>=`, `<`, `>`) whose operand is a call that returns a class or module (e.g. `foo.superclass`), not only a literal constant, since inverting such comparisons is not equivalent. ([@Faseeh06][])

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -50,6 +50,7 @@ module RuboCop
         EQUALITY_METHODS = %i[== != =~ !~ <= >= < >].freeze
         NEGATED_EQUALITY_METHODS = %i[!= !~].freeze
         CAMEL_CASE = /[A-Z]+[a-z]+/.freeze
+        CLASS_HIERARCHY_VALUE_METHODS = %i[class superclass singleton_class].freeze
 
         RESTRICT_ON_SEND = [:!].freeze
 
@@ -171,14 +172,27 @@ module RuboCop
         end
 
         # When comparing classes, `!(Integer < Numeric)` is not the same as
-        # `Integer > Numeric`.
+        # `Integer > Numeric`. The same holds when either operand is a call
+        # that yields a class/module (e.g. `foo.class`, `foo.superclass`)
+        # rather than a literal constant, since `Module#<=` and friends are a
+        # partial order and can return `nil` for unrelated operands.
         def possible_class_hierarchy_check?(lhs, rhs, method)
           CLASS_COMPARISON_METHODS.include?(method) &&
-            (camel_case_constant?(lhs) || (rhs.size == 1 && camel_case_constant?(rhs.first)))
+            (class_hierarchy_operand?(lhs) ||
+              (rhs.size == 1 && class_hierarchy_operand?(rhs.first)))
+        end
+
+        def class_hierarchy_operand?(node)
+          camel_case_constant?(node) || class_hierarchy_value_method?(node)
         end
 
         def camel_case_constant?(node)
           node.const_type? && CAMEL_CASE.match?(node.source)
+        end
+
+        def class_hierarchy_value_method?(node)
+          node.type?(:call) && node.arguments.empty? &&
+            CLASS_HIERARCHY_VALUE_METHODS.include?(node.method_name)
         end
 
         def dot_range(loc)

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -107,6 +107,37 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods, :config do
     expect_no_offenses('!!(string =~ /^\w+$/)')
   end
 
+  it 'allows a class hierarchy check with a literal constant operand' do
+    expect_no_offenses('!(Integer < Numeric)')
+  end
+
+  it 'allows a class hierarchy check with a `.class` call operand' do
+    expect_no_offenses('!(foo.class < Numeric)')
+  end
+
+  it 'allows a class hierarchy check with a `.superclass` call operand' do
+    expect_no_offenses('!(model.superclass <= included_module)')
+  end
+
+  it 'allows a class hierarchy check with a `.singleton_class` call operand' do
+    expect_no_offenses('!(foo.singleton_class >= bar)')
+  end
+
+  it 'allows a class hierarchy check when the class-returning call is the argument' do
+    expect_no_offenses('!(included_module >= model.superclass)')
+  end
+
+  it 'registers an offense for an inverted `==` even when the receiver has a `.superclass` call' do
+    expect_offense(<<~RUBY)
+      !(model.superclass == included_module)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!=` instead of inverting `==`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      model.superclass != included_module
+    RUBY
+  end
+
   it 'allows an inverse method with a block when double negation is used' do
     expect_no_offenses('!!foo.reject { |e| !e }')
   end


### PR DESCRIPTION
Fixes #15577

`Style/InverseMethods` already declines to invert class-hierarchy comparisons (`<=`, `>=`, `<`, `>`), since `Module#<=` and friends are a partial order and can return `nil` (not `false`) for unrelated modules — inverting such a comparison is not equivalent. But `possible_class_hierarchy_check?` only recognized this when an operand was a literal CamelCase constant (`Integer`, `Numeric`), not when it was a variable or method call holding a module — the common shape in a helper that takes the module as an argument.

```ruby
def direct_includer?(model, included_module)
  model <= included_module && !(model.superclass <= included_module)
end
```

`rubocop -A` currently rewrites this to `model.superclass > included_module`, which is wrong: for an unrelated `model.superclass`, the original expression is `true` (or `false`), while `>` returns `nil`.

## Changes
- Broadens the guard to also recognize an operand that's a call known to return a class/module — `.class`, `.superclass`, `.singleton_class` — matching the issue's suggested fix (option 1). `.class` already appears in the cop's own documented example (`!(foo.class < Numeric)`), so this closes a gap in the cop's own stated guarantee.
- Adds spec coverage for the previously-unguarded shapes (receiver and argument position, each of the three methods), plus a case confirming `==`/`!=` inversion is still correctly flagged even when a `.superclass` call is involved, to show the guard is scoped only to the class-hierarchy comparison methods.
- Adds a changelog entry per CONTRIBUTING.md.

## Test plan
- [x] Reproduced the false autocorrect from the issue against current `master`, confirmed fixed
- [x] `bundle exec rspec spec/rubocop/cop/style/inverse_methods_spec.rb` — 116 examples, 0 failures
- [x] `bundle exec rake internal_investigation` (RuboCop lints itself) — clean
- [x] `bundle exec rake documentation_syntax_check` — clean