### PR TITLE
Fix Style/EndlessMethod loop with Style/AmbiguousEndlessMethodDefinition

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260826.md
+++ b/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260826.md
@@ -1,0 +1,1 @@
+* [#15609](https://github.com/rubocop/rubocop/pull/15609): Fix an infinite loop between `Style/EndlessMethod` and `Style/AmbiguousEndlessMethodDefinition`. ([@Starlexxx][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -175,9 +175,7 @@ module RuboCop
             add_offense(node, message: MSG_MULTI_LINE) do |corrector|
               correct_to_multiline(corrector, node)
             end
-          elsif !node.endless? && can_be_made_endless?(node) && single_line_when_made_endless?(node)
-            return if too_long_when_made_endless?(node)
-
+          elsif convertible_to_endless?(node) && single_line_when_made_endless?(node)
             add_offense(node, message: MSG_REQUIRE_SINGLE) do |corrector|
               corrector.replace(node, endless_replacement(node))
             end
@@ -185,12 +183,16 @@ module RuboCop
         end
 
         def handle_require_always_style(node)
-          return if node.endless? || !can_be_made_endless?(node)
-          return if too_long_when_made_endless?(node)
+          return unless convertible_to_endless?(node)
 
           add_offense(node, message: MSG_REQUIRE_ALWAYS) do |corrector|
             corrector.replace(node, endless_replacement(node))
           end
+        end
+
+        def convertible_to_endless?(node)
+          !node.endless? && can_be_made_endless?(node) &&
+            !too_long_when_made_endless?(node) && !ambiguous_when_made_endless?(node)
         end
 
         def handle_disallow_style(node)
@@ -227,6 +229,31 @@ module RuboCop
         def single_line_when_made_endless?(node)
           !endless_replacement(node).include?("\n")
         end
+
+        def ambiguous_when_made_endless?(node)
+          lower_precedence_operation?(node.body) ||
+            ((operation = ambiguous_operation(node)) && lower_precedence_operation?(operation))
+        end
+
+        def lower_precedence_operation?(node)
+          case node.type
+          when :if, :while, :until
+            node.modifier_form?
+          when :and, :or
+            node.semantic_operator?
+          else
+            false
+          end
+        end
+
+        # @!method ambiguous_operation(node)
+        def_node_matcher :ambiguous_operation, <<~PATTERN
+          ^${
+            (if _ <any_def _>)
+            ({and or} any_def _)
+            ({while until} _ any_def)
+          }
+        PATTERN
 
         def too_long_when_made_endless?(node)
           return false unless config.cop_enabled?('Layout/LineLength')

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -397,6 +397,59 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'does not register an offense for a method with a modifier `if` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x if y
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method with a modifier `while` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x while y
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method with an `and` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x and y
+          end
+        RUBY
+      end
+
+      it 'registers an offense and corrects for a method with a `&&` body' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+            x && y
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = x && y
+        RUBY
+      end
+
+      it 'does not register an offense for a method definition with a modifier `if`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end if y
+        RUBY
+      end
+
+      it 'does not register an offense for a method definition followed by `and`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end and y
+        RUBY
+      end
+
       it 'registers an offense and corrects for a single line method with access modifier' do
         expect_offense(<<~RUBY)
           private def my_method
@@ -626,6 +679,30 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
 
         expect_correction(<<~RUBY)
           def my_method = x
+        RUBY
+      end
+
+      it 'does not register an offense for a method with a modifier `if` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x if y
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method with an `or` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x or y
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method definition with a modifier `unless`' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          end unless y
         RUBY
       end
 


### PR DESCRIPTION
With `EnforcedStyle: require_single_line` (or `require_always`), `Style/EndlessMethod` fights `Style/AmbiguousEndlessMethodDefinition` until RuboCop reports an infinite loop:

```ruby
def foo
  bar if baz
end
```

`Style/EndlessMethod` turns this into `def foo = bar if baz`, which actually parses as `(def foo = bar) if baz`, so the correction also changes what the code does. `Style/AmbiguousEndlessMethodDefinition` then rewrites it back, and the two keep going in circles. Same story when the definition itself has a modifier (`def foo ... end if baz`) or sits inside `and`/`or`.

Now the cop skips the conversion when the result would be one of those ambiguous forms. `&&`/`||` bodies still convert as before.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.