### PR TITLE
Fix an infinite loop error for `Layout/EmptyLinesAfterModuleInclusion`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_empty_lines_after_module_inclusion_20260824124654.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_empty_lines_after_module_inclusion_20260824124654.md
@@ -1,0 +1,1 @@
+* [#15597](https://github.com/rubocop/rubocop/pull/15597): Fix an infinite loop error for `Layout/EmptyLinesAfterModuleInclusion` when a module inclusion is directly before `rescue`. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
+++ b/lib/rubocop/cop/layout/empty_lines_after_module_inclusion.rb
@@ -91,7 +91,7 @@ module RuboCop
         end
 
         def next_line_node(node)
-          return if node.parent.if_type?
+          return if node.parent.type?(:if, :rescue, :ensure)
 
           node.right_sibling
         end

--- a/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_after_module_inclusion_spec.rb
@@ -289,4 +289,24 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAfterModuleInclusion, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for `include` directly before `rescue`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        include Foo
+      rescue NameError
+        include Bar
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `include` directly before `ensure`' do
+    expect_no_offenses(<<~RUBY)
+      begin
+        include Foo
+      ensure
+        do_something
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
`Layout/EmptyLinesAfterModuleInclusion` and `Layout/EmptyLinesAroundExceptionHandlingKeywords` fight over an empty line when a module inclusion is the last expression before `rescue` or `ensure`:

```ruby
begin
  include Foo
rescue NameError
  include Bar
end
```

One cop inserts an empty line after `include Foo`, the other removes it as an empty line before `rescue`, and `--autocorrect-all` loops forever. This shows up with the default config on real code (bundler-audit, rspec-core and yard all have this pattern).

The cop already skips an inclusion that has no next sibling; this makes it also skip when the parent is a `rescue`/`ensure`, i.e. when the "next line" is an exception handling keyword rather than code.

Found while fuzzing RuboCop over a corpus of popular gems with [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz), a small harness I'm building to catch cop crashes and autocorrect loops.
