### PR TITLE
Fix `Lint/ArgumentMismatch` false positives for private methods

### DIFF
--- a/changelog/fix_lint_argument_mismatch_false_positives_for_private_methods_20260825182739.md
+++ b/changelog/fix_lint_argument_mismatch_false_positives_for_private_methods_20260825182739.md
@@ -1,0 +1,1 @@
+* [#15610](https://github.com/rubocop/rubocop/pull/15610): Fix `Lint/ArgumentMismatch` registering false positives for calls that resolve to a private method on `Object`, such as a bare `def` written at the top level of a DSL file. ([@HoneyryderChuck][])

--- a/lib/rubocop/cop/lint/argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/argument_mismatch.rb
@@ -77,9 +77,14 @@ module RuboCop
           nil
         end
 
+        # A call with an explicit receiver cannot reach a private method, so its
+        # signature says nothing about the call. This matters because `Object`
+        # closes the singleton ancestry of every constant, and a bare `def` at
+        # the top level of any file — what every block-based DSL produces — is a
+        # private instance method of `Object`.
         def singleton_signature_shape(declaration, method_name)
           member = indexed_singleton_member(declaration, "#{method_name}()")
-          return nil unless member
+          return nil unless member&.public?
 
           indexed_member_shape(member)
         end

--- a/spec/rubocop/cop/lint/argument_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/argument_mismatch_spec.rb
@@ -214,6 +214,44 @@ RSpec.describe RuboCop::Cop::Lint::ArgumentMismatch, :config do
       end
     end
 
+    context 'for a private method reached through `Object`' do
+      # A bare `def` at the top level of a file — the shape every block-based
+      # DSL produces — is a private instance method of `Object`, and `Object`
+      # closes the singleton ancestry of every constant in the project.
+      it 'does not register an offense for a constructor call' do
+        index_with_call(
+          'Report.new(source, :pdf)',
+          'file:///dsl.rb' => "def new\nend\n",
+          'file:///report.rb' => "class Report\n  def initialize(source, format); end\nend\n"
+        )
+
+        expect_no_offenses('Report.new(source, :pdf)', '/call.rb')
+      end
+
+      it 'does not register an offense for a call on a reopened namespace' do
+        index_with_call(
+          'Flipper.enable(:flag, actor)',
+          'file:///dsl.rb' => "def enable\nend\n",
+          'file:///flipper.rb' => "module Flipper\n  module Adapters; end\nend\n"
+        )
+
+        expect_no_offenses('Flipper.enable(:flag, actor)', '/call.rb')
+      end
+
+      it 'still registers an offense once the method is made public' do
+        index_with_call(
+          'Report.build(1)',
+          'file:///base.rb' => "class Base\n  def self.build(a, b); end\nend\n",
+          'file:///report.rb' => "class Report < Base\nend\n"
+        )
+
+        expect_offense(<<~RUBY, '/call.rb')
+          Report.build(1)
+                 ^^^^^ Wrong number of arguments to `build` (given 1, expected 2).
+        RUBY
+      end
+    end
+
     context 'with safe navigation' do
       it 'registers an offense on a safe-navigation call' do
         index_with_call('Report&.generate(source)', 'file:///report.rb' => <<~RUBY)


### PR DESCRIPTION
rubocop messes method definitions retrieved from dsl-like files which are supposed to be scoped to the instance they're evaluated in the context of, attributing them to Object, and escalating them to all of those calls, generating tons or false offenses.

This surfaced in a large rails application using admin, where the pattern below redefined `Object.new`:

```ruby
controller do
  new do
    # bam, there goes Object.new out the window

  enable do
    # bam, Object.enable is now assumed, and this messes our use of
    # the Flipper gem, which defines Flipper.enable(flag, etc, etc)
```

I'll leave and trim some of the slop comments from claude below, as they're also useful context.

-----

A call written with an explicit receiver cannot reach a private method, but the cop accepted whatever `indexed_singleton_member` returned and compared the call against its arity.

That matters more than it sounds, because `Object` closes the singleton ancestry of every constant in a project, and a bare `def` at the top level of a file is a private instance method of `Object`. Every block-based DSL produces that shape — an ActiveAdmin `controller do ... def new ... end end` block, a Rake file, a `.gemspec`. One `def new` anywhere in the project is enough to make every `Foo.new(args)` in it resolve to that method instead of `Foo#initialize` and report `expected 0`; one `def enable` does the same to every `Flipper.enable(flag, actor)`.

Skip the member unless it is public. The shared `indexed_singleton_member` helper deliberately stays visibility-agnostic: `Lint/NameTypo` asks it whether a name exists at all, and a private method still answers that question.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
