### PR TITLE
Fix relative redirects for RemoteConfig

### DIFF
--- a/changelog/fix_remote_config_relative_redirects_20260830141504.md
+++ b/changelog/fix_remote_config_relative_redirects_20260830141504.md
@@ -1,0 +1,1 @@
+* [#15626](https://github.com/rubocop/rubocop/issues/15626): Fix `RemoteConfig` failing to follow relative HTTP redirects for remote configuration files. ([@RedZapdos123][])

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -49,9 +49,9 @@ module RuboCop
       http.use_ssl = uri.instance_of?(URI::HTTPS)
 
       generate_request(uri) do |request|
-        handle_response(http.request(request), limit, &block)
+        handle_response(http.request(request), uri, limit, &block)
       rescue SocketError => e
-        handle_response(e, limit, &block)
+        handle_response(e, uri, limit, &block)
       end
     end
 
@@ -64,12 +64,12 @@ module RuboCop
       yield request
     end
 
-    def handle_response(response, limit, &block)
+    def handle_response(response, uri, limit, &block)
       case response
       when Net::HTTPSuccess, Net::HTTPNotModified, SocketError
         yield response
       when Net::HTTPRedirection
-        request(URI.parse(response['location']), limit - 1, &block)
+        request(URI.join(uri, response['location']), limit - 1, &block)
       else
         begin
           response.error!

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -155,13 +155,34 @@ RSpec.describe RuboCop::RemoteConfig do
       let(:new_location) { 'http://cdn.example.com/rubocop.yml' }
 
       before do
-        stub_request(:get, remote_config_url).to_return(headers: { 'Location' => new_location })
+        stub_request(:get, remote_config_url)
+          .to_return(status: 302, headers: { 'Location' => new_location })
 
         stub_request(:get, new_location)
           .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
       end
 
       it 'follows the redirect and downloads the file' do
+        expect(remote_config).to eq(cached_file_path)
+        expect(File).to exist(cached_file_path)
+      end
+    end
+
+    context 'when the remote URL responds with a relative redirect' do
+      let(:remote_config_url) { 'http://example.com/configs/project.yml' }
+      let(:new_location) { '../shared/base.yml' }
+      let(:redirected_location) { 'http://example.com/shared/base.yml' }
+      let(:cached_file_name) { 'project-e8599307a1a72fe8b3228b9cbb2f0929.yml' }
+
+      before do
+        stub_request(:get, remote_config_url)
+          .to_return(status: 302, headers: { 'Location' => new_location })
+
+        stub_request(:get, redirected_location)
+          .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
+      end
+
+      it 'resolves the redirect relative to the current URL and downloads the file' do
         expect(remote_config).to eq(cached_file_path)
         expect(File).to exist(cached_file_path)
       end


### PR DESCRIPTION
## Description:

Issue #15626 reported that `RemoteConfig` parsed redirect `Location` values as standalone URIs.

In Ruby, a relative redirect such as `Location: ../shared/base.yml` becomes a `URI::Generic` without a host when parsed on its own, so the follow-up request crashes instead of loading the redirected configuration.

This PR updates `RemoteConfig` to resolve redirect `Location` values relative to the current request URI.

It also adds a regression test for a relative HTTP redirect when downloading a remote configuration file.

Closes #15626.

## Checklist:

- [x] I have run linting using `bundle exec rubocop lib/rubocop/remote_config.rb spec/rubocop/remote_config_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/remote_config_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:

```ruby
Dir.mktmpdir do |dir|
  RuboCop::RemoteConfig.new('http://example.com/configs/project.yml', dir).file
end
```

with a remote response of:

```text
GET /configs/project.yml
302 Location: ../shared/base.yml
```

`RemoteConfig` raised:

```text
NoMethodError
undefined method `request_uri' for an instance of URI::Generic
```

The reproduction run looked like this:

<img width="1906" height="1320" alt="image" src="https://github.com/user-attachments/assets/e38004b3-2d97-40b6-97f4-ea5ac9f3d8bb" />

### After the fix:

Running the same reproduction in the fixed branch follows the redirect and downloads the remote configuration successfully.

<img width="1026" height="1010" alt="image" src="https://github.com/user-attachments/assets/b85c26d3-0a2f-44c2-a3fc-764c730fba81" />
