### PR TITLE
Fix Lint/ParenthesesAsGroupedExpression autocorrect for keyword operators

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_lint_parentheses_as_grouped_expression_20260901.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_lint_parentheses_as_grouped_expression_20260901.md
@@ -1,0 +1,1 @@
+* [#15648](https://github.com/rubocop/rubocop/pull/15648): Fix an incorrect autocorrect for `Lint/ParenthesesAsGroupedExpression` when the parentheses contain `and`, `or`, `not`, or a modifier expression. ([@Starlexxx][])

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -46,11 +46,27 @@ module RuboCop
 
         def valid_first_argument?(first_arg)
           first_arg.operator_keyword? || first_arg.hash_type? || ternary_expression?(first_arg) ||
-            compound_range?(first_arg)
+            compound_range?(first_arg) || invalid_bare_argument?(first_arg)
         end
 
         def compound_range?(first_arg)
           first_arg.range_type? && first_arg.parenthesized_call?
+        end
+
+        def invalid_bare_argument?(node)
+          node = node.children.first while node&.begin_type? && node.children.one?
+          return false unless node
+
+          keyword_operator?(node) || modifier_expression?(node)
+        end
+
+        def keyword_operator?(node)
+          (node.operator_keyword? && node.semantic_operator?) ||
+            node.rescue_type? || (node.send_type? && node.prefix_not?)
+        end
+
+        def modifier_expression?(node)
+          node.type?(:if, :while, :until) && node.modifier_form?
         end
 
         def chained_calls?(node)

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -208,4 +208,45 @@ RSpec.describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression, :config do
       RUBY
     end
   end
+
+  it 'does not register an offense for parenthesized `and`' do
+    expect_no_offenses(<<~RUBY)
+      false? (foo and bar)
+    RUBY
+  end
+
+  it 'does not register an offense for parenthesized `or`' do
+    expect_no_offenses(<<~RUBY)
+      false? (foo or bar)
+    RUBY
+  end
+
+  it 'does not register an offense for parenthesized `not`' do
+    expect_no_offenses(<<~RUBY)
+      false? (not foo)
+    RUBY
+  end
+
+  it 'does not register an offense for parenthesized modifier `rescue`' do
+    expect_no_offenses(<<~RUBY)
+      false? (foo rescue bar)
+    RUBY
+  end
+
+  it 'does not register an offense for parenthesized modifier `if`' do
+    expect_no_offenses(<<~RUBY)
+      false? (foo if bar)
+    RUBY
+  end
+
+  it 'registers an offense and corrects for parenthesized `&&`' do
+    expect_offense(<<~RUBY)
+      false? (foo && bar)
+            ^ `(foo && bar)` interpreted as grouped expression.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      false?(foo && bar)
+    RUBY
+  end
 end


### PR DESCRIPTION
Autocorrecting this real-world code from brakeman produces unparseable Ruby:

```ruby
false? (tracker.config.rails[:assets] and tracker.config.rails[:assets][:compile])
```

becomes

```ruby
false?(tracker.config.rails[:assets] and tracker.config.rails[:assets][:compile])
```

```
syntax error, unexpected `and', expecting ')'
```

Removing the space turns the grouping parentheses into an argument list, and `and`, `or`, `not`, and modifier `rescue`/`if`/`unless`/`while`/`until` cannot appear directly inside one. The existing `operator_keyword?` guard never fired because the argument is wrapped in a `begin` node.

Now the cop looks through the parentheses and skips these expressions. `&&`/`||` are still corrected as before.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.