### PR TITLE
Fix an infinite loop error for `Layout/FirstArrayElementIndentation`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_first_array_element_indentation_20260830.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_first_array_element_indentation_20260830.md
@@ -1,0 +1,1 @@
+* [#15638](https://github.com/rubocop/rubocop/issues/15638): Fix an infinite loop error for `Layout/FirstArrayElementIndentation` with `Layout/ArrayAlignment` when `EnforcedStyle: with_fixed_indentation` is configured. ([@RedZapdos123][])

--- a/lib/rubocop/cop/layout/first_array_element_indentation.rb
+++ b/lib/rubocop/cop/layout/first_array_element_indentation.rb
@@ -89,21 +89,34 @@ module RuboCop
               'in an array, relative to %<base_description>s.'
 
         def on_array(node)
-          return if style != :consistent && enforce_first_argument_with_fixed_indentation?
+          return unless node.loc.begin
+          return if autocorrect_incompatible_with_other_cops?(node, nil)
 
-          check(node, nil) if node.loc.begin
+          check(node, nil)
         end
 
         def on_send(node)
-          return if style != :consistent && enforce_first_argument_with_fixed_indentation?
-
           each_argument_node(node, :array) do |array_node, left_parenthesis|
+            next if autocorrect_incompatible_with_other_cops?(array_node, left_parenthesis)
+
             check(array_node, left_parenthesis)
           end
         end
         alias on_csend on_send
 
         private
+
+        def autocorrect_incompatible_with_other_cops?(array_node, left_parenthesis)
+          return false unless enforce_first_argument_with_fixed_indentation?
+          return true if style != :consistent
+
+          # `Layout/ArrayAlignment` does not align single-element arrays.
+          return false if array_node.children.size < 2
+
+          _base_column, indent_base_type =
+            indent_base(array_node.loc.begin, array_node.values.first, left_parenthesis)
+          indent_base_type != :start_of_line
+        end
 
         def autocorrect(corrector, node)
           AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2947,6 +2947,39 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects the indentation of array elements when specifying ' \
+     '`EnforcedStyle: with_fixed_indentation` of `Layout/ArrayAlignment` and ' \
+     '`EnforcedStyle: consistent` of `Layout/FirstArrayElementIndentation`' do
+    create_file('example.rb', <<~RUBY)
+      foo bar: [
+            'foo',
+            'bar'
+      ],
+      baz: 'baz'
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ArrayAlignment:
+        EnforcedStyle: with_fixed_indentation
+      Layout/FirstArrayElementIndentation:
+        EnforcedStyle: consistent
+    YAML
+
+    expect(
+      cli.run(
+        ['--autocorrect', '--only', 'Layout/ArrayAlignment,Layout/FirstArrayElementIndentation']
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      foo bar: [
+        'foo',
+        'bar'
+      ],
+      baz: 'baz'
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_indentation_spec.rb
@@ -10,10 +10,52 @@ RSpec.describe RuboCop::Cop::Layout::FirstArrayElementIndentation, :config do
                         cop_config.merge(supported_styles).merge(
                           'IndentationWidth' => cop_indent
                         ),
+                        'Layout/ArrayAlignment' => array_alignment_config,
                         'Layout/IndentationWidth' => { 'Width' => 2 })
   end
   let(:cop_config) { { 'EnforcedStyle' => 'special_inside_parentheses' } }
+  let(:array_alignment_config) { {} }
   let(:cop_indent) { nil } # use indent from Layout/IndentationWidth
+
+  context 'when Layout/ArrayAlignment uses `with_fixed_indentation`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }
+    let(:array_alignment_config) { { 'EnforcedStyle' => 'with_fixed_indentation' } }
+
+    it 'does not register an offense for a multi-line array value in a multi-pair hash' do
+      expect_no_offenses(<<~RUBY)
+        foo bar: [
+              'foo',
+              'bar'
+        ],
+        baz: 'baz'
+      RUBY
+    end
+
+    it 'registers an offense and corrects a single-element array value in a multi-pair hash' do
+      expect_offense(<<~RUBY)
+        foo bar: [
+        1
+        ^ Use 2 spaces for indentation in an array, relative to the parent hash key.
+        ],
+        ^ Indent the right bracket the same as the parent hash key.
+        baz: 3
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo bar: [
+              1
+            ],
+        baz: 3
+      RUBY
+    end
+
+    it 'does not register an offense for a bracketless array' do
+      expect_no_offenses(<<~RUBY)
+        x = 1,
+            2
+      RUBY
+    end
+  end
 
   context 'when array is operand' do
     it 'accepts correctly indented first element' do


### PR DESCRIPTION
## Description:

Issue #15638 reported that `Layout/FirstArrayElementIndentation` could fight with `Layout/ArrayAlignment` when `EnforcedStyle: with_fixed_indentation` was configured.

The two cops could keep changing the same array indentation back and forth, which caused an infinite autocorrect loop.

This PR updates `Layout/FirstArrayElementIndentation` to treat that `consistent` case as incompatible with `Layout/ArrayAlignment` fixed indentation, so the conflicting autocorrect loop is avoided while compatible `consistent` cases still work.

It also adds regression tests for the conflicting cop behavior and for CLI autocorrection.

Closes #15638.

## Checklist:
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/layout/first_array_element_indentation.rb spec/rubocop/cop/layout/first_array_element_indentation_spec.rb spec/rubocop/cli/autocorrect_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/layout/first_array_element_indentation_spec.rb spec/rubocop/cli/autocorrect_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:
```ruby
foo bar: [1, 2],
baz: 3
```

`Layout/FirstArrayElementIndentation` and `Layout/ArrayAlignment` could enter an autocorrect loop for this configuration:

```yaml
AllCops:
  NewCops: disable

Layout/ArrayAlignment:
  EnforcedStyle: with_fixed_indentation
Layout/FirstArrayElementIndentation:
  EnforcedStyle: consistent
```

<img width="2555" height="1260" alt="image" src="https://github.com/user-attachments/assets/bf72b206-6c98-4223-8e4c-c3d6d2d1c53d" />

### After the fix:
`Layout/FirstArrayElementIndentation` now defers this conflicting case to `Layout/ArrayAlignment`, so autocorrection finishes and produces:

```ruby
foo bar: [1, 2],
baz: 3
```

<img width="2435" height="1380" alt="image" src="https://github.com/user-attachments/assets/2ab6a8b6-cfaf-4818-bbdd-553c3ca4721f" />
