### PR TITLE
Fix an error for `Style/ConstantVisibility` cop

### DIFF
--- a/changelog/fix_an_error_for_style_constant_visibility_with_a_splatted_20260825.md
+++ b/changelog/fix_an_error_for_style_constant_visibility_with_a_splatted_20260825.md
@@ -1,0 +1,1 @@
+* [#15604](https://github.com/rubocop/rubocop/pull/15604): Fix an error for `Style/ConstantVisibility` when a visibility declaration splats anything other than an array literal, e.g. `private_constant(*constants(false))`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/constant_visibility.rb
+++ b/lib/rubocop/cop/style/constant_visibility.rb
@@ -82,12 +82,16 @@ module RuboCop
           end
         end
 
-        # rubocop:disable-next Metrics/AbcSize
+        # rubocop:disable-next Metrics/AbcSize, Metrics/CyclomaticComplexity
         def visibility_declaration?(node)
           node.parent.each_child_node(:send).any? do |child|
             next false unless (arguments = visibility_declaration_for(child))
 
-            arguments = arguments.first.children.first.to_a if arguments.first&.splat_type?
+            if (splat = arguments.first)&.splat_type?
+              next true unless splat.children.first.array_type?
+
+              arguments = splat.children.first.children
+            end
             constant_values = arguments.map do |argument|
               # `respond_to?(:value)` is too broad: `int`/`float` nodes respond to it
               # but their value is a `Numeric`, which has no `to_sym` (e.g.

--- a/spec/rubocop/cop/style/constant_visibility_spec.rb
+++ b/spec/rubocop/cop/style/constant_visibility_spec.rb
@@ -159,6 +159,25 @@ RSpec.describe RuboCop::Cop::Style::ConstantVisibility, :config do
     RUBY
   end
 
+  it 'does not register an offense when splatting something other than an array literal' do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        BAR = 42
+        private_constant(*constants(false))
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a splatted array literal does not name the constant' do
+    expect_offense(<<~RUBY)
+      class Foo
+        BAR = 42
+        ^^^^^^^^ Explicitly make `BAR` public or private using either `#public_constant` or `#private_constant`.
+        private_constant(*%i[BAZ])
+      end
+    RUBY
+  end
+
   it 'does not register an offense in the top level scope' do
     expect_no_offenses(<<~RUBY)
       BAR = 42


### PR DESCRIPTION
An MRE:

```shell
bundle exec rubocop -d --stdin /dev/stdin --config <(cat <<'YAML'
AllCops: {DisabledByDefault: true}
Style/ConstantVisibility: {Enabled: true}
YAML
) <<'RUBY'
class Foo
  BAR = 1

  private_constant(*constants(false))
end
RUBY
```

```
An error occurred while Style/ConstantVisibility cop was inspecting /dev/stdin:2:2.
/lib/rubocop/cop/style/constant_visibility.rb:95:in 'block (2 levels) in RuboCop::Cop::Style::ConstantVisibility#visibility_declaration?': undefined method 'type?' for nil (NoMethodError)

              argument.value.to_sym if argument.type?(:sym, :str)
                                               ^^^^^^
	from /lib/rubocop/cop/style/constant_visibility.rb:91:in 'Array#map'
	from /lib/rubocop/cop/style/constant_visibility.rb:91:in 'block in RuboCop::Cop::Style::ConstantVisibility#visibility_declaration?'
```

Found by the `rubocop-nightly` tool.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
