### PR TITLE
Add a preview channel for unstable behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,55 @@ Key conventions:
 - **Cop description** — the first line of the YARD comment must be a complete
   sentence starting with a verb and ending with a period.
 
+## Preview: Shipping Unstable Behavior
+
+`AllCops: Preview` (or `--preview`) is the opt-in channel for changes that are
+not ready to be the default. Cops read it via `preview?`.
+
+Use it when:
+
+- **An existing cop should start reporting a case it currently misses**, and the
+  change is contested enough that turning it on for everyone would be rude.
+  Without preview this waits for a major release.
+- **An existing cop should correct something differently**, and the new
+  correction needs real-world exposure before it becomes the default.
+- **A new cop is too speculative even for `pending`**, so it ships as
+  `Enabled: preview` in `config/default.yml`. It is opt-in only and, unlike a
+  pending cop, is never reported as needing a decision.
+
+Do **not** use it when:
+
+- The change is a plain bug fix. Those just ship.
+- The cop is new and you already expect it to be on by default eventually. That
+  is what `Enabled: pending` is for.
+
+The rule of thumb: if you already know it should become the default, it is
+`pending`. If you are asking users to help you find out, it is `preview`.
+
+```ruby
+def on_send(node)
+  return unless offense?(node)
+  return if node.csend_type? && !preview?
+
+  add_offense(node)
+end
+```
+
+Cover both paths in specs, since the stable one is what most users run:
+
+```ruby
+context 'when preview is enabled' do
+  let(:all_cops_config) { super().merge('Preview' => true) }
+
+  it 'registers an offense for the safe-navigation form' do
+    # ...
+  end
+end
+```
+
+Preview behavior is unstable by contract: it can change or be withdrawn in any
+release. See `docs/modules/ROOT/pages/versioning.adoc` for the lifecycle.
+
 ## Writing Specs
 
 ```ruby

--- a/changelog/new_add_a_preview_channel_for_unstable_behavior_20260830102108.md
+++ b/changelog/new_add_a_preview_channel_for_unstable_behavior_20260830102108.md
@@ -1,0 +1,1 @@
+* [#15631](https://github.com/rubocop/rubocop/pull/15631): Add a preview channel for unstable behavior. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -116,6 +116,11 @@ AllCops:
   # of extra memory proportional to the bundle's size. Has no effect when
   # `UseProjectIndex` is `false` or when RuboCop does not run inside Bundler.
   ProjectIndexIncludesGems: false
+  # Opts in to unstable behavior: cops that are `Enabled: preview`, and changes
+  # to existing cops that are not ready to be the default yet. Can be overridden
+  # by the `--preview` and `--no-preview` command line options.
+  Preview: false
+
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.
   UseCache: true

--- a/docs/modules/ROOT/pages/configuration/cop_settings.adoc
+++ b/docs/modules/ROOT/pages/configuration/cop_settings.adoc
@@ -21,6 +21,21 @@ xref:versioning.adoc["Versioning"]). Some cops, configured with `Enabled: false`
 in https://github.com/rubocop/rubocop/blob/master/config/default.yml[config/default.yml],
 are disabled by default.
 
+`Enabled` also accepts `preview`, for a cop that is not settled enough to be
+`pending` yet. Those run only for projects that ask for them, with
+`AllCops: Preview: true` or `--preview`:
+
+[source,yaml]
+----
+AllCops:
+  Preview: true
+----
+
+Unlike pending cops, preview cops are never reported as needing a decision -
+opting in is the point. See xref:versioning.adoc#preview["Preview"] for what
+else the setting covers, when to reach for it instead of `pending`, and how it
+interacts with `NewCops`, `--only` and the enable-everything settings.
+
 The cop enabling process can be altered by setting `DisabledByDefault` or
 `EnabledByDefault` (but not both) to `true`. These settings override the default for *all*
 cops to disabled or enabled, except `Lint/Syntax` which is always enabled,

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -579,6 +579,48 @@ def on_send(node)
 end
 ----
 
+=== Shipping unstable behavior with `preview?`
+
+Making an existing cop report a case it used to miss, or correct one
+differently, changes results for every project that has the cop enabled. Such a
+change normally has to wait for a major release. `preview?` is the way to ship
+it sooner, to the projects that ask for it:
+
+[source,ruby]
+----
+def on_send(node)
+  return unless redundant_call?(node)
+  # Flagging the safe-navigation form is new; it is behind preview until we
+  # have heard from enough projects to make it the default.
+  return if node.csend_type? && !preview?
+
+  add_offense(node)
+end
+----
+
+The gate is on for projects running with `AllCops: Preview: true` or
+`--preview`, and off for everyone else. Cover both sides in the specs, since the
+stable path is the one most users are on:
+
+[source,ruby]
+----
+context 'when preview is enabled' do
+  let(:all_cops_config) { super().merge('Preview' => true) }
+
+  it 'registers an offense for the safe-navigation form' do
+    expect_offense(<<~RUBY)
+      foo&.bar
+      ^^^^^^^^ Remove the redundant call.
+    RUBY
+  end
+end
+----
+
+Reach for this only when the change is genuinely contested. A change that is
+plainly a bug fix should just ship, and a whole new cop belongs in `pending`
+instead. See xref:versioning.adoc#preview["Preview"] for the full rule and the
+lifecycle a preview change follows afterwards.
+
 [[common-patterns]]
 == Common patterns
 

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -153,6 +153,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--raise-cop-error`
 | Raise cop-related errors with cause and location. This is used to prevent cops from failing silently. Default is false.
 
+| `--[no-]preview`
+| Opt in to unstable behavior: cops that are `Enabled: preview`, and changes to existing cops that are not the default yet. See xref:versioning.adoc#preview[Preview].
+
 | `--plugin`
 | Plugin RuboCop extension file (see xref:plugins.adoc#loading-plugin-extensions[Loading Plugin Extensions]).
 

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -37,6 +37,7 @@ Here are a few examples:
 | Dropping runtime Ruby version support | Minor
 | Enabling pending cops by default | *Major* (one narrow exception, see below)
 | Changing cop defaults (e.g. `EnforcedStyle`) | *Major*
+| Changing what an existing cop reports or corrects, behind `Preview` | Minor
 | Removing cops without a replacement | *Major*
 | Breaking changes to the Ruby API | *Major*
 | Dropping analysis support for a Ruby version | *Major*
@@ -49,6 +50,97 @@ RuboCop supporting their Ruby runtime.
 NOTE: Prior to RuboCop 1.0 bumps of the minor (second) version number
 were considered major releases and always included new features and/or
 changes to existing features.
+
+== Preview
+
+Some changes cannot ship as a pending cop. A cop that starts reporting a case it
+used to miss, or corrects one differently, changes results for everybody who has
+that cop enabled - so historically such changes have had to wait for a major
+release, whatever their merit.
+
+`Preview` is the channel for those changes. It is off by default:
+
+[source,yaml]
+----
+AllCops:
+  Preview: true
+----
+
+or `--preview` on the command line, which overrides the configuration either way
+(`--no-preview` turns it back off).
+
+It gates two things:
+
+* **Behavior changes to existing cops.** A cop can put an unstable change behind
+  `preview?` and ship it in a minor release. Nothing changes for anyone who has
+  not opted in.
++
+[source,ruby]
+----
+def on_send(node)
+  return unless offense?(node)
+  # Reporting the safe-navigation form is new, and not everyone will agree.
+  return if node.csend_type? && !preview?
+
+  add_offense(node)
+end
+----
+* **Cops that are not ready to be `pending` yet**, marked `Enabled: preview`.
+  Unlike pending cops, they are not reported as needing a decision - opting in is
+  the whole point, so there is nothing to nag about.
+
+[source,yaml]
+----
+Style/SomethingExperimental:
+  Enabled: preview
+----
+
+=== Preview or Pending?
+
+Both settings mean "not on by default", so the line between them matters:
+
+* If we already know something should become the default, it is `pending`. That
+  is a heads-up about a decision already made, which is why pending cops are
+  announced: deciding early beats being surprised at the next major release.
+* If we are asking users to help us find out, it is `preview`. There is no plan
+  to commit to yet, so there is nothing to announce.
+
+The intended lifecycle for a new cop is `preview` (for the brave) to `pending`
+(on for anyone with `NewCops: enable`) to enabled by default in the next major
+release. Not every cop needs the first step.
+
+=== Interaction With Other Settings
+
+The two halves of preview do not answer to the same switches, which is worth
+keeping straight.
+
+A cop marked `Enabled: preview` behaves like any other cop that is off:
+
+* `NewCops: enable` does not turn it on. Pending and preview are independent
+  channels, and opting in to one says nothing about the other.
+* `--only` runs it by name, whether or not preview is on.
+* `--enable-all-cops`, `AllCops: EnabledByDefault` and
+  `AllCops: DisabledByDefault` rewrite the *defaults*, so they cover a cop that
+  ships as `Enabled: preview` in RuboCop's own configuration. An
+  `Enabled: preview` you wrote in your own config is an explicit choice and wins
+  over them, exactly as an explicit `Enabled: false` does.
+
+Behavior gated behind `preview?` answers to the `Preview` setting and nothing
+else. Neither `--only` nor `--enable-all-cops` reaches inside a cop to switch it
+on, so a cop running under `--only` still reports its stable behavior unless
+preview is also on.
+
+Trying preview on a project is one flag, which makes it cheap to report back on
+a change before it becomes the default:
+
+[source,sh]
+----
+$ rubocop --preview
+----
+
+NOTE: Preview behavior is unstable by definition. It can change or be withdrawn
+in any release, which is exactly what the flag buys us: a way to get a change in
+front of users early without committing to it.
 
 == Pending Cops
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -13,7 +13,7 @@ module RuboCop
     DEFAULT_PARALLEL_OPTIONS = %i[
       color config debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed editor_mode except extra_details fail_level fix_layout format formatters
-      ignore_disable_comments lint only only_guide_cops out require safe
+      ignore_disable_comments lint only only_guide_cops out preview require safe
       autocorrect safe_autocorrect autocorrect_all
     ].freeze
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -226,6 +226,16 @@ module RuboCop
       end
     end
 
+    # Whether preview behavior is on, for cops that gate an unstable change
+    # behind it and for cops that are themselves `Enabled: preview`.
+    # `--preview` / `--no-preview` win over `AllCops: Preview`.
+    def preview?(options = {})
+      preview = options[:preview]
+      return preview unless preview.nil?
+
+      for_all_cops['Preview'] == true
+    end
+
     def active_support_extensions_enabled?
       for_all_cops['ActiveSupportExtensionsEnabled']
     end

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -21,7 +21,7 @@ module RuboCop
 
     # @api private
     CONFIG_CHECK_KEYS = %w[Enabled Safe SafeAutoCorrect AutoCorrect References].to_set.freeze
-    CONFIG_CHECK_DEPARTMENTS = %w[pending override_department].freeze
+    CONFIG_CHECK_DEPARTMENTS = %w[pending preview override_department].freeze
     CONFIG_CHECK_AUTOCORRECTS = %w[always contextual disabled].freeze
     private_constant :CONFIG_CHECK_KEYS, :CONFIG_CHECK_DEPARTMENTS
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -288,6 +288,13 @@ module RuboCop
         @config.string_literals_frozen_by_default?
       end
 
+      # Whether the user opted in to unstable behavior, with `--preview` or
+      # `AllCops: Preview`. Cops branch on this to ship a change that is not
+      # ready to be the default yet.
+      def preview?
+        @config.preview?(@options)
+      end
+
       def relevant_file?(file)
         return false unless target_satisfies_all_gem_version_requirements?
         return true unless @config.clusivity_config_for_badge?(self.class.badge)

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -280,6 +280,12 @@ module RuboCop
         config.enabled_new_cop?(cop_name)
       end
 
+      # Preview cops are opt-in and stay silent otherwise, so unlike pending cops
+      # they are never reported as needing a decision.
+      def enabled_preview_cop?(cop_cfg, config)
+        cop_cfg.fetch('Enabled') == 'preview' && config.preview?(@options)
+      end
+
       def names
         clear_enrollment_queue
         @cops_by_badge.keys.map(&:to_s)
@@ -420,7 +426,9 @@ module RuboCop
         # caching which expects cop names or cop classes as keys.
         cfg = config.for_cop(cop_name)
 
-        cop_enabled = cfg.fetch('Enabled') == true || enabled_pending_cop?(cfg, config, cop_name)
+        cop_enabled = cfg.fetch('Enabled') == true ||
+                      enabled_pending_cop?(cfg, config, cop_name) ||
+                      enabled_preview_cop?(cfg, config)
 
         if options.fetch(:safe, false)
           cop_enabled && cfg.fetch('Safe', true)

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -389,7 +389,11 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   def cop_status(status)
     return 'Disabled' unless status
 
-    status == 'pending' ? 'Pending' : 'Enabled'
+    case status
+    when 'pending' then 'Pending'
+    when 'preview' then 'Preview'
+    else 'Enabled'
+    end
   end
 
   # HTML anchor are somewhat limited in what characters they can contain, just

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -103,6 +103,7 @@ module RuboCop
         option(opts, '--enable-pending-cops')
         option(opts, '--disable-all-cops')
         option(opts, '--enable-all-cops')
+        option(opts, '--[no-]preview')
         option(opts, '--ignore-disable-comments')
         option(opts, '--force-exclusion')
         option(opts, '--only-recognized-file-types')
@@ -694,6 +695,10 @@ module RuboCop
                                          '`AllCops/DisabledByDefault` in config files.'],
       display_style_guide:              'Display style guide URLs in offense messages.',
       enable_pending_cops:              'Run with pending cops.',
+      preview:                          ['Opt in to unstable behavior: cops that are',
+                                         '`Enabled: preview`, and changes to existing',
+                                         'cops that are not the default yet.',
+                                         'Overrides `AllCops: Preview`.'],
       enable_all_cops:                  ['Run with all cops enabled, including those',
                                          'disabled by default. Overrides',
                                          '`AllCops/EnabledByDefault` and',

--- a/spec/rubocop/cli/preview_spec.rb
+++ b/spec/rubocop/cli/preview_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'cli spec behavior'
+
+  before do
+    create_file('example.rb', <<~RUBY)
+      # frozen_string_literal: true
+
+      for x in [1, 2] do puts x end
+    RUBY
+  end
+
+  context 'when a cop is `Enabled: preview`' do
+    before do
+      create_file('.rubocop.yml', <<~YAML)
+        Style/For:
+          Enabled: preview
+      YAML
+    end
+
+    it 'leaves the cop out by default' do
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+      expect($stdout.string).not_to include('Style/For')
+    end
+
+    it 'runs the cop with --preview' do
+      expect(cli.run(['--preview', '--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/For')
+    end
+
+    it 'runs the cop when the config opts in' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+        Style/For:
+          Enabled: preview
+      YAML
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/For')
+    end
+
+    it 'lets --no-preview override the config' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+        Style/For:
+          Enabled: preview
+      YAML
+
+      expect(cli.run(['--no-preview', '--format', 'simple', 'example.rb'])).to eq(0)
+      expect($stdout.string).not_to include('Style/For')
+    end
+
+    it 'runs the cop when it is requested explicitly with --only' do
+      expect(cli.run(['--only', 'Style/For', '--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Style/For')
+    end
+
+    it 'is not turned on by `NewCops: enable`' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          NewCops: enable
+        Style/For:
+          Enabled: preview
+      YAML
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+      expect($stdout.string).not_to include('Style/For')
+    end
+
+    it 'is left alone by --enable-all-cops, which only rewrites the defaults' do
+      expect(cli.run(['--enable-all-cops', '--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).not_to include('Style/For')
+    end
+
+    it 'does not nag about it the way pending cops do' do
+      cli.run(['--format', 'simple', 'example.rb'])
+
+      expect($stdout.string).not_to include('not configured')
+      expect($stderr.string).not_to include('not configured')
+    end
+  end
+
+  it 'rejects an unknown `Enabled` value' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/For:
+        Enabled: previewing
+    YAML
+
+    expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(2)
+    expect($stderr.string).to include('is supposed to be a boolean')
+  end
+end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -926,6 +926,36 @@ RSpec.describe RuboCop::Config do
     it { is_expected.to be_cop_enabled('Metrics/MethodLength') }
   end
 
+  describe '#preview?' do
+    subject(:preview) { configuration.preview?(options) }
+
+    let(:options) { {} }
+
+    context 'when `AllCops: Preview` is not set' do
+      let(:hash) { {} }
+
+      it { is_expected.to be(false) }
+
+      context 'when `--preview` is given' do
+        let(:options) { { preview: true } }
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    context 'when `AllCops: Preview` is true' do
+      let(:hash) { { 'AllCops' => { 'Preview' => true } } }
+
+      it { is_expected.to be(true) }
+
+      context 'when `--no-preview` is given' do
+        let(:options) { { preview: false } }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe '#pending_cops' do
     subject(:pending_cops) { configuration.pending_cops.map(&:name) }
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -579,6 +579,30 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     end
   end
 
+  describe '#preview?' do
+    subject { cop.preview? }
+
+    it { is_expected.to be(false) }
+
+    context 'when the `--preview` option is given' do
+      let(:cop_options) { { preview: true } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when `AllCops: Preview` is set' do
+      let(:config) { RuboCop::Config.new('AllCops' => { 'Preview' => true }) }
+
+      it { is_expected.to be(true) }
+
+      context 'when the `--no-preview` option is given' do
+        let(:cop_options) { { preview: false } }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe '#safe_autocorrect?' do
     subject { cop.safe_autocorrect? }
 

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -350,6 +350,43 @@ RSpec.describe RuboCop::Cop::Registry do
       expect(enabled_cops).not_to include(RuboCop::Cop::RSpec::Foo)
     end
 
+    context 'when a cop is in preview' do
+      let(:config) { RuboCop::Config.new('Lint/BooleanSymbol' => { 'Enabled' => 'preview' }) }
+
+      it 'does not include them' do
+        expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+      end
+
+      context 'when specifying the `--preview` command-line option' do
+        let(:options) { { preview: true } }
+
+        it 'includes them' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+      end
+
+      context 'when specifying `Preview: true` in .rubocop.yml' do
+        let(:config) do
+          RuboCop::Config.new(
+            'AllCops' => { 'Preview' => true },
+            'Lint/BooleanSymbol' => { 'Enabled' => 'preview' }
+          )
+        end
+
+        it 'includes them' do
+          expect(enabled_cops).to include(RuboCop::Cop::Lint::BooleanSymbol)
+        end
+
+        context 'when specifying the `--no-preview` command-line option' do
+          let(:options) { { preview: false } }
+
+          it 'does not include them' do
+            expect(enabled_cops).not_to include(RuboCop::Cop::Lint::BooleanSymbol)
+          end
+        end
+      end
+    end
+
     context 'when new cops are introduced' do
       let(:config) { RuboCop::Config.new('Lint/BooleanSymbol' => { 'Enabled' => 'pending' }) }
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                disabled by default. Overrides
                                                `AllCops/EnabledByDefault` and
                                                `AllCops/DisabledByDefault` in config files.
+                  --[no-]preview               Opt in to unstable behavior: cops that are
+                                               `Enabled: preview`, and changes to existing
+                                               cops that are not the default yet.
+                                               Overrides `AllCops: Preview`.
                   --ignore-disable-comments    Report offenses even if they have been manually disabled
                                                with a `rubocop:disable` or `rubocop:todo` directive.
                   --force-exclusion            Any files excluded by `Exclude` in configuration


### PR DESCRIPTION
`pending` only covers a cop's first appearance. There is no channel for changing what an existing cop already does, so a change that alters results has to wait for a major release however good it is - which shapes our release cadence more than anything else.

`AllCops: Preview` (or `--preview`) gates two things: cops marked `Enabled: preview`, and behavior changes inside existing cops, which now branch on `preview?`. Nothing ships enabled, so a project that has not opted in sees no change.

Preview cops deliberately do not get the pending-cop warning - opting in is the point, so there is nothing to nag about. The intended lifecycle is preview, then pending, then on by default in the next major, with the first step optional.

Nothing uses `preview?` yet; this is the mechanism, so the first behavior change that wants it has somewhere to go.