### PR TITLE
[Fix #15590] Fix an infinite loop error for `Layout/FirstArgumentIndentation`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_first_argument_indentation_20260821163919.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_first_argument_indentation_20260821163919.md
@@ -1,0 +1,1 @@
+* [#15590](https://github.com/rubocop/rubocop/issues/15590): Fix an infinite loop error for `Layout/FirstArgumentIndentation` when `EnforcedStyle: with_fixed_indentation` is specified for `Layout/ArgumentAlignment` and `Layout/FirstMethodArgumentLineBreak` is enabled with `AllowMultilineFinalElement: true`. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/first_argument_indentation.rb
+++ b/lib/rubocop/cop/layout/first_argument_indentation.rb
@@ -156,7 +156,8 @@ module RuboCop
           return unless should_check?(node)
           return if same_line?(node, node.first_argument)
           return if enforce_first_argument_with_fixed_indentation? &&
-                    !enable_layout_first_method_argument_line_break?
+                    (!enable_layout_first_method_argument_line_break? ||
+                     conflicts_with_fixed_indentation_alignment?(node))
 
           indent = base_indentation(node) + configured_indentation_width
 
@@ -308,6 +309,25 @@ module RuboCop
 
         def enable_layout_first_method_argument_line_break?
           config.cop_enabled?('Layout/FirstMethodArgumentLineBreak')
+        end
+
+        def conflicts_with_fixed_indentation_alignment?(node)
+          return false unless special_inner_call_indentation?(node)
+          return false unless argument_alignment_applies?(node)
+
+          base_indentation(node) != indentation_of_method_line(node)
+        end
+
+        def argument_alignment_applies?(node)
+          return false if !node.call_type? || node.method?(:[]=)
+
+          node.arguments.size >= 2 ||
+            (node.first_argument.hash_type? && node.first_argument.pairs.count >= 2)
+        end
+
+        def indentation_of_method_line(node)
+          lineno = node.loc.selector ? node.loc.selector.line : node.loc.begin.line
+          processed_source.lines[lineno - 1] =~ /\S/
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2336,6 +2336,42 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects without an infinite loop when using `Layout/ArgumentAlignment`, ' \
+     '`Layout/ClosingParenthesisIndentation`, `Layout/FirstArgumentIndentation`, and ' \
+     '`Layout/FirstMethodArgumentLineBreak` with `AllowMultilineFinalElement: true` ' \
+     'and specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      expect(execute_request(
+               "some_url",
+        :request_method => "PATCH"
+      )).to be_throttled
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+      Layout/FirstMethodArgumentLineBreak:
+        Enabled: true
+        AllowMultilineFinalElement: true
+    YAML
+
+    expect(cli.run(['--autocorrect', '--only', %w[
+      Layout/ArgumentAlignment Layout/ClosingParenthesisIndentation
+      Layout/FirstArgumentIndentation Layout/FirstMethodArgumentLineBreak
+    ].join(',')])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      # frozen_string_literal: true
+
+      expect(execute_request(
+        "some_url",
+        :request_method => "PATCH"
+      )).to be_throttled
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`EnforcedStyle: consistent` of `Layout/FirstArgumentIndentation`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_argument_indentation_spec.rb
@@ -711,6 +711,61 @@ RSpec.describe RuboCop::Cop::Layout::FirstArgumentIndentation, :config do
         RUBY
       end
     end
+
+    context 'when `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
+            '`Layout/FirstMethodArgumentLineBreak` is enabled' do
+      let(:other_cops) do
+        {
+          'Layout/IndentationWidth' => { 'Width' => indentation_width },
+          'Layout/ArgumentAlignment' => { 'EnforcedStyle' => 'with_fixed_indentation' },
+          'Layout/FirstMethodArgumentLineBreak' => { 'Enabled' => true }
+        }
+      end
+
+      it 'accepts an inner method call that does not start its own line, ' \
+         'deferring to `Layout/ArgumentAlignment`' do
+        expect_no_offenses(<<~RUBY)
+          expect(execute_request(
+            "some_url",
+            :request_method => "PATCH"
+          )).to be_throttled
+        RUBY
+      end
+
+      it 'registers an offense and corrects an inner method call that starts its own line' do
+        expect_offense(<<~RUBY)
+          expect(
+            execute_request(
+                 "some_url",
+                 ^^^^^^^^^^ Indent the first argument one step more than `execute_request(`.
+                 :request_method => "PATCH"
+            )).to be_throttled
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(
+            execute_request(
+              "some_url",
+              :request_method => "PATCH"
+            )).to be_throttled
+        RUBY
+      end
+
+      it 'registers an offense and corrects an inner method call with a single argument' do
+        expect_offense(<<~RUBY)
+          run(described_class.new(
+            attributes
+            ^^^^^^^^^^ Indent the first argument one step more than `described_class.new(`.
+          ))
+        RUBY
+
+        expect_correction(<<~RUBY)
+          run(described_class.new(
+                attributes
+          ))
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is consistent' do


### PR DESCRIPTION
Fixes #15590.

The missing ingredient to reproduce the loop was `Layout/FirstMethodArgumentLineBreak` enabled with `AllowMultilineFinalElement: true`:

```yaml
Layout/ArgumentAlignment:
  EnforcedStyle: with_fixed_indentation
Layout/FirstMethodArgumentLineBreak:
  Enabled: true
  AllowMultilineFinalElement: true
```

```ruby
expect(execute_request(
         "some_url",
  :request_method => "PATCH"
)).to be_throttled
```

`Layout/FirstArgumentIndentation` normally defers to `Layout/ArgumentAlignment` when `with_fixed_indentation` is used (#9453), with an exception when `Layout/FirstMethodArgumentLineBreak` is enabled (#10830). That exception assumed `FirstMethodArgumentLineBreak` would always move the inner call onto its own line, making both cops agree on the indentation base. With `AllowMultilineFinalElement: true` the line is not broken, the inner call stays mid-line, and the two cops correct the first argument back and forth forever (`FirstArgumentIndentation` wants the call site column + 1 step, `ArgumentAlignment` wants the line indentation + 1 step).

The fix makes the exception node-aware: when fixed indentation is enforced, the special inner-call rule now yields to `ArgumentAlignment` if their indentation bases disagree, i.e. when the inner call does not start its own line. Once `FirstMethodArgumentLineBreak` does break the line, the bases coincide and this cop applies as before, so the #10830 behavior is preserved. The autocorrected result is:

```ruby
expect(execute_request(
  "some_url",
  :request_method => "PATCH"
)).to be_throttled
```