### PR TITLE
Fix cross-file result cache poisoning via the shared checksum sentinel

### DIFF
--- a/changelog/fix_result_cache_enoent_collision_20260723105124.md
+++ b/changelog/fix_result_cache_enoent_collision_20260723105124.md
@@ -1,0 +1,1 @@
+* [#15621](https://github.com/rubocop/rubocop/pull/15621): Fix incorrect analysis results when the result cache cannot compute a file checksum, which could serve one file's cached results for another file. ([@koic][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -123,7 +123,7 @@ module RuboCop
     end
 
     def valid?
-      File.exist?(@path)
+      !@checksum_unavailable && File.exist?(@path)
     end
 
     def load
@@ -132,6 +132,8 @@ module RuboCop
     end
 
     def save(offenses)
+      return if @checksum_unavailable
+
       dir = File.dirname(@path)
 
       begin
@@ -182,8 +184,11 @@ module RuboCop
       digester.file(file)
       digester.hexdigest
     rescue Errno::ENOENT
-      # Spurious files that come and go should not cause a crash, at least not
-      # here.
+      # Spurious files that come and go should not cause a crash, at least not here.
+      # Every file that fails to checksum shares this sentinel value, so the cache entry
+      # must be neither saved nor considered valid, or one file's cached results could be
+      # served as another's.
+      @checksum_unavailable = true
       '_'
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -325,6 +325,20 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     end
   end
 
+  describe 'when the file checksum cannot be computed' do
+    it 'neither writes nor reads the cache entry shared with other such files' do
+      missing_cache = described_class.new('nonexistent.rb', team, options, config_store, cache_root)
+      missing_cache.save(offenses)
+
+      other_missing_cache = described_class.new(
+        'other_nonexistent.rb', team, options, config_store, cache_root
+      )
+
+      expect(missing_cache).not_to be_valid
+      expect(other_missing_cache).not_to be_valid
+    end
+  end
+
   describe '#save' do
     context 'when the default internal encoding is UTF-8' do
       let(:offenses) do
@@ -375,7 +389,9 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
       cfg = RuboCop::Config.new('AllCops' => { 'MaxFilesInCache' => max_files_in_cache })
       allow(config_store).to receive(:for_pwd).and_return(cfg)
       allow(config_store).to receive(:for_file).with('other.rb').and_return(cfg)
+      allow(config_store).to receive(:for_file).with('some.rb').and_return(cfg)
       create_file('other.rb', ['x = 1'])
+      create_file('some.rb', ['y = 2'])
     end
 
     it 'removes the oldest files in the standard cache_root if needed' do


### PR DESCRIPTION
`ResultCache#file_checksum` rescues `Errno::ENOENT` and returns the sentinel checksum `_`. Every file that fails to checksum therefore resolves to the same cache path, so an entry saved for one such file could be loaded as another file's inspection result, silently dropping or fabricating offenses. For example, during `--auto-gen-config` this can serve one file's `Lint/Syntax` result as another file's inspection result, and the generated `.rubocop_todo.yml` loses that file's offenses entirely.

Make a cache with an uncomputable checksum unusable in both directions: `valid?` returns `false` and `save` is a no-op. The worst case is now a cache miss followed by re-inspection, which matches the intent of the original rescue ("spurious files that come and go").

The `.cleanup` spec relied on the old behavior by saving a cache entry for the nonexistent `some.rb`; it now creates the file, since the example is about pruning two real entries.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
