### PR TITLE
[Fix #15131] Prefer direct bitwise predicate autocorrection

### DIFF
--- a/changelog/fix_prefer_direct_bitwise_predicate_autocorrection_20260825233433.md
+++ b/changelog/fix_prefer_direct_bitwise_predicate_autocorrection_20260825233433.md
@@ -1,0 +1,1 @@
+* [#15131](https://github.com/rubocop/rubocop/issues/15131): Prefer direct bitwise predicate autocorrection. ([@saidM][])

--- a/changelog/fix_prefer_direct_bitwise_predicate_autocorrection_20260825233433.md
+++ b/changelog/fix_prefer_direct_bitwise_predicate_autocorrection_20260825233433.md
@@ -1,1 +1,1 @@
-* [#15131](https://github.com/rubocop/rubocop/issues/15131): Prefer direct bitwise predicate autocorrection. ([@saidM][])
+* [#15131](https://github.com/rubocop/rubocop/issues/15131): Fix false negatives for unparenthesized bitwise operations and prevent conflicting `Style/NumericPredicate` autocorrections. ([@saidM][])

--- a/lib/rubocop/cop/style/bitwise_predicate.rb
+++ b/lib/rubocop/cop/style/bitwise_predicate.rb
@@ -66,16 +66,18 @@ module RuboCop
 
         # @!method bit_operation?(node)
         def_node_matcher :bit_operation?, <<~PATTERN
-          (begin
-            (send _ :& _))
+          {
+            (begin (send _ :& _))
+            (send _ :& _)
+          }
         PATTERN
 
         # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
-          return unless node.receiver&.begin_type?
+          return unless bit_operation?(node.receiver)
           return unless (preferred_method = preferred_method(node))
 
-          bit_operation = node.receiver.children.first
+          bit_operation = node.receiver.begin_type? ? node.receiver.children.first : node.receiver
           lhs, _operator, rhs = *bit_operation
 
           preferred = if preferred_method == 'allbits?' && lhs.source == node.first_argument.source

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -110,13 +110,9 @@ module RuboCop
         end
 
         def handled_by_bitwise_predicate?(node)
-          registry = processed_source.registry
-          bitwise_predicate = registry.find_by_cop_name('Style/BitwisePredicate')
-
           bitwise_predicate_candidate?(node) &&
-            bitwise_predicate &&
-            registry.enabled?(bitwise_predicate, config) &&
-            bitwise_predicate.support_target_ruby_version?(target_ruby_version)
+            config.for_cop('Style/BitwisePredicate').fetch('Enabled') &&
+            BitwisePredicate.support_target_ruby_version?(target_ruby_version)
         end
 
         def check(node)

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -90,6 +90,7 @@ module RuboCop
         def on_send(node)
           numeric, replacement = check(node)
           return unless numeric
+          return if handled_by_bitwise_predicate?(node)
 
           return if allowed_method_name?(node.method_name) ||
                     node.each_ancestor(:send, :any_block).any? do |ancestor|
@@ -106,6 +107,16 @@ module RuboCop
 
         def allowed_method_name?(name)
           allowed_method?(name) || matches_allowed_pattern?(name)
+        end
+
+        def handled_by_bitwise_predicate?(node)
+          registry = processed_source.registry
+          bitwise_predicate = registry.find_by_cop_name('Style/BitwisePredicate')
+
+          bitwise_predicate_candidate?(node) &&
+            bitwise_predicate &&
+            registry.enabled?(bitwise_predicate, config) &&
+            bitwise_predicate.support_target_ruby_version?(target_ruby_version)
         end
 
         def check(node)
@@ -178,6 +189,14 @@ module RuboCop
         # @!method inverted_comparison(node)
         def_node_matcher :inverted_comparison, <<~PATTERN
           (send (int 0) ${:== :> :<} [$(...) !gvar_type?])
+        PATTERN
+
+        # @!method bitwise_predicate_candidate?(node)
+        def_node_matcher :bitwise_predicate_candidate?, <<~PATTERN
+          {
+            (send {(begin (send _ :& _)) (send _ :& _)} {:positive? :zero?})
+            (send {(begin (send _ :& _)) (send _ :& _)} {:> :==} (int 0))
+          }
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/bitwise_predicate_spec.rb
+++ b/spec/rubocop/cop/style/bitwise_predicate_spec.rb
@@ -145,6 +145,17 @@ RSpec.describe RuboCop::Cop::Style::BitwisePredicate, :config do
         RUBY
       end
 
+      it 'registers an offense when the bitwise operation is not parenthesized' do
+        expect_offense(<<~RUBY)
+          variable & flags == 0
+          ^^^^^^^^^^^^^^^^^^^^^ Replace with `variable.nobits?(flags)` for comparison with bit flags.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          variable.nobits?(flags)
+        RUBY
+      end
+
       it 'does not register an offense when using `nobits?` method' do
         expect_no_offenses(<<~RUBY)
           variable.nobits?(flags)

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -33,6 +33,34 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         RUBY
       end
 
+      it 'registers an offense for a bitwise comparison' do
+        expect_offense(<<~RUBY)
+          stat.mode & 0o077 == 0
+          ^^^^^^^^^^^^^^^^^^^^^^ Use `(stat.mode & 0o077).zero?` instead of `stat.mode & 0o077 == 0`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          (stat.mode & 0o077).zero?
+        RUBY
+      end
+
+      context 'when `Style/BitwisePredicate` is enabled' do
+        let(:other_cops) { { 'Style/BitwisePredicate' => { 'Enabled' => true } } }
+
+        it 'does not register an offense for a bitwise comparison' do
+          expect_no_offenses('stat.mode & 0o077 == 0')
+        end
+
+        context 'when target Ruby is older than 2.5', :ruby24, unsupported_on: :prism do
+          it 'registers an offense for a bitwise comparison' do
+            expect_offense(<<~RUBY)
+              stat.mode & 0o077 == 0
+              ^^^^^^^^^^^^^^^^^^^^^^ Use `(stat.mode & 0o077).zero?` instead of `stat.mode & 0o077 == 0`.
+            RUBY
+          end
+        end
+      end
+
       it 'allows comparing against a global variable' do
         expect_no_offenses('$CHILD_STATUS == 0')
         expect_no_offenses('0 == $CHILD_STATUS')

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -33,19 +33,24 @@ RSpec.describe RuboCop::Cop::Style::NumericPredicate, :config do
         RUBY
       end
 
-      it 'registers an offense for a bitwise comparison' do
-        expect_offense(<<~RUBY)
-          stat.mode & 0o077 == 0
-          ^^^^^^^^^^^^^^^^^^^^^^ Use `(stat.mode & 0o077).zero?` instead of `stat.mode & 0o077 == 0`.
-        RUBY
+      context 'when `Style/BitwisePredicate` is disabled' do
+        let(:other_cops) { { 'Style/BitwisePredicate' => { 'Enabled' => false } } }
 
-        expect_correction(<<~RUBY)
-          (stat.mode & 0o077).zero?
-        RUBY
+        it 'registers an offense for a bitwise comparison' do
+          expect_offense(<<~RUBY)
+            stat.mode & 0o077 == 0
+            ^^^^^^^^^^^^^^^^^^^^^^ Use `(stat.mode & 0o077).zero?` instead of `stat.mode & 0o077 == 0`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            (stat.mode & 0o077).zero?
+          RUBY
+        end
       end
 
       context 'when `Style/BitwisePredicate` is enabled' do
         let(:other_cops) { { 'Style/BitwisePredicate' => { 'Enabled' => true } } }
+        let(:registry) { RuboCop::Cop::Registry.new([described_class]) }
 
         it 'does not register an offense for a bitwise comparison' do
           expect_no_offenses('stat.mode & 0o077 == 0')


### PR DESCRIPTION
This fixes #15131

When both `Style/NumericPredicate` and `Style/BitwisePredicate` are enabled, RuboCop currently applies an intermediate correction before suggesting the bitwise predicate. This change lets `Style/BitwisePredicate` handle the original expression directly and makes `Style/NumericPredicate` defer when the bitwise cop is available.

Added specs for parenthesized and unparenthesized expressions, as well as configurations where `Style/BitwisePredicate` is disabled or unsupported.

---

Before submitting the PR make sure the following are checked:

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote a clear commit message.
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
- [x] Added an entry (file) to the changelog folder.