### PR TITLE
Autoload the deprecated IgnoredMethods and IgnoredPattern aliases

### DIFF
--- a/changelog/fix_autoload_deprecated_ignored_methods_and_ignored_pattern_aliases.md
+++ b/changelog/fix_autoload_deprecated_ignored_methods_and_ignored_pattern_aliases.md
@@ -1,0 +1,1 @@
+* [#15588](https://github.com/rubocop/rubocop/pull/15588): Fix `RuboCop::Cop::IgnoredMethods` and `RuboCop::Cop::IgnoredPattern` being unreachable after `require 'rubocop'`. ([@SeanLF][])

--- a/lib/rubocop/cop/mixin.rb
+++ b/lib/rubocop/cop/mixin.rb
@@ -41,6 +41,9 @@ module RuboCop
     autoload :HashAlignmentStyles, "#{__dir__}/mixin/hash_alignment_styles"
     autoload :HashSubset, "#{__dir__}/mixin/hash_subset"
     autoload :HashTransformMethod, "#{__dir__}/mixin/hash_transform_method"
+    # Deprecated aliases of `AllowedMethods` and `AllowedPattern`, defined in those files.
+    autoload :IgnoredMethods, "#{__dir__}/mixin/allowed_methods"
+    autoload :IgnoredPattern, "#{__dir__}/mixin/allowed_pattern"
     autoload :IntegerNode, "#{__dir__}/mixin/integer_node"
     autoload :Interpolation, "#{__dir__}/mixin/interpolation"
     autoload :LineLengthHelp, "#{__dir__}/mixin/line_length_help"

--- a/spec/rubocop/lazy_loading_spec.rb
+++ b/spec/rubocop/lazy_loading_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe 'cop lazy loading' do # rubocop:disable RSpec/DescribeClass
     expect(values['length']).to eq(values['configured'])
   end
 
+  it 'keeps the deprecated mixin aliases reachable' do
+    output = run_script(<<~RUBY)
+      require 'rubocop'
+
+      puts "ignored_methods=\#{RuboCop::Cop::IgnoredMethods}"
+      puts "ignored_pattern=\#{RuboCop::Cop::IgnoredPattern}"
+    RUBY
+
+    values = output.scan(/^(\w+)=(.+)$/).to_h
+    expect(values['ignored_methods']).to eq('RuboCop::Cop::AllowedMethods')
+    expect(values['ignored_pattern']).to eq('RuboCop::Cop::AllowedPattern')
+  end
+
   it 'does not register a cop twice when its file is required directly' do
     output = run_script(<<~RUBY)
       require 'rubocop'


### PR DESCRIPTION
`RuboCop::Cop::IgnoredMethods` and `RuboCop::Cop::IgnoredPattern` — the deprecated aliases added in #10829 "in order to not break extensions" — are unreachable after a bare `require "rubocop"` since cops became lazily loaded in #14983:

```console
$ docker run --rm ruby:3.4 sh -c 'gem install rubocop -v 1.89.0 --no-document -q >/dev/null && ruby -e "require \"rubocop\"; puts RuboCop::Cop::IgnoredMethods"'
-e:1:in '<main>': uninitialized constant RuboCop::Cop::IgnoredMethods (NameError)
```

The same command with `-v 1.88.2` prints `RuboCop::Cop::AllowedMethods`. The aliases are defined inside `allowed_methods.rb` / `allowed_pattern.rb`, so they only ever resolved as a side effect of eager cop loading; `mixin.rb` has never registered them.

The spec lives in `lazy_loading_spec.rb` and asserts through a fresh `ruby -Ilib` process, since the constants resolve trivially once the suite has loaded cops.

Happy to make this a removal instead if you would rather retire the aliases.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
