### PR TITLE
[Fix #15607] Recognize `warn_indent` as a magic comment

### DIFF
--- a/changelog/change_recognize_warn_indent_as_a_magic_comment_20260826180418.md
+++ b/changelog/change_recognize_warn_indent_as_a_magic_comment_20260826180418.md
@@ -1,0 +1,1 @@
+* [#15607](https://github.com/rubocop/rubocop/issues/15607): Recognize `warn_indent` as a magic comment. This fixes a false positive for `Layout/EmptyLineAfterMagicComment` and makes `Lint/OrderedMagicComments` and `Style/MagicCommentFormat` aware of it. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -618,7 +618,7 @@ Layout/EmptyLineAfterMagicComment:
   StyleGuide: '#separate-magic-comments-from-code'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '1.90'
+  VersionChanged: '<<next>>'
   # The minimum number of empty lines required after the last magic comment. Set this
   # to `2` when using YARD, which otherwise treats the magic comments as documentation
   # for the first module or class in the file. `Layout/EmptyLines` has to be disabled
@@ -2289,7 +2289,7 @@ Lint/OrderedMagicComments:
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '0.53'
-  VersionChanged: '1.37'
+  VersionChanged: '<<next>>'
 
 Lint/OutOfRangeRegexpRef:
   Description: 'Checks for out of range reference for Regexp because it always returns nil.'
@@ -4752,6 +4752,7 @@ Style/MagicCommentFormat:
   Description: 'Use a consistent style for magic comments.'
   Enabled: pending
   VersionAdded: '1.35'
+  VersionChanged: '<<next>>'
   EnforcedStyle: snake_case
   SupportedStyles:
     # `snake` will enforce the magic comment is written

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -12,6 +12,7 @@ module RuboCop
       encoding: '(?:en)?coding',
       frozen_string_literal: 'frozen[_-]string[_-]literal',
       rbs_inline: 'rbs_inline',
+      warn_indent: 'warn[_-]indent',
       shareable_constant_value: 'shareable[_-]constant[_-]value',
       typed: 'typed'
     }.freeze
@@ -38,6 +39,7 @@ module RuboCop
       frozen_string_literal_specified? ||
         encoding_specified? ||
         rbs_inline_specified? ||
+        warn_indent_specified? ||
         shareable_constant_value_specified? ||
         typed_specified?
     end
@@ -77,6 +79,13 @@ module RuboCop
       specified?(frozen_string_literal)
     end
 
+    # Was a warn_indent specified?
+    #
+    # @return [Boolean]
+    def warn_indent_specified?
+      specified?(warn_indent)
+    end
+
     # Was a shareable_constant_value specified?
     #
     # @return [Boolean]
@@ -98,6 +107,13 @@ module RuboCop
       else
         setting
       end
+    end
+
+    # Expose the `warn_indent` value.
+    #
+    # @return [String] for warn_indent config
+    def warn_indent
+      extract_warn_indent
     end
 
     # Expose the `shareable_constant_value` value coerced to a boolean if possible.
@@ -216,6 +232,10 @@ module RuboCop
       # Emacs comments cannot specify RBS::inline behavior.
       def extract_rbs_inline_value; end
 
+      def extract_warn_indent
+        match(KEYWORDS[:warn_indent])
+      end
+
       def extract_shareable_constant_value
         match(KEYWORDS[:shareable_constant_value])
       end
@@ -257,6 +277,9 @@ module RuboCop
 
       # Vim comments cannot specify RBS::inline behavior.
       def extract_rbs_inline_value; end
+
+      # Vim comments cannot specify indentation warning behavior.
+      def warn_indent; end
 
       # Vim comments cannot specify shareable constant values behavior.
       def shareable_constant_value; end
@@ -314,6 +337,10 @@ module RuboCop
 
       def extract_rbs_inline_value
         extract(/\A\s*#\s*#{KEYWORDS[:rbs_inline]}:\s*#{TOKEN}\s*\z/io)
+      end
+
+      def extract_warn_indent
+        extract(/\A\s*#\s*#{KEYWORDS[:warn_indent]}:\s*#{TOKEN}\s*\z/io)
       end
 
       def extract_shareable_constant_value

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     RUBY
   end
 
+  it 'registers an offense when code that immediately follows `warn_indent` comment' do
+    expect_offense(<<~RUBY)
+      # warn_indent: true
+      class Foo; end
+      ^ Expected at least 1 empty line after magic comments; found 0.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # warn_indent: true
+
+      class Foo; end
+    RUBY
+  end
+
   it 'registers an offense for documentation immediately following comment' do
     expect_offense(<<~RUBY)
       # frozen_string_literal: true
@@ -100,6 +114,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment, :config do
     expect_no_offenses(<<~RUBY)
       # frozen_string_literal: true
       # encoding: utf-8
+
+      class Foo; end
+    RUBY
+  end
+
+  it 'accepts magic comment with `warn_indent`' do
+    expect_no_offenses(<<~RUBY)
+      # frozen_string_literal: true
+      # shareable_constant_value: literal
+      # warn_indent: true
 
       class Foo; end
     RUBY

--- a/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
+++ b/spec/rubocop/cop/lint/ordered_magic_comments_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe RuboCop::Cop::Lint::OrderedMagicComments, :config do
   end
 
   it 'registers an offense and corrects when an `encoding` magic comment does not precede ' \
+     'a `warn_indent` magic comment' do
+    expect_offense(<<~RUBY)
+      # warn_indent: true
+      # encoding: ascii
+      ^^^^^^^^^^^^^^^^^ The encoding magic comment should precede all other magic comments.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # encoding: ascii
+      # warn_indent: true
+    RUBY
+  end
+
+  it 'registers an offense and corrects when an `encoding` magic comment does not precede ' \
      'a `shareable_constant_value` magic comment' do
     expect_offense(<<~RUBY)
       # shareable_constant_value: literal

--- a/spec/rubocop/cop/style/magic_comment_format_spec.rb
+++ b/spec/rubocop/cop/style/magic_comment_format_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe RuboCop::Cop::Style::MagicCommentFormat, :config do
       RUBY
     end
 
+    it 'registers an offense for kebab case in `warn_indent`' do
+      expect_offense(<<~RUBY)
+        # warn-indent: true
+          ^^^^^^^^^^^ Prefer snake case for magic comments.
+
+        puts 1
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # warn_indent: true
+
+        puts 1
+      RUBY
+    end
+
     it 'registers an offense for kebab case in emacs style' do
       expect_offense(<<~RUBY)
         # -*- encoding: ASCII-8BIT; frozen-string-literal: true -*-

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RuboCop::MagicComment do
   shared_examples 'magic comment' do |comment, expectations = {}|
     encoding = expectations[:encoding]
     frozen_string = expectations[:frozen_string_literal]
+    warn_indent = expectations[:warn_indent]
     shareable_constant_value = expectations[:shareable_constant_value]
     typed = expectations[:typed]
 
@@ -13,6 +14,10 @@ RSpec.describe RuboCop::MagicComment do
 
     it "returns #{frozen_string.inspect} for frozen_string_literal when comment is #{comment}" do
       expect(described_class.parse(comment).frozen_string_literal).to eql(frozen_string)
+    end
+
+    it "returns #{warn_indent.inspect} for warn_indent when comment is #{comment}" do
+      expect(described_class.parse(comment).warn_indent).to eql(warn_indent)
     end
 
     it "returns #{shareable_constant_value.inspect} for shareable_constant_value " \
@@ -57,6 +62,11 @@ RSpec.describe RuboCop::MagicComment do
   it_behaves_like 'magic comment', '# FROZEN-STRING-LITERAL: true', frozen_string_literal: true
 
   it_behaves_like 'magic comment', '# fRoZeN-sTrInG_lItErAl: true', frozen_string_literal: true
+
+  it_behaves_like 'magic comment', '# warn_indent: true', warn_indent: 'true'
+  it_behaves_like 'magic comment', '# warn-indent: false', warn_indent: 'false'
+  it_behaves_like 'magic comment', '# WARN_INDENT: true', warn_indent: 'true'
+  it_behaves_like 'magic comment', '# -*- warn_indent: true -*-', warn_indent: 'true'
 
   it_behaves_like 'magic comment', '# shareable_constant_value: literal', shareable_constant_value: 'literal'
 
@@ -203,6 +213,12 @@ RSpec.describe RuboCop::MagicComment do
 
     context 'with a frozen string literal comment' do
       let(:comment) { '# frozen-string-literal: true' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with a warn indent comment' do
+      let(:comment) { '# warn-indent: true' }
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
`RuboCop::MagicComment` knew about `encoding`, `frozen_string_literal`, `shareable_constant_value` and the tool-level `rbs_inline` and `typed` sigils, but not `warn_indent`, even though Ruby honours it:

```console
$ printf 'def foo\n  if true\n   end\nend\n' | ruby -w -c
-:3: warning: mismatched indentations at 'end' with 'if' at 2

$ printf '# warn_indent: false\ndef foo\n  if true\n   end\nend\n' | ruby -w -c
Syntax OK
```

Because `MagicComment#any?` answered false for it, every magic-comment-aware cop treated it as an ordinary comment.
`Layout/EmptyLineAfterMagicComment` therefore took the comment before it as the last magic comment and demanded an empty line in front of the `warn_indent` line:

```ruby
# frozen_string_literal: true
# shareable_constant_value: literal
# warn_indent: true # was: Expected at least 1 empty line after magic comments
```

Recognizing the keyword changes what three cops report, so their `VersionChanged` is bumped:

- `Layout/EmptyLineAfterMagicComment` stops reporting the case above, and starts requiring an empty line when `warn_indent` is the last magic comment before code.
- `Lint/OrderedMagicComments` now requires the encoding comment to precede a `warn_indent` one.
- `Style/MagicCommentFormat` now normalizes `# warn-indent:` like the other directives, since its directive pattern is built from `MagicComment::KEYWORDS`.

`Lint/DuplicateMagicComment` is unaffected: it only tracks `encoding` and `frozen_string_literal` by design.

Fixes #15607.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
