### PR TITLE
Fix an error for `Layout/HashAlignment` when the first pair of a hash omits its value

### DIFF
--- a/changelog/fix_an_error_for_layout_hash_alignment_when_the_first_pair_omits_its_value_20260827215346.md
+++ b/changelog/fix_an_error_for_layout_hash_alignment_when_the_first_pair_omits_its_value_20260827215346.md
@@ -1,0 +1,1 @@
+* [#15623](https://github.com/rubocop/rubocop/pull/15623): Fix an error for `Layout/HashAlignment` when the first pair of a hash omits its value. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/hash_alignment_styles.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment_styles.rb
@@ -55,8 +55,7 @@ module RuboCop
       # Common functionality for checking alignment of hash values.
       module ValueAlignment
         def checkable_layout?(node)
-          !node.pairs_on_same_line? && !node.mixed_delimiters? &&
-            node.pairs.none? { |pair| value_on_later_line?(pair) }
+          !node.pairs_on_same_line? && !node.mixed_delimiters? && alignable_values?(node)
         end
 
         def deltas(first_pair, current_pair)
@@ -68,6 +67,12 @@ module RuboCop
         end
 
         private
+
+        def alignable_values?(node)
+          return false if node.pairs.first.value_omission?
+
+          node.pairs.none? { |pair| value_on_later_line?(pair) }
+        end
 
         def value_on_later_line?(pair)
           pair.value && pair.key.last_line != pair.value.first_line

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -866,6 +866,29 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
     end
   end
 
+  context 'when the first pair omits its value', :ruby31 do
+    let(:cop_config) { { 'EnforcedColonStyle' => 'separator' } }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        f(
+          aa:,
+          b: nil
+        )
+      RUBY
+    end
+
+    it 'still checks a hash whose first pair has a value' do
+      expect_offense(<<~RUBY)
+        f(
+          aaa: nil,
+          bb:
+          ^^^ Align the separators of a hash literal if they span more than one line.
+        )
+      RUBY
+    end
+  end
+
   context 'with table alignment configuration' do
     let(:cop_config) do
       {


### PR DESCRIPTION
An MRE:

```shell
$ bundle exec rubocop --stdin /dev/stdin -a -d --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Layout/HashAlignment:
  Enabled: true
  EnforcedColonStyle: separator
YAML
) <<'RUBY'
f(
  aa:,
  b: nil
)
RUBY

An error occurred while Layout/HashAlignment cop was inspecting /dev/stdin:2:2.
parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from /parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from /parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from /parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
```

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
