### PR TITLE
Fix an error for `Layout/ElseAlignment` cop

### DIFF
--- a/changelog/fix_an_error_for_layout_else_alignment_when_rescue_else_is_in_a_class_body_20260901154507.md
+++ b/changelog/fix_an_error_for_layout_else_alignment_when_rescue_else_is_in_a_class_body_20260901154507.md
@@ -1,0 +1,1 @@
+* [#15646](https://github.com/rubocop/rubocop/pull/15646): Fix an error for `Layout/ElseAlignment` when `else` is used with `rescue` in a `class`, `module`, or singleton class body. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -93,6 +93,7 @@ module RuboCop
           when :def, :defs then base_for_method_definition(parent)
           when :kwbegin then parent.loc.begin
           when :block, :numblock, :itblock then start_line_range(parent)
+          when :class, :module, :sclass then parent.loc.keyword
           else node.loc.keyword
           end
         end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -737,6 +737,123 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment, :config do
     end
   end
 
+  context 'with class/rescue/else/end' do
+    it 'accepts a correctly aligned else' do
+      expect_no_offenses(<<~RUBY)
+        class MyClass
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for misaligned else' do
+      expect_offense(<<~RUBY)
+        class MyClass
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+          else
+          ^^^^ Align `else` with `class`.
+          puts 'normal handling'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyClass
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+  end
+
+  context 'with module/rescue/else/end' do
+    it 'accepts a correctly aligned else' do
+      expect_no_offenses(<<~RUBY)
+        module MyModule
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for misaligned else' do
+      expect_offense(<<~RUBY)
+        module MyModule
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+          else
+          ^^^^ Align `else` with `module`.
+          puts 'normal handling'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module MyModule
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+  end
+
+  context 'with sclass/rescue/else/ensure/end' do
+    it 'accepts a correctly aligned else' do
+      expect_no_offenses(<<~RUBY)
+        class << self
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        ensure
+          puts 'cleanup'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for misaligned else' do
+      expect_offense(<<~RUBY)
+        class << self
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+          else
+          ^^^^ Align `else` with `class`.
+          puts 'normal handling'
+        ensure
+          puts 'cleanup'
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class << self
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        ensure
+          puts 'cleanup'
+        end
+      RUBY
+    end
+  end
+
   context 'ensure/rescue/else in Block Argument' do
     it 'accepts a correctly aligned else' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/ElseAlignment:
  Enabled: true
YAML
) <<'RUBY'
class A
rescue
else
end
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
An error occurred while Layout/ElseAlignment cop was inspecting /dev/stdin:2:0.
lib/rubocop/cop/mixin/range_help.rb:104:in 'RuboCop::Cop::RangeHelp#effective_column': undefined method 'line' for nil (NoMethodError)

        if range.line == 1 && @processed_source.raw_source.codepoints.first == BYTE_ORDER_MARK
                ^^^^^
	from lib/rubocop/cop/mixin/range_help.rb:94:in 'RuboCop::Cop::RangeHelp#column_offset_between'
	from lib/rubocop/cop/layout/else_alignment.rb:128:in 'RuboCop::Cop::Layout::ElseAlignment#check_alignment'
	from lib/rubocop/cop/layout/else_alignment.rb:54:in 'RuboCop::Cop::Layout::ElseAlignment#on_rescue'
	from lib/rubocop/cop/commissioner.rb:109:in 'Kernel#public_send'
	from lib/rubocop/cop/commissioner.rb:109:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
```

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
