### PR TITLE
[Fix #15589] Fix `--lsp` and `--mcp` being ignored in server mode

### DIFF
--- a/changelog/fix_lsp_and_mcp_being_ignored_in_server_mode_20260821114320.md
+++ b/changelog/fix_lsp_and_mcp_being_ignored_in_server_mode_20260821114320.md
@@ -1,0 +1,1 @@
+* [#15589](https://github.com/rubocop/rubocop/issues/15589): Fix `--lsp` and `--mcp` being silently ignored when the RuboCop server is running: they now start the protocol server in the current process instead of being forwarded to the server as a lint request. ([@koic][])

--- a/docs/modules/ROOT/pages/usage/server.adoc
+++ b/docs/modules/ROOT/pages/usage/server.adoc
@@ -34,6 +34,8 @@ RuboCop server starting on 127.0.0.1:55772.
 NOTE: The `rubocop` command is executed using the server process if a server is started.
 Whenever a server process is not running, it will load the RuboCop runtime files and execute.
 (same behavior as with RuboCop 1.30 and lower)
+`--lsp` and `--mcp` are exceptions: they always run in the current process, even while
+a server is running, because they serve their protocol on standard input and output.
 
 If a server is already running, the command only displays the server's PID. A new server will not be started.
 

--- a/exe/rubocop
+++ b/exe/rubocop
@@ -8,7 +8,7 @@ server_cli = RuboCop::Server::CLI.new
 exit_status = server_cli.run
 exit exit_status if server_cli.exit?
 
-if RuboCop::Server.running?
+if RuboCop::Server.forward_to_server?
   exit_status = RuboCop::Server::ClientCommand::Exec.new.run
 else
   require 'rubocop'

--- a/lib/rubocop/server.rb
+++ b/lib/rubocop/server.rb
@@ -17,6 +17,11 @@ module RuboCop
   module Server
     TIMEOUT = 20
 
+    # Options that start a long-lived protocol server on stdio in the current process.
+    # They must never be forwarded to the server process, which would run them as
+    # a lint request and silently produce no protocol response.
+    IN_PROCESS_PROTOCOL_OPTIONS = %w[--lsp --mcp].freeze
+
     autoload :CLI, 'rubocop/server/cli'
     autoload :Cache, 'rubocop/server/cache'
     autoload :ClientCommand, 'rubocop/server/client_command'
@@ -34,6 +39,15 @@ module RuboCop
         return false unless support_server? # Never running.
 
         Cache.pid_running?
+      end
+
+      # Whether the invocation should be forwarded to the running server process.
+      # `--lsp` and `--mcp` always run in the current process even when the server is running:
+      # they serve a protocol on stdio, which the server's `exec` command cannot do.
+      def forward_to_server?(argv = ARGV)
+        return false unless running?
+
+        (IN_PROCESS_PROTOCOL_OPTIONS & argv).empty?
       end
 
       def wait_for_running_status!(expected)

--- a/spec/rubocop/server/rubocop_server_spec.rb
+++ b/spec/rubocop/server/rubocop_server_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe 'rubocop --server', :isolated_environment do # rubocop:disable RS
       end
     end
 
+    context 'when using `--mcp` while the server is running' do
+      it 'starts the MCP server in the current process instead of forwarding to the server' do
+        create_file('.rubocop.yml', <<~YAML)
+          AllCops:
+            NewCops: disable
+            SuggestExtensions: false
+        YAML
+
+        expect(`ruby -I . "#{rubocop}" --start-server`).to include('RuboCop server starting on')
+
+        request = {
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18', capabilities: {},
+            clientInfo: { name: 'probe', version: '1.0' }
+          }
+        }
+        stdout, _stderr, status = Open3.capture3(
+          "ruby -I . \"#{rubocop}\" --mcp", stdin_data: "#{JSON.generate(request)}\n"
+        )
+
+        expect(status).to be_success
+        expect(stdout).to include('"serverInfo"')
+      end
+    end
+
     context 'when using --config option after update specified config file' do
       it 'displays a restart information message' do
         create_file('.rubocop_todo.yml', <<~YAML)

--- a/spec/rubocop/server_spec.rb
+++ b/spec/rubocop/server_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Server do
+  describe '.forward_to_server?' do
+    context 'when the server is running' do
+      before { allow(described_class).to receive(:running?).and_return(true) }
+
+      it 'is true for a lint invocation' do
+        expect(described_class).to be_forward_to_server(['lib'])
+      end
+
+      it 'is false when `--lsp` is given' do
+        expect(described_class).not_to be_forward_to_server(['--lsp'])
+      end
+
+      it 'is false when `--mcp` is given' do
+        expect(described_class).not_to be_forward_to_server(['--mcp'])
+      end
+    end
+
+    context 'when the server is not running' do
+      before { allow(described_class).to receive(:running?).and_return(false) }
+
+      it 'is false' do
+        expect(described_class).not_to be_forward_to_server(['lib'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the RuboCop server was running, every invocation was forwarded to the server process via the `exec` client command, including `--lsp` and `--mcp`. The server ran them as a lint request, so the invocation exited 0 without ever serving the protocol - editors and MCP clients spawning `rubocop --lsp` / `rubocop --mcp` silently stopped working for anyone with server mode enabled.

These options start a long-lived protocol server on stdio, which the server's `exec` command cannot do, so they now always run in the current process. The decision lives in `RuboCop::Server.forward_to_server?` rather than in `exe/rubocop` so that it is unit-testable; an end-to-end spec starts a real server and asserts that `--mcp` still answers an `initialize` request.

Fixes #15589.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
