### PR TITLE
Fix an infinite loop error for `Lint/AssignmentInCondition`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_lint_assignment_in_condition_20260824125607.md
+++ b/changelog/fix_an_infinite_loop_error_for_lint_assignment_in_condition_20260824125607.md
@@ -1,0 +1,1 @@
+* [#15598](https://github.com/rubocop/rubocop/pull/15598): Fix an infinite loop error for `Lint/AssignmentInCondition` when an assignment is inside `defined?`. ([@Starlexxx][])

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -106,6 +106,8 @@ module RuboCop
         def traverse_node(node, &block)
           # if the node is a block, any assignments are irrelevant
           return if node.any_block_type?
+          # an assignment inside `defined?` is never executed
+          return if node.defined_type?
 
           result = yield node if ASGN_TYPES.include?(node.type)
 

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -277,6 +277,21 @@ RSpec.describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     RUBY
   end
 
+  it 'does not register an offense for assignment inside `defined?`' do
+    expect_no_offenses(<<~RUBY)
+      if defined?(foo.bar = ())
+        foo.bar = false
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for local variable assignment inside `defined?`' do
+    expect_no_offenses(<<~RUBY)
+      if defined?(test = 10)
+      end
+    RUBY
+  end
+
   context 'safe assignment is allowed' do
     it 'accepts = in condition surrounded with braces' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
`Lint/AssignmentInCondition` wraps an assignment inside `defined?` in parentheses, and `Style/RedundantParentheses` immediately removes them, so `--autocorrect-all` loops forever on the feature-detection idiom used e.g. in rspec-rails:

```ruby
if defined?(Foo.bar = ())
  Foo.bar = false
end
```

An assignment inside `defined?` is never executed and is not the condition being tested, so the cop now skips the whole `defined?` subtree.

Found while fuzzing RuboCop over a corpus of popular gems with [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz), a small harness I'm building to catch cop crashes and autocorrect loops.
