### PR TITLE
Fix an error for `Style/HashLookupMethod` cop when the key is itself a lookup

### DIFF
--- a/changelog/fix_an_error_for_style_hash_lookup_method_when_the_key_is_itself_a_lookup_20260830014831.md
+++ b/changelog/fix_an_error_for_style_hash_lookup_method_when_the_key_is_itself_a_lookup_20260830014831.md
@@ -1,0 +1,1 @@
+* [#15624](https://github.com/rubocop/rubocop/pull/15624): Fix an error for `Style/HashLookupMethod` when the looked-up key is itself a hash lookup. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -57,12 +57,15 @@ module RuboCop
 
         def on_send(node)
           return if (receiver = node.receiver) && allowed_receiver?(receiver)
+          return if part_of_ignored_node?(node)
 
           if offense_for_brackets?(node)
+            ignore_node(node.first_argument)
             add_offense(node.loc.selector, message: BRACKET_MSG) do |corrector|
               correct_fetch_to_brackets(corrector, node)
             end
           elsif offense_for_fetch?(node)
+            ignore_node(node.first_argument)
             add_offense(node, message: FETCH_MSG) do |corrector|
               correct_brackets_to_fetch(corrector, node)
             end

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
       expect_no_offenses('fetch(key) { default }')
     end
 
+    it 'registers an offense for the outer call when the key is itself a fetch' do
+      expect_offense(<<~RUBY)
+        a.fetch(b.fetch(:y))
+          ^^^^^ Use `Hash#[]` instead of `Hash#fetch`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a[b[:y]]
+      RUBY
+    end
+
     context 'when using safe navigation operator' do
       it 'does not register an offense for fetch with one argument' do
         # The bracket equivalent would be the unreadable `hash&.[](key)`.
@@ -132,6 +143,33 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
           hash&.fetch(key)
         RUBY
       end
+    end
+  end
+
+  context 'with EnforcedStyle: fetch and a key that is itself a lookup' do
+    let(:cop_config) { { 'EnforcedStyle' => 'fetch' } }
+
+    it 'registers an offense for the outer call and corrects both' do
+      expect_offense(<<~RUBY)
+        a[b[:y]]
+        ^^^^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.fetch(b.fetch(:y))
+      RUBY
+    end
+
+    it 'registers both offenses when the nesting is in the receiver' do
+      expect_offense(<<~RUBY)
+        a[:x][:y]
+        ^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+        ^^^^^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.fetch(:x).fetch(:y)
+      RUBY
     end
   end
 


### PR DESCRIPTION
An MRE:
```shell
$ bundle exec rubocop -d --stdin /dev/stdin --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/HashLookupMethod:
  Enabled: true
  EnforcedStyle: fetch
YAML
) <<'RUBY'
a[b[:y]]
RUBY

An error occurred while Style/HashLookupMethod cop was inspecting /dev/stdin:1:2.
gems/parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:98:in 'Parser::Source::TreeRewriter::Action#with'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:125:in 'Parser::Source::TreeRewriter::Action#place_in_hierarchy'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:107:in 'Parser::Source::TreeRewriter::Action#do_combine'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:118:in 'Parser::Source::TreeRewriter::Action#place_in_hierarchy'
	from gems/parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:132:in 'block in Parser::Source::TreeRewriter::Action#combine_children'

```

Found by `rubocop-nightly`.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
