### PR TITLE
Fix an infinite loop error for `Layout/FirstParameterIndentation`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_first_parameter_indentation_20260830.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_first_parameter_indentation_20260830.md
@@ -1,0 +1,1 @@
+* [#15639](https://github.com/rubocop/rubocop/issues/15639): Fix an infinite loop error for `Layout/FirstParameterIndentation` with `Layout/ParameterAlignment` when `EnforcedStyle: with_fixed_indentation` is configured. ([@RedZapdos123][])

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -53,12 +53,18 @@ module RuboCop
         def on_def(node)
           return if node.arguments.empty?
           return if node.arguments.loc.begin.nil?
+          return if autocorrect_incompatible_with_other_cops?(node)
 
           check(node)
         end
         alias on_defs on_def
 
         private
+
+        def autocorrect_incompatible_with_other_cops?(node)
+          node.arguments.size >= 2 &&
+            style == :align_parentheses && enforce_parameter_with_fixed_indentation?
+        end
 
         def autocorrect(corrector, node)
           AlignmentCorrector.correct(corrector, processed_source, node, @column_delta)
@@ -94,6 +100,11 @@ module RuboCop
             configured_indentation_width: configured_indentation_width,
             base_description: base_description
           )
+        end
+
+        def enforce_parameter_with_fixed_indentation?
+          parameter_alignment_config = config.for_enabled_cop('Layout/ParameterAlignment')
+          parameter_alignment_config['EnforcedStyle'] == 'with_fixed_indentation'
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -2840,6 +2840,39 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects method parameters when specifying `EnforcedStyle: with_fixed_indentation` of ' \
+     '`Layout/ParameterAlignment` and `EnforcedStyle: align_parentheses` of ' \
+     '`Layout/FirstParameterIndentation`' do
+    create_file('example.rb', <<~RUBY)
+      def foo(
+               a,
+               bb
+      )
+      end
+    RUBY
+
+    create_file('.rubocop.yml', <<~YAML)
+      Layout/ParameterAlignment:
+        EnforcedStyle: with_fixed_indentation
+      Layout/FirstParameterIndentation:
+        EnforcedStyle: align_parentheses
+    YAML
+
+    expect(
+      cli.run(
+        ['--autocorrect', '--only', 'Layout/ParameterAlignment,Layout/FirstParameterIndentation']
+      )
+    ).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo(
+        a,
+        bb
+      )
+      end
+    RUBY
+  end
+
   it 'does not crash Lint/SafeNavigationWithEmpty and accepts Style/SafeNavigation ' \
      'when checking `foo&.empty?` in a conditional' do
     create_file('example.rb', <<~RUBY)

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -7,9 +7,43 @@ RSpec.describe RuboCop::Cop::Layout::FirstParameterIndentation, :config do
                         cop_config.merge(supported_styles).merge(
                           'IndentationWidth' => cop_indent
                         ),
+                        'Layout/ParameterAlignment' => parameter_alignment_config,
                         'Layout/IndentationWidth' => { 'Width' => 2 })
   end
+  let(:parameter_alignment_config) { {} }
   let(:cop_indent) { nil } # use indent from Layout/IndentationWidth
+
+  context 'when Layout/ParameterAlignment uses `with_fixed_indentation`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'align_parentheses' } }
+    let(:parameter_alignment_config) { { 'EnforcedStyle' => 'with_fixed_indentation' } }
+
+    it 'does not register an offense for a multi-line method definition' do
+      expect_no_offenses(<<~RUBY)
+        def foo(
+                 a,
+                 bb
+        )
+        end
+      RUBY
+    end
+
+    it 'registers an offense and corrects a single-parameter method definition' do
+      expect_offense(<<~RUBY)
+        def foo(
+        a
+        ^ Use 2 spaces for indentation in method args, relative to the position of the opening parenthesis.
+        )
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo(
+                 a
+        )
+        end
+      RUBY
+    end
+  end
 
   context 'consistent style' do
     let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }


### PR DESCRIPTION
## Description:

Issue #15639 reported that `Layout/FirstParameterIndentation` could fight with `Layout/ParameterAlignment` when `EnforcedStyle: with_fixed_indentation` was configured.

The two cops could keep changing the same parameter indentation back and forth, which caused an infinite autocorrect loop.

This PR updates `Layout/FirstParameterIndentation` to treat that `align_parentheses` case as incompatible with `Layout/ParameterAlignment` fixed indentation, so the conflicting autocorrect loop is avoided.

It also adds regression tests for the conflicting cop behavior and for CLI autocorrection.

Closes #15639.

## Checklist:
- [x] I have run linting using `bundle exec rubocop lib/rubocop/cop/layout/first_parameter_indentation.rb spec/rubocop/cop/layout/first_parameter_indentation_spec.rb spec/rubocop/cli/autocorrect_spec.rb`.
- [x] I have run focused tests using `bundle exec rspec spec/rubocop/cop/layout/first_parameter_indentation_spec.rb spec/rubocop/cli/autocorrect_spec.rb`.
- [x] I have run the full verification suite using `bundle exec rake default`.

### Before the fix:
```ruby
def foo(a, bb)
end
```

`Layout/FirstParameterIndentation` and `Layout/ParameterAlignment` could enter an autocorrect loop for this configuration:

```yaml
AllCops:
  NewCops: disable

Layout/ParameterAlignment:
  EnforcedStyle: with_fixed_indentation
Layout/FirstParameterIndentation:
  EnforcedStyle: align_parentheses
```

<img width="2570" height="1220" alt="image" src="https://github.com/user-attachments/assets/d2aa56ad-12bc-498d-8a56-010b11284373" />

### After the fix:
`Layout/FirstParameterIndentation` now defers this conflicting case to `Layout/ParameterAlignment`, so autocorrection finishes and produces:

```ruby
def foo(a, bb)
end
```

<img width="2450" height="1380" alt="image" src="https://github.com/user-attachments/assets/a6c04e72-bb07-4278-81d1-57b0c872cc6f" />
