### PR TITLE
Fix Naming/BlockForwarding autocorrect clash with Style/MethodDefParentheses

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_naming_block_forwarding_20260826.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_naming_block_forwarding_20260826.md
@@ -1,0 +1,1 @@
+* [#15612](https://github.com/rubocop/rubocop/pull/15612): Fix an incorrect autocorrect for `Naming/BlockForwarding` with `Style/MethodDefParentheses`. ([@Starlexxx][])

--- a/lib/rubocop/cop/naming/block_forwarding.rb
+++ b/lib/rubocop/cop/naming/block_forwarding.rb
@@ -62,7 +62,10 @@ module RuboCop
         MSG = 'Use %<style>s block forwarding.'
 
         def self.autocorrect_incompatible_with
-          [Lint::AmbiguousOperator, Style::ArgumentsForwarding, Style::ExplicitBlockArgument]
+          [
+            Lint::AmbiguousOperator, Style::ArgumentsForwarding,
+            Style::ExplicitBlockArgument, Style::MethodDefParentheses
+          ]
         end
 
         def on_def(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -656,6 +656,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Naming/BlockForwarding` with `Style/MethodDefParentheses`' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.2
+    YAML
+    source = <<~RUBY
+      def foo &block
+        bar(&block)
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Naming/BlockForwarding,Style/MethodDefParentheses'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo(&)
+        bar(&)
+      end
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: explicit` of `Naming/BlockForwarding` with `Style/ArgumentsForwarding`' do
     create_file('.rubocop.yml', <<~YAML)
       AllCops:


### PR DESCRIPTION
Running both cops on a parenless def produces unparseable code:

```ruby
def each &block
  foo(&block)
end
```

becomes

```ruby
def each(&))
  foo(&)
end
```

Both cops add parentheses around the arguments in the same pass, and the two `)` insertions at the same position stack up. Adding `Style/MethodDefParentheses` to `autocorrect_incompatible_with` defers it to the next pass, where the parentheses already exist.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.