### PR TITLE
Fix false positives for Lint/CopDirectiveSyntax with directive text in reasons

### DIFF
--- a/changelog/fix_cop_directive_syntax_reason_text_20260830143254.md
+++ b/changelog/fix_cop_directive_syntax_reason_text_20260830143254.md
@@ -1,0 +1,1 @@
+* [#15636](https://github.com/rubocop/rubocop/issues/15636): Fix `Lint/CopDirectiveSyntax` falsely reporting multiple directives when valid reason text mentions another directive. ([@RedZapdos123][])

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -92,7 +92,7 @@ module RuboCop
         private
 
         def check_directive(comment, directive_comment)
-          if (directives = multiple_directives(comment))
+          if (directives = multiple_directives(comment, directive_comment))
             add_offense(comment, message: "#{COMMON_MSG} #{MULTIPLE_DIRECTIVES_MSG}") do |corrector|
               merge_directives(corrector, comment, directives)
             end
@@ -107,11 +107,20 @@ module RuboCop
 
         # Everything after the first directive in a comment is trailing text as
         # far as the parser is concerned, so a second directive written on the
-        # same line disables nothing at all.
-        def multiple_directives(comment)
+        # same line disables nothing at all. A valid `--` reason may mention a
+        # directive as plain text, which should not be treated as another one.
+        def multiple_directives(comment, directive_comment)
           matches = comment.text.to_enum(:scan, DirectiveComment::DIRECTIVE_COMMENT_REGEXP)
                            .map { Regexp.last_match }
+          matches = filter_reason_matches(matches, directive_comment)
+
           matches if matches.size > 1
+        end
+
+        def filter_reason_matches(matches, directive_comment)
+          return matches unless directive_comment.reason
+
+          [matches.first, *matches.drop(1).reject { |match| match.post_match.match?(/\S/) }]
         end
 
         def merge_directives(corrector, comment, directives)

--- a/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
+++ b/spec/rubocop/cop/lint/cop_directive_syntax_spec.rb
@@ -94,9 +94,21 @@ RSpec.describe RuboCop::Cop::Lint::CopDirectiveSyntax, :config do
     RUBY
   end
 
+  it 'does not register an offense when a trailing comment mentions another directive' do
+    expect_no_offenses(<<~RUBY)
+      # rubocop:disable Layout/LineLength -- see # rubocop:disable Style/Encoding in old branch
+    RUBY
+  end
+
   it 'does not register an offense for a single line directive with trailing comment' do
     expect_no_offenses(<<~RUBY)
       a = 1 # rubocop:disable Layout/LineLength -- This is a good comment.
+    RUBY
+  end
+
+  it 'does not register an offense for a single line directive whose trailing comment mentions another directive' do
+    expect_no_offenses(<<~RUBY)
+      a = 1 # rubocop:disable Layout/LineLength -- see # rubocop:disable Style/Encoding in old branch
     RUBY
   end
 


### PR DESCRIPTION
## Description:

Issue #15636 reported that `Lint/CopDirectiveSyntax` treated directive-looking text inside a valid `--` reason as a second directive.

That produced a malformed directive offense even though the text after `--` was only explanatory text.

This PR updates `Lint/CopDirectiveSyntax` to ignore directive-looking text embedded in valid `--` reasons while still reporting a standalone second directive on the same line.

It also adds regression tests for full-line and end-of-line directives whose reasons mention another directive.

Closes #15636.

## Checklist:

- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/lint/cop_directive_syntax.rb spec/rubocop/cop/lint/cop_directive_syntax_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/lint/cop_directive_syntax_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:

```ruby
# rubocop:disable Layout/LineLength -- see # rubocop:disable Style/Encoding in old branch
x = 1
```

`Lint/CopDirectiveSyntax` reported:

```text
Malformed directive comment detected. Only the first directive on a line takes effect. List the cop names in a single directive instead.
```

The reproduction run looked like this:

<img width="1972" height="514" alt="image" src="https://github.com/user-attachments/assets/271c931c-f1cf-4463-b558-fd673383d62c" />

### After the fix:

Running the same reproduction in the fixed branch reports no offenses.

<img width="1521" height="452" alt="image" src="https://github.com/user-attachments/assets/34d6f989-9207-42d4-a0a1-fd651681993b" />
