### PR TITLE
Fix Style/ParenthesesAroundCondition loop with Lint/AssignmentInCondition

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_style_parentheses_around_condition_20260828.md
+++ b/changelog/fix_an_infinite_loop_error_for_style_parentheses_around_condition_20260828.md
@@ -1,0 +1,1 @@
+* [#15618](https://github.com/rubocop/rubocop/pull/15618): Fix an infinite loop between `Style/ParenthesesAroundCondition` with `AllowSafeAssignment: false` and `Lint/AssignmentInCondition`. ([@Starlexxx][])

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -123,8 +123,13 @@ module RuboCop
 
         def parens_allowed?(node)
           parens_required?(node) ||
-            (safe_assignment?(node) && safe_assignment_allowed?) ||
+            (safe_assignment?(node) && safe_assignment_kept?) ||
             (node.multiline? && allow_multiline_conditions?)
+        end
+
+        def safe_assignment_kept?
+          safe_assignment_allowed? ||
+            config.for_enabled_cop('Lint/AssignmentInCondition')['AllowSafeAssignment']
         end
 
         def allow_multiline_conditions?

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2639,6 +2639,32 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `AllowSafeAssignment: false` of `Style/ParenthesesAroundCondition` and ' \
+     '`Lint/AssignmentInCondition`' do
+    create_file('example.rb', <<~RUBY)
+      if (a = b)
+        c
+      end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Style/ParenthesesAroundCondition:
+        AllowSafeAssignment: false
+    YAML
+
+    expect(
+      cli.run(
+        ['--autocorrect', '--only', 'Style/ParenthesesAroundCondition,Lint/AssignmentInCondition']
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      if (a = b)
+        c
+      end
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -255,6 +255,35 @@ RSpec.describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
         end
       RUBY
     end
+
+    context 'when `Lint/AssignmentInCondition` allows safe assignment' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Style/ParenthesesAroundCondition' => cop_config,
+          'Lint/AssignmentInCondition' => { 'Enabled' => true, 'AllowSafeAssignment' => true }
+        )
+      end
+
+      it 'accepts variable assignment in condition surrounded with parentheses' do
+        expect_no_offenses(<<~RUBY)
+          if (test = 10)
+          end
+        RUBY
+      end
+
+      it 'does not accept parentheses around a non-assignment condition' do
+        expect_offense(<<~RUBY)
+          if (test == 10)
+             ^^^^^^^^^^^^ Don't use parentheses around the condition of an `if`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          if test == 10
+          end
+        RUBY
+      end
+    end
   end
 
   context 'parentheses in multiline conditions are allowed' do


### PR DESCRIPTION
With `AllowSafeAssignment: false` on `Style/ParenthesesAroundCondition`, the two cops fight until RuboCop reports an infinite loop:

```ruby
if (a = b)
  c
end
```

```
Infinite loop detected ... caused by Style/ParenthesesAroundCondition -> Lint/AssignmentInCondition
```

The style cop strips the parentheses, then `Lint/AssignmentInCondition` (whose own `AllowSafeAssignment` defaults to true) wraps the assignment right back.

Now `Style/ParenthesesAroundCondition` keeps the parentheses around a safe assignment when an enabled `Lint/AssignmentInCondition` allows safe assignment, so the lint cop wins. With `AllowSafeAssignment: false` on both cops the previous behavior is unchanged.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.