### PR TITLE
Fix an error for `Style/AccessModifierDeclarations` cop with duplciated access modifiers

### DIFF
--- a/changelog/fix_an_error_for_style_access_modifier_declarations_when_repeated_20260830030255.md
+++ b/changelog/fix_an_error_for_style_access_modifier_declarations_when_repeated_20260830030255.md
@@ -1,0 +1,1 @@
+* [#15625](https://github.com/rubocop/rubocop/pull/15625): Fix an error for `Style/AccessModifierDeclarations` when a body repeats the same access modifier. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/access_modifier_declarations.rb
+++ b/lib/rubocop/cop/style/access_modifier_declarations.rb
@@ -347,7 +347,8 @@ module RuboCop
         end
 
         def remove_modifier_node_within_begin(corrector, modifier_node, begin_node)
-          def_node = begin_node.children[begin_node.children.index(modifier_node) + 1]
+          modifier_index = begin_node.children.find_index { |child| child.equal?(modifier_node) }
+          def_node = begin_node.children[modifier_index + 1]
           # Stop the removal range at the first comment that precedes the def, if
           # any exist. Without this, comments between the modifier and the def are
           # dropped because they fall inside the removed range.

--- a/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_declarations_spec.rb
@@ -1012,6 +1012,30 @@ RSpec.describe RuboCop::Cop::Style::AccessModifierDeclarations, :config do
         end
       end
 
+      context 'when a body repeats the same access modifier' do
+        let(:cop_config) { { 'EnforcedStyle' => 'inline' } }
+
+        it 'registers an offense for each and inlines them' do
+          expect_offense(<<~RUBY, access_modifier: access_modifier)
+            class A
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+              def b; end
+              %{access_modifier}
+              ^{access_modifier} `#{access_modifier}` should be inlined in method definitions.
+              def c; end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class A
+              #{access_modifier} def b; end
+              #{access_modifier} def c; end
+            end
+          RUBY
+        end
+      end
+
       it_behaves_like 'always accepted', access_modifier
     end
   end


### PR DESCRIPTION
An MRE:

```shell
$ bundle exec rubocop -d --stdin /dev/stdin --autocorrect-all -d --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/AccessModifierDeclarations:
  Enabled: true
  EnforcedStyle: inline
YAML
) <<'RUBY'
class A
  private
  def b; end
  private
  def c; end
end
RUBY

An error occurred while Style/AccessModifierDeclarations cop was inspecting /dev/stdin:4:2.
parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
