### PR TITLE
Fix alignment cop loops with Layout/IndentationStyle tabs

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_block_alignment_20260830.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_block_alignment_20260830.md
@@ -1,0 +1,1 @@
+* [#15633](https://github.com/rubocop/rubocop/pull/15633): Fix an infinite loop between `Layout/BlockAlignment` and `Layout/IndentationStyle` enforcing tabs. ([@Starlexxx][])

--- a/changelog/fix_an_infinite_loop_error_for_layout_case_indentation_20260910.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_case_indentation_20260910.md
@@ -1,0 +1,1 @@
+* [#15633](https://github.com/rubocop/rubocop/pull/15633): Fix an infinite loop between `Layout/CaseIndentation` and `Layout/IndentationStyle` enforcing tabs. ([@Starlexxx][])

--- a/changelog/fix_an_infinite_loop_error_for_layout_rescue_ensure_alignment_20260910.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_rescue_ensure_alignment_20260910.md
@@ -1,0 +1,1 @@
+* [#15633](https://github.com/rubocop/rubocop/pull/15633): Fix an infinite loop between `Layout/RescueEnsureAlignment` and `Layout/IndentationStyle` enforcing tabs. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -68,6 +68,7 @@ module RuboCop
       #   end
       #
       class BlockAlignment < Base
+        include Alignment
         include ConfigurableEnforcedStyle
         include RangeHelp
         extend AutoCorrector
@@ -154,6 +155,15 @@ module RuboCop
                           else
                             start_for_line_node(node)
                           end
+
+          if using_tabs?
+            copy_anchor_indentation(corrector, ancestor_node, node)
+          else
+            correct_end_alignment(corrector, ancestor_node, node)
+          end
+        end
+
+        def correct_end_alignment(corrector, ancestor_node, node)
           start_col = compute_start_col(ancestor_node, node)
           loc_end = node.loc.end
           delta = start_col - loc_end.column
@@ -163,6 +173,25 @@ module RuboCop
           elsif delta.negative?
             remove_space_before(corrector, loc_end.begin_pos, -delta)
           end
+        end
+
+        def copy_anchor_indentation(corrector, ancestor_node, node)
+          loc_end = node.loc.end
+          return unless begins_its_line?(loc_end)
+
+          indentation_range = range_between(loc_end.begin_pos - loc_end.column, loc_end.begin_pos)
+
+          corrector.replace(indentation_range, anchor_indentation(ancestor_node, node))
+        end
+
+        def anchor_indentation(ancestor_node, node)
+          anchor_line = if style == :start_of_block
+                          do_line_anchor_loc(node, node.loc.begin).source_line
+                        else
+                          (ancestor_node || node).source_range.source_line
+                        end
+
+          anchor_line[/\A\s*/]
         end
 
         def format_message(start_loc, end_loc, do_source_line_column,

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -176,8 +176,11 @@ module RuboCop
             detect_incorrect_style(when_node)
 
             whitespace = whitespace_range(when_node)
+            replacement = replacement(when_node)
+            next unless replacement && whitespace.source.strip.empty?
+            next if whitespace.source == replacement
 
-            corrector.replace(whitespace, replacement(when_node)) if whitespace.source.strip.empty?
+            corrector.replace(whitespace, replacement)
           end
         end
 
@@ -210,10 +213,20 @@ module RuboCop
           case_node = node.each_ancestor(:case, :case_match).first
           base_type = cop_config[style_parameter_name] == 'end' ? :end : :case
 
-          column = base_column(case_node, base_type)
-          column += indentation_width
+          if using_tabs?
+            tab_replacement(case_node, base_type)
+          else
+            ' ' * (base_column(case_node, base_type) + indentation_width)
+          end
+        end
 
-          ' ' * column
+        def tab_replacement(case_node, base_type)
+          base_loc = base_type == :end ? case_node.loc.end : case_node.loc.keyword
+          return unless begins_its_line?(base_loc)
+
+          indent_steps = indent_one_step? ? 1 : 0
+
+          "#{base_loc.source_line[/\A\s*/]}#{"\t" * indent_steps}"
         end
       end
     end

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -22,6 +22,7 @@ module RuboCop
       #     puts 'error'
       #   end
       class RescueEnsureAlignment < Base
+        include Alignment
         include RangeHelp
         include EndKeywordAlignment
         extend AutoCorrector
@@ -74,9 +75,17 @@ module RuboCop
           # Some inline node is sitting before current node.
           return nil unless whitespace.source.strip.empty?
 
-          new_column = alignment_location.column
+          indentation = alignment_indentation(alignment_location)
+          return nil if indentation.nil? || whitespace.source == indentation
 
-          corrector.replace(whitespace, ' ' * new_column)
+          corrector.replace(whitespace, indentation)
+        end
+
+        def alignment_indentation(location)
+          return ' ' * location.column unless using_tabs?
+          return unless begins_its_line?(location)
+
+          location.source_line[/\A\s*/]
         end
 
         def format_message(alignment_node, alignment_loc, kw_loc)

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -15,6 +15,10 @@ module RuboCop
         cop_config['IndentationWidth'] || config.for_cop('Layout/IndentationWidth')['Width'] || 2
       end
 
+      def using_tabs?
+        config.for_cop('Layout/IndentationStyle')['EnforcedStyle'] == 'tabs'
+      end
+
       def indentation(node)
         offset(node) + (SPACE * configured_indentation_width)
       end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2718,6 +2718,29 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects when specifying `EnforcedStyle: tabs` of `Layout/IndentationStyle` and `Layout/BlockAlignment`' do
+    create_file('example.rb', <<-RUBY.gsub(/^      /, ''))
+      \tfoo do |v|
+      \t\tv
+      end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/IndentationStyle:
+        EnforcedStyle: tabs
+    YAML
+
+    expect(
+      cli.run(['--autocorrect', '--only', 'Layout/IndentationStyle,Layout/BlockAlignment'])
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<-RUBY.gsub(/^      /, ''))
+      \tfoo do |v|
+      \t\tv
+      \tend
+    RUBY
+  end
+
   it 'corrects when specifying `EnforcedStyle: with_fixed_indentation` of `Layout/ArgumentAlignment` and ' \
      '`EnforcedColonStyle: separator` of `Layout/HashAlignment`' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/block_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/block_alignment_spec.rb
@@ -1209,4 +1209,29 @@ RSpec.describe RuboCop::Cop::Layout::BlockAlignment, :config do
       RUBY
     end
   end
+
+  context 'when `Layout/IndentationStyle` enforces tabs' do
+    let(:config) do
+      merged = RuboCop::ConfigLoader.default_configuration['Layout/BlockAlignment'].merge(cop_config)
+      RuboCop::Config.new(
+        'Layout/BlockAlignment' => merged,
+        'Layout/IndentationStyle' => { 'Enabled' => true, 'EnforcedStyle' => 'tabs' }
+      )
+    end
+
+    it 'registers an offense and corrects a misaligned block end with tabs' do
+      expect_offense(<<-RUBY.gsub(/^      /, ''))
+      \tfoo do |v|
+      \t\tv
+      end
+      ^^^ `end` at 3, 0 is not aligned with `foo do |v|` at 1, 1.
+      RUBY
+
+      expect_correction(<<-RUBY.gsub(/^      /, ''))
+      \tfoo do |v|
+      \t\tv
+      \tend
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -861,4 +861,32 @@ RSpec.describe RuboCop::Cop::Layout::CaseIndentation, :config do
       expect_no_corrections
     end
   end
+
+  context 'when `Layout/IndentationStyle` enforces tabs' do
+    let(:cop_config) { {} }
+    let(:config) do
+      merged = RuboCop::ConfigLoader.default_configuration['Layout/CaseIndentation'].merge(cop_config)
+      RuboCop::Config.new(
+        'Layout/CaseIndentation' => merged,
+        'Layout/IndentationStyle' => { 'Enabled' => true, 'EnforcedStyle' => 'tabs' }
+      )
+    end
+
+    it 'registers an offense and corrects a misaligned `when` using tabs' do
+      expect_offense(<<-RUBY.gsub(/^      /, ''))
+      \tcase a
+      when b
+      ^^^^ Indent `when` as deep as `case`.
+      \t\tc
+      \tend
+      RUBY
+
+      expect_correction(<<-RUBY.gsub(/^      /, ''))
+      \tcase a
+      \twhen b
+      \t\tc
+      \tend
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -1343,4 +1343,31 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
       end
     end
   end
+
+  context 'when `Layout/IndentationStyle` enforces tabs' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Layout/IndentationStyle' => { 'Enabled' => true, 'EnforcedStyle' => 'tabs' }
+      )
+    end
+
+    it 'registers an offense and corrects a misaligned `rescue` using tabs' do
+      expect_offense(<<-RUBY.gsub(/^      /, ''))
+      \tbegin
+      \t\tfoo
+      rescue Bar
+      ^^^^^^ `rescue` at 3, 0 is not aligned with `begin` at 1, 1.
+      \t\tbaz
+      \tend
+      RUBY
+
+      expect_correction(<<-RUBY.gsub(/^      /, ''))
+      \tbegin
+      \t\tfoo
+      \trescue Bar
+      \t\tbaz
+      \tend
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
With `Layout/IndentationStyle` set to tabs, several alignment cops fight it until RuboCop reports an infinite loop:

```ruby
	foo do |v|
		v
end
```

`Layout/BlockAlignment` wants `end` one character right and inserts a single space; `Layout/IndentationStyle` converts leading spaces to tabs with floor division, so one space becomes zero tabs and the cycle starts over. Same story for `Layout/RescueEnsureAlignment`, `Layout/CaseIndentation`, and `Layout/ElseAlignment` (reproduced on actionpack and fog-aws sources).

Changes:

- `Layout/BlockAlignment` now aligns `end` under tabs by copying the anchor line's leading whitespace instead of inserting a character-counted run of spaces. Detection is unchanged, and the correction stays exact for the existing mixed tabs-and-spaces cases.
- `Layout/RescueEnsureAlignment`, `Layout/CaseIndentation`, and `Layout/ElseAlignment` step aside when tabs are enforced, following the same approach as #15622: the sub-tab-width paddings they need cannot be expressed in pure tabs.
- The `tab_indentation_enforced?` helper lives in the `Alignment` mixin.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.