### PR TITLE
Improve Lint/UnusedPrivateMethod precision

### DIFF
--- a/changelog/change_add_allowed_names_and_allowed_patterns_to_lint_unused_private_method_20260821085033.md
+++ b/changelog/change_add_allowed_names_and_allowed_patterns_to_lint_unused_private_method_20260821085033.md
@@ -1,0 +1,1 @@
+* [#15593](https://github.com/rubocop/rubocop/pull/15593): Add `AllowedNames` and `AllowedPatterns` options to `Lint/UnusedPrivateMethod`. ([@bbatsov][])

--- a/changelog/fix_skip_ruby_runtime_hooks_in_lint_unused_private_method_20260821085034.md
+++ b/changelog/fix_skip_ruby_runtime_hooks_in_lint_unused_private_method_20260821085034.md
@@ -1,0 +1,1 @@
+* [#15593](https://github.com/rubocop/rubocop/pull/15593): Fix false positives for `Lint/UnusedPrivateMethod` for private definitions of Ruby runtime hooks like `inherited` and `const_missing`. ([@bbatsov][])

--- a/changelog/fix_treat_interpolated_literal_prefixes_as_references_in_lint_unused_private_method_20260821085034.md
+++ b/changelog/fix_treat_interpolated_literal_prefixes_as_references_in_lint_unused_private_method_20260821085034.md
@@ -1,0 +1,1 @@
+* [#15593](https://github.com/rubocop/rubocop/pull/15593): Fix false positives for `Lint/UnusedPrivateMethod` when a method name is composed with an interpolated symbol or string prefix. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2701,7 +2701,10 @@ Lint/UnusedPrivateMethod:
   # would be reported as false positives. It is intended for occasional
   # dead-code sweeps rather than permanent enforcement.
   Enabled: false
+  AllowedNames: []
+  AllowedPatterns: []
   VersionAdded: '1.89'
+  VersionChanged: '<<next>>'
 
 Lint/UriEscapeUnescape:
   Description: >-

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -14,10 +14,12 @@ module RuboCop
       # in the indexed project (regardless of the receiver), when it is the source
       # of an `alias`, or when its name appears in the same file as a symbol or
       # inside a string literal (covering `send(:name)` and declarative DSLs like
-      # `before_action :name`). Methods defined in classes or modules with
-      # descendants are not checked, since they may be invoked through `super`
-      # or inherited dispatch, and neither are methods whose names are built
-      # dynamically (e.g. `send("do_#{action}")`).
+      # `before_action :name`). An interpolated symbol or string with a literal
+      # prefix (e.g. `send(:"format_#{type}")`) counts as a reference to every
+      # method whose name starts with that prefix; fully dynamic names cannot
+      # be detected. Methods defined in classes or modules with descendants are
+      # not checked, since they may be invoked through `super` or inherited
+      # dispatch.
       #
       # The cop is disabled by default because symbol-based references from
       # *other* files (e.g. a Rails callback declared in a concern) cannot be
@@ -55,6 +57,7 @@ module RuboCop
         MSG = 'Private method `%<method>s` appears to be unused.'
 
         IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!=]?/.freeze
+        NAME_PREFIX_PATTERN = /[a-zA-Z_]\w*\z/.freeze
 
         # Methods invoked implicitly by the Ruby runtime.
         IMPLICITLY_INVOKED_METHODS = %i[
@@ -78,6 +81,7 @@ module RuboCop
 
         def on_new_investigation
           @literal_names = nil
+          @literal_name_prefixes = nil
           super
         end
 
@@ -114,7 +118,8 @@ module RuboCop
         def referenced?(method_name)
           name = method_name.to_s
 
-          referenced_names.include?(name) || literal_names.include?(name)
+          referenced_names.include?(name) || literal_names.include?(name) ||
+            literal_name_prefixes.any? { |prefix| name.start_with?(prefix) }
         end
 
         def referenced_names
@@ -148,6 +153,29 @@ module RuboCop
                 value.scan(IDENTIFIER_PATTERN) { |token| names << token }
               end
             end
+        end
+
+        # The leading literal fragment of an interpolated symbol or string acts
+        # as a method-name prefix: `send(:"format_#{type}")` may invoke any
+        # method whose name starts with `format_`. Only the leading fragment
+        # qualifies (a mid-string fragment is not a name prefix), and a fully
+        # dynamic name contributes nothing.
+        def literal_name_prefixes
+          @literal_name_prefixes ||=
+            processed_source.ast.each_descendant(:dsym, :dstr)
+                            .with_object(Set.new) do |literal, prefixes|
+              prefix = interpolation_prefix(literal)
+              prefixes << prefix if prefix
+            end
+        end
+
+        def interpolation_prefix(node)
+          return nil if node.children.all?(&:str_type?)
+
+          leading_fragment = node.children.first
+          return nil unless leading_fragment&.str_type?
+
+          leading_fragment.value[NAME_PREFIX_PATTERN]
         end
 
         # A method defined in a class or module with descendants may be invoked

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -57,9 +57,16 @@ module RuboCop
         IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!=]?/.freeze
 
         # Methods invoked implicitly by the Ruby runtime.
-        IMPLICITLY_INVOKED_METHODS = %i[initialize initialize_copy initialize_clone
-                                        initialize_dup method_missing respond_to_missing?
-                                        marshal_dump marshal_load].to_set.freeze
+        IMPLICITLY_INVOKED_METHODS = %i[
+          initialize initialize_copy initialize_clone initialize_dup
+          method_missing respond_to_missing? marshal_dump marshal_load
+          coerce instance_variables_to_inspect
+          inherited included extended prepended
+          append_features extend_object prepend_features
+          const_missing const_added
+          method_added method_removed method_undefined
+          singleton_method_added singleton_method_removed singleton_method_undefined
+        ].to_set.freeze
 
         class << self
           # The reference-name set is a property of the index, not of the cop

--- a/lib/rubocop/cop/lint/unused_private_method.rb
+++ b/lib/rubocop/cop/lint/unused_private_method.rb
@@ -21,6 +21,11 @@ module RuboCop
       # not checked, since they may be invoked through `super` or inherited
       # dispatch.
       #
+      # Methods whose names are composed by a framework (e.g. Rails
+      # `attribute_method_suffix` generating `attribute?` methods) can be
+      # excluded from the check with `AllowedNames` (exact names) or
+      # `AllowedPatterns` (regular expressions).
+      #
       # The cop is disabled by default because symbol-based references from
       # *other* files (e.g. a Rails callback declared in a concern) cannot be
       # detected and would be reported as false positives. It is best suited
@@ -51,7 +56,26 @@ module RuboCop
       #     end
       #   end
       #
+      # @example AllowedNames: ['attribute?']
+      #   # good - the name is explicitly allowed
+      #   class Contact
+      #     private
+      #
+      #     def attribute?
+      #     end
+      #   end
+      #
+      # @example AllowedPatterns: ['_hook\z']
+      #   # good - the name matches an allowed pattern
+      #   class Service
+      #     private
+      #
+      #     def before_save_hook
+      #     end
+      #   end
+      #
       class UnusedPrivateMethod < Base
+        include AllowedPattern
         include ProjectIndexHelp
 
         MSG = 'Private method `%<method>s` appears to be unused.'
@@ -101,11 +125,18 @@ module RuboCop
 
         def checkable_declaration(node)
           return nil if IMPLICITLY_INVOKED_METHODS.include?(node.method_name)
+          return nil if allowed_name?(node.method_name)
           return nil if node.each_ancestor(:any_def, :any_block, :sclass).any?
           return nil unless (namespace_node = node.each_ancestor(:class, :module).first)
 
           declaration = method_declaration(node, namespace_node)
           declaration if declaration&.private?
+        end
+
+        def allowed_name?(method_name)
+          name = method_name.to_s
+
+          cop_config.fetch('AllowedNames', []).include?(name) || matches_allowed_pattern?(name)
         end
 
         def method_declaration(node, namespace_node)

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -243,6 +243,135 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
       expect_no_offenses(source, '/lib/current.rb')
     end
 
+    it 'does not register an offense when an interpolated symbol provides the name prefix' do
+      source = <<~'RUBY'
+        class Service
+          def call(type)
+            send(:"format_#{type}")
+          end
+
+          private
+
+          def format_octal
+          end
+
+          def format_hex
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'does not register an offense when an interpolated string provides the name prefix' do
+      source = <<~'RUBY'
+        class Service
+          def call(action)
+            send("do_#{action}")
+          end
+
+          private
+
+          def do_start
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
+    it 'registers an offense for a private method not matching an interpolated prefix' do
+      source = <<~'RUBY'
+        class Service
+          def call(type)
+            send(:"format_#{type}")
+          end
+
+          private
+
+          def render_html
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_offense(<<~'RUBY', '/lib/current.rb')
+        class Service
+          def call(type)
+            send(:"format_#{type}")
+          end
+
+          private
+
+          def render_html
+          ^^^^^^^^^^^^^^^ Private method `render_html` appears to be unused.
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when the interpolated name has no literal prefix' do
+      source = <<~'RUBY'
+        class Service
+          def call(type)
+            send(:"#{type}_format")
+          end
+
+          private
+
+          def octal_format
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_offense(<<~'RUBY', '/lib/current.rb')
+        class Service
+          def call(type)
+            send(:"#{type}_format")
+          end
+
+          private
+
+          def octal_format
+          ^^^^^^^^^^^^^^^^ Private method `octal_format` appears to be unused.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not treat a mid-string fragment as a name prefix' do
+      source = <<~'RUBY'
+        class Service
+          def call(type, suffix)
+            send(:"#{type}format_#{suffix}")
+          end
+
+          private
+
+          def format_octal
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_offense(<<~'RUBY', '/lib/current.rb')
+        class Service
+          def call(type, suffix)
+            send(:"#{type}format_#{suffix}")
+          end
+
+          private
+
+          def format_octal
+          ^^^^^^^^^^^^^^^^ Private method `format_octal` appears to be unused.
+          end
+        end
+      RUBY
+    end
+
     # Symbol-based references from other files cannot be detected; this is
     # the documented reason the cop is disabled by default.
     it 'registers an offense (known limitation) when the method is referenced only ' \

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -142,6 +142,32 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
       expect_no_offenses(source, '/lib/current.rb')
     end
 
+    it 'does not register an offense for runtime hook methods' do
+      source = <<~RUBY
+        class Service
+          private
+
+          def inherited(subclass)
+          end
+
+          def const_missing(name)
+          end
+
+          def method_added(name)
+          end
+
+          def singleton_method_undefined(name)
+          end
+
+          def coerce(other)
+          end
+        end
+      RUBY
+      cop.project_index = build_index('file:///lib/current.rb' => source)
+
+      expect_no_offenses(source, '/lib/current.rb')
+    end
+
     it 'does not register an offense for a singleton method' do
       source = <<~RUBY
         class Service

--- a/spec/rubocop/cop/lint/unused_private_method_spec.rb
+++ b/spec/rubocop/cop/lint/unused_private_method_spec.rb
@@ -394,6 +394,76 @@ RSpec.describe RuboCop::Cop::Lint::UnusedPrivateMethod, :config do
       RUBY
     end
 
+    context 'with AllowedNames' do
+      let(:cop_config) { { 'AllowedNames' => ['attribute?'] } }
+
+      it 'does not register an offense for an allowed name' do
+        source = <<~RUBY
+          class Contact
+            private
+
+            def attribute?
+            end
+          end
+        RUBY
+        cop.project_index = build_index('file:///lib/current.rb' => source)
+
+        expect_no_offenses(source, '/lib/current.rb')
+      end
+
+      it 'registers an offense for a name that is not allowed' do
+        cop.project_index = index_with_current
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Service
+            def call
+            end
+
+            private
+
+            def helper
+            ^^^^^^^^^^ Private method `helper` appears to be unused.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with AllowedPatterns' do
+      let(:cop_config) { { 'AllowedPatterns' => ['_hook\z'] } }
+
+      it 'does not register an offense for a name matching an allowed pattern' do
+        source = <<~RUBY
+          class Service
+            private
+
+            def before_save_hook
+            end
+          end
+        RUBY
+        cop.project_index = build_index('file:///lib/current.rb' => source)
+
+        expect_no_offenses(source, '/lib/current.rb')
+      end
+
+      it 'registers an offense for a name not matching any allowed pattern' do
+        cop.project_index = index_with_current
+
+        expect_offense(<<~RUBY, '/lib/current.rb')
+          class Service
+            def call
+            end
+
+            private
+
+            def helper
+            ^^^^^^^^^^ Private method `helper` appears to be unused.
+            end
+          end
+        RUBY
+      end
+    end
+
     describe 'the reference-name cache' do
       it 'is computed once per index and shared across cop instances' do
         index = index_with_current


### PR DESCRIPTION
Three precision improvements driven by running the cop over rails corpora:

- Ruby runtime hooks (`inherited`, `const_missing`, `method_added`, `coerce`, ...) are now treated as implicitly invoked, so private hook definitions stop being flagged.
- The leading literal fragment of an interpolated symbol/string counts as a name prefix, so `send(:"format_#{type}")` marks `format_octal` and friends as used - previously these were false positives (five in RuboCop's own codebase).
- New `AllowedNames`/`AllowedPatterns` options for dynamically-composed names the index can't see (e.g. Rails' `attribute_method_suffix` machinery).