### PR TITLE
Add `--diff` to preview autocorrection without writing files

### DIFF
--- a/changelog/new_add_diff_to_preview_autocorrection_without_writing_files_20260830101458.md
+++ b/changelog/new_add_diff_to_preview_autocorrection_without_writing_files_20260830101458.md
@@ -1,0 +1,1 @@
+* [#15628](https://github.com/rubocop/rubocop/pull/15628): Add `--diff` to preview autocorrection without writing files. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/usage/autocorrect.adoc
+++ b/docs/modules/ROOT/pages/usage/autocorrect.adoc
@@ -91,6 +91,37 @@ The `--disable-uncorrectable` flag generates `# rubocop:todo` comments in the
 code to suppress reporting of offenses that could not be corrected
 automatically. This is useful for gradually adopting new cops.
 
+== Previewing corrections
+
+[source,sh]
+----
+$ rubocop --diff
+----
+
+The `--diff` flag prints a unified diff of what autocorrection would change and
+leaves every file untouched. It turns on safe autocorrection by itself, and
+follows the mode you pick when combined with `-A` or `-x`.
+
+The exit status is non-zero whenever there is something to correct - a patch
+means work is left, whatever `--fail-level` says. That makes it a useful CI
+check: the build fails with the patch that would fix it right there in the log.
+
+[source,sh]
+----
+# Fail the build when anything is not formatted the way the project wants,
+# and show what would change.
+$ rubocop --diff
+
+# Take the patch and apply it locally.
+$ rubocop --diff --format quiet | git apply
+----
+
+It cannot be combined with `--auto-gen-config`, which exists to write a file.
+
+NOTE: Offenses still show up in the report as corrected, because they were
+corrected in memory. Nothing is written to disk. Use `--format quiet` to see the
+diff on its own.
+
 == Configuring autocorrect per cop
 
 Individual cops can have their autocorrect behavior configured in `.rubocop.yml`.

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -57,6 +57,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--disable-uncorrectable`
 | Used with --autocorrect to annotate any offenses that do not support autocorrect with `rubocop:todo` comments.
 
+| `--diff`
+| Print a unified diff of what autocorrection would change, without writing any files. See xref:usage/autocorrect.adoc[Autocorrect].
+
 | `-D/--[no-]display-cop-names`
 | Displays cop names in offense messages. Default is true.
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -34,6 +34,7 @@ require_relative 'rubocop/name_similarity'
 require_relative 'rubocop/path_util'
 require_relative 'rubocop/platform'
 require_relative 'rubocop/string_interpreter'
+require_relative 'rubocop/unified_diff'
 require_relative 'rubocop/util'
 require_relative 'rubocop/warning'
 

--- a/lib/rubocop/cli/command/execute_runner.rb
+++ b/lib/rubocop/cli/command/execute_runner.rb
@@ -28,7 +28,16 @@ module RuboCop
             all_passed || @options[:auto_gen_config]
           end
 
-          maybe_print_corrected_source
+          if @options[:diff]
+            print_diffs(runner.diffs)
+          else
+            maybe_print_corrected_source
+          end
+
+          # A diff means autocorrectable offenses are still in the working
+          # tree, so the run has not passed even though they were "corrected"
+          # in memory.
+          all_pass_or_excluded &&= runner.diffs.empty?
 
           merge_todo_audit_status(runner_status(runner, all_pass_or_excluded))
         end
@@ -117,6 +126,17 @@ module RuboCop
           return unless Gem.loaded_specs.key?('rubocop')
 
           "#{Gem.loaded_specs['rubocop'].metadata['bug_tracker_uri']}\n"
+        end
+
+        def print_diffs(diffs)
+          return if diffs.empty?
+          # Integration tools own stdout when they ask for a machine-readable
+          # format, so the diff would only corrupt their input.
+          return if INTEGRATION_FORMATTERS.include?(@options[:format])
+
+          output = @options[:stderr] ? $stderr : $stdout
+          output.puts
+          diffs.each { |diff| output.print(diff) }
         end
 
         def maybe_print_corrected_source

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -33,6 +33,8 @@ module RuboCop
 
       define_options.parse!(args)
 
+      imply_autocorrect_for_diff
+
       @validator.validate_compatibility
 
       if @options[:stdin]
@@ -50,6 +52,15 @@ module RuboCop
     end
 
     private
+
+    # `--diff` is a dry run of autocorrection, so it turns autocorrection on
+    # unless the user already picked a mode with `-a`, `-A` or `-x`.
+    def imply_autocorrect_for_diff
+      return unless @options[:diff] && !@options[:autocorrect]
+
+      @options[:safe_autocorrect] = true
+      @options[:autocorrect] = true
+    end
 
     # rubocop:disable-next Metrics/AbcSize
     def define_options
@@ -161,6 +172,8 @@ module RuboCop
         end
 
         option(opts, '--disable-uncorrectable')
+
+        option(opts, '--diff')
       end
     end
     # rubocop:enable Naming/InclusiveLanguage
@@ -400,6 +413,7 @@ module RuboCop
       validate_display_only_failed_and_display_only_correctable
       validate_display_only_correctable_and_autocorrect
       validate_lsp_and_editor_mode
+      validate_diff
       validate_enable_all_cops_and_disable_all_cops
       disable_parallel_when_invalid_option_combo
 
@@ -445,6 +459,14 @@ module RuboCop
 
       raise OptionArgumentError,
             '--display-only-failed cannot be used together with other display options.'
+    end
+
+    # `--diff` promises not to write anything, and `--auto-gen-config` exists to
+    # write a file.
+    def validate_diff
+      return unless @options.key?(:diff) && @options.key?(:auto_gen_config)
+
+      raise OptionArgumentError, '--diff cannot be used with --auto-gen-config.'
     end
 
     def validate_lsp_and_editor_mode
@@ -572,6 +594,10 @@ module RuboCop
       disable_uncorrectable:            ['Used with --autocorrect to annotate any',
                                          'offenses that do not support autocorrect',
                                          'with `rubocop:todo` comments.'],
+      diff:                             ['Print a unified diff of what autocorrection',
+                                         'would change, without writing any files.',
+                                         'Turns on safe autocorrection unless a mode',
+                                         'was already given with -a, -A or -x.'],
       no_exclude_limit:                 ['Do not set the limit for how many files to exclude.'],
       force_exclusion:                  ['Any files excluded by `Exclude` in configuration',
                                          'files will be excluded, even if given explicitly',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -53,7 +53,7 @@ module RuboCop
       Lint/RedundantCopDisableDirective RedundantCopDisableDirective Lint
     ].freeze
 
-    attr_reader :errors, :warnings
+    attr_reader :errors, :warnings, :diffs
     attr_writer :aborting
 
     def initialize(options, config_store)
@@ -63,6 +63,7 @@ module RuboCop
       @warnings = []
       @aborting = false
       @inspected_files = []
+      @diffs = []
       @report_queue = {}
     end
 
@@ -205,8 +206,7 @@ module RuboCop
     end
 
     def run_in_parallel?(files)
-      return false if @options[:auto_gen_config]
-      return false unless @options[:parallel]
+      return false unless parallel_supported_by_options?
 
       if files.size <= 1
         puts 'Skipping parallel inspection: only a single file needs inspection' if @options[:debug]
@@ -218,6 +218,13 @@ module RuboCop
       puts 'Running parallel inspection' if @options[:debug]
 
       true
+    end
+
+    # `--auto-gen-config` needs the offenses of every file in one place, and
+    # `--diff` collects the diffs in this process, where a worker's copy of
+    # them would be lost.
+    def parallel_supported_by_options?
+      @options[:parallel] && !@options[:auto_gen_config] && !@options[:diff]
     end
 
     def project_index_disables_parallel?
@@ -379,6 +386,7 @@ module RuboCop
     def do_inspection_loop(file)
       # We can reuse the prism result since the source did not change yet.
       processed_source = get_processed_source(file, @prism_result)
+      original_source = processed_source.raw_source
       # This variable is 2d array used to track corrected offenses after each
       # inspection iteration. This is used to output meaningful infinite loop
       # error message.
@@ -391,11 +399,7 @@ module RuboCop
       # once. The corrections are kept in memory while iterating and written
       # back to the file when the loop is done.
       iterate_until_no_changes(processed_source, offenses_by_iteration) do
-        # The offenses that couldn't be corrected will be found again so we
-        # only keep the corrected ones in order to avoid duplicate reporting.
-        !offenses_by_iteration.empty? && offenses_by_iteration.last.select!(&:corrected?)
-        team, new_offenses, updated_source_file = inspect_iteration(processed_source)
-        offenses_by_iteration.push(new_offenses)
+        team, updated_source_file = inspect_and_correct(processed_source, offenses_by_iteration)
 
         # We have to reprocess the source to pickup the changes. Since the
         # change could (theoretically) introduce parsing errors, we break the
@@ -411,15 +415,49 @@ module RuboCop
       # Return summary of corrected offenses after all iterations
       [processed_source, offenses_by_iteration.flatten.uniq]
     ensure
-      # Write the file once, even when the loop was left through an exception
-      # (e.g. an infinite correction loop), like the per-iteration writes
-      # used to be.
-      File.write(file, corrected_source) if corrected_source
+      finalize_corrections(file, original_source, corrected_source)
+    end
+
+    def inspect_and_correct(processed_source, offenses_by_iteration)
+      # The offenses that couldn't be corrected will be found again so we
+      # only keep the corrected ones in order to avoid duplicate reporting.
+      !offenses_by_iteration.empty? && offenses_by_iteration.last.select!(&:corrected?)
+      team, new_offenses, updated_source_file = inspect_iteration(processed_source)
+      offenses_by_iteration.push(new_offenses)
+
+      [team, updated_source_file]
+    end
+
+    # Write the file once, even when the loop was left through an exception
+    # (e.g. an infinite correction loop), like the per-iteration writes used
+    # to be. Under `--diff` nothing is written at all.
+    def finalize_corrections(file, original_source, corrected_source)
+      if @options[:diff]
+        record_diff(file, original_source, corrected_source)
+      elsif corrected_source
+        File.write(file, corrected_source)
+      end
+    end
+
+    # `--diff` reports what autocorrection would do instead of doing it. With
+    # `--stdin` the corrected source is handed back through the options rather
+    # than deferred, so that is where the new source comes from.
+    def record_diff(file, original_source, corrected_source)
+      new_source = @options[:stdin] || corrected_source
+      return unless original_source && new_source
+
+      # The original source is the file as it is on disk, so the corrected one
+      # has to go through the same line ending conversion `File.write` would
+      # apply, or on Windows every single line reads as changed.
+      new_source = emulate_write_read_cycle(new_source)
+
+      diff = UnifiedDiff.new(PathUtil.smart_path(file), original_source, new_source).to_s
+      @diffs << diff unless diff.empty?
     end
 
     def inspect_iteration(processed_source)
       team = mobilize_team(processed_source)
-      team.defer_corrections = in_memory_corrections_possible?
+      team.defer_corrections = @options[:diff] || in_memory_corrections_possible?
       offenses, updated_source_file = inspect_file(processed_source, team)
       [team, offenses, updated_source_file]
     end

--- a/lib/rubocop/unified_diff.rb
+++ b/lib/rubocop/unified_diff.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # Renders a unified diff between two versions of a file's source.
+  #
+  # RuboCop has no diffing dependency and this output is meant to be read by
+  # people (and occasionally piped into `git apply`), so the goal is a diff
+  # that is correct and readable, not one that matches `diff -u` byte for byte.
+  #
+  # @api private
+  class UnifiedDiff
+    CONTEXT_LINES = 3
+    NO_NEWLINE_MARKER = "\\ No newline at end of file\n"
+
+    # Finding a minimal diff costs time and memory proportional to the square
+    # of the number of edits. Past this many edits the file was rewritten
+    # rather than corrected, so the changed region is reported as a single
+    # replacement instead.
+    MAX_EDIT_DISTANCE = 400
+
+    def initialize(path, old_source, new_source)
+      @path = path
+      @old_lines = old_source.lines
+      @new_lines = new_source.lines
+    end
+
+    # @return [String] the diff, or an empty string when the sources are identical
+    def to_s
+      return '' if @old_lines == @new_lines
+
+      hunks = hunks_for(edit_script)
+      return '' if hunks.empty?
+
+      ["--- a/#{@path}\n", "+++ b/#{@path}\n", *hunks].join
+    end
+
+    private
+
+    def edit_script
+      prefix = common_prefix_length
+      suffix = common_suffix_length(prefix)
+      old_last = @old_lines.length - suffix
+      new_last = @new_lines.length - suffix
+
+      [
+        *@old_lines[0...prefix].map { |line| [:equal, line] },
+        *middle_script(@old_lines[prefix...old_last], @new_lines[prefix...new_last]),
+        *@old_lines[old_last..].map { |line| [:equal, line] }
+      ]
+    end
+
+    def common_prefix_length
+      length = 0
+      length += 1 while length < @old_lines.length && @old_lines[length] == @new_lines[length]
+      length
+    end
+
+    def common_suffix_length(prefix)
+      length = 0
+      max = [@old_lines.length, @new_lines.length].min - prefix
+      while length < max &&
+            @old_lines[@old_lines.length - 1 - length] == @new_lines[@new_lines.length - 1 - length]
+        length += 1
+      end
+      length
+    end
+
+    def middle_script(old_lines, new_lines)
+      # The region that actually differs is diffed on its own, so the rest of
+      # the algorithm works on these two slices rather than the whole file.
+      @from_lines = old_lines
+      @to_lines = new_lines
+
+      myers_script ||
+        [*old_lines.map { |line| [:delete, line] }, *new_lines.map { |line| [:insert, line] }]
+    end
+
+    # Myers' diff algorithm. Each round `d` extends the furthest reaching path
+    # for every diagonal `k`; the first path to reach the end of both sources
+    # is a shortest edit script, which is then reconstructed from the saved
+    # rounds. Returns `nil` when the sources are too different to bother.
+    def myers_script
+      trace = []
+      furthest = Hash.new(0)
+      max_distance = [@from_lines.length + @to_lines.length, MAX_EDIT_DISTANCE].min
+
+      0.upto(max_distance) do |distance|
+        trace << furthest.dup
+
+        (-distance).step(distance, 2) do |diagonal|
+          furthest[diagonal] = advance(furthest, diagonal, distance)
+
+          return backtrack(trace) if reached_end?(furthest[diagonal], diagonal)
+        end
+      end
+
+      nil
+    end
+
+    def reached_end?(old_index, diagonal)
+      old_index >= @from_lines.length && old_index - diagonal >= @to_lines.length
+    end
+
+    # Picks the better of the two paths reaching this diagonal, then follows
+    # the diagonal as far as the lines match.
+    def advance(furthest, diagonal, distance)
+      old_index = start_of_path(furthest, diagonal, distance)
+
+      follow_diagonal(old_index, old_index - diagonal)
+    end
+
+    # A path arrives at this diagonal either from the one above it (having
+    # inserted a line) or the one below it (having deleted one); whichever
+    # reached further wins.
+    def previous_diagonal(furthest, diagonal, distance)
+      if diagonal == -distance ||
+         (diagonal != distance && furthest[diagonal - 1] < furthest[diagonal + 1])
+        diagonal + 1
+      else
+        diagonal - 1
+      end
+    end
+
+    def start_of_path(furthest, diagonal, distance)
+      previous = previous_diagonal(furthest, diagonal, distance)
+
+      previous > diagonal ? furthest[previous] : furthest[previous] + 1
+    end
+
+    # Matching lines cost nothing, so the path slides along them for free.
+    def follow_diagonal(old_index, new_index)
+      while old_index < @from_lines.length && new_index < @to_lines.length &&
+            @from_lines[old_index] == @to_lines[new_index]
+        old_index += 1
+        new_index += 1
+      end
+
+      old_index
+    end
+
+    def backtrack(trace)
+      script = []
+      position = [@from_lines.length, @to_lines.length]
+
+      trace.each_with_index.reverse_each do |furthest, distance|
+        previous = previous_position(furthest, distance, *position)
+        position = walk_diagonal(script, position, previous)
+        next if distance.zero?
+
+        position = record_edit(script, position, previous)
+      end
+
+      script
+    end
+
+    # Both sides step back together for as long as their lines match.
+    def walk_diagonal(script, position, previous)
+      old_index, new_index = position
+
+      while old_index > previous[0] && new_index > previous[1]
+        old_index -= 1
+        new_index -= 1
+        script.unshift([:equal, @from_lines[old_index]])
+      end
+
+      [old_index, new_index]
+    end
+
+    def record_edit(script, position, previous)
+      old_index, new_index = position
+
+      if old_index == previous[0]
+        new_index -= 1
+        script.unshift([:insert, @to_lines[new_index]])
+      else
+        old_index -= 1
+        script.unshift([:delete, @from_lines[old_index]])
+      end
+
+      [old_index, new_index]
+    end
+
+    def previous_position(furthest, distance, old_index, new_index)
+      previous = previous_diagonal(furthest, old_index - new_index, distance)
+      previous_old = furthest[previous]
+
+      [previous_old, previous_old - previous]
+    end
+
+    def hunks_for(script)
+      changed = script.each_index.reject { |index| script[index].first == :equal }
+      return [] if changed.empty?
+
+      ranges_for(changed, script.length).map { |range| hunk(script, range) }
+    end
+
+    # Every change is shown with a few lines of context around it, and changes
+    # whose context would overlap are shown as a single hunk.
+    def ranges_for(changed, script_length)
+      ranges = []
+
+      changed.each do |index|
+        first = [index - CONTEXT_LINES, 0].max
+        last = [index + CONTEXT_LINES, script_length - 1].min
+
+        if ranges.last && first <= ranges.last.last + 1
+          ranges[-1] = (ranges.last.first..last)
+        else
+          ranges << (first..last)
+        end
+      end
+
+      ranges
+    end
+
+    def hunk(script, range)
+      old_start, new_start = start_positions(script, range.first)
+      old_count = script[range].count { |kind, _| kind != :insert }
+      new_count = script[range].count { |kind, _| kind != :delete }
+      body = script[range].map { |kind, line| formatted_line(kind, line) }
+
+      [
+        "@@ -#{position(old_start, old_count)} +#{position(new_start, new_count)} @@\n",
+        *body
+      ].join
+    end
+
+    def start_positions(script, index)
+      old_line = 1
+      new_line = 1
+
+      script[0...index].each do |entry|
+        old_line += 1 unless entry.first == :insert
+        new_line += 1 unless entry.first == :delete
+      end
+
+      [old_line, new_line]
+    end
+
+    # An empty side is anchored to the line it follows, which is how `diff`
+    # reports a pure insertion or deletion, and a single line drops the count.
+    def position(start, count)
+      case count
+      when 0 then "#{start - 1},0"
+      when 1 then start.to_s
+      else "#{start},#{count}"
+      end
+    end
+
+    def formatted_line(kind, line)
+      marker = { equal: ' ', delete: '-', insert: '+' }.fetch(kind)
+      return "#{marker}#{line}" if line.end_with?("\n")
+
+      "#{marker}#{line}\n#{NO_NEWLINE_MARKER}"
+    end
+  end
+end

--- a/spec/rubocop/cli/diff_spec.rb
+++ b/spec/rubocop/cli/diff_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --diff', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'cli spec behavior'
+
+  let(:source) { <<~RUBY }
+    # frozen_string_literal: true
+
+    x = "foo"
+    puts x
+  RUBY
+
+  before { create_file('example.rb', source) }
+
+  # The diff carries the file's own line endings, which are CRLF on Windows.
+  def output
+    $stdout.string.gsub("\r\n", "\n")
+  end
+
+  it 'prints what autocorrection would change without writing the file' do
+    expect(cli.run(['--diff', '--format', 'quiet', 'example.rb'])).to eq(1)
+    expect(File.read('example.rb')).to eq(source)
+    expect(output).to include(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,4 +1,4 @@
+       # frozen_string_literal: true
+      #{' '}
+      -x = "foo"
+      +x = 'foo'
+       puts x
+    DIFF
+  end
+
+  it 'reports offenses that only unsafe autocorrection would fix when given -A' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      x = 1
+      puts x.to_s
+    RUBY
+
+    expect(cli.run(['--diff', '-A', '--format', 'quiet', 'example.rb'])).to eq(1)
+    expect(output).to include('-puts x.to_s')
+    expect(output).to include('+puts x')
+  end
+
+  it 'leaves offenses that cannot be autocorrected out of the diff' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      def foo(a, b, c, d, e, f)
+        [a, b, c, d, e, f]
+      end
+    RUBY
+
+    expect(cli.run(['--diff', '--format', 'quiet', '--only', 'Metrics/ParameterLists',
+                    'example.rb'])).to eq(1)
+    expect(output).not_to include('--- a/example.rb')
+  end
+
+  it 'succeeds when there is nothing to correct' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      x = 'foo'
+      puts x
+    RUBY
+
+    expect(cli.run(['--diff', '--format', 'quiet', 'example.rb'])).to eq(0)
+    expect(output).not_to include('--- a/example.rb')
+  end
+
+  it 'restricts the diff to layout changes when combined with -x' do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      x = "foo"
+      puts x  if x
+    RUBY
+
+    expect(cli.run(['--diff', '-x', '--format', 'quiet', 'example.rb'])).to eq(1)
+    expect(output).to include('-puts x  if x')
+    expect(output).to include('+puts x if x')
+    expect(output).not_to include("+x = 'foo'")
+  end
+
+  it 'diffs the source read from stdin' do
+    $stdin = StringIO.new(source)
+
+    expect(cli.run(['--diff', '--format', 'quiet', '--stdin', 'example.rb'])).to eq(1)
+    expect(output).to include('-x = "foo"')
+    expect(output).to include("+x = 'foo'")
+  ensure
+    $stdin = STDIN
+  end
+
+  it 'fails whatever the fail level says, since a patch means work is left' do
+    expect(cli.run(['--diff', '--fail-level', 'error', '--format', 'quiet', 'example.rb'])).to eq(1)
+    expect(output).to include('--- a/example.rb')
+  end
+
+  it 'refuses to run with --auto-gen-config, which exists to write a file' do
+    expect(cli.run(['--diff', '--auto-gen-config', 'example.rb'])).to eq(2)
+    expect($stderr.string).to include('--diff cannot be used with --auto-gen-config.')
+    expect(Pathname.new('.rubocop_todo.yml')).not_to exist
+  end
+
+  it 'omits the diff when a machine-readable format was requested' do
+    expect(cli.run(['--diff', '--format', 'json', 'example.rb'])).to eq(1)
+    expect(output).not_to include('--- a/example.rb')
+    expect { JSON.parse($stdout.string) }.not_to raise_error
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -185,6 +185,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --disable-uncorrectable      Used with --autocorrect to annotate any
                                                offenses that do not support autocorrect
                                                with `rubocop:todo` comments.
+                  --diff                       Print a unified diff of what autocorrection
+                                               would change, without writing any files.
+                                               Turns on safe autocorrection unless a mode
+                                               was already given with -a, -A or -x.
 
           Config Generation:
                   --auto-gen-config            Generate a configuration file acting as a

--- a/spec/rubocop/unified_diff_spec.rb
+++ b/spec/rubocop/unified_diff_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::UnifiedDiff do
+  def diff(old_source, new_source, path = 'example.rb')
+    described_class.new(path, old_source, new_source).to_s
+  end
+
+  it 'returns an empty string for identical sources' do
+    expect(diff("a\nb\n", "a\nb\n")).to eq('')
+  end
+
+  it 'names both sides of the diff after the path' do
+    expect(diff("a\n", "b\n", 'lib/example.rb')).to start_with(<<~DIFF)
+      --- a/lib/example.rb
+      +++ b/lib/example.rb
+    DIFF
+  end
+
+  it 'reports a changed line as a deletion followed by an insertion' do
+    expect(diff("a\nb\nc\n", "a\nB\nc\n")).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,3 +1,3 @@
+       a
+      -b
+      +B
+       c
+    DIFF
+  end
+
+  it 'reports inserted lines' do
+    expect(diff("a\nb\n", "a\nx\ny\nb\n")).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,2 +1,4 @@
+       a
+      +x
+      +y
+       b
+    DIFF
+  end
+
+  it 'reports deleted lines' do
+    expect(diff("a\nb\nc\n", "a\nc\n")).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,3 +1,2 @@
+       a
+      -b
+       c
+    DIFF
+  end
+
+  it 'anchors an insertion into an empty file to line 0' do
+    expect(diff('', "a\n")).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -0,0 +1 @@
+      +a
+    DIFF
+  end
+
+  it 'marks a missing newline at the end of the file' do
+    expect(diff("a\nb", "a\nB")).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,2 +1,2 @@
+       a
+      -b
+      \\ No newline at end of file
+      +B
+      \\ No newline at end of file
+    DIFF
+  end
+
+  it 'surrounds each change with three lines of context' do
+    old_source = (1..12).map { |number| "#{number}\n" }.join
+    new_source = old_source.sub("2\n", "two\n")
+
+    expect(diff(old_source, new_source)).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,5 +1,5 @@
+       1
+      -2
+      +two
+       3
+       4
+       5
+    DIFF
+  end
+
+  it 'reports distant changes as separate hunks' do
+    old_source = (1..20).map { |number| "#{number}\n" }.join
+    new_source = old_source.sub("2\n", "two\n").sub("18\n", "eighteen\n")
+
+    expect(diff(old_source, new_source)).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -1,5 +1,5 @@
+       1
+      -2
+      +two
+       3
+       4
+       5
+      @@ -15,6 +15,6 @@
+       15
+       16
+       17
+      -18
+      +eighteen
+       19
+       20
+    DIFF
+  end
+
+  it 'merges changes whose context overlaps into one hunk' do
+    old_source = (1..10).map { |number| "#{number}\n" }.join
+    new_source = old_source.sub("3\n", "three\n").sub("6\n", "six\n")
+
+    expect(diff(old_source, new_source).scan('@@ -').size).to eq(1)
+  end
+
+  it 'reports a wholly rewritten region as one replacement' do
+    old_source = (1..600).map { |number| "old #{number}\n" }.join
+    new_source = (1..600).map { |number| "new #{number}\n" }.join
+    result = diff(old_source, new_source)
+
+    expect(result.lines.count { |line| line.start_with?('-') && !line.start_with?('---') })
+      .to eq(600)
+    expect(result.lines.count { |line| line.start_with?('+') && !line.start_with?('+++') })
+      .to eq(600)
+  end
+
+  it 'diffs a large file with few changes quickly' do
+    old_source = (1..5000).map { |number| "line #{number}\n" }.join
+    new_source = old_source.sub("line 4000\n", "LINE 4000\n")
+
+    expect(diff(old_source, new_source)).to eq(<<~DIFF)
+      --- a/example.rb
+      +++ b/example.rb
+      @@ -3997,7 +3997,7 @@
+       line 3997
+       line 3998
+       line 3999
+      -line 4000
+      +LINE 4000
+       line 4001
+       line 4002
+       line 4003
+    DIFF
+  end
+end


### PR DESCRIPTION
Seeing what `-a` would do means running it and reading `git diff`, which is awkward locally and impossible in CI. `--diff` runs the correction in memory and prints the patch instead, exiting non-zero when there is one, so a CI job can fail with the fix in its log.

The diff comes from a small Myers implementation rather than a new dependency; a file that was rewritten rather than corrected falls back to a single replacement hunk so the minimal-diff search can't blow up on pathological input.

Offenses are still reported as `[Corrected]` since they were corrected in memory, with nothing written to disk. `--format quiet` gives the diff on its own.