### PR TITLE
Backfill cop severities so they say what should break a build

### DIFF
--- a/changelog/change_backfill_cop_severities_so_they_say_what_should_break_a_build_20260830103113.md
+++ b/changelog/change_backfill_cop_severities_so_they_say_what_should_break_a_build_20260830103113.md
@@ -1,0 +1,1 @@
+* [#15632](https://github.com/rubocop/rubocop/pull/15632): Backfill cop severities so they say what should break a build. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1694,6 +1694,7 @@ Lint/AmbiguousOperatorPrecedence:
                  Checks for expressions containing multiple binary operations with
                  ambiguous precedence.
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.21'
 
 Lint/AmbiguousRange:
@@ -1783,6 +1784,7 @@ Lint/ConstantResolution:
   Description: 'Checks that constants are fully qualified with `::`.'
   VersionChanged: '1.89'
   Enabled: false
+  Severity: convention
   VersionAdded: '0.86'
   # Restrict this cop to only looking at certain names
   Only: []
@@ -1911,6 +1913,7 @@ Lint/DisjunctiveAssignmentInConstructor:
   Description: 'In constructor, plain assignment is preferred over disjunctive.'
   StyleGuide: '#disjunctive-assignment-in-constructor'
   Enabled: true
+  Severity: convention
   Safe: false
   VersionAdded: '0.62'
   VersionChanged: '0.88'
@@ -2015,6 +2018,7 @@ Lint/EmptyBlock:
 Lint/EmptyClass:
   Description: 'Checks for classes and metaclasses without a body.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.3'
   AllowComments: false
 
@@ -2041,6 +2045,7 @@ Lint/EmptyExpression:
 Lint/EmptyFile:
   Description: 'Enforces that Ruby source files are not empty.'
   Enabled: true
+  Severity: convention
   AllowComments: true
   VersionAdded: '0.90'
 
@@ -2118,6 +2123,7 @@ Lint/HeredocMethodCallPosition:
                  the receiver of the call is a HEREDOC.
   StyleGuide: '#heredoc-method-calls'
   Enabled: false
+  Severity: convention
   VersionAdded: '0.68'
 
 Lint/IdentityComparison:
@@ -2215,6 +2221,7 @@ Lint/MisplacedMagicComment:
 Lint/MissingCopEnableDirective:
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.52'
   VersionChanged: '1.90'
   # Maximum number of consecutive lines the cop can be disabled for.
@@ -2394,17 +2401,20 @@ Lint/RedundantCopDisableDirective:
                  Note: this cop is not disabled when disabling all cops.
                  It must be explicitly disabled.
   Enabled: true
+  Severity: convention
   VersionAdded: '0.76'
 
 Lint/RedundantCopEnableDirective:
   Description: Checks for rubocop:enable comments that can be removed.
   Enabled: true
+  Severity: convention
   VersionAdded: '0.76'
   VersionChanged: '1.90'
 
 Lint/RedundantDirGlobSort:
   Description: 'Checks for redundant `sort` method to `Dir.glob` and `Dir[]`.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.8'
   VersionChanged: '1.26'
   SafeAutoCorrect: false
@@ -2412,17 +2422,20 @@ Lint/RedundantDirGlobSort:
 Lint/RedundantRegexpQuantifiers:
   Description: 'Checks for redundant quantifiers in Regexps.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.53'
 
 Lint/RedundantRequireStatement:
   Description: 'Checks for unnecessary `require` statement.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.76'
   VersionChanged: '1.73'
 
 Lint/RedundantSafeNavigation:
   Description: 'Checks for redundant safe navigation calls.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.93'
   VersionChanged: '1.79'
   AllowedMethods:
@@ -2443,6 +2456,7 @@ Lint/RedundantSafeNavigation:
 Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.76'
   VersionChanged: '1.7'
   AllowPercentLiteralArrayArgument: true
@@ -2451,22 +2465,26 @@ Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
   StyleGuide: '#no-to-s'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.19'
   VersionChanged: '0.77'
 
 Lint/RedundantTypeConversion:
   Description: 'Checks for redundantly converting a literal to the same type.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.72'
 
 Lint/RedundantWithIndex:
   Description: 'Checks for redundant `with_index`.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.50'
 
 Lint/RedundantWithObject:
   Description: 'Checks for redundant `with_object`.'
   Enabled: true
+  Severity: convention
   SafeAutoCorrect: false
   VersionAdded: '0.51'
   VersionChanged: '1.88'
@@ -2631,6 +2649,7 @@ Lint/SuppressedExceptionInNumberConversion:
 Lint/SymbolConversion:
   Description: 'Checks for unnecessary symbol conversions.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.9'
   VersionChanged: '1.16'
   EnforcedStyle: strict
@@ -2671,11 +2690,13 @@ Lint/TrailingCommaInAttributeDeclaration:
 Lint/TripleQuotes:
   Description: 'Checks for useless triple quote constructs.'
   Enabled: pending
+  Severity: convention
   VersionAdded: '1.9'
 
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
+  Severity: convention
   VersionAdded: '0.21'
   AllowKeywordBlockArguments: false
 
@@ -2737,6 +2758,7 @@ Lint/UnusedBlockArgument:
   Description: 'Checks for unused block arguments.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  Severity: convention
   AutoCorrect: contextual
   VersionAdded: '0.21'
   VersionChanged: '1.61'
@@ -2747,6 +2769,7 @@ Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
+  Severity: convention
   AutoCorrect: contextual
   VersionAdded: '0.21'
   VersionChanged: '1.69'
@@ -2766,6 +2789,7 @@ Lint/UnusedPrivateMethod:
   # would be reported as false positives. It is intended for occasional
   # dead-code sweeps rather than permanent enforcement.
   Enabled: false
+  Severity: refactor
   AllowedNames: []
   AllowedPatterns: []
   VersionAdded: '1.89'
@@ -2890,6 +2914,7 @@ Metrics/AbcSize:
     - https://wiki.c2.com/?AbcMetric
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by more than a third of projects; those that keep it split evenly between 20 and 30.
   Preview:
@@ -2906,6 +2931,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by nearly a third of projects; the raised limits range from 30 to 300.
   Preview:
@@ -2927,6 +2953,7 @@ Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting.'
   StyleGuide: '#three-is-the-number-thou-shalt-count'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by a fifth of projects; almost nobody adjusts the limit instead.
   Preview:
@@ -2940,6 +2967,7 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by a third of projects; those that keep it set the limit three times higher.
   Preview:
@@ -2953,6 +2981,7 @@ Metrics/ClassLength:
 Metrics/CollectionLiteralLength:
   Description: 'Checks for `Array` or `Hash` literals with many entries.'
   Enabled: pending
+  Severity: refactor
   VersionAdded: '1.47'
   VersionChanged: '1.88'
   Max: 250
@@ -2961,6 +2990,7 @@ Metrics/CollectionLiteralLength:
 Metrics/CyclomaticComplexity:
   Description: 'Checks that the cyclomatic complexity of methods is not higher than the configured maximum.'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by a third of projects; those that keep it raise the limit to 10 or more.
   Preview:
@@ -2975,6 +3005,7 @@ Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
   StyleGuide: '#short-methods'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected outright by a third of projects; the ones that keep it disagree on the limit.
   Preview:
@@ -2990,6 +3021,7 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Description: 'Avoid modules longer than 100 lines of code.'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Same story as `ClassLength`.
   Preview:
@@ -3004,6 +3036,7 @@ Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: '#too-many-params'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Rejected by a fifth of projects, more than raise the limit.
   Preview:
@@ -3017,6 +3050,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Description: 'Checks that the perceived complexity of methods is not higher than the configured maximum.'
   Enabled: true
+  Severity: refactor
   # Expected to be disabled by default in the next major release.
   # Same story as `CyclomaticComplexity`.
   Preview:
@@ -3404,6 +3438,7 @@ Naming/VariableNumber:
 Security/CompoundHash:
   Description: 'Checks for `hash` implementations that combine values manually instead of delegating to `Array#hash`.'
   Enabled: pending
+  Severity: warning
   Safe: false
   VersionAdded: '1.28'
   VersionChanged: '1.51'
@@ -3411,6 +3446,7 @@ Security/CompoundHash:
 Security/Eval:
   Description: 'Checks for the use of `Kernel#eval` and `Binding#eval` with dynamic arguments.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.47'
 
 Security/IoMethods:
@@ -3418,6 +3454,7 @@ Security/IoMethods:
                  Checks for the first argument to `IO.read`, `IO.binread`, `IO.write`, `IO.binwrite`,
                  `IO.foreach`, and `IO.readlines`.
   Enabled: pending
+  Severity: warning
   Safe: false
   VersionAdded: '1.22'
 
@@ -3429,6 +3466,7 @@ Security/JSONLoad:
     - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load'
     - 'https://bugs.ruby-lang.org/issues/19528'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.43'
   VersionChanged: '1.22'
   # Autocorrect here will change to a method that may cause crashes depending
@@ -3442,11 +3480,13 @@ Security/MarshalLoad:
   References:
     - 'https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.47'
 
 Security/Open:
   Description: 'Checks for the use of `Kernel#open` and `URI.open` with dynamic data.'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.53'
   VersionChanged: '1.0'
   Safe: false
@@ -3458,6 +3498,7 @@ Security/YAMLLoad:
   References:
     - 'https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
+  Severity: warning
   VersionAdded: '0.47'
   SafeAutoCorrect: false
 

--- a/docs/modules/ROOT/pages/configuration/cop_settings.adoc
+++ b/docs/modules/ROOT/pages/configuration/cop_settings.adoc
@@ -88,19 +88,10 @@ Style/Alias:
 
 == Severity
 
-Each cop has a default severity level based on which department it belongs
-to. The level is normally `warning` for `Lint` and `convention` for all the
-others, but this can be changed in user configuration. Cops can customize their
-severity level. Allowed values are `info`, `refactor`, `convention`, `warning`, `error`
-and `fatal`.
-
-Cops with severity `info` will be reported but will not cause `rubocop` to return
-a non-zero value.
-
-There is one exception from the general rule above and that is `Lint/Syntax`, a
-special cop that checks for syntax errors before the other cops are invoked. It
-cannot be disabled and its severity (`fatal`) cannot be changed in
-configuration.
+Every cop reports its offenses at a severity, which is what `--fail-level`
+filters on and what the leading letter in the output shows. Allowed values are
+`info`, `refactor`, `convention`, `warning`, `error` and `fatal`, and any cop's
+severity can be set in configuration:
 
 [source,yaml]
 ----
@@ -110,6 +101,54 @@ Lint:
 Metrics/CyclomaticComplexity:
   Severity: warning
 ----
+
+A cop configured this way keeps reporting exactly what it reported before. The
+setting has always meant "report this cop's offenses at this level", and it
+still does.
+
+Cops with severity `info` will be reported but will not cause `rubocop` to return
+a non-zero value.
+
+`Lint/Syntax` is the one exception to all of this: it checks for syntax errors
+before any other cop runs, and neither its `Enabled` nor its `Severity` (`fatal`)
+can be changed in configuration.
+
+=== How RuboCop assigns them
+
+The severities that ship in
+https://github.com/rubocop/rubocop/blob/master/config/default.yml[config/default.yml]
+answer one question: should this fail a build?
+
+|===
+| Severity | What it says
+
+| `warning`
+| The code is probably wrong: a likely bug, a security problem, or something that
+  misbehaves at runtime. Worth failing a build over.
+
+| `convention`
+| A matter of style and consistency. The code works; it does not read the way the
+  project wants it to.
+
+| `refactor`
+| A maintainability smell - size, complexity, dead code. Something to fix
+  deliberately, not something to be blocked by.
+
+| `info`
+| Advisory only, and never causes a non-zero exit.
+|===
+
+That puts the line between blocking and advisory at `--fail-level warning`.
+`error` and `fatal` are left to RuboCop itself.
+
+A cop's department sets its starting point - `warning` for `Lint`, `convention`
+for the rest - and individual cops override it where that reading is wrong. A
+`Lint` cop that reports redundant but harmless code (`Lint/RedundantSplatExpansion`,
+say) is a `convention`, a `Security` cop is a `warning`, and the `Metrics` cops
+are `refactor`.
+
+This is how the defaults are chosen, not a rule about the setting. Your own
+`Severity` values mean whatever your project wants them to mean.
 
 == Details
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1350,11 +1350,11 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
       C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
       C:  3:  1: Style/Documentation: Missing top-level documentation comment for class A.
-      W:  4:  3: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/MethodLength.
+      C:  4:  3: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Metrics/MethodLength.
       C:  5:  3: [Corrected] Layout/IndentationWidth: Use 2 (not 6) spaces for indentation.
-      W:  5: 22: [Corrected] Lint/RedundantCopEnableDirective: Unnecessary enabling of Metrics/MethodLength.
-      W:  7: 54: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/For.
-      W:  9:  5: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/ClassVars.
+      C:  5: 22: [Corrected] Lint/RedundantCopEnableDirective: Unnecessary enabling of Metrics/MethodLength.
+      C:  7: 54: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/For.
+      C:  9:  5: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/ClassVars.
 
       1 file inspected, 8 offenses detected, 7 offenses corrected
     RESULT
@@ -2127,7 +2127,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       == example.rb ==
       C:  1:  8: Style/BlockDelimiters: Prefer {...} over do...end for single-line blocks.
       C:  2: 34: Style/Semicolon: Do not use semicolons to terminate expressions.
-      W:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
+      C:  3: 27: Lint/UnusedMethodArgument: Unused method argument - bar.
 
       1 file inspected, 3 offenses detected
     RESULT
@@ -3675,7 +3675,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
       example.rb:1:1: W: [Corrected] Lint/ImplicitStringConcatenation: Combine "" and "string" into a single string literal, rather than using implicit string concatenation.
       """string"""
       ^^^^^^^^^^
-      example.rb:1:1: W: [Corrected] Lint/TripleQuotes: Delimiting a string with multiple quotes has no effect, use a single quote instead.
+      example.rb:1:1: C: [Corrected] Lint/TripleQuotes: Delimiting a string with multiple quotes has no effect, use a single quote instead.
       """string"""
       ^^^^^^^^^^^^
       example.rb:1:3: W: [Corrected] Lint/ImplicitStringConcatenation: Combine "string" and "" into a single string literal, rather than using implicit string concatenation.

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
         expect($stdout.string).to eq(<<~OUTPUT)
           == example.rb ==
           C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-          W:  1: 21: [Corrected] Lint/UnusedMethodArgument: Unused method argument - some_arg. If it's necessary, use _ or _some_arg as an argument name to indicate that it won't be used. If it's unnecessary, remove it. You can also write as ordinary_method(*) if you want the method to accept any arguments but don't care about them.
+          C:  1: 21: [Corrected] Lint/UnusedMethodArgument: Unused method argument - some_arg. If it's necessary, use _ or _some_arg as an argument name to indicate that it won't be used. If it's unnecessary, remove it. You can also write as ordinary_method(*) if you want the method to accept any arguments but don't care about them.
           C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
-          W:  5: 29: [Todo] Lint/UnusedMethodArgument: Unused method argument - some_keyword_arg. You can also write as method_with_keyword_arg(*) if you want the method to accept any arguments but don't care about them.
+          C:  5: 29: [Todo] Lint/UnusedMethodArgument: Unused method argument - some_keyword_arg. You can also write as method_with_keyword_arg(*) if you want the method to accept any arguments but don't care about them.
 
           1 file inspected, 4 offenses detected, 4 offenses corrected
         OUTPUT
@@ -244,11 +244,11 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
-            C:  3:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
-            C:  3:  3: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
-            C:  3:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
-            C:  4:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
-            C:  4:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
+            R:  3:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
+            R:  3:  3: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
+            R:  3:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
+            R:  4:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
+            R:  4:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
             W:  4: 32: [Corrected] Lint/CopDirectiveSyntax: Malformed directive comment detected. Only the first directive on a line takes effect. List the cop names in a single directive instead.
 
             1 file inspected, 8 offenses detected, 8 offenses corrected
@@ -454,7 +454,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           expect($stderr.string).to eq('')
           expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
-            C:  1:  1: [Todo] Metrics/MethodLength: Method has too many lines. [3/2]
+            R:  1:  1: [Todo] Metrics/MethodLength: Method has too many lines. [3/2]
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1286,7 +1286,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       expect(cli.run(['--format', 'emacs', '--display-cop-names', 'example1.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-        #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+        #{file}:1:8: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
         #{file}:1:26: C: [Correctable] Migration/DepartmentName: Department name is missing.
         #{file}:1:41: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
       RESULT
@@ -1297,7 +1297,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(cli.run(['--format', 'emacs', '--no-display-cop-names', 'example1.rb'])).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
           #{file}:1:1: C: [Correctable] Missing frozen string literal comment.
-          #{file}:1:8: W: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
+          #{file}:1:8: C: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
           #{file}:1:26: C: [Correctable] Department name is missing.
           #{file}:1:41: C: [Correctable] Trailing whitespace detected.
         RESULT
@@ -1316,7 +1316,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         expect(cli.run(['--format', 'emacs', '--display-cop-names', 'example1.rb'])).to eq(1)
         expect($stdout.string).to eq(<<~RESULT)
           #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-          #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+          #{file}:1:8: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
           #{file}:1:26: C: [Correctable] Migration/DepartmentName: Department name is missing.
           #{file}:1:41: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
         RESULT
@@ -1327,7 +1327,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
           expect(cli.run(['--format', 'emacs', 'example1.rb'])).to eq(1)
           expect($stdout.string).to eq(<<~RESULT)
             #{file}:1:1: C: [Correctable] Missing frozen string literal comment.
-            #{file}:1:8: W: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
+            #{file}:1:8: C: [Correctable] Unnecessary disabling of `Style/NumericLiterals`.
             #{file}:1:26: C: [Correctable] Department name is missing.
             #{file}:1:41: C: [Correctable] Trailing whitespace detected.
           RESULT
@@ -1348,7 +1348,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
       expect(cli.run(['--format', 'emacs', '--extra-details', 'example1.rb'])).to eq(1)
       expect($stdout.string).to eq(<<~RESULT)
         #{file}:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
-        #{file}:1:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
+        #{file}:1:8: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/NumericLiterals`.
         #{file}:1:47: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected. Trailing space is just sloppy.
       RESULT
 
@@ -1376,7 +1376,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       expect(cli.run(['--format', 'emacs', '--display-style-guide', 'example1.rb'])).to eq(1)
 
-      output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
+      output = "#{file}:1:6: W: [Correctable] Security/JSONLoad: " \
                "Prefer `JSON.parse` over `JSON.load`. (#{urls})"
       expect($stdout.string.lines.to_a[-1]).to eq([output, ''].join("\n"))
     end
@@ -2148,11 +2148,10 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
             end
           RUBY
 
-          expect(cli.run(['--fail-level', 'warning',
+          expect(cli.run(['--fail-level', 'convention',
                           '--display-only-fail-level-offenses',
                           target_file])).to eq 1
           expect($stderr.string).to eq('')
-          expect($stdout.string).to include('1 file inspected, 1 offense detected')
           expect($stdout.string).to include('RedundantCopDisableDirective')
         end
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -551,9 +551,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       # not honored and gets reported with a suggestion instead.
       # 2 real cops were enabled, but only 1 had been disabled correctly.
       expect($stdout.string).to eq(<<~RESULT)
-        #{abs('example.rb')}:3:19: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/LineLength` (did you mean `Layout/LineLength`?).
+        #{abs('example.rb')}:3:19: C: Lint/RedundantCopDisableDirective: Unnecessary disabling of `Style/LineLength` (did you mean `Layout/LineLength`?).
         #{abs('example.rb')}:4:121: C: Layout/LineLength: Line is too long. [130/120]
-        #{abs('example.rb')}:8:21: W: [Correctable] Lint/RedundantCopEnableDirective: Unnecessary enabling of Layout/LineLength.
+        #{abs('example.rb')}:8:21: C: [Correctable] Lint/RedundantCopEnableDirective: Unnecessary enabling of Layout/LineLength.
         #{abs('example.rb')}:9:121: C: Layout/LineLength: Line is too long. [132/120]
         #{abs('example.rb')}:11:5: C: [Correctable] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
       RESULT
@@ -687,9 +687,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to eq('')
         expect($stdout.string).to eq(<<~RESULT)
           #{abs('example.rb')}:3:121: C: Layout/LineLength: Line is too long. [130/120]
-          #{abs('example.rb')}:4:1: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
-          #{abs('example.rb')}:5:12: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Layout/LineLength`, `Metrics/ClassLength`.
-          #{abs('example.rb')}:6:8: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
+          #{abs('example.rb')}:4:1: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
+          #{abs('example.rb')}:5:12: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of `Layout/LineLength`, `Metrics/ClassLength`.
+          #{abs('example.rb')}:6:8: C: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of all cops.
         RESULT
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -1147,7 +1147,8 @@ RSpec.describe RuboCop::ConfigLoader do
               'Max' => 5,
               'CountAsOne' => [],
               'AllowedMethods' => [],
-              'AllowedPatterns' => []
+              'AllowedPatterns' => [],
+              'Severity' => 'refactor'
             }
           )
         expect { expect(configuration_from_file.to_h).to eq(config) }.not_to output.to_stderr

--- a/spec/rubocop/cop/lint/empty_file_spec.rb
+++ b/spec/rubocop/cop/lint/empty_file_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Lint::EmptyFile, :config do
     expect(offenses.size).to eq(1)
     offense = offenses.first
     expect(offense.message).to eq('Empty file detected.')
-    expect(offense.severity).to eq(:warning)
+    expect(offense.severity).to eq(:convention)
   end
 
   it 'does not register an offense when the file contains code' do


### PR DESCRIPTION
Only 11 of 614 cops set a severity, so severity is currently a restatement of the department: `warning` for Lint, `convention` for everything else. That leaves `--fail-level` with no useful line to draw.

The rubric, now documented alongside the setting: `warning` means the code is probably wrong, `convention` means style, `refactor` means a maintainability smell. That puts the blocking/advisory boundary at `--fail-level warning`.

Three groups move. Security cops become warnings. Metrics cops become refactors. Two dozen Lint cops that report harmless-but-noisy code - redundant conversions, unused arguments, directive hygiene - become conventions. Style, Layout and Naming keep their department defaults.

Worth deciding deliberately: this changes cop defaults, which the versioning policy lists as major-release material. In practice nobody on the default fail level sees a change in what passes, since `refactor` and above still fail there - what changes is the letter in the output, and the line that projects setting `--fail-level warning` get. Happy to hold it for the next major if that reading is too generous.

The individual calls are the arguable part, and the diff is one line per cop.