### PR TITLE
Add new Lint/SuperArgumentMismatch cop

### DIFF
--- a/changelog/new_add_new_lint_super_argument_mismatch_cop_20260821112622.md
+++ b/changelog/new_add_new_lint_super_argument_mismatch_cop_20260821112622.md
@@ -1,0 +1,1 @@
+* [#15594](https://github.com/rubocop/rubocop/pull/15594): Add new `Lint/SuperArgumentMismatch` cop. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -2548,6 +2548,13 @@ Lint/StructNewOverride:
   Enabled: true
   VersionAdded: '0.81'
 
+Lint/SuperArgumentMismatch:
+  Description: >-
+    Checks for `super` calls that pass the wrong number of positional
+    arguments to the overridden implementation, using the project index.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 Lint/SuppressedException:
   Description: "Don't suppress exceptions."
   StyleGuide: '#dont-hide-exceptions'

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -141,6 +141,10 @@ when a similarly named alternative exists, and suggests it. `CheckConstants` and
 the wrong number of positional arguments to a singleton method defined in the project, when
 the receiver and its whole ancestry are resolved in the index.
 
+`Lint/SuperArgumentMismatch` (pending) reports `super` calls with explicit arguments that
+pass the wrong number of positional arguments to the overridden implementation, when the
+enclosing class and its whole ancestry are resolved in the index.
+
 Index-aware cops automatically pick up the index whenever it is built; no per-cop opt-in is required.
 
 == Notes

--- a/lib/rubocop/cop/lint.rb
+++ b/lib/rubocop/cop/lint.rb
@@ -129,6 +129,7 @@ module RuboCop
       register_cop :ShadowedException, "#{__dir__}/lint/shadowed_exception"
       register_cop :ShadowingOuterLocalVariable, "#{__dir__}/lint/shadowing_outer_local_variable"
       register_cop :StructNewOverride, "#{__dir__}/lint/struct_new_override"
+      register_cop :SuperArgumentMismatch, "#{__dir__}/lint/super_argument_mismatch"
       register_cop :SuppressedException, "#{__dir__}/lint/suppressed_exception"
       register_cop :SuppressedExceptionInNumberConversion, "#{__dir__}/lint/suppressed_exception_in_number_conversion"
       register_cop :SymbolConversion, "#{__dir__}/lint/symbol_conversion"

--- a/lib/rubocop/cop/lint/argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/argument_mismatch.rb
@@ -40,6 +40,7 @@ module RuboCop
       #
       class ArgumentMismatch < Base
         include ProjectIndexHelp
+        include IndexedMethodArity
 
         MSG = 'Wrong number of arguments to `%<method>s` (given %<given>d, expected %<expected>s).'
 
@@ -60,19 +61,8 @@ module RuboCop
 
         private
 
-        def arity_satisfied?(given, min, max)
-          given >= min && (max.nil? || given <= max)
-        end
-
         def message(node, given, min, max)
           format(MSG, method: node.method_name, given: given, expected: expected_range(min, max))
-        end
-
-        def expected_range(min, max)
-          return "#{min}+" if max.nil?
-          return min.to_s if min == max
-
-          "#{min}..#{max}"
         end
 
         # `[min, max, has_keywords]` for the called singleton method, or nil when
@@ -91,67 +81,7 @@ module RuboCop
           member = indexed_singleton_member(declaration, "#{method_name}()")
           return nil unless member
 
-          definitions = member.definitions.grep(Rubydex::MethodDefinition)
-          return nil if definitions.empty?
-
-          signature_shape(definitions.flat_map(&:signatures))
-        end
-
-        # A single agreed `[min, max, has_keywords]` shape across every signature,
-        # or nil when the method has no signature, forwards arguments, or its
-        # definitions disagree on arity (e.g. reopened with a different one).
-        def signature_shape(signatures)
-          shapes = signatures.filter_map { |signature| shape_for(signature) }.uniq
-          shapes.one? ? shapes.first : nil
-        end
-
-        def shape_for(signature)
-          return nil if signature.forward_parameter
-
-          min = signature.positional_parameters.size + signature.post_parameters.size
-
-          [min, maximum_positional(signature, min), keyword_parameters?(signature)]
-        end
-
-        def maximum_positional(signature, min)
-          return nil if signature.rest_positional_parameter
-
-          min + signature.optional_positional_parameters.size
-        end
-
-        def keyword_parameters?(signature)
-          !signature.keyword_parameters.empty? ||
-            !signature.optional_keyword_parameters.empty? ||
-            !signature.rest_keyword_parameter.nil?
-        end
-
-        # The number of positional arguments the call passes, or nil when it
-        # cannot be determined statically (argument forwarding).
-        def positional_argument_count(node, callee_has_keywords)
-          arguments = node.arguments
-          return nil if forwards_arguments?(arguments)
-
-          arguments = arguments[0...-1] if arguments.last&.block_pass_type?
-          return arguments.size unless (keyword_hash = keyword_hash(arguments.last))
-          return nil if double_splat?(keyword_hash)
-
-          # A keyword-style hash passed to a method with no keyword parameters is
-          # received as a single positional hash argument.
-          callee_has_keywords ? arguments.size - 1 : arguments.size
-        end
-
-        def forwards_arguments?(arguments)
-          arguments.any? do |argument|
-            argument.type?(:splat, :forwarded_args, :forwarded_restarg, :forwarded_kwrestarg)
-          end
-        end
-
-        def keyword_hash(node)
-          node if node&.hash_type? && !node.braces?
-        end
-
-        def double_splat?(hash_node)
-          hash_node.each_child_node.any?(&:kwsplat_type?)
+          indexed_member_shape(member)
         end
       end
     end

--- a/lib/rubocop/cop/lint/super_argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/super_argument_mismatch.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks for `super` calls with explicit arguments that pass the wrong
+      # number of positional arguments to the overridden implementation, using
+      # the project index.
+      #
+      # The check is powered by the project-wide index, so it only runs when
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
+      # Without the index the cop does nothing.
+      #
+      # Only `super` inside a plain instance method defined directly in a class
+      # body is considered, and only when the enclosing class resolves in the
+      # index and its entire ancestry is resolved, so a superclass method coming
+      # from a gem, the standard library, or a dynamic definition never produces
+      # an offense. The overridden implementation is the first ancestor after
+      # the enclosing class in the index's method resolution order that defines
+      # the method; when it is not a plain method definition (an `attr_*` or an
+      # alias) or its definitions disagree on arity, the call is not checked.
+      # Calls that forward arguments (`*`, `**`, `...`) are skipped, and bare
+      # `super` (which forwards the current method's parameters) is not checked.
+      # Methods the index attributes to `Object`, `Kernel`, or `BasicObject`
+      # are never used as the overridden implementation, since a `def` inside
+      # a block at the top level (`Struct.new do ... end`) is indexed under
+      # `Object` even though it defines a method somewhere else entirely.
+      #
+      # @example
+      #   # Given the project defines:
+      #   #   class Base
+      #   #     def initialize(name, size); end
+      #   #   end
+      #
+      #   # bad
+      #   class Widget < Base
+      #     def initialize(name)
+      #       super(name)
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Widget < Base
+      #     def initialize(name)
+      #       super(name, 0)
+      #     end
+      #   end
+      #
+      class SuperArgumentMismatch < Base
+        include ProjectIndexHelp
+        include IndexedMethodArity
+
+        MSG = 'Wrong number of arguments to `super` ' \
+              '(given %<given>d, expected %<expected>s for `%<parent>s#%<method>s`).'
+
+        # Blocks that change what method (or scope) `super` refers to, or in
+        # which `super` is not statically resolvable.
+        CONTEXT_CHANGING_BLOCKS = %i[
+          define_method define_singleton_method class_eval class_exec
+          module_eval module_exec instance_eval instance_exec refine
+        ].freeze
+
+        # Methods the index attributes to the root namespaces are not
+        # trustworthy super targets: a `def` inside a block at the top level
+        # (`Struct.new do ... end`, `Class.new do ... end`) is indexed under
+        # `Object` even though it defines a method somewhere else entirely.
+        BUILTIN_ROOTS = %w[Object Kernel BasicObject].freeze
+
+        def on_super(node)
+          return unless project_index
+
+          def_node = enclosing_instance_method(node)
+          return unless def_node
+
+          shape, parent = resolved_super_shape(def_node)
+          return unless shape
+
+          min, max, has_keywords = shape
+          given = positional_argument_count(node, has_keywords)
+          return if given.nil? || arity_satisfied?(given, min, max)
+
+          add_offense(node.loc.keyword,
+                      message: message(def_node.method_name, parent, given, min, max))
+        end
+
+        private
+
+        def message(method_name, parent, given, min, max)
+          format(MSG, given: given, expected: expected_range(min, max),
+                      parent: parent.name, method: method_name)
+        end
+
+        # The `def` node whose method the `super` call re-dispatches, or nil
+        # when the context is not statically known: `super` inside a
+        # singleton method, inside `define_method` or an eval/refine block,
+        # or outside any method.
+        def enclosing_instance_method(node)
+          node.each_ancestor(:any_def, :any_block, :sclass).each do |ancestor|
+            case ancestor.type
+            when :def then return ancestor
+            when :defs, :sclass then return nil
+            else
+              return nil if CONTEXT_CHANGING_BLOCKS.include?(ancestor.method_name)
+            end
+          end
+
+          nil
+        end
+
+        # `[[min, max, has_keywords], parent]` for the implementation `super`
+        # dispatches to, or nil when the enclosing class or the overridden
+        # method is not statically known.
+        def resolved_super_shape(def_node)
+          declaration = enclosing_class_declaration(def_node)
+          return nil unless declaration
+          return nil unless fully_resolved_index_ancestry?(declaration, ignore_extend: true)
+
+          super_method_shape(declaration, def_node.method_name)
+        rescue StandardError
+          nil
+        end
+
+        # The index declaration of the class whose body directly contains
+        # `def_node`, or nil when the method is not defined directly in a
+        # class body (module methods are excluded because their `super`
+        # target depends on where the module is mixed in) or the class does
+        # not resolve in the index.
+        def enclosing_class_declaration(def_node)
+          class_node = def_node.each_ancestor(:class, :module, :sclass, :any_block).first
+          return nil unless class_node&.class_type?
+
+          declaration = project_index[lexical_nesting_of(def_node).join('::')]
+          return nil unless declaration.is_a?(Rubydex::Namespace)
+          return nil unless declared_at?(declaration, class_node)
+
+          declaration
+        end
+
+        # Whether one of the declaration's definitions is the given class
+        # node, anchoring the name-based lookup to the source being
+        # inspected (a qualified identifier like `class Foo::Bar` can
+        # resolve to a namespace other than the joined nesting names).
+        def declared_at?(declaration, class_node)
+          declaration.definitions.any? do |definition|
+            location = definition.location
+            location.uri.start_with?(FILE_URI_PREFIX) &&
+              location.to_display.start_line == class_node.first_line &&
+              same_file?(location.to_file_path, processed_source.file_path)
+          end
+        end
+
+        # The shape of the first implementation of `method_name` after the
+        # enclosing class in the index's method resolution order, or nil
+        # when no indexed ancestor defines it (e.g. it comes from a gem or
+        # the standard library, which are not indexed).
+        def super_method_shape(declaration, method_name)
+          ancestors = declaration.ancestors.to_a
+          position = ancestors.index { |ancestor| ancestor.name == declaration.name }
+          return nil unless position
+
+          ancestors.drop(position + 1).each do |ancestor|
+            return nil if BUILTIN_ROOTS.include?(ancestor.name)
+
+            member = ancestor.member("#{method_name}()")
+            next unless member
+
+            # The first definer along the chain is the receiving
+            # implementation; when its shape is unknown there is nothing
+            # further to check.
+            shape = indexed_member_shape(member)
+            return shape && [shape, ancestor]
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin.rb
+++ b/lib/rubocop/cop/mixin.rb
@@ -44,6 +44,7 @@ module RuboCop
     # Deprecated aliases of `AllowedMethods` and `AllowedPattern`, defined in those files.
     autoload :IgnoredMethods, "#{__dir__}/mixin/allowed_methods"
     autoload :IgnoredPattern, "#{__dir__}/mixin/allowed_pattern"
+    autoload :IndexedMethodArity, "#{__dir__}/mixin/indexed_method_arity"
     autoload :IntegerNode, "#{__dir__}/mixin/integer_node"
     autoload :Interpolation, "#{__dir__}/mixin/interpolation"
     autoload :LineLengthHelp, "#{__dir__}/mixin/line_length_help"

--- a/lib/rubocop/cop/mixin/indexed_method_arity.rb
+++ b/lib/rubocop/cop/mixin/indexed_method_arity.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Shared machinery for cops that compare a call site's arguments against
+    # a method signature from the project index (`Rubydex::Signature`).
+    #
+    # A signature is reduced to a shape - `[min, max, has_keywords]` where
+    # `max` is nil for a rest parameter - and the number of positional
+    # arguments a call passes is counted with Ruby's semantics for trailing
+    # keyword hashes: keywords passed to a method with no keyword parameters
+    # collapse into a single positional hash.
+    module IndexedMethodArity
+      private
+
+      def arity_satisfied?(given, min, max)
+        given >= min && (max.nil? || given <= max)
+      end
+
+      def expected_range(min, max)
+        return "#{min}+" if max.nil?
+        return min.to_s if min == max
+
+        "#{min}..#{max}"
+      end
+
+      # The agreed `[min, max, has_keywords]` shape of an indexed member's
+      # method definitions, or nil when the member is not backed by plain
+      # method definitions (attr, alias), has no signature, forwards
+      # arguments, or its definitions disagree on arity (e.g. reopened with
+      # a different one).
+      def indexed_member_shape(member)
+        definitions = member.definitions.grep(Rubydex::MethodDefinition)
+        return nil if definitions.empty?
+
+        signature_shape(definitions.flat_map(&:signatures))
+      end
+
+      def signature_shape(signatures)
+        shapes = signatures.filter_map { |signature| shape_for(signature) }.uniq
+        shapes.one? ? shapes.first : nil
+      end
+
+      def shape_for(signature)
+        return nil if signature.forward_parameter
+
+        min = signature.positional_parameters.size + signature.post_parameters.size
+
+        [min, maximum_positional(signature, min), keyword_parameters?(signature)]
+      end
+
+      def maximum_positional(signature, min)
+        return nil if signature.rest_positional_parameter
+
+        min + signature.optional_positional_parameters.size
+      end
+
+      def keyword_parameters?(signature)
+        !signature.keyword_parameters.empty? ||
+          !signature.optional_keyword_parameters.empty? ||
+          !signature.rest_keyword_parameter.nil?
+      end
+
+      # The number of positional arguments the call passes, or nil when it
+      # cannot be determined statically (argument forwarding).
+      def positional_argument_count(node, callee_has_keywords)
+        arguments = node.arguments
+        return nil if forwards_arguments?(arguments)
+
+        arguments = arguments[0...-1] if arguments.last&.block_pass_type?
+        return arguments.size unless (keyword_hash = keyword_hash(arguments.last))
+        return nil if double_splat?(keyword_hash)
+
+        # A keyword-style hash passed to a method with no keyword parameters is
+        # received as a single positional hash argument.
+        callee_has_keywords ? arguments.size - 1 : arguments.size
+      end
+
+      def forwards_arguments?(arguments)
+        arguments.any? do |argument|
+          argument.type?(:splat, :forwarded_args, :forwarded_restarg, :forwarded_kwrestarg)
+        end
+      end
+
+      def keyword_hash(node)
+        node if node&.hash_type? && !node.braces?
+      end
+
+      def double_splat?(hash_node)
+        hash_node.each_child_node.any?(&:kwsplat_type?)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/super_argument_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/super_argument_mismatch_spec.rb
@@ -1,0 +1,506 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Lint::SuperArgumentMismatch, :config do
+  it 'does not register an offense without a project index' do
+    expect_no_offenses(<<~RUBY)
+      class Widget < Base
+        def initialize(name)
+          super(name)
+        end
+      end
+    RUBY
+  end
+
+  context 'with a project index', :project_index do
+    # The cop anchors the enclosing class to the inspected file, so the child's
+    # index URI must round-trip through the same path expansion the runner
+    # applies - drive-less fake paths behave differently on Windows.
+    let(:child_path) { File.expand_path('child.rb') }
+
+    def file_uri(path)
+      path.start_with?('/') ? "file://#{path}" : "file:///#{path}"
+    end
+
+    # Index the parent definitions together with the inspected file. This
+    # mirrors production, where the file being linted is part of the
+    # whole-project index.
+    def index_with_child(child, parents)
+      cop.project_index = build_index(parents.merge(file_uri(child_path) => child))
+    end
+
+    context 'for a fixed-arity overridden method' do
+      let(:parent) do
+        { 'file:///base.rb' => <<~RUBY }
+          class Base
+            def initialize(name, size); end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when too few arguments are given' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name)
+              super(name)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Widget < Base
+            def initialize(name)
+              super(name)
+              ^^^^^ Wrong number of arguments to `super` (given 1, expected 2 for `Base#initialize`).
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when too many arguments are given' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name)
+              super(name, 1, 2)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Widget < Base
+            def initialize(name)
+              super(name, 1, 2)
+              ^^^^^ Wrong number of arguments to `super` (given 3, expected 2 for `Base#initialize`).
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for `super()` with no arguments' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name)
+              super()
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Widget < Base
+            def initialize(name)
+              super()
+              ^^^^^ Wrong number of arguments to `super` (given 0, expected 2 for `Base#initialize`).
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when the arity matches' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name)
+              super(name, 0)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not register an offense for bare `super`' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name)
+              super
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not register an offense when arguments are forwarded' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(*args)
+              super(*args)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'ignores a trailing block-pass argument' do
+        source = <<~RUBY
+          class Widget < Base
+            def initialize(name, &block)
+              super(name, &block)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Widget < Base
+            def initialize(name, &block)
+              super(name, &block)
+              ^^^^^ Wrong number of arguments to `super` (given 1, expected 2 for `Base#initialize`).
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'for optional and rest parameters' do
+      let(:parent) do
+        { 'file:///base.rb' => <<~RUBY }
+          class Base
+            def add(a, b = 0); end
+            def sum(first, *rest); end
+          end
+        RUBY
+      end
+
+      it 'accepts a call within the optional range' do
+        source = <<~RUBY
+          class Child < Base
+            def add(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'registers an offense past the optional maximum' do
+        source = <<~RUBY
+          class Child < Base
+            def add(a)
+              super(a, 1, 2)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Child < Base
+            def add(a)
+              super(a, 1, 2)
+              ^^^^^ Wrong number of arguments to `super` (given 3, expected 1..2 for `Base#add`).
+            end
+          end
+        RUBY
+      end
+
+      it 'reports the minimum with a trailing plus for a rest parameter' do
+        source = <<~RUBY
+          class Child < Base
+            def sum(first)
+              super()
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Child < Base
+            def sum(first)
+              super()
+              ^^^^^ Wrong number of arguments to `super` (given 0, expected 1+ for `Base#sum`).
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with keyword arguments' do
+      it 'folds keywords into a positional hash when the parent has none' do
+        source = <<~RUBY
+          class Child < Base
+            def opts(hash)
+              super(a: 1, b: 2)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => <<~RUBY)
+          class Base
+            def opts(hash); end
+          end
+        RUBY
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not count keywords as positional when the parent declares them' do
+        source = <<~RUBY
+          class Child < Base
+            def build(name)
+              super(name, size: 1)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => <<~RUBY)
+          class Base
+            def build(name, size:); end
+          end
+        RUBY
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'skips a call that forwards a double splat' do
+        source = <<~RUBY
+          class Child < Base
+            def build(name, **opts)
+              super(name, extra, **opts)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => <<~RUBY)
+          class Base
+            def build(name); end
+          end
+        RUBY
+
+        expect_no_offenses(source, child_path)
+      end
+    end
+
+    context 'with modules in the ancestry' do
+      it 'resolves the implementation through an included module' do
+        source = <<~RUBY
+          class Child < Base
+            include Extras
+
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(
+          source,
+          'file:///base.rb' => "class Base\n  def run(a, b); end\nend\n",
+          'file:///extras.rb' => "module Extras\n  def run(a, b, c); end\nend\n"
+        )
+
+        expect_offense(<<~RUBY, child_path)
+          class Child < Base
+            include Extras
+
+            def run(a)
+              super(a)
+              ^^^^^ Wrong number of arguments to `super` (given 1, expected 3 for `Extras#run`).
+            end
+          end
+        RUBY
+      end
+
+      it 'skips a method defined in a prepended module of the same class' do
+        source = <<~RUBY
+          class Child < Base
+            prepend Wrapper
+
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(
+          source,
+          'file:///base.rb' => "class Base\n  def run(a); end\nend\n",
+          'file:///wrapper.rb' => "module Wrapper\n  def run(a, b); end\nend\n"
+        )
+
+        # `super` from `Child#run` skips the prepended `Wrapper#run` and
+        # dispatches to `Base#run`, whose arity matches.
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not check `super` inside a method defined in a module' do
+        source = <<~RUBY
+          module Helper
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => "class Base\n  def run(a, b); end\nend\n")
+
+        expect_no_offenses(source, child_path)
+      end
+    end
+
+    context 'when the context is not statically known' do
+      let(:parent) do
+        { 'file:///base.rb' => <<~RUBY }
+          class Base
+            def run(a, b); end
+          end
+        RUBY
+      end
+
+      it 'does not check `super` inside a singleton method' do
+        source = <<~RUBY
+          class Child < Base
+            def self.run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not check `super` inside `define_method`' do
+        source = <<~RUBY
+          class Child < Base
+            define_method(:run) do |a|
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'checks `super` inside an ordinary block' do
+        source = <<~RUBY
+          class Child < Base
+            def run(a)
+              [a].each { |x| super(x) }
+            end
+          end
+        RUBY
+        index_with_child(source, parent)
+
+        expect_offense(<<~RUBY, child_path)
+          class Child < Base
+            def run(a)
+              [a].each { |x| super(x) }
+                             ^^^^^ Wrong number of arguments to `super` (given 1, expected 2 for `Base#run`).
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when the overridden implementation is not checkable' do
+      it 'does not register an offense when no indexed ancestor defines the method' do
+        source = <<~RUBY
+          class Child < Base
+            def to_s
+              super()
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => "class Base\nend\n")
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not use a method the index attributes to `Object` as the target' do
+        source = <<~RUBY
+          class Child < Base
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        # `def run` inside a block at the top level is indexed under `Object`
+        # even though it actually defines a method on the anonymous struct.
+        index_with_child(
+          source,
+          'file:///base.rb' => "class Base\nend\n",
+          'file:///post.rb' => "Post = Struct.new(:title) do\n  def run(a, b); end\nend\n"
+        )
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not register an offense when the ancestry is not fully resolved' do
+        source = <<~RUBY
+          class Child < Unknown
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => "class Base\n  def run(a, b); end\nend\n")
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not register an offense when the parent method is an attr writer pair' do
+        source = <<~RUBY
+          class Child < Base
+            def value(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => "class Base\n  attr_reader :value\nend\n")
+
+        expect_no_offenses(source, child_path)
+      end
+
+      it 'does not register an offense when parent definitions disagree on arity' do
+        source = <<~RUBY
+          class Child < Base
+            def run(a)
+              super(a)
+            end
+          end
+        RUBY
+        index_with_child(
+          source,
+          'file:///base.rb' => "class Base\n  def run(a, b); end\nend\n",
+          'file:///base_ext.rb' => "class Base\n  def run(a, b, c); end\nend\n"
+        )
+
+        expect_no_offenses(source, child_path)
+      end
+    end
+
+    context 'for a nested class' do
+      it 'resolves the enclosing class through the lexical nesting' do
+        source = <<~RUBY
+          module App
+            class Child < Base
+              def run(a)
+                super(a)
+              end
+            end
+          end
+        RUBY
+        index_with_child(source, 'file:///base.rb' => <<~RUBY)
+          module App
+            class Base
+              def run(a, b); end
+            end
+          end
+        RUBY
+
+        expect_offense(<<~RUBY, child_path)
+          module App
+            class Child < Base
+              def run(a)
+                super(a)
+                ^^^^^ Wrong number of arguments to `super` (given 1, expected 2 for `App::Base#run`).
+              end
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #15523: checks explicit `super(...)` calls against the parent implementation's signature via the project index, sharing the comparison machinery through a new `IndexedMethodArity` mixin (extracted from `Lint/ArgumentMismatch`, which stays behaviorally unchanged).

Unlike a def-site override check, this is per-call-site, so it catches the refactor scenario: a parent's signature changes and a child's stale `super` keeps compiling until it raises at runtime - including across gems (verified by mutation: adding a param to `ActiveSupport::BacktraceCleaner#clean` flags railties' subclass). Zero false positives over RuboCop's own repo and all of rails (157 verified signature comparisons).

Scoped conservatively: plain instance defs in class bodies only - module `super` targets depend on the mix-in site, and singleton MRO involves `extend`s the instance ancestry doesn't model. Bare `super` (zsuper) is a possible phase 2.