### PR TITLE
Fix an infinite loop for `Style/EndlessMethod` cop

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260902031741.md
+++ b/changelog/fix_an_infinite_loop_error_for_style_endless_method_20260902031741.md
@@ -1,0 +1,1 @@
+* [#15651](https://github.com/rubocop/rubocop/pull/15651): Fix an infinite loop error for `Style/EndlessMethod` when a method body is a block spread over several lines. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -175,7 +175,7 @@ module RuboCop
             add_offense(node, message: MSG_MULTI_LINE) do |corrector|
               correct_to_multiline(corrector, node)
             end
-          elsif !node.endless? && can_be_made_endless?(node) && node.body.single_line?
+          elsif !node.endless? && can_be_made_endless?(node) && single_line_when_made_endless?(node)
             return if too_long_when_made_endless?(node)
 
             add_offense(node, message: MSG_REQUIRE_SINGLE) do |corrector|
@@ -222,6 +222,10 @@ module RuboCop
 
         def can_be_made_endless?(node)
           node.body && !node.body.begin_type? && !node.body.kwbegin_type?
+        end
+
+        def single_line_when_made_endless?(node)
+          !endless_replacement(node).include?("\n")
         end
 
         def too_long_when_made_endless?(node)

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -738,4 +738,30 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
       end
     end
   end
+
+  context 'when the body is a block spread over several lines', :ruby30 do
+    let(:cop_config) { { 'EnforcedStyle' => 'require_single_line' } }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def a
+          b
+            .c { d }
+        end
+      RUBY
+    end
+
+    it 'still registers an offense for a body that really is on one line' do
+      expect_offense(<<~RUBY)
+        def a
+        ^^^^^ Use endless method definitions for single line methods.
+          b { c }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def a = b { c }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_single_line
YAML
) <<'RUBY'
def a
  b
    .c { d }
end
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
Infinite loop detected in /dev/stdin and caused by Style/EndlessMethod -> Style/EndlessMethod

/dev/stdin:1:1: C: [Corrected] Style/EndlessMethod: Use endless method definitions for single line methods.
def a ...
^^^^^
/dev/stdin:1:1: C: [Corrected] Style/EndlessMethod: Avoid endless method definitions with multiple lines.
def a = b ...
^^^^^^^^^
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
