### PR TITLE
Fix `Lint/ArgumentMismatch` false positives for constructor calls

### DIFF
--- a/changelog/fix_lint_argument_mismatch_false_positives_for_constructor_calls_20260825183015.md
+++ b/changelog/fix_lint_argument_mismatch_false_positives_for_constructor_calls_20260825183015.md
@@ -1,0 +1,1 @@
+* [#15611](https://github.com/rubocop/rubocop/pull/15611): Fix `Lint/ArgumentMismatch` registering false positives for `Foo.new` calls, which are documented as out of scope but were checked against whichever `new` the project index could reach. ([@HoneyryderChuck][])

--- a/lib/rubocop/cop/lint/argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/argument_mismatch.rb
@@ -21,7 +21,9 @@ module RuboCop
       #
       # Constructor calls (`Foo.new`) and keyword-argument validation are out of
       # scope: only positional arity of explicitly defined singleton methods is
-      # checked.
+      # checked. `new` is skipped outright, because `Class#new` is not in the
+      # index: any `new` the index does find sits below it in the method
+      # resolution order, where Ruby would never reach it.
       #
       # @example
       #   # Given the project defines:
@@ -45,8 +47,7 @@ module RuboCop
         MSG = 'Wrong number of arguments to `%<method>s` (given %<given>d, expected %<expected>s).'
 
         def on_send(node)
-          return unless project_index
-          return unless node.receiver&.const_type?
+          return unless checkable_call?(node)
 
           shape = resolved_signature_shape(node)
           return unless shape
@@ -60,6 +61,10 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def checkable_call?(node)
+          project_index && node.receiver&.const_type? && !node.method?(:new)
+        end
 
         def message(node, given, min, max)
           format(MSG, method: node.method_name, given: given, expected: expected_range(min, max))

--- a/spec/rubocop/cop/lint/argument_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/argument_mismatch_spec.rb
@@ -252,6 +252,31 @@ RSpec.describe RuboCop::Cop::Lint::ArgumentMismatch, :config do
       end
     end
 
+    context 'for a constructor call' do
+      # `Report.new` dispatches through `Class#new`, which the index does not
+      # carry. Every `new` it can find is further down the singleton ancestry,
+      # past where Ruby stops looking.
+      it 'does not register an offense against an `Object` method named `new`' do
+        index_with_call(
+          'Report.new(source, :pdf)',
+          'file:///core_ext.rb' => "class Object\n  def new(template); end\nend\n",
+          'file:///report.rb' => "class Report\n  def initialize(source, format); end\nend\n"
+        )
+
+        expect_no_offenses('Report.new(source, :pdf)', '/call.rb')
+      end
+
+      it 'does not register an offense against the constructor itself' do
+        index_with_call('Report.new(source)', 'file:///report.rb' => <<~RUBY)
+          class Report
+            def initialize(source, format); end
+          end
+        RUBY
+
+        expect_no_offenses('Report.new(source)', '/call.rb')
+      end
+    end
+
     context 'with safe navigation' do
       it 'registers an offense on a safe-navigation call' do
         index_with_call('Report&.generate(source)', 'file:///report.rb' => <<~RUBY)


### PR DESCRIPTION
`Class.new` ain't indexed, but redefinitions of `SomeClass.new` still try to lookup for the definition. this skips it.

--------------------

The cop documents constructor calls as out of scope — it never compares a `Foo.new(...)` call against `Foo#initialize` — but nothing implemented that. `new` went through the same singleton lookup as any other method, so the call was checked against whatever `new` the index happened to reach.

Whatever it reaches is always the wrong answer. `Class#new` is what `Foo.new` actually dispatches to, and it is not in the index; `Class` and `Module` are present as empty shells. Lookup therefore falls past the point where Ruby stops and lands on `Object`'s instance methods, which sit further down the singleton ancestry. A project that defines `Object#new` for its own purposes turned every `Foo.new(a, b)` in the codebase into an offense measured against that method's arity.

Skip `new` outright.

This is independent of the private-method fix: the method found here can be perfectly public and still be unreachable, because `Class#new` shadows it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
