### PR TITLE
Fix an infinite loop error for `Layout/CommentIndentation`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_comment_indentation_20260824.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_comment_indentation_20260824.md
@@ -1,0 +1,1 @@
+* [#15599](https://github.com/rubocop/rubocop/pull/15599): Fix an infinite loop error for `Layout/CommentIndentation` when many comment blocks with the same indentation are separated by empty lines. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -64,10 +64,10 @@ module RuboCop
           autocorrect_one(corrector, comment)
         end
 
-        # Corrects all comment lines that occur immediately before the given
-        # comment and have the same indentation. This is to avoid a long chain
-        # of correcting, saving the file, parsing and inspecting again, and
-        # then correcting one more line, and so on.
+        # Corrects all preceding comment lines that have the same indentation
+        # and are separated from the given comment by nothing but blank lines.
+        # This is to avoid a long chain of correcting, saving the file, parsing
+        # and inspecting again, and then correcting one more line, and so on.
         def autocorrect_preceding_comments(corrector, comment)
           comments = processed_source.comments
           index = comments.index(comment)
@@ -82,7 +82,10 @@ module RuboCop
         def should_correct?(preceding_comment, reference_comment)
           loc = preceding_comment.loc
           ref_loc = reference_comment.loc
-          loc.line == ref_loc.line - 1 && loc.column == ref_loc.column
+          return false unless loc.column == ref_loc.column
+          return false unless own_line_comment?(preceding_comment)
+
+          ((loc.line + 1)...ref_loc.line).all? { |line| processed_source[line - 1].blank? }
         end
 
         def autocorrect_one(corrector, comment)

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe RuboCop::Cop::Layout::CommentIndentation, :config do
       end
     end
 
+    it 'corrects same-column comment blocks separated by empty lines in a single pass' do
+      expect_offense(<<~RUBY)
+        class Foo
+        # a
+        # b
+
+        # c
+
+        # d
+        ^^^ Incorrect indentation detected (column 0 instead of 2).
+          def bar; end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY, loop: false)
+        class Foo
+          # a
+          # b
+
+          # c
+
+          # d
+          def bar; end
+        end
+      RUBY
+    end
+
     it 'registers offenses and corrects before __END__ but not after' do
       expect_offense(<<~RUBY)
          #


### PR DESCRIPTION
On a file with many same-column comment paragraphs separated by empty lines (the generated `lib/vips/methods.rb` in ruby-vips is ~3300 such lines), `Layout/CommentIndentation` corrects one paragraph per pass: only the paragraph adjacent to code gets an offense, because every other comment derives its expected indentation from the (equally misindented) comment below it. With more than 200 paragraphs this exceeds `MAX_ITERATIONS`, so `--autocorrect-all` aborts with "Infinite loop detected" and leaves the file half-corrected.

The autocorrect already drags along the comment lines directly above the offense to avoid exactly this kind of chain; this change lets that chain cross empty lines between same-column blocks, so the whole file converges in a single pass.

Found while fuzzing RuboCop over a corpus of popular gems with [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz), a small harness I'm building to catch cop crashes and autocorrect loops.
