### PR TITLE
Fix an error for `Style/HashSyntax` cop

### DIFF
--- a/changelog/fix_an_error_for_style_hash_syntax_when_hash_rockets_enforced_20260831130828.md
+++ b/changelog/fix_an_error_for_style_hash_syntax_when_hash_rockets_enforced_20260831130828.md
@@ -1,0 +1,1 @@
+* [#15642](https://github.com/rubocop/rubocop/pull/15642): Fix an error for `Style/HashSyntax` when hash rockets are enforced and a hash value repeats its key. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -87,13 +87,17 @@ module RuboCop
       def ignore_mixed_hash_shorthand_syntax?(hash_node)
         target_ruby_version <= 3.0 ||
           !%w[consistent either_consistent].include?(enforced_shorthand_syntax) ||
-          !hash_node.hash_type?
+          !hash_node.hash_type? || hash_rockets_enforced?(hash_node)
       end
 
       def ignore_hash_shorthand_syntax?(pair_node)
         target_ruby_version <= 3.0 || enforced_shorthand_syntax == 'either' ||
           %w[consistent either_consistent].include?(enforced_shorthand_syntax) ||
-          !pair_node.parent.hash_type?
+          !pair_node.parent.hash_type? || hash_rockets_enforced?(pair_node.parent)
+      end
+
+      def hash_rockets_enforced?(hash_node)
+        style == :hash_rockets || force_hash_rockets?(hash_node.pairs)
       end
 
       def enforced_shorthand_syntax

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -2012,4 +2012,45 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
     end
   end
+
+  context 'when hash rockets are enforced and a value repeats its key', :ruby31 do
+    context 'by EnforcedStyle' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'hash_rockets', 'EnforcedShorthandSyntax' => 'always' }
+      end
+
+      it 'converts to a hash rocket rather than to shorthand' do
+        expect_offense(<<~RUBY)
+          f(a: a)
+            ^^ Use hash rockets syntax.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(:a => a)
+        RUBY
+      end
+    end
+
+    context 'by UseHashRocketsWithSymbolValues' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'ruby19',
+          'EnforcedShorthandSyntax' => 'always',
+          'UseHashRocketsWithSymbolValues' => true
+        }
+      end
+
+      it 'converts to hash rockets rather than to shorthand' do
+        expect_offense(<<~RUBY)
+          f(a: :sym, b: b)
+            ^^ Use hash rockets syntax.
+                     ^^ Use hash rockets syntax.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(:a => :sym, :b => b)
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```shell
$ bundle exec rubocop --stdin /dev/stdin --autocorrect-all -d --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/HashSyntax:
  Enabled: true
  EnforcedStyle: hash_rockets
  EnforcedShorthandSyntax: always
YAML
) <<'RUBY'
f(a: a)
RUBY

An error occurred while Style/HashSyntax cop was inspecting /dev/stdin:1:2.
parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser-3.3.11.1/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from parser-3.3.11.1/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
