### PR TITLE
Fix an error for `Layout/HashAlignment` cop

### DIFF
--- a/changelog/fix_an_error_for_layout_hash_alignment_when_a_value_starts_below_its_key_20260827121350.md
+++ b/changelog/fix_an_error_for_layout_hash_alignment_when_a_value_starts_below_its_key_20260827121350.md
@@ -1,0 +1,1 @@
+* [#15613](https://github.com/rubocop/rubocop/pull/15613): Fix an error for `Layout/HashAlignment` when a hash value starts on the line below its key. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/hash_alignment_styles.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment_styles.rb
@@ -55,7 +55,8 @@ module RuboCop
       # Common functionality for checking alignment of hash values.
       module ValueAlignment
         def checkable_layout?(node)
-          !node.pairs_on_same_line? && !node.mixed_delimiters?
+          !node.pairs_on_same_line? && !node.mixed_delimiters? &&
+            node.pairs.none? { |pair| value_on_later_line?(pair) }
         end
 
         def deltas(first_pair, current_pair)
@@ -67,6 +68,10 @@ module RuboCop
         end
 
         private
+
+        def value_on_later_line?(pair)
+          pair.value && pair.key.last_line != pair.value.first_line
+        end
 
         def separator_delta(first_pair, current_pair, key_delta)
           if current_pair.hash_rocket?

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -827,6 +827,45 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
 
   it_behaves_like 'not on separate lines'
 
+  context 'when a value starts on the line below its key' do
+    let(:cop_config) do
+      {
+        'EnforcedHashRocketStyle' => 'separator',
+        'EnforcedColonStyle' => 'separator',
+        'EnforcedLastArgumentHashStyle' => 'always_inspect'
+      }
+    end
+
+    it 'does not register an offense for a hash rocket pair' do
+      expect_no_offenses(<<~RUBY)
+        f("aaaa" =>
+             foo,
+          "b" => 2)
+      RUBY
+    end
+
+    it 'does not register an offense for a colon pair' do
+      expect_no_offenses(<<~RUBY)
+        f(aaaa:
+             foo,
+          b: 2)
+      RUBY
+    end
+
+    it 'still checks a hash whose values all start on their key\'s line' do
+      expect_offense(<<~RUBY)
+        f("aaaa" => foo,
+          "b" => 2)
+          ^^^^^^^^ Align the separators of a hash literal if they span more than one line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f("aaaa" => foo,
+             "b" => 2)
+      RUBY
+    end
+  end
+
   context 'with table alignment configuration' do
     let(:cop_config) do
       {


### PR DESCRIPTION
An MRE (syntax curruption):

```shell
$ bundle exec rubocop --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/HashAlignment:
  Enabled: true
  EnforcedHashRocketStyle: separator
  EnforcedColonStyle: separator
YAML
) <<'RUBY'
Config.new("A" =>
           foo,
           "B" => 2)
RUBY

====================
Config.new("A" =>
           foo,
           2)

```

An MRE (error):

```shell
$ bundle exec rubocop --stdin /dev/stdin --raise-cop-error --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/HashAlignment:
  Enabled: true
  EnforcedHashRocketStyle: separator
  EnforcedColonStyle: separator
YAML
) <<'RUBY'
f("aaaa" =>
     foo,
  "b" => 2)
RUBY
Inspecting 1 file

0 files inspected, no offenses detected
Error: cause: #<Parser::ClobberingError: Parser::Source::TreeRewriter detected clobbering>
```

Found by `rubocop-nightly`.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
