### PR TITLE
Index Ruby core and stdlib RBS signatures

### DIFF
--- a/changelog/fix_index_ruby_core_and_stdlib_rbs_signatures_20260827143000.md
+++ b/changelog/fix_index_ruby_core_and_stdlib_rbs_signatures_20260827143000.md
@@ -1,0 +1,1 @@
+* [#15620](https://github.com/rubocop/rubocop/pull/15620): Fix the project index missing Ruby's core and standard library definitions, which made index-backed cops resolve names past where Ruby stops looking. ([@HoneyryderChuck][])

--- a/docs/modules/ROOT/pages/usage/project_index.adoc
+++ b/docs/modules/ROOT/pages/usage/project_index.adoc
@@ -34,6 +34,23 @@ its standard file-local behavior.
 The integration requires Ruby 3.2 or later. On Ruby 3.1 and older, `AllCops/UseProjectIndex`
 has no effect even if set to `true`.
 
+=== Core and standard library definitions
+
+The index always includes the RBS signature files of Ruby's core and standard library,
+taken from the newest `rbs` gem installed on the system (`rbs` does not have to be part of
+the bundle). Without them the index knows that `Object`, `Module` and `Class` exist but not
+what they define, so it cannot tell an unknown name from a core one: `Foo.new` would find no
+`Class#new` and keep walking into `Object`'s instance methods, where any top-level `def new`
+in the project would answer the lookup. When no `rbs` installation can be found, indexing
+proceeds without them.
+
+A signature declares a method or a constant, it does not define one, so cops that report a
+definition living in another file (`Lint/DuplicateMethods`, `Lint/ConstantReassignment`)
+never point at an `.rbs` file: monkey patching a core method is not a duplicate definition.
+For the same reason `Lint/NameTypo` does not spell-check against a namespace it only knows
+through signatures - they are curated rather than derived, so a name missing from them is
+not evidence of a typo.
+
 === Indexing gem sources
 
 By default the index covers only the project's own files, so ancestry chains and members

--- a/lib/rubocop/cop/lint/argument_mismatch.rb
+++ b/lib/rubocop/cop/lint/argument_mismatch.rb
@@ -84,7 +84,8 @@ module RuboCop
         # private instance method of `Object`.
         def singleton_signature_shape(declaration, method_name)
           member = indexed_singleton_member(declaration, "#{method_name}()")
-          return nil unless member&.public?
+          return nil unless member
+          return nil if member.private?
 
           indexed_member_shape(member)
         end

--- a/lib/rubocop/cop/lint/missing_super.rb
+++ b/lib/rubocop/cop/lint/missing_super.rb
@@ -166,9 +166,13 @@ module RuboCop
 
         # With the project index, the offense is skipped when the class' whole ancestry
         # is resolvable and none of the inherited ancestors defines `initialize` —
-        # `super` would only reach the no-op `Object#initialize`. An unresolvable
+        # `super` would only reach the no-op `BasicObject#initialize`. An unresolvable
         # superclass or mixin anywhere in the chain (e.g. a class from a gem) means
         # the ancestry cannot be verified and the offense is kept.
+        #
+        # The stateless roots are excluded from that scan: they are the ancestors whose
+        # `initialize` is the no-op `super` reaches anyway, and once Ruby's core
+        # signatures are part of the index `BasicObject` does declare one.
         def index_verified_stateless_ancestry?(class_node)
           return false unless project_index
 
@@ -176,7 +180,9 @@ module RuboCop
           return false unless declaration.is_a?(Rubydex::Class)
 
           ancestors = declaration.ancestors.to_a
-          inherited = ancestors.reject { |ancestor| ancestor.name == declaration.name }
+          inherited = ancestors.reject do |ancestor|
+            ancestor.name == declaration.name || STATELESS_CLASSES.include?(ancestor.name)
+          end
           return false if inherited.any? { |ancestor| ancestor.member('initialize()') }
 
           # `extend` affects the singleton class and cannot introduce an

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -149,11 +149,25 @@ module RuboCop
 
         # Whether the index can be trusted to list everything the namespace
         # defines. A name missing from an incomplete member list is not
-        # evidence of a typo, so both gaps have to be ruled out first:
+        # evidence of a typo, so every gap has to be ruled out first:
         # an ancestor that does not resolve may contribute the name, and so
-        # may a gem that reopens the namespace.
+        # may a gem that reopens the namespace or an RBS signature that does
+        # not declare all of it.
         def complete_index_members?(declaration)
-          fully_resolved_index_ancestry?(declaration) && !gem_owned_namespace?(declaration)
+          fully_resolved_index_ancestry?(declaration) &&
+            !gem_owned_namespace?(declaration) &&
+            !signature_only_namespace?(declaration)
+        end
+
+        # Whether everything the index knows about the namespace comes from RBS
+        # signatures (or Rubydex's built-in stubs) rather than from Ruby source.
+        # Ruby's core and standard library reach the index that way, and those
+        # signatures are curated rather than derived: they lag the implementation
+        # (`Net::HTTPClientException` is missing while its deprecated alias
+        # `HTTPServerException` is declared) and cannot show what a gem adds to a
+        # stdlib namespace at runtime.
+        def signature_only_namespace?(declaration)
+          declaration.definitions.none? { |definition| ruby_definition?(definition) }
         end
 
         # Whether the namespace's root segment names a gem in the bundle,
@@ -205,8 +219,7 @@ module RuboCop
           declaration = resolve_constant_in_index(node.receiver)
           return nil unless declaration.is_a?(Rubydex::Namespace)
           return nil if responds_in_index?(declaration, node.method_name.to_s, base)
-          return nil unless fully_resolved_index_ancestry?(declaration)
-          return nil if gem_owned_namespace?(declaration)
+          return nil unless complete_index_members?(declaration)
 
           declaration
         end

--- a/lib/rubocop/cop/mixin/project_index_help.rb
+++ b/lib/rubocop/cop/mixin/project_index_help.rb
@@ -13,6 +13,7 @@ module RuboCop
     module ProjectIndexHelp
       BUILTIN_DOCUMENT_URI = 'rubydex:built-in'
       FILE_URI_PREFIX = 'file://'
+      SIGNATURE_EXTENSION = '.rbs'
       # Matches the spurious leading slash before a Windows drive letter that
       # remains after stripping `file://` from a `file:///C:/...` URI.
       WINDOWS_DRIVE_PREFIX = %r{\A/(?=[A-Za-z]:[/\\])}.freeze
@@ -35,19 +36,31 @@ module RuboCop
 
       private
 
-      # Returns the definitions among `definitions` that live in a file other than the
-      # one being inspected, ordered by path and line. Definitions without a `file://`
-      # URI (e.g. Rubydex's built-in declarations) are ignored.
+      # Returns the definitions among `definitions` that live in a Ruby file other than
+      # the one being inspected, ordered by path and line.
       def definitions_in_other_files(definitions)
         current = processed_source.file_path
 
         definitions
-          .select { |definition| definition.location.uri.start_with?(FILE_URI_PREFIX) }
+          .select { |definition| ruby_definition?(definition) }
           .reject { |definition| File.identical?(definition.location.to_file_path, current) }
           .sort_by do |definition|
           [definition.location.to_file_path,
            definition.location.start_line]
         end
+      end
+
+      # Whether the definition comes from Ruby source, as opposed to an RBS signature
+      # file or one of Rubydex's built-in declarations. A signature declares a method or
+      # a constant, it does not define one, so an implementation and its `.rbs`
+      # declaration are not two definitions of the same thing. Ruby's core and standard
+      # library reach the index as the signature files of the `rbs` gem, so without this
+      # every reopening of a core class and every constant that shares a core name would
+      # look like a redefinition.
+      def ruby_definition?(definition)
+        uri = definition.location.uri
+
+        uri.start_with?(FILE_URI_PREFIX) && !uri.end_with?(SIGNATURE_EXTENSION)
       end
 
       def prior_definition_in_other_file(definitions)

--- a/lib/rubocop/project_index_loader.rb
+++ b/lib/rubocop/project_index_loader.rb
@@ -56,11 +56,30 @@ module RuboCop
     # or methods are involved.
     def build_index(paths)
       graph = Rubydex::Graph.new
-      graph.index_all(paths.map(&:to_s))
+      graph.index_all(paths.map(&:to_s) + core_definition_paths(graph))
       graph.resolve
       graph
     rescue StandardError => e
       warn Rainbow("rubydex index build failed: #{e.message}. Continuing without it.").yellow
+    end
+
+    # The RBS signature files of Ruby's core and standard library. Rubydex declares
+    # `BasicObject`, `Kernel`, `Object`, `Module` and `Class` with empty bodies so that
+    # ancestries linearize, but their members come from these files alone. Without them
+    # the index cannot tell "this name does not exist" from "this name is core", and a
+    # lookup does not stop where Ruby stops: `Foo.new` finds no `Class#new` in the
+    # singleton ancestry and walks on into `Object`'s instance methods, where a single
+    # top-level `def new` answers every constructor lookup in the project.
+    #
+    # Rubydex gathers these paths for `Graph#index_workspace`, which RuboCop does not use:
+    # the index is built from RuboCop's own target list, so that `AllCops/Include` and
+    # `Exclude` govern it and every inspected file is indexed. No public API exposes the
+    # paths on their own yet (Shopify/rubydex#1027), hence the `send`; versions without
+    # the method, and systems without an `rbs` gem, simply contribute nothing.
+    def core_definition_paths(graph)
+      return [] unless graph.respond_to?(:add_core_rbs_definition_paths, true)
+
+      [].tap { |paths| graph.send(:add_core_rbs_definition_paths, paths) }
     end
 
     # The Ruby source files of every gem in the project's bundle, for

--- a/spec/rubocop/cop/lint/argument_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/argument_mismatch_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe RuboCop::Cop::Lint::ArgumentMismatch, :config do
       end
     end
 
+    context 'for a private singleton method' do
+      # An explicit receiver cannot reach a private method, so the call does not
+      # resolve to it. This is what keeps `Kernel`'s methods out of the picture:
+      # they are private instance methods of `Object`, and therefore sit in the
+      # singleton ancestry of every constant once the core signatures are indexed.
+      let(:callee) do
+        { 'file:///report.rb' => <<~RUBY }
+          class Report
+            class << self
+              private
+
+              def generate(source, format); end
+            end
+          end
+        RUBY
+      end
+
+      it 'does not register an offense' do
+        index_with_call('Report.generate(source)', callee)
+
+        expect_no_offenses('Report.generate(source)', '/call.rb')
+      end
+    end
+
     context 'for optional and rest parameters' do
       let(:callee) do
         { 'file:///calc.rb' => <<~RUBY }

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -2126,6 +2126,32 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
       expect(offenses).to be_empty
     end
 
+    it 'does not report a definition whose other site is an RBS signature' do
+      Dir.mktmpdir do |tmpdir|
+        # Ruby's core and standard library reach the index as the `rbs` gem's
+        # signature files. A signature declares a method, it does not define one, so
+        # monkey patching a core method is not a cross-file duplicate.
+        File.write(File.join(tmpdir, 'core_ext.rb'), <<~RUBY)
+          class Array
+            def sum(identity = nil, &block)
+              super
+            end
+          end
+        RUBY
+        # Same for a project class that merely shares a name with a stdlib one.
+        File.write(File.join(tmpdir, 'collides.rb'), <<~RUBY)
+          class Set
+            def initialize(items)
+              @items = items
+            end
+          end
+        RUBY
+        write_rubocop_config(tmpdir, 'AllCops' => { 'UseProjectIndex' => true })
+
+        expect(cop_offenses(tmpdir)).to be_empty
+      end
+    end
+
     it 'does not report duplicates whose other definition site matches `AllowedCrossFilePaths`' do
       offenses = run_with_config(
         'AllCops' => { 'UseProjectIndex' => true },

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -143,6 +143,30 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
         end
       end
 
+      context 'when the namespace is known only from an RBS signature' do
+        before do
+          # Ruby's core and standard library reach the index as the `rbs` gem's
+          # signature files, which are curated and lag the implementation: the
+          # deprecated `HTTPServerException` is declared while its replacement
+          # `HTTPClientException` is not. A name missing from them is therefore
+          # not evidence of a typo.
+          cop.project_index = build_index(
+            'file:///sig/net-http.rbs' => <<~RBS
+              module Net
+                class HTTPServerException
+                end
+              end
+            RBS
+          )
+        end
+
+        it 'does not register an offense for a constant it does not declare' do
+          expect_no_offenses(<<~RUBY)
+            Net::HTTPClientException
+          RUBY
+        end
+      end
+
       it 'registers an offense when the file contains a binary string literal' do
         expect_offense(<<~'RUBY')
           DATA = "\xFF\xFE".b

--- a/spec/rubocop/project_index_loader_spec.rb
+++ b/spec/rubocop/project_index_loader_spec.rb
@@ -32,6 +32,52 @@ RSpec.describe RuboCop::ProjectIndexLoader do
     end
   end
 
+  describe '.build_index', :project_index do
+    def staged_project(source)
+      Dir.mktmpdir do |tmpdir|
+        path = File.join(tmpdir, 'app.rb')
+        File.write(path, source)
+        yield tmpdir, path
+      end
+    end
+
+    it 'indexes the RBS signatures of Ruby core' do
+      staged_project("class Report\nend\n") do |_tmpdir, path|
+        graph = described_class.build_index([path])
+
+        # Rubydex declares `Class` built-in with an empty body; its members come from
+        # the core signatures alone. `Class#new` is what stops a constructor lookup
+        # where Ruby stops it, instead of walking on into `Object`'s instance methods.
+        expect(graph['Class'].members.map(&:name)).to include('Class#new()')
+      end
+    end
+
+    it 'indexes the project when the core signatures cannot be located' do
+      staged_project("class Report\nend\n") do |_tmpdir, path|
+        allow(Gem).to receive(:path).and_return([])
+
+        graph = described_class.build_index([path])
+
+        expect(graph['Report']).not_to be_nil
+        expect(graph['Class'].members.to_a).to be_empty
+      end
+    end
+
+    it 'does not let the core `BasicObject#initialize` signature make an ancestry stateful' do
+      # `BasicObject` declares `initialize` in the core signatures, but it is the
+      # no-op `super` would reach anyway, so `Lint/MissingSuper` must still treat a
+      # root-only ancestry as stateless.
+      source = "class Report\n  def initialize\n    @foo = 1\n  end\nend\n"
+      staged_project(source) do |tmpdir, _path|
+        write_rubocop_config(tmpdir, 'AllCops' => { 'UseProjectIndex' => true })
+
+        offenses = project_index_offenses(tmpdir)
+
+        expect(offenses.select { |offense| offense['cop_name'] == 'Lint/MissingSuper' }).to be_empty
+      end
+    end
+  end
+
   describe 'AllCops/ProjectIndexIncludesGems', :project_index do
     let(:child_source) do
       <<~RUBY

--- a/spec/support/project_index_metadata.rb
+++ b/spec/support/project_index_metadata.rb
@@ -14,10 +14,13 @@ module ProjectIndexSpecHelpers
   }.freeze
 
   # Builds a resolved in-memory index from a `uri => source` hash, for specs
-  # that exercise index-aware cop logic directly.
+  # that exercise index-aware cop logic directly. A `.rbs` URI is indexed as an
+  # RBS signature, the way Ruby's core and standard library reach the index.
   def build_index(sources)
     graph = Rubydex::Graph.new
-    sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+    sources.each do |uri, source|
+      graph.index_source(uri, source, uri.end_with?('.rbs') ? 'rbs' : 'ruby')
+    end
     graph.resolve
     graph
   end


### PR DESCRIPTION
Rubydex declares the core roots with empty bodies, so the index knew those names existed but nothing they define, and a lookup could not stop where Ruby stops: `Foo.new` found no `Class#new` and walked on into `Object`'s instance methods.

Adds the `rbs` gem's core and stdlib paths to the index, and adjusts the cops the added declarations would mislead: `Lint/DuplicateMethods` and `Lint/ConstantReassignment` ignore RBS definitions, `Lint/MissingSuper` skips the stateless roots when looking for an inherited `initialize`, `Lint/NameTypo` does not spell-check signature-only namespaces, and `Lint/ArgumentMismatch` ignores private members.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ x Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
