### PR TITLE
Fix Layout/IndentationWidth error on under-indented code with tabs

### DIFF
--- a/changelog/fix_an_error_for_layout_indentation_width_with_tabs_20260825173945.md
+++ b/changelog/fix_an_error_for_layout_indentation_width_with_tabs_20260825173945.md
@@ -1,0 +1,1 @@
+* [#15602](https://github.com/rubocop/rubocop/pull/15602): Fix an error for `Layout/IndentationWidth` on under-indented code with tab indentation. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -440,7 +440,7 @@ module RuboCop
                   begin_pos - indentation
                 end
 
-          pos = indentation >= 0 ? ind..begin_pos : begin_pos..ind
+          pos = ind <= begin_pos ? ind..begin_pos : begin_pos..ind
           range_between(pos.begin, pos.end)
         end
 

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -2489,6 +2489,21 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth, :config do
         RUBY
       end
 
+      it 'registers an offense when the body is indented with fewer tabs than the base' do
+        expect_offense(<<-RUBY.gsub(/^        /, ''))
+        \t\ta = if b
+        \tc
+        ^ Use 1 (not -1) tabs for indentation.
+        \t\tend
+        RUBY
+
+        expect_correction(<<-RUBY.gsub(/^        /, ''))
+        \t\ta = if b
+        \t\t\tc
+        \t\tend
+        RUBY
+      end
+
       context "when `Layout/IndentationStyle` has a different `IndentationWidth` than this cop's `Width`" do
         let(:indentation_style_config) { { 'EnforcedStyle' => 'tabs', 'IndentationWidth' => 4 } }
 


### PR DESCRIPTION
`Layout/IndentationWidth` crashes when `Layout/IndentationStyle` enforces tabs and a line is indented less than its base:

```ruby
		a = if b
	c
		end
```

```
Parser::Source::Range: end_pos must not be less than begin_pos
```

`offending_range` decides which end of the range comes first by the sign of the indentation offset. In tabs mode `ind` never exceeds `begin_pos`, so a negative offset builds an inverted range. Now the ends are simply ordered by value, spaces behave as before.