### PR TITLE
Fix Lint/LiteralAsCondition autocorrect for parenthesized return

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_literal_as_condition_20260830.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_literal_as_condition_20260830.md
@@ -1,0 +1,1 @@
+* [#15634](https://github.com/rubocop/rubocop/pull/15634): Fix an incorrect autocorrect for `Lint/LiteralAsCondition` when the other operand is a parenthesized `return`. ([@Starlexxx][])

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -48,7 +48,7 @@ module RuboCop
           add_offense(node.lhs) do |corrector|
             # Don't autocorrect `'foo' && return` because having `return` as
             # the leftmost node can lead to a void value expression syntax error.
-            next if node.rhs.type?(:return, :break, :next)
+            next if void_value_expression?(node.rhs)
 
             corrector.replace(node, node.rhs.source)
           end
@@ -60,7 +60,7 @@ module RuboCop
           add_offense(node.lhs) do |corrector|
             # Don't autocorrect `'foo' && return` because having `return` as
             # the leftmost node can lead to a void value expression syntax error.
-            next if node.rhs.type?(:return, :break, :next)
+            next if void_value_expression?(node.rhs)
 
             corrector.replace(node, node.rhs.source)
           end
@@ -174,6 +174,12 @@ module RuboCop
         end
 
         private
+
+        def void_value_expression?(node)
+          node = node.children.last while node&.begin_type?
+
+          node&.type?(:return, :break, :next)
+        end
 
         def check_for_literal(node)
           cond = condition(node)

--- a/spec/rubocop/cop/lint/literal_as_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_as_condition_spec.rb
@@ -805,6 +805,28 @@ RSpec.describe RuboCop::Cop::Lint::LiteralAsCondition, :config do
       expect_no_corrections
     end
 
+    it 'registers an offense but does not autocorrect when a parenthesized `return` is used after `||`' do
+      expect_offense(<<~RUBY)
+        def clone(opts = nil || (return self))
+                         ^^^ Literal `nil` appeared as a condition.
+          super
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense but does not autocorrect when a parenthesized `return` is used after `&&`' do
+      expect_offense(<<~RUBY)
+        def foo(opts = 123 && (foo; return self))
+                       ^^^ Literal `123` appeared as a condition.
+          super
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
     it 'registers an offense but does not autocorrect when inside `if` and `return` is used after `&&`' do
       expect_offense(<<~RUBY)
         def foo


### PR DESCRIPTION
Autocorrecting this real-world code from sequel produces unparseable Ruby:

```ruby
def clone(opts = nil || (return self))
  super(provenance_opts(opts))
end
```

becomes

```ruby
def clone(opts = (return self))
```

```
void value expression (SyntaxError)
```

The cop already skips the correction when the other operand is a bare `return`, but the check only looked at the node type, so `(return self)` slipped through. The guard now looks through `begin` wrappers.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.