### PR TITLE
Fix an error for `Style/DocumentationMethod` cop

### DIFF
--- a/changelog/fix_an_error_for_style_documentation_method_with_a_preceding_modifier_argument_20260901155902.md
+++ b/changelog/fix_an_error_for_style_documentation_method_with_a_preceding_modifier_argument_20260901155902.md
@@ -1,0 +1,1 @@
+* [#15647](https://github.com/rubocop/rubocop/pull/15647): Fix an error for `Style/DocumentationMethod` when an inline `module_function`/`ruby2_keywords` `def` is preceded by another argument. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -119,6 +119,7 @@ module RuboCop
 
         def on_def(node)
           return if node.method?(:initialize)
+          return if allowed_methods.include?(node.method_name)
 
           parent = node.parent
           modifier_node?(parent) ? check(parent) : check(node)
@@ -130,21 +131,12 @@ module RuboCop
         def check(node)
           return if non_public?(node) && !require_for_non_public_methods?
           return if documentation_comment?(node)
-          return if method_allowed?(node)
 
           add_offense(node)
         end
 
         def require_for_non_public_methods?
           cop_config['RequireForNonPublicMethods']
-        end
-
-        def method_allowed?(node)
-          # For a modifier form like `module_function def foo; end`, `node` is the
-          # `module_function`/`ruby2_keywords` send; the real method name is on its
-          # `def`/`defs` argument, not the modifier itself.
-          method_name = node.send_type? ? node.first_argument.method_name : node.method_name
-          allowed_methods.include?(method_name)
         end
 
         def allowed_methods

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -1038,6 +1038,32 @@ RSpec.describe RuboCop::Cop::Style::DocumentationMethod, :config do
             end
           RUBY
         end
+
+        it 'ignores an allowed inline def preceded by another argument' do
+          expect_no_offenses(<<~RUBY)
+            module Foo
+              ruby2_keywords :baz, def bar; end
+            end
+          RUBY
+        end
+
+        it 'registers an offense for a non-allowed inline def preceded by another argument' do
+          expect_offense(<<~RUBY)
+            module Foo
+              ruby2_keywords :bar, def baz; end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+            end
+          RUBY
+        end
+
+        it 'registers an offense for a non-allowed `module_function` def preceded by another argument' do
+          expect_offense(<<~RUBY)
+            module Foo
+              module_function :bar, def baz; end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing method documentation comment.
+            end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/DocumentationMethod:
  Enabled: true
YAML
) <<'RUBY'
ruby2_keywords :a, def b
end
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
An error occurred while Style/DocumentationMethod cop was inspecting /dev/stdin:1:19.
lib/rubocop/cop/style/documentation_method.rb:146:in 'RuboCop::Cop::Style::DocumentationMethod#method_allowed?': undefined method 'method_name' for an instance of RuboCop::AST::SymbolNode (NoMethodError)

          method_name = node.send_type? ? node.first_argument.method_name : node.method_name
                                                             ^^^^^^^^^^^^
Did you mean?  method
	from lib/rubocop/cop/style/documentation_method.rb:133:in 'RuboCop::Cop::Style::DocumentationMethod#check'
	from lib/rubocop/cop/style/documentation_method.rb:124:in 'RuboCop::Cop::Style::DocumentationMethod#on_def'
	from lib/rubocop/cop/commissioner.rb:109:in 'Kernel#public_send'
	from lib/rubocop/cop/commissioner.rb:109:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_responding_cops'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
