### PR TITLE
Fix an error for `Style/AccessModifierDeclarations` cop

### DIFF
--- a/changelog/fix_an_error_for_style_access_modifier_declarations_with_modifier_if.md
+++ b/changelog/fix_an_error_for_style_access_modifier_declarations_with_modifier_if.md
@@ -1,0 +1,1 @@
+* [#15603](https://github.com/rubocop/rubocop/pull/15603): Fix an error for `Style/AccessModifierDeclarations` with `EnforcedStyle: inline` when an access modifier is the body of an `if` without an `else` branch. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -316,7 +316,7 @@ module RuboCop
         end
 
         def select_grouped_def_nodes(node)
-          node.right_siblings.take_while do |sibling|
+          node.right_siblings.compact.take_while do |sibling|
             !(sibling.send_type? && sibling.bare_access_modifier_declaration?)
           end.select(&:def_type?)
         end

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -719,6 +719,32 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
   context 'when `inline` is configured' do
     let(:cop_config) { { 'EnforcedStyle' => 'inline' } }
 
+    it 'does not register an offense when the access modifier is the body of a modifier `if`' do
+      expect_no_offenses(<<~RUBY)
+        class Test
+          private if condition
+          def foo; end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the access modifier is the body of an `if` without an `else`' do
+      expect_no_offenses(<<~RUBY)
+        class Test
+          if condition
+            private
+          end
+          def foo; end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when the access modifier is the body of a modifier `if` at the top level' do
+      expect_no_offenses(<<~RUBY)
+        private if condition
+      RUBY
+    end
+
     %w[private protected public module_function].each do |access_modifier|
       it "offends when #{access_modifier} is not inlined" do
         expect_offense(<<~RUBY, access_modifier: access_modifier)


### PR DESCRIPTION
An MRE:

```shell
bundle exec rubocop -d --stdin /dev/stdin --config <(cat <<'YAML'
AllCops: {DisabledByDefault: true}
Style/AccessModifierDeclarations: {Enabled: true, EnforcedStyle: inline}
YAML
) <<'RUBY'
private if x
RUBY
```

```
lib/rubocop/cop/style/access_modifier_declarations.rb:320:in 'block in RuboCop::Cop::Style::AccessModifierDeclarations#select_grouped_def_nodes': undefined method 'send_type?' for nil (NoMethodError)

            !(sibling.send_type? && sibling.bare_access_modifier_declaration?)
                     ^^^^^^^^^^^
	from lib/rubocop/cop/style/access_modifier_declarations.rb:319:in 'Array#take_while'
	from lib/rubocop/cop/style/access_modifier_declarations.rb:319:in 'RuboCop::Cop::Style::AccessModifierDeclarations#select_grouped_def_nodes'
	from lib/rubocop/cop/style/access_modifier_declarations.rb:244:in 'RuboCop::Cop::Style::AccessModifierDeclarations#offense?'
	from lib/rubocop/cop/style/access_modifier_declarations.rb:175:in 'RuboCop::Cop::Style::AccessModifierDeclarations#on_send'
	from lib/rubocop/cop/commissioner.rb:145:in 'Kernel#public_send'
```

Found by the `rubocop-nightly` tool.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
