### PR TITLE
Add `Offense#real_last_column` and use it in `JSONFormatter`

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -236,6 +236,16 @@ module RuboCop
         column + 1
       end
 
+      # @api private
+      #
+      # The minimum value of `real_column` is 1, so the minimum value of
+      # `real_last_column` is also 1. A non-zero `last_column` is used as is,
+      # because the 0-based end-exclusive column is the same as the 1-based
+      # column of the last character.
+      def real_last_column
+        last_column.zero? ? 1 : last_column
+      end
+
       # @api public
       #
       # @return [Boolean]

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -66,16 +66,12 @@ module RuboCop
         hash
       end
 
-      # TODO: Consider better solution for Offense#real_column.
-      #       The minimum value of `start_column: real_column` is 1.
-      #       So, the minimum value of `last_column` should be 1.
-      #       And non-zero value of `last_column` should be used as is.
       def hash_for_location(offense)
         {
           start_line:   offense.line,
           start_column: offense.real_column,
           last_line:    offense.last_line,
-          last_column:  offense.last_column.zero? ? 1 : offense.last_column,
+          last_column:  offense.real_last_column,
           length:       offense.location.length,
           # `line` and `column` exist for compatibility.
           # Use `start_line` and `start_column` instead.

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe RuboCop::Cop::Offense do
     end
   end
 
+  describe '#real_last_column' do
+    let(:location) do
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source_buffer.source = "abc\n"
+      Parser::Source::Range.new(source_buffer, 0, 3)
+    end
+
+    it 'returns the 1-based column of the last character' do
+      expect(offense.real_last_column).to eq 3
+    end
+  end
+
   describe '#severity_level' do
     subject(:severity_level) do
       described_class.new(severity, location, 'message', 'CopName').severity.level
@@ -228,6 +240,10 @@ RSpec.describe RuboCop::Cop::Offense do
 
     it 'returns a real column' do
       expect(offense.real_column).to eq 1
+    end
+
+    it 'returns a real last column' do
+      expect(offense.real_last_column).to eq 1
     end
 
     it 'returns a highlighted area' do


### PR DESCRIPTION
The JSON formatter carried a TODO from the #10241 fix: the conversion that keeps `last_column` consistent with `start_column` (whose minimum value, coming from `Offense#real_column`, is 1) lived as an inline ternary in the formatter. A zero `last_column` arises from `Offense::NO_LOCATION`, which cops using `add_global_offense` produce.

Move that knowledge into `Offense#real_last_column`, next to `real_column` where the 1-based output convention is defined, so the formatter no longer needs to know about the `NO_LOCATION` edge case. The JSON output is unchanged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
