### PR TITLE
Document the corrector removal methods with the argument they take

### DIFF
--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -46,7 +46,7 @@ module RuboCop
 
       # Removes `size` characters prior to the source range.
       #
-      # @param [Parser::Source::Range, RuboCop::AST::Node] range or node
+      # @param [Parser::Source::Range, RuboCop::AST::Node] node_or_range
       # @param [Integer] size
       def remove_preceding(node_or_range, size)
         range = to_range(node_or_range)
@@ -58,7 +58,7 @@ module RuboCop
       # If `size` is greater than the size of `range`, the removed region can
       # overrun the end of `range`.
       #
-      # @param [Parser::Source::Range, RuboCop::AST::Node] range or node
+      # @param [Parser::Source::Range, RuboCop::AST::Node] node_or_range
       # @param [Integer] size
       def remove_leading(node_or_range, size)
         range = to_range(node_or_range)
@@ -70,7 +70,7 @@ module RuboCop
       # If `size` is greater than the size of `range`, the removed region can
       # overrun the beginning of `range`.
       #
-      # @param [Parser::Source::Range, RuboCop::AST::Node] range or node
+      # @param [Parser::Source::Range, RuboCop::AST::Node] node_or_range
       # @param [Integer] size
       def remove_trailing(node_or_range, size)
         range = to_range(node_or_range)


### PR DESCRIPTION
`Corrector#remove_preceding`, `#remove_leading` and `#remove_trailing` each document their first argument as `range`, and each takes `node_or_range`. YARD binds by the name in that slot, so the tag documents an argument that is not there and the real one goes undocumented.

`#swap`, 2 methods below them in the same file, already writes it as `node_or_range1` and `node_or_range2`, so this is the house form rather than my preference.

The prose after the type reads "range or node", which is probably how it happened: the description was written into the name slot.

Documentation only, no behaviour change. No changelog entry, since nothing user visible changes.

How I found them: a checker I wrote that compares each documented name against the signature under it. It read 64 of the 64 documented comments in this repository, and these 3 were all it had to say.
