### PR TITLE
Fix Layout/HashAlignment loop with Layout/IndentationStyle tabs

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_hash_alignment_20260829.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_hash_alignment_20260829.md
@@ -1,0 +1,1 @@
+* [#15622](https://github.com/rubocop/rubocop/pull/15622): Fix an infinite loop between `Layout/HashAlignment` and `Layout/IndentationStyle` enforcing tabs. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -318,6 +318,7 @@ module RuboCop
           # We can't use the instance variable inside the lambda. That would
           # just give each lambda the same reference and they would all get the
           # last value of each. A local variable fixes the problem.
+          return if tab_indented_key_insertion?(node, delta)
 
           if node.value && node.respond_to?(:value_omission?) && !node.value_omission?
             correct_key_value(corrector, delta, node.key.source_range,
@@ -327,6 +328,12 @@ module RuboCop
             delta_value = delta[:key] || 0
             correct_no_value(corrector, delta_value, node.source_range)
           end
+        end
+
+        def tab_indented_key_insertion?(node, delta)
+          return false unless tab_indentation_enforced?
+
+          (delta[:key] || 0).positive? && begins_its_line?(node.source_range)
         end
 
         def correct_no_value(corrector, key_delta, key)
@@ -384,6 +391,10 @@ module RuboCop
         def enforce_first_argument_with_fixed_indentation?
           argument_alignment_config = config.for_enabled_cop('Layout/ArgumentAlignment')
           argument_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
+        end
+
+        def tab_indentation_enforced?
+          config.for_enabled_cop('Layout/IndentationStyle')['EnforcedStyle'] == 'tabs'
         end
 
         def same_line?(node1, node2)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2798,6 +2798,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'does not loop when specifying `EnforcedStyle: tabs` of `Layout/IndentationStyle` and ' \
+     '`Layout/HashAlignment`' do
+    create_file('example.rb', <<~RUBY)
+      h = { foo: 1,
+            bar: 2 }
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/IndentationStyle:
+        EnforcedStyle: tabs
+    YAML
+
+    expect(
+      cli.run(['--autocorrect', '--only', 'Layout/IndentationStyle,Layout/HashAlignment'])
+    ).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<-RUBY.gsub(/^      /, ''))
+      h = { foo: 1,
+      \t\t\tbar: 2 }
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`Layout/HashAlignment` and `Layout/FirstHashElementIndentation`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -1854,4 +1854,51 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
       end
     end
   end
+
+  context 'when `Layout/IndentationStyle` enforces tabs' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/HashAlignment' => default_cop_config.merge(cop_config),
+        'Layout/ArgumentAlignment' => argument_alignment_config,
+        'Layout/IndentationStyle' => { 'Enabled' => true, 'EnforcedStyle' => 'tabs' }
+      )
+    end
+
+    it 'registers an offense but does not correct a tab-indented key needing an insertion' do
+      expect_offense(<<-RUBY.gsub(/^      /, ''))
+      h = { foo: 1,
+      \t\t\tbar: 2 }
+         ^^^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense but does not correct a space-indented key needing an insertion' do
+      expect_offense(<<~RUBY)
+        h = { foo: 1,
+          bar: 2 }
+          ^^^^^^ Align the keys of a hash literal if they span more than one line.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense and corrects an over-indented tab-only key' do
+      expect_offense(<<-RUBY.gsub(/^      /, ''))
+      h = {
+      \tfoo: 1,
+      \t\t\tbar: 2
+         ^^^^^^ Align the keys of a hash literal if they span more than one line.
+      }
+      RUBY
+
+      expect_correction(<<-RUBY.gsub(/^      /, ''))
+      h = {
+      \tfoo: 1,
+      \tbar: 2
+      }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
With `Layout/IndentationStyle` set to tabs, the two cops fight until RuboCop reports an infinite loop:

```ruby
h = { foo: 1,
      bar: 2 }
```

```
Infinite loop detected ... caused by Layout/HashAlignment -> Layout/IndentationStyle -> Layout/HashAlignment, Layout/IndentationStyle
```

`Layout/HashAlignment` measures alignment in character columns and pads with spaces, while `Layout/IndentationStyle` rewrites leading whitespace to tabs (with floor division), shifting the character columns again. There is no stable state: key alignment is generally not expressible in pure tabs.

Now `Layout/HashAlignment` steps aside when `Layout/IndentationStyle` enforces tabs, same as it already does for `Layout/ArgumentAlignment` with fixed indentation. Tab indentation itself still lines keys up visually where the tab width allows (in the example above `bar` ends up at the same display column as `foo`).

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.