### PR TITLE
Add `--changed` to inspect only the files git says changed

### DIFF
--- a/changelog/new_add_changed_to_inspect_only_the_files_git_says_changed_20260830101507.md
+++ b/changelog/new_add_changed_to_inspect_only_the_files_git_says_changed_20260830101507.md
@@ -1,0 +1,1 @@
+* [#15629](https://github.com/rubocop/rubocop/pull/15629): Add `--changed` to inspect only the files git says changed. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -45,6 +45,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `-C/--cache`
 | Store and reuse results for faster operation.
 
+| `--changed[=REVISION]`
+| Inspect only the files that differ from a git revision, defaulting to `HEAD`. Untracked files count as changed.
+
 | `-d/--debug`
 | Displays some extra debug output.
 

--- a/docs/modules/ROOT/pages/usage/getting_started.adoc
+++ b/docs/modules/ROOT/pages/usage/getting_started.adoc
@@ -98,6 +98,49 @@ $ rubocop -x
 
 TIP: Review the diff after running autocorrect, especially with `-A`. See xref:usage/autocorrect.adoc[Autocorrect] for more details on safe vs. unsafe corrections.
 
+== Inspecting Only What Changed
+
+On a large project you often care only about the code you just touched.
+`--changed` asks git which files differ and inspects those:
+
+[source,sh]
+----
+# Files you have modified since the last commit, including untracked ones
+$ rubocop --changed
+
+# Everything your branch changes relative to main - useful on CI
+$ rubocop --changed=main
+----
+
+Deleted files are skipped, and `Include`/`Exclude` still apply, so the result is
+the intersection of "what git says changed" and "what RuboCop would inspect
+anyway". Paths given on the command line narrow it further, so
+`rubocop --changed lib` inspects the changed files under `lib`.
+
+Two things it is good for. On a large codebase that is mid-adoption, it keeps a
+local run fast and focused on the code you are actually touching:
+
+[source,sh]
+----
+$ rubocop --changed --diff
+----
+
+And on CI, it holds new code to a standard the whole repository does not meet
+yet, without a todo file:
+
+[source,sh]
+----
+$ git fetch origin main --depth=1
+$ rubocop --changed=origin/main
+----
+
+NOTE: The whole file is inspected, not just the lines that changed, so a file you
+touched can still report an offense from a part you did not write. Tools like
+https://github.com/prontolabs/pronto[Pronto] exist for line-level filtering.
+
+In a repository without any commits every file counts as changed, and outside a
+git repository `--changed` reports the error rather than guessing.
+
 == Editor Integration
 
 For the best experience, set up RuboCop in your editor so you get real-time feedback as you type. RuboCop has a xref:usage/lsp.adoc[built-in LSP server] that works with any editor that supports the Language Server Protocol.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -27,6 +27,7 @@ require_relative 'rubocop/ext/regexp_parser'
 require_relative 'rubocop/core_ext/string'
 require_relative 'rubocop/ext/processed_source'
 
+require_relative 'rubocop/changed_files'
 require_relative 'rubocop/error'
 require_relative 'rubocop/file_finder'
 require_relative 'rubocop/file_patterns'

--- a/lib/rubocop/changed_files.rb
+++ b/lib/rubocop/changed_files.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module RuboCop
+  # Lists the files that differ from a git revision, for `--changed`.
+  #
+  # Shelling out to `git` keeps RuboCop free of a version control dependency,
+  # and means the answer is exactly what git would give on the command line.
+  #
+  # @api private
+  class ChangedFiles
+    DEFAULT_REVISION = 'HEAD'
+    FILESYSTEM_ENCODING = Encoding.find('filesystem')
+
+    def initialize(revision = nil)
+      @revision = revision || DEFAULT_REVISION
+    end
+
+    # Files that were added or modified since the revision, as absolute paths.
+    # Deleted files are left out - there is nothing left to inspect - and
+    # untracked files are included, since a file that is new to the working
+    # tree has changed as surely as one git already knows about.
+    #
+    # @return [Set<String>]
+    def paths
+      root = repository_root
+
+      (modified_paths + untracked_paths).to_set { |path| File.expand_path(path, root) }
+    end
+
+    private
+
+    def repository_root
+      filesystem_path(git('rev-parse', '--show-toplevel').b.chomp)
+    end
+
+    def modified_paths
+      # `diff.relative` would make git report paths relative to the current
+      # directory rather than to the repository root.
+      split_paths(
+        git('-c', 'diff.relative=false', 'diff', '--name-only', '--diff-filter=d', '-z', @revision)
+      )
+    rescue Error
+      raise unless unborn_head?
+
+      # A repository without commits has nothing to diff against, and
+      # everything in it is untracked - which is what the caller wants to hear
+      # rather than an error about `HEAD` not resolving.
+      []
+    end
+
+    def unborn_head?
+      return false unless @revision == DEFAULT_REVISION
+
+      _stdout, _stderr, status = Open3.capture3('git', 'rev-parse', '--verify', '--quiet', 'HEAD')
+      !status.success?
+    end
+
+    def untracked_paths
+      # `--full-name` anchors the paths to the repository root, the way the
+      # paths from `git diff` already are.
+      split_paths(git('ls-files', '--others', '--exclude-standard', '--full-name', '-z'))
+    end
+
+    # The `-z` above is what makes these usable: without it git wraps any path
+    # that is not plain ASCII in quotes and octal escapes, and those files drop
+    # out of the comparison without a word.
+    def split_paths(output)
+      output.b.split("\0").reject(&:empty?).map { |path| filesystem_path(path) }
+    end
+
+    # git hands back bytes, which Ruby tags with the encoding the process
+    # happens to have been started in - splitting those bytes as US-ASCII raises
+    # on any path that is not. They have to end up in the encoding `Dir.glob`
+    # uses, or a path with a non-ASCII character in it never matches the file
+    # list it is compared against.
+    #
+    # On POSIX those bytes are already the filesystem's own, so the encoding is
+    # simply corrected. Windows is the exception: git converts paths to UTF-8 on
+    # the way out, while Ruby reports file names in the local code page, so the
+    # two have to be reconciled.
+    def filesystem_path(path)
+      path = path.dup
+
+      return path.force_encoding(FILESYSTEM_ENCODING) unless Platform.windows?
+
+      path.force_encoding(Encoding::UTF_8).encode(FILESYSTEM_ENCODING)
+    rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+      # A name the local code page cannot represent. Nothing good is left to do
+      # with it, and dropping it would be worse than reporting it as-is.
+      path.force_encoding(FILESYSTEM_ENCODING)
+    end
+
+    def git(*args)
+      stdout, stderr, status = Open3.capture3('git', *args)
+
+      raise Error, git_error_message(stderr) unless status.success?
+
+      stdout
+    rescue Errno::ENOENT
+      raise Error, '--changed requires git to be installed and on your PATH.'
+    end
+
+    def git_error_message(stderr)
+      message = stderr.strip
+      message = 'git failed with no output on standard error.' if message.empty?
+
+      "--changed could not ask git which files changed: #{message}"
+    end
+  end
+end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -109,6 +109,10 @@ module RuboCop
         option(opts, '--ignore-parent-exclusion')
         option(opts, '--ignore-unrecognized-cops')
         option(opts, '--force-default-config')
+        option(opts, '--changed [REVISION]') do |revision|
+          @options[:changed] = revision || ChangedFiles::DEFAULT_REVISION
+          @validator.validate_changed_revision(revision)
+        end
         option(opts, '-s', '--stdin FILE')
         option(opts, '--editor-mode')
         option(opts, '-P', '--[no-]parallel')
@@ -414,6 +418,7 @@ module RuboCop
       validate_display_only_correctable_and_autocorrect
       validate_lsp_and_editor_mode
       validate_diff
+      validate_changed_and_stdin
       validate_enable_all_cops_and_disable_all_cops
       disable_parallel_when_invalid_option_combo
 
@@ -467,6 +472,12 @@ module RuboCop
       return unless @options.key?(:diff) && @options.key?(:auto_gen_config)
 
       raise OptionArgumentError, '--diff cannot be used with --auto-gen-config.'
+    end
+
+    def validate_changed_and_stdin
+      return unless @options.key?(:changed) && @options.key?(:stdin)
+
+      raise OptionArgumentError, '--changed cannot be used with --stdin.'
     end
 
     def validate_lsp_and_editor_mode
@@ -531,6 +542,17 @@ module RuboCop
 
     def incompatible_options
       @incompatible_options ||= @options.keys & Options::EXITING_OPTIONS
+    end
+
+    # OptionParser hands `--changed lib/` the path as the revision, which is a
+    # natural thing to type, so point at the fix rather than at git's error.
+    def validate_changed_revision(revision)
+      return unless revision && File.exist?(revision)
+
+      raise OptionArgumentError,
+            "--changed takes a git revision, but `#{revision}` is a path. Write the revision " \
+            "as `--changed=#{revision}` if that is really what you meant, or drop it to " \
+            'compare against HEAD.'
     end
 
     def validate_exclude_limit_option
@@ -610,6 +632,10 @@ module RuboCop
       ignore_parent_exclusion:          ['Prevent from inheriting `AllCops/Exclude` from',
                                          'parent folders.'],
       ignore_unrecognized_cops:         ['Ignore unrecognized cops or departments in the config.'],
+      changed:                          ['Inspect only the files that differ from a git',
+                                         'revision, defaulting to HEAD. Untracked files',
+                                         'count as changed. Pass a revision with',
+                                         '`--changed=REVISION`.'],
       force_default_config:             ['Use default configuration even if configuration',
                                          'files are present in the directory tree.'],
       format:                           ['Choose an output formatter. This option',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -74,7 +74,7 @@ module RuboCop
       # inconsistencies between workers.
       ResultCache.source_checksum
 
-      target_files = find_target_files(paths)
+      target_files = only_changed(find_target_files(paths))
       build_project_index(target_files)
 
       if @options[:list_target_files]
@@ -95,6 +95,16 @@ module RuboCop
     end
 
     private
+
+    # The project index is deliberately built from the unfiltered file list:
+    # cross-file offenses must not depend on which files happen to have changed.
+    def only_changed(target_files)
+      return target_files unless @options[:changed]
+
+      changed = ChangedFiles.new(@options[:changed]).paths
+
+      target_files.select { |file| changed.include?(file) }.freeze
+    end
 
     def find_target_files(paths)
       target_finder = TargetFinder.new(@config_store, @options)

--- a/spec/rubocop/changed_files_spec.rb
+++ b/spec/rubocop/changed_files_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::ChangedFiles do
+  subject(:changed_files) { described_class.new(revision) }
+
+  let(:revision) { nil }
+
+  def git(*args)
+    _stdout, stderr, status = Open3.capture3('git', *args)
+
+    raise "git #{args.join(' ')} failed: #{stderr}" unless status.success?
+  end
+
+  def commit_all(message)
+    git('add', '-A')
+    git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', message)
+  end
+
+  def write(path, contents = "# frozen_string_literal: true\n")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+  end
+
+  def basenames
+    changed_files.paths.map { |path| File.basename(path) }.sort
+  end
+
+  # Paths come back in the filesystem's encoding, which is the local code page
+  # on Windows rather than UTF-8. Compare the characters, not the bytes.
+  def basenames_as_utf8
+    basenames.map { |name| name.encode(Encoding::UTF_8) }
+  end
+
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      # Symlinked temporary directories (`/tmp` on macOS) make git and
+      # `File.expand_path` disagree about the repository root.
+      Dir.chdir(File.realpath(tmpdir)) do
+        git('init')
+        example.run
+      end
+    end
+  end
+
+  before do
+    write('lib/untouched.rb')
+    write('lib/modified.rb')
+    write('lib/deleted.rb')
+    commit_all('init')
+  end
+
+  it 'returns absolute paths that exist on disk' do
+    write('lib/modified.rb', "# frozen_string_literal: true\n# changed\n")
+
+    expect(changed_files.paths).to all(start_with(Dir.pwd))
+    expect(changed_files.paths).to all(satisfy { |path| File.exist?(path) })
+  end
+
+  # Without `-z`, git reports these quoted and octal-escaped, and they quietly
+  # fall out of the comparison.
+  it 'reports paths that are not plain ASCII' do
+    write('lib/café.rb')
+    write('lib/naïve.rb', "# frozen_string_literal: true\n# changed\n")
+    commit_all('accents')
+    write('lib/café.rb', "# frozen_string_literal: true\n# changed\n")
+
+    expect(basenames_as_utf8).to eq(['café.rb'])
+    expect(changed_files.paths).to all(satisfy { |path| File.exist?(path) })
+  end
+
+  # git hands back bytes, which Ruby tags with the encoding the process was
+  # started in. Under a US-ASCII locale that used to raise
+  # `invalid byte sequence in US-ASCII` for every non-ASCII path.
+  it 'does not depend on the encoding the process was started in' do
+    allow(Open3).to receive(:capture3).and_wrap_original do |original, *args|
+      stdout, stderr, status = original.call(*args)
+      [stdout.dup.force_encoding(Encoding::US_ASCII), stderr, status]
+    end
+
+    write('lib/café.rb')
+    commit_all('accents')
+    write('lib/café.rb', "# frozen_string_literal: true\n# changed\n")
+    write('lib/untracked_café.rb')
+
+    expect(basenames_as_utf8).to eq(['café.rb', 'untracked_café.rb'])
+  end
+
+  # Unreachable on POSIX, where git's bytes are already the filesystem's.
+  context 'when git reports UTF-8 but the filesystem uses another encoding' do
+    before do
+      allow(RuboCop::Platform).to receive(:windows?).and_return(true)
+      stub_const("#{described_class}::FILESYSTEM_ENCODING", Encoding::WINDOWS_1252)
+    end
+
+    # Asserting the characters rather than the encoding of the returned string:
+    # `File.expand_path` does not preserve the tag on every implementation, and
+    # what matters is that the name survives the conversion intact.
+    it 'converts the paths into the encoding the file list uses' do
+      write('lib/café.rb')
+      commit_all('accents')
+      write('lib/café.rb', "# frozen_string_literal: true\n# changed\n")
+
+      expect(basenames_as_utf8).to eq(['café.rb'])
+    end
+
+    it 'reports a name the code page cannot represent rather than dropping it' do
+      write('lib/日本語.rb')
+      commit_all('kanji')
+      write('lib/日本語.rb', "# frozen_string_literal: true\n# changed\n")
+
+      expect(basenames.size).to eq(1)
+    end
+  end
+
+  it 'reports paths containing spaces' do
+    write('lib/with space.rb')
+    commit_all('spaces')
+    write('lib/with space.rb', "# frozen_string_literal: true\n# changed\n")
+
+    expect(basenames).to eq(['with space.rb'])
+  end
+
+  it 'reports files modified in the working tree' do
+    write('lib/modified.rb', "# frozen_string_literal: true\n# changed\n")
+
+    expect(basenames).to eq(['modified.rb'])
+  end
+
+  it 'reports staged files' do
+    write('lib/modified.rb', "# frozen_string_literal: true\n# changed\n")
+    git('add', 'lib/modified.rb')
+
+    expect(basenames).to eq(['modified.rb'])
+  end
+
+  it 'reports untracked files' do
+    write('lib/untracked.rb')
+
+    expect(basenames).to eq(['untracked.rb'])
+  end
+
+  it 'ignores files excluded by gitignore' do
+    write('.gitignore', "ignored.rb\n")
+    write('lib/ignored.rb')
+
+    expect(basenames).to eq(['.gitignore'])
+  end
+
+  it 'leaves out deleted files' do
+    git('rm', 'lib/deleted.rb')
+
+    expect(basenames).to be_empty
+  end
+
+  it 'reports nothing when the working tree is clean' do
+    expect(changed_files.paths).to be_empty
+  end
+
+  it 'reports paths relative to the repository root when run from a subdirectory' do
+    write('lib/modified.rb', "# frozen_string_literal: true\n# changed\n")
+
+    Dir.chdir('lib') { expect(basenames).to eq(['modified.rb']) }
+  end
+
+  context 'in a repository without any commits' do
+    around do |example|
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(File.realpath(tmpdir)) do
+          git('init')
+          example.run
+        end
+      end
+    end
+
+    it 'reports everything in the working tree' do
+      write('lib/brand_new.rb')
+
+      expect(basenames).to eq(['brand_new.rb'])
+    end
+
+    it 'still raises for a revision that was asked for by name' do
+      changed_files = described_class.new('HEAD~1')
+
+      expect { changed_files.paths }.to raise_error(RuboCop::Error)
+    end
+  end
+
+  context 'with an explicit revision' do
+    let(:revision) { 'HEAD~1' }
+
+    it 'compares against that revision' do
+      write('lib/modified.rb', "# frozen_string_literal: true\n# changed\n")
+      commit_all('second')
+
+      expect(basenames).to eq(['modified.rb'])
+    end
+
+    it 'raises a RuboCop error when the revision is unknown' do
+      changed_files = described_class.new('no-such-revision')
+
+      expect { changed_files.paths }
+        .to raise_error(RuboCop::Error, /--changed could not ask git which files changed/)
+    end
+  end
+
+  context 'when run outside a git repository' do
+    it 'raises a RuboCop error' do
+      Dir.mktmpdir do |outside|
+        Dir.chdir(outside) do
+          expect { changed_files.paths }.to raise_error(RuboCop::Error, /not a git repository/)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cli/changed_spec.rb
+++ b/spec/rubocop/cli/changed_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --changed', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'cli spec behavior'
+
+  def git(*args)
+    _stdout, stderr, status = Open3.capture3('git', *args)
+
+    raise "git #{args.join(' ')} failed: #{stderr}" unless status.success?
+  end
+
+  def commit_all(message)
+    git('add', '-A')
+    git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', message)
+  end
+
+  let(:offending_source) { "# frozen_string_literal: true\n\nputs \"offense\"\n" }
+
+  before do
+    git('init')
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        NewCops: disable
+        SuggestExtensions: false
+    YAML
+    create_file('untouched.rb', offending_source)
+    commit_all('init')
+  end
+
+  it 'inspects only the files that differ from HEAD' do
+    create_file('modified.rb', offending_source)
+
+    expect(cli.run(['--changed', '--format', 'files'])).to eq(1)
+    expect($stdout.string.split("\n").map { |path| File.basename(path) }).to eq(['modified.rb'])
+  end
+
+  it 'inspects nothing when the working tree is clean' do
+    expect(cli.run(['--changed', '--format', 'simple'])).to eq(0)
+    expect($stdout.string).to include('no offenses detected')
+  end
+
+  it 'accepts a revision to compare against' do
+    create_file('modified.rb', offending_source)
+    commit_all('second')
+
+    expect(cli.run(['--changed=HEAD~1', '--format', 'files'])).to eq(1)
+    expect($stdout.string.split("\n").map { |path| File.basename(path) }).to eq(['modified.rb'])
+  end
+
+  it 'narrows the given paths rather than replacing them' do
+    create_file('lib/modified.rb', offending_source)
+    create_file('spec/modified_spec.rb', offending_source)
+
+    expect(cli.run(['--changed', '--format', 'files', 'lib'])).to eq(1)
+    expect($stdout.string.split("\n").map { |path| File.basename(path) }).to eq(['modified.rb'])
+  end
+
+  it 'explains what to do when given a path instead of a revision' do
+    create_file('lib/modified.rb', offending_source)
+
+    expect(cli.run(['--changed', 'lib'])).to eq(2)
+    expect($stderr.string).to include('--changed takes a git revision, but `lib` is a path.')
+  end
+
+  it 'cannot be combined with --stdin' do
+    expect(cli.run(['--changed', '--stdin', 'example.rb'])).to eq(2)
+    expect($stderr.string).to include('--changed cannot be used with --stdin.')
+  end
+
+  it 'reports git failures' do
+    expect(cli.run(['--changed=no-such-revision'])).to eq(2)
+    expect($stderr.string).to include('--changed could not ask git which files changed')
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                   --ignore-unrecognized-cops   Ignore unrecognized cops or departments in the config.
                   --force-default-config       Use default configuration even if configuration
                                                files are present in the directory tree.
+                  --changed [REVISION]         Inspect only the files that differ from a git
+                                               revision, defaulting to HEAD. Untracked files
+                                               count as changed. Pass a revision with
+                                               `--changed=REVISION`.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
                                                reports. This is useful for editor integration.
                   --editor-mode                Optimize real-time feedback in editors,


### PR DESCRIPTION
This was turned down twice as too version-control-specific (#2182, #5477), with `git diff --name-only | xargs rubocop` as the answer. That workaround inspects the whole project when the diff is empty, chokes on deleted files, and needs `--force-exclusion` to respect the config, and every linter people also use has since grown the feature.

It is a file-list filter and nothing more: git is shelled out to rather than depended on, and the intersection happens after the usual target finding, so Include/Exclude and command line paths keep working. Filtering to changed *lines* stays out of scope, which is what Pronto is for.

`--changed=REVISION` needs the `=`, since OptionParser would otherwise read the path in `rubocop --changed lib` as a revision; that case now errors with an explanation.