### PR TITLE
Fix Layout/ArgumentAlignment loop with Layout/HashAlignment separator style

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_argument_alignment_20260827.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_argument_alignment_20260827.md
@@ -1,0 +1,1 @@
+* [#15614](https://github.com/rubocop/rubocop/pull/15614): Fix an infinite loop between `Layout/ArgumentAlignment` and `Layout/HashAlignment` with separator style. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/argument_alignment.rb
+++ b/lib/rubocop/cop/layout/argument_alignment.rb
@@ -81,6 +81,8 @@ module RuboCop
           last_arg = node.last_argument
 
           if last_arg.hash_type? && !last_arg.braces?
+            return items if enforce_hash_argument_with_separator?
+
             items += last_arg.pairs
           else
             items << last_arg

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2532,6 +2532,32 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
   end
 
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
+     '`EnforcedColonStyle: separator` of `Layout/HashAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      validates :foo,
+                bar: 1,
+                bazqux: 2
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArgumentAlignment:
+        EnforcedStyle: with_fixed_indentation
+      Layout/HashAlignment:
+        EnforcedColonStyle: separator
+    YAML
+
+    expect(
+      cli.run(['--autocorrect', '--only', 'Layout/ArgumentAlignment,Layout/HashAlignment'])
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      validates :foo,
+                bar: 1,
+             bazqux: 2
+    RUBY
+  end
+
+  it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
     create_file('example.rb', <<~RUBY)
       do_something(

--- a/spec/rubocop/cop/layout/argument_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/argument_alignment_spec.rb
@@ -442,6 +442,37 @@ RSpec.describe RuboCop::Cop::Layout::ArgumentAlignment, :config do
       RUBY
     end
 
+    context 'when `Layout/HashAlignment` is set to `EnforcedColonStyle: separator`' do
+      let(:config) do
+        RuboCop::Config.new('Layout/ArgumentAlignment' => cop_config,
+                            'Layout/HashAlignment' => {
+                              'Enabled' => true, 'EnforcedColonStyle' => 'separator'
+                            },
+                            'Layout/IndentationWidth' => { 'Width' => indentation_width })
+      end
+
+      it 'does not register an offense for a separator-aligned hash argument' do
+        expect_no_offenses(<<~RUBY)
+          validates :foo,
+                    bar: 1,
+                 bazqux: 2
+        RUBY
+      end
+
+      it 'registers an offense and corrects misindented non-hash arguments' do
+        expect_offense(<<~RUBY)
+          func(:foo,
+               :bar)
+               ^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          func(:foo,
+            :bar)
+        RUBY
+      end
+    end
+
     it 'registers an offense and corrects when missed indentation kwargs' do
       expect_offense(<<~RUBY)
         func1(foo: 'foo',


### PR DESCRIPTION
`EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` together with `EnforcedColonStyle: separator` (or `EnforcedHashRocketStyle: separator`) of `Layout/HashAlignment` ends in an infinite loop:

```ruby
validates :foo,
          bar: 1,
          bazqux: 2
```

```
Infinite loop detected ... caused by Layout/HashAlignment -> Layout/ArgumentAlignment, Layout/HashAlignment
```

`ArgumentAlignment` flattens the pairs of a braceless hash argument and pins every line to fixed indentation, while separator alignment needs a ragged left edge. The cops keep undoing each other.

`with_first_argument` already defers to separator alignment via `autocorrect_incompatible_with_other_cops?`. This does the same for `with_fixed_indentation`, but narrower: the braceless hash argument is left to `Layout/HashAlignment`, other arguments are still checked.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.