### PR TITLE
Add a SARIF formatter

### DIFF
--- a/changelog/new_add_a_sarif_formatter_20260830101446.md
+++ b/changelog/new_add_a_sarif_formatter_20260830101446.md
@@ -1,0 +1,1 @@
+* [#15627](https://github.com/rubocop/rubocop/pull/15627): Add a SARIF formatter. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -29,6 +29,7 @@ or the default `progress` format if no `-f/--format` is specified before the `-o
 | JUnit | `junit` | CI systems like Jenkins (machine-parsable)
 | TAP | `tap` | Test Anything Protocol consumers (machine-parsable)
 | GitHub Actions | `github` | GitHub Actions annotations
+| SARIF | `sarif` | GitHub code scanning and other SARIF consumers (machine-parsable)
 | HTML | `html` | HTML report for sharing / CI artifacts
 | Markdown | `markdown` | Markdown report for PR comments
 | File List | `files` | Pipe file names to other tools (machine-parsable)
@@ -426,3 +427,38 @@ $ rubocop --format github
 
 ::error file=lib/foo.rb,line=6,col=5::Style/Documentation: Missing top-level class documentation comment.
 ----
+
+== SARIF Formatter
+
+Formats offenses as https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html[SARIF 2.1.0],
+the standard interchange format for static analysis results. It's understood by
+https://docs.github.com/en/code-security/code-scanning[GitHub code scanning], Azure DevOps and
+other tools that aggregate analyzer output.
+
+[source,sh]
+----
+$ rubocop --format sarif --out rubocop.sarif
+----
+
+The point of it is getting offenses into a tool that collects results from
+several analyzers. On GitHub that means uploading the file, after which offenses
+show up as code scanning alerts on the pull request, annotated on the diff:
+
+[source,yaml]
+----
+# .github/workflows/rubocop.yml
+- run: bundle exec rubocop --format sarif --out rubocop.sarif
+  continue-on-error: true # let the upload happen even when there are offenses
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: rubocop.sarif
+----
+
+SARIF only defines three severity levels, so RuboCop's `info`, `refactor` and `convention`
+severities are all reported as `note`, `warning` stays `warning`, and `error` and `fatal`
+become `error`.
+
+Each cop that reported an offense is described once under `runs[].tool.driver.rules`, with its
+description and a link to its documentation. Offenses suppressed by a `rubocop:disable` directive
+(shown with `--display-suppressed`) are reported as SARIF suppressions, along with the reason
+given in the directive.

--- a/lib/rubocop/formatter.rb
+++ b/lib/rubocop/formatter.rb
@@ -24,6 +24,7 @@ module RuboCop
     autoload :PacmanFormatter, 'rubocop/formatter/pacman_formatter'
     autoload :ProgressFormatter, 'rubocop/formatter/progress_formatter'
     autoload :QuietFormatter, 'rubocop/formatter/quiet_formatter'
+    autoload :SARIFFormatter, 'rubocop/formatter/sarif_formatter'
     autoload :TapFormatter, 'rubocop/formatter/tap_formatter'
     autoload :WorstOffendersFormatter, 'rubocop/formatter/worst_offenders_formatter'
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -23,6 +23,7 @@ module RuboCop
         '[pa]cman'      => 'PacmanFormatter',
         '[p]rogress'    => 'ProgressFormatter',
         '[q]uiet'       => 'QuietFormatter',
+        '[sa]rif'       => 'SARIFFormatter',
         '[s]imple'      => 'SimpleTextFormatter',
         '[t]ap'         => 'TapFormatter',
         '[w]orst'       => 'WorstOffendersFormatter'

--- a/lib/rubocop/formatter/sarif_formatter.rb
+++ b/lib/rubocop/formatter/sarif_formatter.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module RuboCop
+  module Formatter
+    # This formatter formats the report data in SARIF 2.1.0, the OASIS standard
+    # for static analysis results. It's understood by GitHub code scanning,
+    # Azure DevOps, and other tools that aggregate analyzer output.
+    #
+    # SARIF only knows three severity levels, so RuboCop's `info`, `refactor`
+    # and `convention` severities are all reported as `note`.
+    class SARIFFormatter < BaseFormatter
+      SCHEMA_URI = 'https://json.schemastore.org/sarif-2.1.0.json'
+      SARIF_VERSION = '2.1.0'
+      INFORMATION_URI = 'https://rubocop.org'
+
+      SEVERITY_LEVELS = {
+        info: 'note',
+        refactor: 'note',
+        convention: 'note',
+        warning: 'warning',
+        error: 'error',
+        fatal: 'error'
+      }.freeze
+
+      def initialize(output, options = {})
+        super
+
+        @rules = []
+        @rule_indexes = {}
+        @results = []
+        @config_store = nil
+      end
+
+      def file_started(_file, options)
+        @config_store = options[:config_store]
+      end
+
+      def file_finished(file, offenses)
+        offenses.each do |offense|
+          @results << result_for(file, offense)
+        end
+      end
+
+      def finished(_inspected_files)
+        output.write(report.to_json)
+      end
+
+      private
+
+      def report
+        {
+          '$schema': SCHEMA_URI,
+          version: SARIF_VERSION,
+          runs: [{ tool: { driver: driver }, results: @results }]
+        }
+      end
+
+      def driver
+        {
+          name: 'RuboCop',
+          version: RuboCop::Version::STRING,
+          semanticVersion: RuboCop::Version::STRING,
+          informationUri: INFORMATION_URI,
+          rules: @rules
+        }
+      end
+
+      def result_for(file, offense)
+        result = {
+          ruleId: offense.cop_name,
+          ruleIndex: rule_index_for(file, offense),
+          level: SEVERITY_LEVELS.fetch(offense.severity.name, 'warning'),
+          message: { text: offense.message },
+          locations: [location_for(file, offense)],
+          partialFingerprints: fingerprints_for(offense)
+        }
+
+        # Suppressed offenses are only reported under `--display-suppressed`.
+        # SARIF has a first-class representation for them, so consumers can
+        # tell them apart from offenses that were never triggered.
+        result[:suppressions] = [suppression_for(offense)] if offense.disabled?
+        result
+      end
+
+      # The URI is relative to the working directory, which is what consumers
+      # expect to resolve against their own checkout. No `uriBaseId`: it would
+      # have to be declared under `originalUriBaseIds` to mean anything, and
+      # every consumer that matters resolves relative paths without it.
+      def location_for(file, offense)
+        {
+          physicalLocation: {
+            artifactLocation: { uri: uri_for(file) },
+            region: region_for(offense)
+          }
+        }
+      end
+
+      def region_for(offense)
+        # SARIF columns are 1-based and `endColumn` points at the character
+        # *after* the region, while `real_last_column` is the last character.
+        {
+          startLine: offense.first_line,
+          startColumn: offense.real_column,
+          endLine: offense.last_line,
+          endColumn: offense.real_last_column + 1
+        }
+      end
+
+      # GitHub uses these to match an alert across runs. Without them it falls
+      # back to the file path, which makes alerts churn whenever a file moves.
+      def fingerprints_for(offense)
+        source_line = offense.location.source_line
+        { primaryLocationLineHash: Digest::SHA256.hexdigest("#{offense.cop_name}#{source_line}") }
+      end
+
+      def suppression_for(offense)
+        suppression = { kind: 'inSource' }
+        suppression[:justification] = offense.justification if offense.justification
+        suppression
+      end
+
+      def rule_index_for(file, offense)
+        @rule_indexes[offense.cop_name] ||= begin
+          @rules << rule_for(file, offense)
+          @rules.size - 1
+        end
+      end
+
+      def rule_for(file, offense)
+        cop_class = Cop::Registry.global.find_by_cop_name(offense.cop_name)
+        description = description_for(file, offense)
+        help_uri = cop_class && Cop::Documentation.url_for(cop_class, config_for(file))
+
+        rule = {
+          id: offense.cop_name,
+          name: offense.cop_name,
+          shortDescription: { text: description },
+          fullDescription: { text: description },
+          help: help_for(description, help_uri),
+          defaultConfiguration: { level: default_level_for(file, offense, cop_class) },
+          properties: { tags: [offense.cop_name.split('/').first] }
+        }
+        rule[:helpUri] = help_uri if help_uri
+        rule
+      end
+
+      def help_for(description, help_uri)
+        help = { text: description }
+        help[:markdown] = "#{description}\n\n[Documentation](#{help_uri})" if help_uri
+        help
+      end
+
+      def description_for(file, offense)
+        cop_config(file, offense)['Description'] || offense.cop_name
+      end
+
+      def default_level_for(file, offense, cop_class)
+        severity = cop_config(file, offense)['Severity'] ||
+                   (cop_class&.lint? ? :warning : :convention)
+
+        SEVERITY_LEVELS.fetch(severity.to_sym, 'warning')
+      end
+
+      def cop_config(file, offense)
+        config_for(file)&.for_cop(offense.cop_name) || {}
+      end
+
+      # `file_started` is not called when a formatter is used directly through
+      # the API, so there may be no config to consult.
+      def config_for(file)
+        @config_store&.for_file(file)
+      end
+
+      def uri_for(file)
+        PathUtil.smart_path(file).tr('\\', '/')
+      end
+    end
+  end
+end

--- a/spec/rubocop/formatter/sarif_formatter_spec.rb
+++ b/spec/rubocop/formatter/sarif_formatter_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Formatter::SARIFFormatter do
+  subject(:formatter) { described_class.new(output) }
+
+  let(:output) { StringIO.new }
+  let(:report) { JSON.parse(output.string) }
+  let(:run) { report['runs'].first }
+  let(:source_buffer) do
+    buffer = Parser::Source::Buffer.new('/path/to/file.rb', 1)
+    buffer.source = "puts 'foo'\nputs 'bar'\n"
+    buffer
+  end
+  let(:location) { Parser::Source::Range.new(source_buffer, 5, 10) }
+  let(:offense) do
+    RuboCop::Cop::Offense.new(:convention, location, 'Prefer double quotes.',
+                              'Style/StringLiterals')
+  end
+
+  def finish(file = '/path/to/file.rb', offenses = [offense])
+    formatter.file_finished(file, offenses)
+    formatter.finished([file])
+  end
+
+  it 'emits a SARIF 2.1.0 document with a single run' do
+    finish
+
+    expect(report['$schema']).to eq('https://json.schemastore.org/sarif-2.1.0.json')
+    expect(report['version']).to eq('2.1.0')
+    expect(report['runs'].size).to eq(1)
+  end
+
+  it 'describes RuboCop as the driver' do
+    finish
+
+    driver = run['tool']['driver']
+    expect(driver['name']).to eq('RuboCop')
+    expect(driver['version']).to eq(RuboCop::Version::STRING)
+    expect(driver['informationUri']).to eq('https://rubocop.org')
+  end
+
+  it 'emits a valid document when there are no offenses' do
+    finish('/path/to/file.rb', [])
+
+    expect(run['results']).to be_empty
+    expect(run['tool']['driver']['rules']).to be_empty
+  end
+
+  describe 'results' do
+    it 'reports the offense message and cop name' do
+      finish
+
+      result = run['results'].first
+      expect(result['ruleId']).to eq('Style/StringLiterals')
+      expect(result['message']['text']).to eq('Prefer double quotes.')
+    end
+
+    it 'reports a 1-based region with an exclusive end column' do
+      finish
+
+      region = run['results'].first['locations'].first['physicalLocation']['region']
+      expect(region).to eq(
+        'startLine' => 1, 'startColumn' => 6, 'endLine' => 1, 'endColumn' => 11
+      )
+    end
+
+    it 'reports the file path relative to the working directory' do
+      file = File.join(Dir.pwd, 'lib', 'foo.rb')
+      finish(file)
+
+      artifact = run['results'].first['locations'].first['physicalLocation']['artifactLocation']
+      expect(artifact).to eq('uri' => 'lib/foo.rb')
+    end
+
+    it 'fingerprints the offense so alerts survive a file move' do
+      finish
+
+      fingerprints = run['results'].first['partialFingerprints']
+      expect(fingerprints['primaryLocationLineHash']).to eq(
+        Digest::SHA256.hexdigest("Style/StringLiterals#{location.source_line}")
+      )
+    end
+
+    it 'does not mark ordinary offenses as suppressed' do
+      finish
+
+      expect(run['results'].first).not_to have_key('suppressions')
+    end
+  end
+
+  describe 'severity mapping' do
+    { info: 'note', refactor: 'note', convention: 'note',
+      warning: 'warning', error: 'error', fatal: 'error' }.each do |severity, level|
+      it "reports #{severity} offenses as #{level}" do
+        offense = RuboCop::Cop::Offense.new(severity, location, 'Message', 'Cop/Name')
+        finish('/path/to/file.rb', [offense])
+
+        expect(run['results'].first['level']).to eq(level)
+      end
+    end
+  end
+
+  describe 'rules' do
+    it 'emits one rule per cop and points results at it by index' do
+      other = RuboCop::Cop::Offense.new(:convention, location, 'Another message.',
+                                        'Style/StringLiterals')
+      third = RuboCop::Cop::Offense.new(:warning, location, 'Different cop.', 'Lint/Void')
+      finish('/path/to/file.rb', [offense, other, third])
+
+      rules = run['tool']['driver']['rules']
+      expect(rules.map { |rule| rule['id'] }).to eq(%w[Style/StringLiterals Lint/Void])
+      expect(run['results'].map { |result| result['ruleIndex'] }).to eq([0, 0, 1])
+    end
+
+    it 'tags each rule with its department' do
+      finish
+
+      expect(run['tool']['driver']['rules'].first['properties']['tags']).to eq(['Style'])
+    end
+
+    it 'falls back to the cop name when there is no configuration to consult' do
+      finish
+
+      rule = run['tool']['driver']['rules'].first
+      expect(rule['shortDescription']['text']).to eq('Style/StringLiterals')
+    end
+
+    it 'omits the documentation URL for cops it knows nothing about' do
+      offense = RuboCop::Cop::Offense.new(:convention, location, 'Message', 'Custom/Cop')
+      finish('/path/to/file.rb', [offense])
+
+      rule = run['tool']['driver']['rules'].first
+      expect(rule).not_to have_key('helpUri')
+      expect(rule['help']).not_to have_key('markdown')
+    end
+
+    context 'when the configuration is available' do
+      let(:config_store) do
+        instance_double(RuboCop::ConfigStore, for_file: RuboCop::ConfigLoader.default_configuration)
+      end
+
+      before { formatter.file_started('/path/to/file.rb', config_store: config_store) }
+
+      it 'documents the rule with the cop description and documentation URL' do
+        finish
+
+        rule = run['tool']['driver']['rules'].first
+        expect(rule['shortDescription']['text']).to eq(
+          RuboCop::ConfigLoader.default_configuration
+                               .for_cop('Style/StringLiterals')['Description']
+        )
+        expect(rule['helpUri']).to eq(
+          'https://docs.rubocop.org/rubocop/cops_style.html#stylestringliterals'
+        )
+        expect(rule['help']['markdown']).to include('[Documentation](')
+      end
+
+      it 'reports the configured severity as the rule default' do
+        finish
+
+        rules = run['tool']['driver']['rules']
+        expect(rules.first['defaultConfiguration']['level']).to eq('note')
+      end
+    end
+  end
+
+  describe 'suppressed offenses' do
+    let(:offense) do
+      RuboCop::Cop::Offense.new(:convention, location, 'Prefer double quotes.',
+                                'Style/StringLiterals', :disabled,
+                                justification: 'external API')
+    end
+
+    it 'marks them as suppressed in source with the directive reason' do
+      finish
+
+      expect(run['results'].first['suppressions']).to eq(
+        [{ 'kind' => 'inSource', 'justification' => 'external API' }]
+      )
+    end
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                  [pa]cman
                                                  [p]rogress (default)
                                                  [q]uiet
+                                                 [sa]rif
                                                  [s]imple
                                                  [t]ap
                                                  [w]orst


### PR DESCRIPTION
SARIF is what GitHub code scanning and most result aggregators ingest, so getting RuboCop output in front of them currently means a third-party gem.

Two decisions worth a look: SARIF has only three severity levels, so info, refactor and convention all land on `note`; and offenses suppressed by a directive are reported as real SARIF suppressions carrying the `--` reason, instead of vanishing the way they do elsewhere.