### PR TITLE
Fix Style/GuardClause autocorrect clash with Style/MissingElse

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause_20260831.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_guard_clause_20260831.md
@@ -1,0 +1,1 @@
+* [#15645](https://github.com/rubocop/rubocop/pull/15645): Fix an incorrect autocorrect for `Style/GuardClause` with `Style/MissingElse`. ([@Starlexxx][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -109,6 +109,10 @@ module RuboCop
         MSG = 'Use a guard clause (`%<example>s`) instead of wrapping the ' \
               'code inside a conditional expression.'
 
+        def self.autocorrect_incompatible_with
+          [Style::MissingElse]
+        end
+
         def on_def(node)
           body = node.body
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -678,6 +678,37 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/GuardClause` with `Style/MissingElse`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/EmptyElse:
+        EnforcedStyle: empty
+      Style/MissingElse:
+        Enabled: true
+    YAML
+    source = <<~RUBY
+      def rename(hash)
+        if hash
+          do_this
+          do_that
+        end
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Style/GuardClause,Style/MissingElse,Style/EmptyElse'
+                   ])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def rename(hash)
+        return unless hash
+          do_this
+          do_that
+      #{'  '}
+      end
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: explicit` of `Naming/BlockForwarding` with `Style/ArgumentsForwarding`' do
     create_file('.rubocop.yml', <<~YAML)
       AllCops:


### PR DESCRIPTION
With `Style/MissingElse` enabled and `Style/EmptyElse` set to `empty`, autocorrecting both cops in one pass breaks the file:

```ruby
def rename(hash)
  if hash
    do_this
    do_that
  end
end
```

becomes

```ruby
def rename(hash)
  return unless hash
    do_this
    do_that
  else; nil;
end
```

```
else without rescue is useless (SyntaxError)
```

`Style/MissingElse` inserts `else; nil;` while `Style/GuardClause` rewrites the same `if` into a guard clause, and the merged edits leave an orphaned `else` in the method body. Adding `Style/MissingElse` to `autocorrect_incompatible_with` of `Style/GuardClause` defers it to the next pass, where the guard clause no longer needs an `else`.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.