### PR TITLE
Improve `Style/DisableCopsWithinSourceCodeDirective` configuration

### DIFF
--- a/changelog/change_match_departments_in_allowed_cops_and_disallowed_cops_20260901234000.md
+++ b/changelog/change_match_departments_in_allowed_cops_and_disallowed_cops_20260901234000.md
@@ -1,0 +1,1 @@
+* [#15650](https://github.com/rubocop/rubocop/pull/15650): Make `AllowedCops` and `DisallowedCops` of `Style/DisableCopsWithinSourceCodeDirective` match department names as well as cop names. ([@bbatsov][])

--- a/changelog/change_rename_allow_trailing_comment_to_allow_with_reason_20260901233959.md
+++ b/changelog/change_rename_allow_trailing_comment_to_allow_with_reason_20260901233959.md
@@ -1,0 +1,1 @@
+* [#15650](https://github.com/rubocop/rubocop/pull/15650): Rename the `AllowTrailingComment` option of `Style/DisableCopsWithinSourceCodeDirective` to `AllowWithReason`. ([@bbatsov][])

--- a/changelog/new_add_allowed_directives_to_exempt_directive_kinds_20260901234001.md
+++ b/changelog/new_add_allowed_directives_to_exempt_directive_kinds_20260901234001.md
@@ -1,0 +1,1 @@
+* [#15650](https://github.com/rubocop/rubocop/pull/15650): Add `AllowedDirectives` option to `Style/DisableCopsWithinSourceCodeDirective`, exempting directive kinds such as generated `rubocop:todo` comments. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4034,7 +4034,11 @@ Style/DisableCopsWithinSourceCodeDirective:
   Enabled: false
   VersionAdded: '0.82'
   VersionChanged: '1.90'
+  # Cop or department names. A directive is exempt only when everything it
+  # disables is listed here.
   AllowedCops: []
+  # Cop or department names. When set, only directives touching these are
+  # flagged.
   DisallowedCops: []
   # Permit a directive that carries a `-- reason` justification, instead of
   # forbidding directives outright.

--- a/config/default.yml
+++ b/config/default.yml
@@ -4036,7 +4036,9 @@ Style/DisableCopsWithinSourceCodeDirective:
   VersionChanged: '1.90'
   AllowedCops: []
   DisallowedCops: []
-  AllowTrailingComment: false
+  # Permit a directive that carries a `-- reason` justification, instead of
+  # forbidding directives outright.
+  AllowWithReason: false
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/config/default.yml
+++ b/config/default.yml
@@ -4043,6 +4043,9 @@ Style/DisableCopsWithinSourceCodeDirective:
   # Permit a directive that carries a `-- reason` justification, instead of
   # forbidding directives outright.
   AllowWithReason: false
+  # Directive forms this cop ignores entirely. One or more of `disable`,
+  # `todo`, `disable-next`, `todo-next`, `push`, `next`.
+  AllowedDirectives: []
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -154,6 +154,10 @@ changed_parameters:
     parameters: IgnoreCopDirectives
     alternative: AllowCopDirectives
     severity: warning
+  - cops: Style/DisableCopsWithinSourceCodeDirective
+    parameters: AllowTrailingComment
+    alternative: AllowWithReason
+    severity: warning
   - cops:
       - Lint/BlockAlignment
       - Layout/BlockAlignment

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -19,7 +19,7 @@ module RuboCop
       # allowlisting all other cops. `AllowedCops` and `DisallowedCops` should not
       # both be set at the same time; if `DisallowedCops` is set, it takes precedence.
       #
-      # With `AllowTrailingComment` set to `true`, a disable directive carrying
+      # With `AllowWithReason` set to `true`, a disable directive carrying
       # a `--` trailing justification comment is allowed, so a team can require
       # every disable to be documented instead of banning them outright. Enable
       # directives are not checked in this mode, since they end a suppression
@@ -58,7 +58,7 @@ module RuboCop
       #   foo
       #   # rubocop:enable Metrics/AbcSize
       #
-      # @example AllowTrailingComment: true
+      # @example AllowWithReason: true
       #   # bad
       #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
       #
@@ -77,7 +77,7 @@ module RuboCop
         def on_new_investigation
           processed_source.comments.each do |comment|
             directive = DirectiveComment.new(comment)
-            next if allow_trailing_comment? && (directive.reason || directive.enabled?)
+            next if allow_with_reason? && (directive.reason || directive.enabled?)
 
             directive_cops = directive_cops(directive)
             disallowed_cops = compute_disallowed_cops(directive_cops)
@@ -116,7 +116,7 @@ module RuboCop
         end
 
         def offense_message(disallowed_cops)
-          if allow_trailing_comment?
+          if allow_with_reason?
             MSG_MISSING_REASON
           elsif any_cops_allowed? || disallowed_cops_config.any?
             format(MSG_FOR_COPS, cops: "`#{disallowed_cops.join('`, `')}`")
@@ -130,8 +130,8 @@ module RuboCop
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
         end
 
-        def allow_trailing_comment?
-          cop_config['AllowTrailingComment']
+        def allow_with_reason?
+          cop_config['AllowWithReason']
         end
 
         def allowed_cops

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -23,6 +23,12 @@ module RuboCop
       # allowlisting all other cops. `AllowedCops` and `DisallowedCops` should not
       # both be set at the same time; if `DisallowedCops` is set, it takes precedence.
       #
+      # `AllowedDirectives` names directive forms - `disable`, `todo`,
+      # `disable-next`, `todo-next`, `push`, `next` - and exempts them from the
+      # cop entirely. `rubocop:todo` is the usual candidate, since
+      # `--disable-uncorrectable` generates those and they record debt rather
+      # than a decision someone should be asked to justify.
+      #
       # With `AllowWithReason` set to `true`, a disable directive carrying
       # a `--` trailing justification comment is allowed, so a team can require
       # every disable to be documented instead of banning them outright. Enable
@@ -62,6 +68,13 @@ module RuboCop
       #   foo
       #   # rubocop:enable Metrics/AbcSize
       #
+      # @example AllowedDirectives: [todo]
+      #   # good - the cop does not look at `todo` directives at all
+      #   x = 0 # rubocop:todo Layout/SpaceAroundOperators
+      #
+      #   # bad
+      #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
+      #
       # @example AllowedCops: [Metrics]
       #   # good - every cop the directive disables is in an exempt department
       #   # rubocop:disable Metrics/AbcSize
@@ -88,6 +101,7 @@ module RuboCop
         def on_new_investigation
           processed_source.comments.each do |comment|
             directive = DirectiveComment.new(comment)
+            next if exempt_mode?(directive)
             next if allow_with_reason? && (directive.reason || directive.enabled?)
 
             directive_cops = directive_cops(directive)
@@ -139,6 +153,14 @@ module RuboCop
         def directive_cops(directive)
           match_captures = directive.match_captures
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
+        end
+
+        def exempt_mode?(directive)
+          allowed_directives.include?(directive.mode)
+        end
+
+        def allowed_directives
+          @allowed_directives ||= Array(cop_config['AllowedDirectives'])
         end
 
         def allow_with_reason?

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -12,6 +12,10 @@ module RuboCop
       # Specific cops can be allowed with the `AllowedCops` configuration. Note that
       # if this configuration is set, `rubocop:disable all` is still disallowed.
       #
+      # `AllowedCops` and `DisallowedCops` accept cop names and department names
+      # alike. Listing a cop does not cover its whole department: a directive
+      # disabling `Metrics` is broader than one disabling `Metrics/AbcSize`.
+      #
       # Alternatively, specific cops can be disallowed with the `DisallowedCops`
       # configuration. When `DisallowedCops` is set, only directives for the listed
       # cops (and `all`) will be flagged. This is useful when you want
@@ -58,6 +62,13 @@ module RuboCop
       #   foo
       #   # rubocop:enable Metrics/AbcSize
       #
+      # @example AllowedCops: [Metrics]
+      #   # good - every cop the directive disables is in an exempt department
+      #   # rubocop:disable Metrics/AbcSize
+      #   def foo
+      #   end
+      #   # rubocop:enable Metrics/AbcSize
+      #
       # @example AllowWithReason: true
       #   # bad
       #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
@@ -95,10 +106,10 @@ module RuboCop
             if directive_cops.include?('all')
               directive_cops
             else
-              directive_cops.uniq.select { |cop| disallowed_cops_config.include?(cop) }
+              directive_cops.uniq.select { |cop| listed?(disallowed_cops_config, cop) }
             end
           else
-            directive_cops.reject { |cop| allowed_cops.include?(cop) }
+            directive_cops.reject { |cop| cop != 'all' && listed?(allowed_cops, cop) }
           end
         end
 
@@ -136,6 +147,12 @@ module RuboCop
 
         def allowed_cops
           @allowed_cops ||= Array(cop_config['AllowedCops']).to_set
+        end
+
+        # A name matches either outright or through its department, so
+        # `Metrics` covers `Metrics/AbcSize` but not the other way round.
+        def listed?(names, cop)
+          names.include?(cop) || names.include?(cop.split('/').first)
         end
 
         def any_cops_allowed?

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
     end
   end
 
+  context 'with AllowedDirectives and no other configuration' do
+    let(:cop_config) { { 'AllowedDirectives' => ['todo'] } }
+
+    it 'ignores the exempt kind while still forbidding the rest' do
+      expect_no_offenses(<<~RUBY)
+        x = 0 # rubocop:todo Layout/SpaceAroundOperators
+      RUBY
+
+      expect_offense(<<~RUBY)
+        y = 0 # rubocop:disable Layout/SpaceAroundOperators
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable/enable directives are not permitted.
+      RUBY
+    end
+  end
+
   context 'with DisallowedCops' do
     let(:cop_config) { { 'DisallowedCops' => ['Lint/Void', 'Security/Eval'] } }
 
@@ -328,6 +343,32 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
         x = 0 # rubocop:todo Layout/SpaceAroundOperators
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
       RUBY
+    end
+
+    context 'when AllowedDirectives exempts todo directives' do
+      let(:cop_config) do
+        { 'AllowWithReason' => true, 'AllowedDirectives' => %w[todo todo-next] }
+      end
+
+      it 'does not register an offense for a `todo` directive without a justification' do
+        expect_no_offenses(<<~RUBY)
+          x = 0 # rubocop:todo Layout/SpaceAroundOperators
+        RUBY
+      end
+
+      it 'does not register an offense for a `todo-next` directive' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:todo-next Layout/SpaceAroundOperators
+          x = 0
+        RUBY
+      end
+
+      it 'still registers an offense for a plain disable without a justification' do
+        expect_offense(<<~RUBY)
+          x = 0 # rubocop:disable Layout/SpaceAroundOperators
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+        RUBY
+      end
     end
 
     context 'when AllowedCops names a department' do

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
     RUBY
   end
 
-  context 'when AllowTrailingComment is true' do
-    let(:cop_config) { { 'AllowTrailingComment' => true } }
+  context 'when AllowWithReason is true' do
+    let(:cop_config) { { 'AllowWithReason' => true } }
 
     it 'does not register an offense for a `disable-next` with a justification' do
       expect_no_offenses(<<~RUBY)
@@ -332,7 +332,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
 
     context 'combined with AllowedCops' do
       let(:cop_config) do
-        { 'AllowTrailingComment' => true, 'AllowedCops' => ['Metrics/AbcSize'] }
+        { 'AllowWithReason' => true, 'AllowedCops' => ['Metrics/AbcSize'] }
       end
 
       it 'does not register an offense for an allowed cop without a justification' do

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -330,6 +330,57 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
       RUBY
     end
 
+    context 'when AllowedCops names a department' do
+      let(:cop_config) { { 'AllowWithReason' => true, 'AllowedCops' => ['Metrics'] } }
+
+      it 'does not register an offense for a cop in that department' do
+        expect_no_offenses(<<~RUBY)
+          # rubocop:disable Metrics/AbcSize
+          def foo
+          end
+          # rubocop:enable Metrics/AbcSize
+        RUBY
+      end
+
+      it 'registers an offense for a cop outside it' do
+        expect_offense(<<~RUBY)
+          x = 0 # rubocop:disable Layout/SpaceAroundOperators
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+        RUBY
+      end
+    end
+
+    context 'when AllowedCops names a cop but a directive disables its whole department' do
+      let(:cop_config) { { 'AllowWithReason' => true, 'AllowedCops' => ['Metrics/AbcSize'] } }
+
+      it 'registers an offense, since the directive is broader than the exemption' do
+        expect_offense(<<~RUBY)
+          # rubocop:disable Metrics
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+          def foo
+          end
+          # rubocop:enable Metrics
+        RUBY
+      end
+    end
+
+    context 'when DisallowedCops names a department' do
+      let(:cop_config) { { 'AllowWithReason' => true, 'DisallowedCops' => ['Lint'] } }
+
+      it 'registers an offense for a cop in that department' do
+        expect_offense(<<~RUBY)
+          foo # rubocop:disable Lint/Void
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
+        RUBY
+      end
+
+      it 'does not register an offense for a cop outside it' do
+        expect_no_offenses(<<~RUBY)
+          x = 0 # rubocop:disable Layout/SpaceAroundOperators
+        RUBY
+      end
+    end
+
     context 'combined with AllowedCops' do
       let(:cop_config) do
         { 'AllowWithReason' => true, 'AllowedCops' => ['Metrics/AbcSize'] }


### PR DESCRIPTION
Dogfooding the `AllowTrailingComment` option added in #15073 turned up three things worth fixing before it settles.

`AllowedCops` and `DisallowedCops` matched exact cop names only, so `AllowedCops: [Metrics]` covered a literal `rubocop:disable Metrics` and nothing else - not the `Metrics/AbcSize` disables it was surely meant for. They now match a department too, one way only: listing `Metrics/AbcSize` does not exempt a directive that disables all of `Metrics`, which is the broader act.

The option name said what the comment looks like rather than what it is for, so it becomes `AllowWithReason`. It shipped a week ago in 1.90, so the old name goes through the usual obsoletion path with a warning.

`AllowedDirectiveModes` is new. Whether a generated `rubocop:todo` has to justify itself was previously settled inside the cop, and it is really a project's call: `--disable-uncorrectable` writes those directives, so a team using both features got reported for markers our own tooling produced, while a team that wants every suppression explained is equally reasonable. The option names directive kinds rather than singling out `todo`, and removes them from the cop's view entirely, so it works whether the cop is forbidding directives outright or asking them to carry a reason. Default is empty - today's behavior exactly.

Measured on this repo with `AllowWithReason: true`: 348 offenses bare, 82 with `AllowedCops: [Metrics, RSpec]`, 77 also exempting todos.

This supersedes #15630, which proposed a separate `Lint/MissingCopDisableReason` cop before I noticed it duplicated `AllowTrailingComment` almost exactly.