### PR TITLE
Fix an infinite loop for `Style/EndlessMethod`

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260831134343.md
+++ b/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260831134343.md
@@ -1,0 +1,1 @@
+* [#15644](https://github.com/rubocop/rubocop/pull/15644): Fix an infinite loop error for `Style/EndlessMethod` when an indented method definition would exceed `Layout/LineLength` once made endless. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -227,13 +227,7 @@ module RuboCop
         def too_long_when_made_endless?(node)
           return false unless config.cop_enabled?('Layout/LineLength')
 
-          offset = modifier_offset(node)
-
-          endless_replacement(node).length + offset > max_line_length
-        end
-
-        def modifier_offset(node)
-          same_line?(node.parent, node) ? node.loc.column - node.parent.loc.column : 0
+          endless_replacement(node).length + node.loc.column > max_line_length
         end
       end
     end

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -426,6 +426,31 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
         RUBY
       end
 
+      it 'takes the indentation into account' do
+        expect_no_offenses(<<~RUBY)
+          module A
+            module B
+              def my_method
+                'this_string_puts_the_endless_form_just_over_the_limit______'
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense when the same body fits at the top level' do
+        expect_offense(<<~RUBY)
+          def my_method
+          ^^^^^^^^^^^^^ Use endless method definitions for single line methods.
+            'this_string_puts_the_endless_form_just_over_the_limit______'
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def my_method = 'this_string_puts_the_endless_form_just_over_the_limit______'
+        RUBY
+      end
+
       it 'does not register an offense when the endless with access modifier version excess Metrics/MaxLineLength[Max]' do
         expect_no_offenses(<<~RUBY)
           private def my_method


### PR DESCRIPTION
An MRE:

```shell
$ bundle exec rubocop --stdin /dev/stdin --autocorrect-all -d --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Layout/LineLength:
  Enabled: true
  Max: 40
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_single_line
YAML
) <<'RUBY'
module A
  module B
    def m
      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
    end
  end
end
RUBY

Infinite loop detected in /dev/stdin and caused by Style/EndlessMethod -> Layout/LineLength
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
