### PR TITLE
Fix Layout/LineLength SplitStrings loop on trailing-space split point

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_line_length_20260828.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_line_length_20260828.md
@@ -1,0 +1,1 @@
+* [#15619](https://github.com/rubocop/rubocop/pull/15619): Fix an infinite loop for `Layout/LineLength` with `SplitStrings: true` when the split point lands on a trailing space. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/line_length.rb
+++ b/lib/rubocop/cop/layout/line_length.rb
@@ -104,6 +104,11 @@ module RuboCop
         alias on_defs on_def
 
         def on_new_investigation
+          @breakable_range_by_line_index = {}
+          @breakable_string_delimiters = {}
+          @endless_methods_by_line = {}
+          @heredocs = nil
+
           return unless processed_source.raw_source.include?(';')
 
           check_for_breakable_semicolons(processed_source)
@@ -288,7 +293,7 @@ module RuboCop
           source_range = node.source_range
           relevant_substr = largest_possible_string(node)
 
-          if (space_pos = relevant_substr.rindex(/\s/))
+          if (space_pos = breakable_space_position(node, relevant_substr))
             source_range.resize(space_pos + 1)
           elsif (escape_pos = relevant_substr.rindex(/\\(u[\da-f]{0,4}|x[\da-f]{0,2})?\z/))
             source_range.resize(escape_pos)
@@ -298,6 +303,19 @@ module RuboCop
 
             source_range.adjust(end_pos: adjustment)
           end
+        end
+
+        def breakable_space_position(node, substr)
+          limit = string_content_length(node) - 1
+          space_pos = substr.rindex(/\s/)
+          space_pos = substr[0, limit].rindex(/\s/) if space_pos && space_pos + 1 > limit
+          space_pos
+        end
+
+        def string_content_length(node)
+          content_end = node.loc?(:end) ? node.loc.end.begin_pos : node.source_range.end_pos
+
+          content_end - node.source_range.begin_pos
         end
 
         def breakable_dstr_begin_position(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2749,6 +2749,34 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects long lines with a trailing-space split point when specifying `SplitStrings: true` of ' \
+     '`Layout/LineLength` with `Layout/LineEndStringConcatenationIndentation` and ' \
+     '`Style/StringLiterals`' do
+    create_file('example.rb', <<~'RUBY')
+      foo("aaaaaaaaaaaaaaaaaaaaaaaa#{b} cc dd " \
+          "ee")
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/LineLength:
+        Max: 40
+        SplitStrings: true
+    YAML
+
+    expect(
+      cli.run(
+        ['--autocorrect', '--only',
+         'Layout/LineLength,Layout/LineEndStringConcatenationIndentation,Style/StringLiterals']
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~'RUBY')
+      foo("aaaaaaaaaaaaaaaaaaaaaaaa#{b} cc " \
+          'dd ' \
+          'ee')
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -891,6 +891,22 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             end
           end
 
+          context 'when the last space is at the end of the string content' do
+            it 'breaks the string at the previous space' do
+              expect_offense(<<~'RUBY')
+                foo("aaaaaaaaaaaaaaaaaaaaaaaaa#{b} cc dd " \
+                                                        ^^^^ Line is too long. [44/40]
+                    "ee")
+              RUBY
+
+              expect_correction(<<~'RUBY')
+                foo("aaaaaaaaaaaaaaaaaaaaaaaaa#{b} cc " \
+                "dd " \
+                    "ee")
+              RUBY
+            end
+          end
+
           context 'when there is already a continuation' do
             it 'breaks the string at the limit' do
               expect_offense(<<~'RUBY')


### PR DESCRIPTION
With `SplitStrings: true`, `Layout/LineLength` loops forever when the chosen split point is the trailing space of the string content:

```ruby
foo("aaaaaaaaaaaaaaaaaaaaaaaa#{b} cc dd " \
    "ee")
```

The break lands after the last space, the remainder is empty, and every pass inserts another `"" \` fragment without ever shortening the line. Together with `Layout/LineEndStringConcatenationIndentation` and `Style/StringLiterals` reshuffling the fragments this shows up as an infinite loop.

Two changes:

- When the last space would leave an empty remainder, break at the previous space instead, so every split makes progress.
- Reset the cop's per-investigation caches (`@breakable_range_by_line_index` etc.) in `on_new_investigation` — they leaked between investigations of the same cop instance, which the new spec exposed as a "Correction target buffer is not current" error.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.