### PR TITLE
Fix Layout/ExtraSpacing loop with Layout/SpaceAroundOperators

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_extra_spacing_20260828.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_extra_spacing_20260828.md
@@ -1,0 +1,1 @@
+* [#15617](https://github.com/rubocop/rubocop/pull/15617): Fix an infinite loop between `Layout/ExtraSpacing` with `ForceEqualSignAlignment` and `Layout/SpaceAroundOperators`. ([@Starlexxx][])

--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -182,7 +182,18 @@ module RuboCop
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength
       def relevant_assignment_lines(line_range)
-        relevant_lines(line_range) { |line_number| assignment_lines.include?(line_number) }
+        relevant_lines(line_range, interrupting_operator_lines) do |line_number|
+          assignment_lines.include?(line_number)
+        end
+      end
+
+      def interrupting_operator_lines
+        @interrupting_operator_lines ||=
+          processed_source.tokens.each_with_object(Set.new) do |token, lines|
+            next unless ASSIGNMENT_OR_COMPARISON_TOKENS.include?(token.type)
+
+            lines << token.line unless assignment_lines.include?(token.line)
+          end
       end
 
       def alignment_lines(line_number)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2531,6 +2531,30 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `ForceEqualSignAlignment: true` of `Layout/ExtraSpacing` and ' \
+     '`Layout/SpaceAroundOperators`' do
+    create_file('example.rb', <<~RUBY)
+      aaaa = b
+      e << f
+      g += h
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ExtraSpacing:
+        ForceEqualSignAlignment: true
+    YAML
+
+    expect(
+      cli.run(['--autocorrect', '--only', 'Layout/ExtraSpacing,Layout/SpaceAroundOperators'])
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      aaaa = b
+      e << f
+      g += h
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -685,6 +685,23 @@ RSpec.describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       RUBY
     end
 
+    it 'does not register an offense when assignments are separated by a line ' \
+       'with another alignable operator' do
+      expect_no_offenses(<<~RUBY)
+        aaaa = b
+        e << f
+        g += h
+      RUBY
+    end
+
+    it 'does not register an offense when assignments are separated by a comparison' do
+      expect_no_offenses(<<~RUBY)
+        aaaa = b
+        raise if e == f
+        g += h
+      RUBY
+    end
+
     it 'registers an offense and corrects consecutive assignments that are not aligned' do
       expect_offense(<<~RUBY)
         a = 1


### PR DESCRIPTION
With `ForceEqualSignAlignment: true`, `Layout/ExtraSpacing` fights `Layout/SpaceAroundOperators` until RuboCop reports an infinite loop:

```ruby
aaaa = b
e << f
g += h
```

`ExtraSpacing` groups the assignments on lines 1 and 3, skipping the `<<` line, and pushes `+=` under the `=` column. `SpaceAroundOperators` only accepts alignment with the nearest line, sees the `<<` at a different column there, and strips the spaces back. Round and round.

Now a line with an alignable operator (`<<`, `==`, etc.) that is not itself an assignment ends the alignment group, so the two cops agree.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.