### PR TITLE
[Fix #11696] Fix `Style/DataInheritance` false positive for constants

### DIFF
--- a/changelog/fix_style_data_inheritance_to_not_register_an_offense_when_the_class_body_20260901131924.md
+++ b/changelog/fix_style_data_inheritance_to_not_register_an_offense_when_the_class_body_20260901131924.md
@@ -1,0 +1,1 @@
+* [#11696](https://github.com/rubocop/rubocop/issues/11696): Fix `Style/DataInheritance` to not register an offense when the class body defines constants, nested classes, or nested modules. ([@MatheusRich][])

--- a/lib/rubocop/cop/style/data_inheritance.rb
+++ b/lib/rubocop/cop/style/data_inheritance.rb
@@ -10,6 +10,10 @@ module RuboCop
       #   Autocorrection is unsafe because it will change the inheritance
       #   tree (e.g. return value of `Module#ancestors`) of the constant.
       #
+      #   It is also unsafe because constants that the class body resolves through its
+      #   ancestors (e.g. one provided by an included module) fall out of scope inside
+      #   the block.
+      #
       # @example
       #   # bad
       #   class Person < Data.define(:first_name, :last_name)
@@ -42,6 +46,7 @@ module RuboCop
 
         def on_class(node)
           return unless data_define?(node.parent_class)
+          return if defines_constants?(node.body)
 
           add_offense(node.parent_class) do |corrector|
             corrector.remove(range_with_surrounding_space(node.loc.keyword, newlines: false))
@@ -58,6 +63,15 @@ module RuboCop
         PATTERN
 
         private
+
+        # Constants, including nested classes and modules, are scoped to the class when they
+        # are defined in a class body, but leak into the enclosing namespace once moved into a
+        # `Data.define` block, so such a class cannot be rewritten as an assignment.
+        def defines_constants?(class_body)
+          return false unless class_body
+
+          class_body.each_node(:casgn, :class, :module).any?
+        end
 
         def correct_parent(parent, corrector)
           if parent.block_type?

--- a/spec/rubocop/cop/style/data_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/data_inheritance_spec.rb
@@ -123,6 +123,40 @@ RSpec.describe RuboCop::Cop::Style::DataInheritance, :config do
       RUBY
     end
 
+    it 'accepts extending instance of `Data.define` when the class body assigns a constant' do
+      expect_no_offenses(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name)
+          MAX_AGE = 120
+        end
+      RUBY
+    end
+
+    it 'accepts extending instance of `Data.define` when a constant is assigned in a nested scope' do
+      expect_no_offenses(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name)
+          if something
+            MAX_AGE = 120
+          end
+        end
+      RUBY
+    end
+
+    it 'accepts extending instance of `Data.define` when the class body defines a nested class' do
+      expect_no_offenses(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name)
+          class Error < StandardError; end
+        end
+      RUBY
+    end
+
+    it 'accepts extending instance of `Data.define` when the class body defines a nested module' do
+      expect_no_offenses(<<~RUBY)
+        class Person < Data.define(:first_name, :last_name)
+          module Helpers; end
+        end
+      RUBY
+    end
+
     it 'accepts plain class' do
       expect_no_offenses(<<~RUBY)
         class Person


### PR DESCRIPTION
[#11696](https://github.com/rubocop/rubocop/issues/11696) is closed, but [I pointed out on it](https://github.com/rubocop/rubocop/issues/11696#issuecomment-1861641394) that there were improvements to be made, which I'm addressing here.

The cop would rewrite `class Person < Data.define(:x)` as `Person = Data.define(:x) do ... end`. That didn't work for constants, as a constant defined inside the block lands in the enclosing namespace rather than on the class, so `Person::MAX_AGE` stops resolving. Nested classes and modules go the same way, since defining one is itself a constant assignment.

The correction could assign them after the block instead, as `Person::MAX_AGE = 120`, but that is ugly enough that it is simpler to leave these classes alone. The cop now stays quiet when the class body defines any constant.

One related problem stays undetectable: a class body can resolve a constant through its ancestors, say one provided by an included module, and that lookup fails inside the block. Spotting it would mean knowing what the included module defines, which a static check cannot do, so the safety note now mentions it and the autocorrect stays unsafe.

## Next steps

`Style/StructInheritance` has the same hole, since `Struct.new` takes a block in the same way, and its specs do not cover constants either. That could be a follow-up PR if this approach looks right.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
