### PR TITLE
Require a justification for our own cop directives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,13 @@ Naming/PredicatePrefix:
     - def_node_matcher
     - def_node_search
 
+Style/DisableCopsWithinSourceCodeDirective:
+  Enabled: true
+  AllowWithReason: true
+  AllowedCops:
+    - Metrics
+    - RSpec
+
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays
   # look like unannotated format string tokens to this cop.

--- a/changelog/fix_ignore_directives_quoted_inside_other_comments_20260902113245.md
+++ b/changelog/fix_ignore_directives_quoted_inside_other_comments_20260902113245.md
@@ -1,0 +1,1 @@
+* [#15653](https://github.com/rubocop/rubocop/pull/15653): Fix `Style/DisableCopsWithinSourceCodeDirective` reading directive text quoted inside other comments, such as documentation examples, as a real directive. ([@bbatsov][])

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -39,7 +39,7 @@ require_relative 'rubocop/unified_diff'
 require_relative 'rubocop/util'
 require_relative 'rubocop/warning'
 
-# rubocop:disable Style/RequireOrder
+# rubocop:disable Style/RequireOrder -- ordered by load dependency, not alphabetically
 
 require_relative 'rubocop/project_index_loader'
 require_relative 'rubocop/cop/util'

--- a/lib/rubocop/config_obsoletion.rb
+++ b/lib/rubocop/config_obsoletion.rb
@@ -15,7 +15,7 @@ module RuboCop
       'changed_parameters' => ChangedParameter,
       'changed_enforced_styles' => ChangedEnforcedStyles
     }.freeze
-    LOAD_RULES_CACHE = {} # rubocop:disable Style/MutableConstant
+    LOAD_RULES_CACHE = {} # rubocop:disable Style/MutableConstant -- a cache, written to at runtime
     private_constant :LOAD_RULES_CACHE
 
     attr_reader :rules, :warnings

--- a/lib/rubocop/cop/badge.rb
+++ b/lib/rubocop/cop/badge.rb
@@ -45,7 +45,7 @@ module RuboCop
 
       def hash
         # Do hashing manually to reduce Array allocations.
-        department.hash ^ cop_name.hash # rubocop:disable Security/CompoundHash
+        department.hash ^ cop_name.hash # rubocop:disable Security/CompoundHash -- hashing manually avoids the Array allocation
       end
 
       def match?(other)

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -49,7 +49,7 @@ module RuboCop
       InvestigationReport = Struct.new(:cop, :processed_source, :offenses, :corrector)
 
       # List of methods names to restrict calls for `on_send` / `on_csend`
-      RESTRICT_ON_SEND = Set[].freeze # rubocop:disable InternalAffairs/UselessRestrictOnSend
+      RESTRICT_ON_SEND = Set[].freeze # rubocop:disable InternalAffairs/UselessRestrictOnSend -- the base class default, which cops override
 
       # List of cops that should not try to autocorrect at the same
       # time as this cop
@@ -326,7 +326,7 @@ module RuboCop
 
       ### Reserved for Commissioner
 
-      # rubocop:disable Layout/ClassStructure
+      # rubocop:disable Layout/ClassStructure -- grouped under the Commissioner heading above
       # @api private
       def callbacks_needed
         self.class.callbacks_needed

--- a/lib/rubocop/cop/correctors.rb
+++ b/lib/rubocop/cop/correctors.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Cop # rubocop:disable Style/Documentation
+  module Cop # rubocop:disable Style/Documentation -- a namespace that only autoloads the correctors below
     # Autoloads corrector classes used by cops. Classes are autoloaded to reduce the number of
     # required classes because they're referenced only when autocorrection is performed.
 
-    # rubocop:disable Layout/LineLength
+    # rubocop:disable Layout/LineLength -- the autoload paths do not wrap
     autoload :AlignmentCorrector, 'rubocop/cop/correctors/alignment_corrector'
     autoload :ConditionCorrector, 'rubocop/cop/correctors/condition_corrector'
     autoload :EachToForCorrector, 'rubocop/cop/correctors/each_to_for_corrector'

--- a/lib/rubocop/cop/gemspec/require_mfa.rb
+++ b/lib/rubocop/cop/gemspec/require_mfa.rb
@@ -92,7 +92,7 @@ module RuboCop
           (str "true")
         PATTERN
 
-        def on_block(node) # rubocop:disable Metrics/MethodLength, InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable Metrics/MethodLength, InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- the gemspec block is matched by its named block variable
           gem_specification(node) do |block_var|
             metadata_value = metadata(node)
             mfa_value = mfa_value(metadata_value)

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -147,7 +147,7 @@ module RuboCop
                                     badge: badge,
                                     version_added: version_added)
 
-        injector.inject do # rubocop:disable Lint/UnexpectedBlockArity
+        injector.inject do # rubocop:disable Lint/UnexpectedBlockArity -- this `inject` is the injector API, not `Enumerable#inject`
           output.puts(format(CONFIGURATION_ADDED_MESSAGE,
                              configuration_file_path: config_file_path))
         end

--- a/lib/rubocop/cop/internal_affairs/on_send_without_on_csend.rb
+++ b/lib/rubocop/cop/internal_affairs/on_send_without_on_csend.rb
@@ -75,7 +75,7 @@ module RuboCop
           @on_csend_definition = node if node.new_identifier.value == :on_csend
         end
 
-        def on_send(node) # rubocop:disable InternalAffairs/OnSendWithoutOnCSend
+        def on_send(node) # rubocop:disable InternalAffairs/OnSendWithoutOnCSend -- this cop is what enforces the rule, and does not apply to itself
           return unless (new_identifier = node.first_argument)
           return unless new_identifier.basic_literal?
 

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -400,7 +400,7 @@ module RuboCop
           if body_node.rescue_type?
             check_rescue?(body_node)
           elsif body_node.ensure_type?
-            block_body, = *body_node # rubocop:disable InternalAffairs/NodeDestructuring
+            block_body, = *body_node # rubocop:disable InternalAffairs/NodeDestructuring -- `EnsureNode` has no accessor for the protected body
             if block_body&.rescue_type?
               check_rescue?(block_body)
             else

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -29,7 +29,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- checks spacing inside a block parameter list
           arguments = node.arguments
 
           return unless node.arguments? && pipes?(arguments)

--- a/lib/rubocop/cop/lint/cop_directive_syntax.rb
+++ b/lib/rubocop/cop/lint/cop_directive_syntax.rb
@@ -57,7 +57,7 @@ module RuboCop
         COMMON_MSG = 'Malformed directive comment detected.'
 
         MISSING_MODE_NAME_MSG = 'The mode name is missing.'
-        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, `disable-next`, `enable-next`, `todo`, `todo-next`, `next`, `push`, or `pop`.' # rubocop:disable Layout/LineLength
+        INVALID_MODE_NAME_MSG = 'The mode name must be one of `enable`, `disable`, `disable-next`, `enable-next`, `todo`, `todo-next`, `next`, `push`, or `pop`.' # rubocop:disable Layout/LineLength -- the message lists every mode and does not wrap
         MISSING_COP_NAME_MSG = 'The cop name is missing.'
         MULTIPLE_DIRECTIVES_MSG = 'Only the first directive on a line takes effect. ' \
                                   'List the cop names in a single directive instead.'

--- a/lib/rubocop/cop/lint/empty_block.rb
+++ b/lib/rubocop/cop/lint/empty_block.rb
@@ -63,7 +63,7 @@ module RuboCop
       class EmptyBlock < Base
         MSG = 'Empty block detected.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- an empty block has no parameters to number
           return if node.body
           return if allow_empty_lambdas? && node.lambda_or_proc?
           return if cop_config['AllowComments'] && allow_comment?(node)

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable-next Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective -- the examples below read as real directives
 module RuboCop
   module Cop
     module Lint

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -95,7 +95,7 @@ module RuboCop
         MSG = 'Method definitions must not be nested. Use `lambda` instead.'
 
         def on_def(node)
-          subject, = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          subject, = *node # rubocop:disable InternalAffairs/NodeDestructuring -- the first child differs between `def` and `defs`
           return if node.defs_type? && allowed_subject_type?(subject)
 
           def_ancestor = node.each_ancestor(:any_def).first

--- a/lib/rubocop/cop/lint/non_deterministic_require_order.rb
+++ b/lib/rubocop/cop/lint/non_deterministic_require_order.rb
@@ -67,7 +67,7 @@ module RuboCop
 
         # NOTE: itblock is not handled because this cop is limited to Ruby <= 2.7
         # via `maximum_target_ruby_version`, so itblock nodes (Ruby 3.4+) are never encountered.
-        def on_block(node) # rubocop:disable InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/ItblockHandler -- limited to Ruby <= 2.7, where `it` blocks do not exist
           return unless node.body
           return unless unsorted_dir_loop?(node.send_node)
 

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -2,7 +2,7 @@
 
 # The Lint/RedundantCopDisableDirective cop needs to be disabled so as
 # to be able to provide a (bad) example of a redundant disable.
-# rubocop:disable-next Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective -- the examples below read as real directives
 module RuboCop
   module Cop
     module Lint

--- a/lib/rubocop/cop/migration/department_name.rb
+++ b/lib/rubocop/cop/migration/department_name.rb
@@ -2,7 +2,7 @@
 
 # Lint/RedundantCopDisableDirective needs to be disabled so as
 # to be able to provide examples of rubocop:disable comments.
-# rubocop:disable-next Lint/RedundantCopDisableDirective
+# rubocop:disable-next Lint/RedundantCopDisableDirective -- the examples below read as real directives
 module RuboCop
   module Cop
     module Migration

--- a/lib/rubocop/cop/mixin.rb
+++ b/lib/rubocop/cop/mixin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Cop # rubocop:disable Style/Documentation
+  module Cop # rubocop:disable Style/Documentation -- a namespace that only autoloads the mixins below
     # Autoloads mixin modules included by cops. Mixins are autoloaded to reduce the number of
     # requires because they're used only when the relevant cop class is loaded.
 
@@ -14,7 +14,7 @@ module RuboCop
     autoload :AllowedReceivers, "#{__dir__}/mixin/allowed_receivers"
     autoload :ForbiddenIdentifiers, "#{__dir__}/mixin/forbidden_identifiers"
     autoload :ForbiddenPattern, "#{__dir__}/mixin/forbidden_pattern"
-    autoload :AutoCorrector, "#{__dir__}/mixin/auto_corrector" # rubocop:todo Naming/InclusiveLanguage
+    autoload :AutoCorrector, "#{__dir__}/mixin/auto_corrector" # rubocop:todo Naming/InclusiveLanguage -- the file is named `auto_corrector.rb`
     autoload :CheckAssignment, "#{__dir__}/mixin/check_assignment"
     autoload :CheckLineBreakable, "#{__dir__}/mixin/check_line_breakable"
     autoload :CheckSingleLineSuitability, "#{__dir__}/mixin/check_single_line_suitability"

--- a/lib/rubocop/cop/mixin/alignment.rb
+++ b/lib/rubocop/cop/mixin/alignment.rb
@@ -66,7 +66,7 @@ module RuboCop
       end
 
       # @deprecated Use processed_source.line_with_comment?(line)
-      def end_of_line_comment(line) # rubocop:disable Naming/PredicateMethod
+      def end_of_line_comment(line) # rubocop:disable Naming/PredicateMethod -- a deprecated shim kept under its original name
         warn Rainbow(<<~WARNING).yellow, uplevel: 1
           `end_of_line_comment` is deprecated. Use `processed_source.line_with_comment?` instead.
         WARNING

--- a/lib/rubocop/cop/mixin/annotation_comment.rb
+++ b/lib/rubocop/cop/mixin/annotation_comment.rb
@@ -45,7 +45,7 @@ module RuboCop
         match.captures
       end
 
-      KEYWORDS_REGEX_CACHE = {} # rubocop:disable Style/MutableConstant
+      KEYWORDS_REGEX_CACHE = {} # rubocop:disable Style/MutableConstant -- a cache, written to at runtime
       private_constant :KEYWORDS_REGEX_CACHE
 
       def regex

--- a/lib/rubocop/cop/mixin/hash_transform_method.rb
+++ b/lib/rubocop/cop/mixin/hash_transform_method.rb
@@ -38,7 +38,7 @@ module RuboCop
          (block (send _ :each_with_object (hash)) ...)}
       PATTERN
 
-      def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+      def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- the patterns matched here all name their block parameters
         on_bad_each_with_object(node) do |*match|
           handle_possible_offense(node, match, 'each_with_object')
         end

--- a/lib/rubocop/cop/naming/block_parameter_name.rb
+++ b/lib/rubocop/cop/naming/block_parameter_name.rb
@@ -38,7 +38,7 @@ module RuboCop
       class BlockParameterName < Base
         include UncommunicativeName
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- there are no parameter names to check
           return unless node.arguments?
 
           check(node, node.arguments)

--- a/lib/rubocop/cop/style/arguments_forwarding.rb
+++ b/lib/rubocop/cop/style/arguments_forwarding.rb
@@ -202,7 +202,7 @@ module RuboCop
           rest_arg, kwrest_arg, block_arg = *forwardable_args
           registered_block_arg_offense = false
 
-          send_classifications.each do |send_node, c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength
+          send_classifications.each do |send_node, c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength -- the block parameter list does not wrap
             if !forward_rest && !forward_kwrest && c != :all_anonymous
               if allow_anonymous_forwarding_in_block?(forward_block_arg)
                 register_forward_block_arg_offense(!forward_rest, node.arguments, block_arg)
@@ -232,7 +232,7 @@ module RuboCop
 
           rest_arg, kwrest_arg, block_arg = *forwardable_args
 
-          send_classifications.each do |send_node, _c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength
+          send_classifications.each do |send_node, _c, forward_rest, forward_kwrest, forward_block_arg| # rubocop:disable Layout/LineLength -- the block parameter list does not wrap
             if allow_anonymous_forwarding_in_block?(forward_rest)
               register_forward_args_offense(def_node.arguments, rest_arg)
               register_forward_args_offense(send_node, forward_rest)

--- a/lib/rubocop/cop/style/case_like_if.rb
+++ b/lib/rubocop/cop/style/case_like_if.rb
@@ -106,7 +106,7 @@ module RuboCop
           when :or
             find_target(node.lhs)
           when :match_with_lvasgn
-            lhs, rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring
+            lhs, rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring -- `match_with_lvasgn` has no named operand accessors
             if lhs.regexp_type?
               rhs
             elsif rhs.regexp_type?
@@ -171,7 +171,7 @@ module RuboCop
               return collect_conditions(node.lhs, target, conditions) &&
                      collect_conditions(node.rhs, target, conditions)
             when :match_with_lvasgn
-              lhs, rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring
+              lhs, rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring -- `match_with_lvasgn` has no named operand accessors
               condition_from_binary_op(lhs, rhs, target)
             when :send
               condition_from_send_node(node, target)
@@ -258,7 +258,7 @@ module RuboCop
         def regexp_with_working_captures?(node)
           case node.type
           when :match_with_lvasgn
-            lhs, _rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring
+            lhs, _rhs = *node # rubocop:disable InternalAffairs/NodeDestructuring -- `match_with_lvasgn` has no named operand accessors
             node.loc.selector.source == '=~' && regexp_with_named_captures?(lhs)
           when :send
             node.method?(:match) &&

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable Lint/RedundantCopDisableDirective -- the examples below read as real directives
 
 module RuboCop
   module Cop
@@ -101,8 +101,7 @@ module RuboCop
         def on_new_investigation
           processed_source.comments.each do |comment|
             directive = DirectiveComment.new(comment)
-            next if exempt_mode?(directive)
-            next if allow_with_reason? && (directive.reason || directive.enabled?)
+            next if ignored?(directive)
 
             directive_cops = directive_cops(directive)
             disallowed_cops = compute_disallowed_cops(directive_cops)
@@ -153,6 +152,16 @@ module RuboCop
         def directive_cops(directive)
           match_captures = directive.match_captures
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
+        end
+
+        # A directive mentioned inside another comment - documentation, or prose
+        # about directives - suppresses nothing, so there is nothing to forbid
+        # or to ask a justification for.
+        def ignored?(directive)
+          return true unless directive.start_with_marker?
+          return true if exempt_mode?(directive)
+
+          allow_with_reason? && (directive.reason || directive.enabled?)
         end
 
         def exempt_mode?(directive)

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         MSG = 'Use `Integer#times` for a simple loop which iterates a fixed number of times.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- only matches blocks that take no parameters
           return unless offending?(node)
 
           send_node = node.send_node

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         MSG = 'Omit pipes for the empty block parameters.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- the offense is an empty `||`
           send_node = node.send_node
           check(node) unless send_node.send_type? && send_node.lambda_literal?
         end

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         MSG = 'Omit parentheses for the empty lambda parameters.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- the offense is an empty `()`
           send_node = node.send_node
           return unless send_node.send_type?
 

--- a/lib/rubocop/cop/style/file_null.rb
+++ b/lib/rubocop/cop/style/file_null.rb
@@ -54,7 +54,7 @@ module RuboCop
           @contain_dev_null_string_in_file = ast.each_descendant(:str).any? do |str|
             content = str.str_content
 
-            valid_string?(content) && content.downcase == '/dev/null' # rubocop:disable Style/FileNull
+            valid_string?(content) && content.downcase == '/dev/null' # rubocop:disable Style/FileNull -- the cop needs the literal it is matching
           end
         end
 
@@ -62,7 +62,7 @@ module RuboCop
           value = node.value
           return unless valid_string?(value)
           return if acceptable?(node)
-          return if value.downcase == 'nul' && !@contain_dev_null_string_in_file # rubocop:disable Style/FileNull
+          return if value.downcase == 'nul' && !@contain_dev_null_string_in_file # rubocop:disable Style/FileNull -- the cop needs the literal it is matching
           return unless REGEXP.match?(value)
 
           add_offense(node, message: format(MSG, source: value)) do |corrector|

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -228,7 +228,7 @@ module RuboCop
           "Prefer #{message_text(style)} over #{message_text(detected_style)}."
         end
 
-        # rubocop:disable-next Style/FormatStringToken
+        # rubocop:disable-next Style/FormatStringToken -- the cop needs the token style it is matching
         def message_text(style)
           {
             annotated: 'annotated tokens (like `%<foo>s`)',

--- a/lib/rubocop/cop/style/magic_comment_format.rb
+++ b/lib/rubocop/cop/style/magic_comment_format.rb
@@ -187,7 +187,7 @@ module RuboCop
             issues[:directives] << directive if directive_offends?(directive)
           end
 
-          comment.values.each do |value| # rubocop:disable Style/HashEachMethods
+          comment.values.each do |value| # rubocop:disable Style/HashEachMethods -- the receiver is a magic comment, not a Hash
             issues[:values] << value if wrong_capitalization?(value.source, value_capitalization)
           end
 

--- a/lib/rubocop/cop/style/nil_lambda.rb
+++ b/lib/rubocop/cop/style/nil_lambda.rb
@@ -48,7 +48,7 @@ module RuboCop
           { ({return next break} nil) (nil) }
         PATTERN
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- a lambda whose body is `nil` uses no parameters
           return unless node.lambda_or_proc?
           return unless nil_return?(node.body)
           # `return` inside a non-lambda proc returns from the enclosing method,

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -117,7 +117,7 @@ module RuboCop
         end
 
         def ternary_replacement(node)
-          condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring -- takes all three branches in one step
 
           "#{expr_replacement(condition)} ? " \
             "#{expr_replacement(if_branch)} : " \

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -184,7 +184,7 @@ module RuboCop
           def accesses?(rhs, lhs)
             if lhs.method?(:[]=)
               # FIXME: Workaround `rubocop:disable` comment for JRuby.
-              # rubocop:disable-next Performance/RedundantEqualityComparisonBlock
+              # rubocop:disable-next Performance/RedundantEqualityComparisonBlock -- a JRuby workaround, as the comment above says
               matching_calls(rhs, lhs.receiver, :[]).any? { |args| args == lhs.arguments }
             else
               access_method = lhs.method_name.to_s.chop.to_sym

--- a/lib/rubocop/cop/style/redundant_condition.rb
+++ b/lib/rubocop/cop/style/redundant_condition.rb
@@ -119,7 +119,7 @@ module RuboCop
         end
 
         def offense?(node)
-          _condition, _if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          _condition, _if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring -- takes all three branches in one step
           return false if use_if_branch?(else_branch) || use_hash_key_assignment?(else_branch)
 
           synonymous_condition_and_branch?(node) && !node.elsif? &&
@@ -143,7 +143,7 @@ module RuboCop
         end
 
         def synonymous_condition_and_branch?(node)
-          condition, if_branch, _else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          condition, if_branch, _else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring -- takes all three branches in one step
           # e.g.
           #   if var
           #     var
@@ -192,7 +192,7 @@ module RuboCop
         end
 
         def branches_have_assignment?(node)
-          _condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          _condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring -- takes all three branches in one step
 
           return false unless if_branch && else_branch
 
@@ -294,7 +294,7 @@ module RuboCop
         end
 
         def make_ternary_form(node)
-          _condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring
+          _condition, if_branch, else_branch = *node # rubocop:disable InternalAffairs/NodeDestructuring -- takes all three branches in one step
           arithmetic_operation = use_arithmetic_operation?(if_branch)
 
           ternary_form = [

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -52,7 +52,7 @@ module RuboCop
             ${nil? basic_literal? const_type?})
         PATTERN
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- the matched body is a literal or a constant
           redundant_fetch_block_candidate?(node) do |send, body|
             return if should_not_check?(send, body)
 

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         MSG = 'Name `%<method>s` block params `|%<params>s|`.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- checks block parameter names
           return unless node.single_line?
 
           return unless eligible_method?(node)

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -101,7 +101,7 @@ module RuboCop
                       'module (don\'t forget to require it) over `%<global>s`.'
         MSG_REGULAR = 'Prefer `%<prefer>s` over `%<global>s`.'
 
-        ENGLISH_VARS = { # rubocop:disable Style/MutableConstant
+        ENGLISH_VARS = { # rubocop:disable Style/MutableConstant -- merged into below, then frozen
           :$: => [:$LOAD_PATH],
           :$" => [:$LOADED_FEATURES],
           :$0 => [:$PROGRAM_NAME],

--- a/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_block_args.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         MSG = 'Useless trailing comma present in block arguments.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler -- a trailing comma needs an explicit parameter list
           # lambda literal (`->`) never has block arguments.
           return if node.send_node.lambda_literal?
           return unless useless_trailing_comma?(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -63,7 +63,7 @@ module RuboCop
           end
         else
           # Use a block version to avoid allocating enumerators.
-          node.each_descendant do # rubocop:disable Lint/UnreachableLoop
+          node.each_descendant do # rubocop:disable Lint/UnreachableLoop -- the block form avoids allocating an enumerator
             return true
           end
         end

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -58,7 +58,7 @@ module RuboCop
         if output_path
           dir_path = File.dirname(output_path)
           FileUtils.mkdir_p(dir_path)
-          output = File.open(output_path, 'w') # rubocop:disable Style/FileOpen
+          output = File.open(output_path, 'w') # rubocop:disable Style/FileOpen -- the file is closed by `close_output_files`, not by a block
         else
           output = $stdout
         end

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -74,7 +74,7 @@ module RuboCop
         end
 
         # Make Kernel#binding public.
-        # rubocop:disable-next Lint/UselessMethodDefinition
+        # rubocop:disable-next Lint/UselessMethodDefinition -- redefined only to make `Kernel#binding` public
         def binding
           super
         end
@@ -143,7 +143,7 @@ module RuboCop
         }.freeze
 
         # Make Kernel#binding public.
-        # rubocop:disable-next Lint/UselessMethodDefinition
+        # rubocop:disable-next Lint/UselessMethodDefinition -- redefined only to make `Kernel#binding` public
         def binding
           super
         end

--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -47,7 +47,7 @@ module RuboCop
         end
       end
 
-      # rubocop:disable-next Layout/LineLength,Metrics/AbcSize,Metrics/MethodLength
+      # rubocop:disable-next Layout/LineLength,Metrics/AbcSize,Metrics/MethodLength -- the XML is emitted line by line
       def finished(_inspected_files)
         output.puts %(<?xml version='1.0'?>)
         output.puts %(<testsuites>)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -150,7 +150,7 @@ module RuboCop
       end
     end
 
-    # rubocop:todo Naming/InclusiveLanguage
+    # rubocop:todo Naming/InclusiveLanguage -- `--auto-correct` is the deprecated flag name
     # the autocorrect command-line arguments map to the autocorrect @options values like so:
     #                            :fix_layout  :autocorrect  :safe_autocorrect  :autocorrect_all
     # -x, --fix-layout           true         true          -                  -

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -44,7 +44,7 @@ module RuboCop
       uri.start_with?('http://', 'https://')
     end
 
-    SMART_PATH_CACHE = {} # rubocop:disable Style/MutableConstant
+    SMART_PATH_CACHE = {} # rubocop:disable Style/MutableConstant -- a cache, written to at runtime
     private_constant :SMART_PATH_CACHE
 
     def smart_path(path)

--- a/lib/rubocop/plugin/loader.rb
+++ b/lib/rubocop/plugin/loader.rb
@@ -8,7 +8,7 @@ module RuboCop
     # A class for loading and resolving plugins.
     # @api private
     class Loader
-      # rubocop:disable Layout/LineLength
+      # rubocop:disable Layout/LineLength -- the comment on each key does not wrap
       DEFAULT_PLUGIN_CONFIG = {
         'enabled' => true,
         'require_path' => nil, # If not set, will be set to the plugin name

--- a/lib/rubocop/rake_task.rb
+++ b/lib/rubocop/rake_task.rb
@@ -74,7 +74,7 @@ module RuboCop
 
     def setup_subtasks(name, *args, &task_block) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       namespace(name) do
-        # rubocop:todo-next Naming/InclusiveLanguage
+        # rubocop:todo-next Naming/InclusiveLanguage -- the deprecated flag spelling is the subject here
         task(:auto_correct, *args) do |_, task_args|
           require 'rainbow'
           warn Rainbow(

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1177,7 +1177,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
             EnforcedStyle: #{style}
         YAML
         expect(cli.run(['--autocorrect-all'])).to eq(0)
-        # rubocop:disable-next Style/HashLikeCase
+        # rubocop:disable-next Style/HashLikeCase -- the source under test is what it is
         corrected = case style
                     when :semantic
                       <<~RUBY

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1403,7 +1403,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         printed_config = if defined?(YAML.unsafe_load) # RUBY_VERSION >= '3.1.0'
                            YAML.unsafe_load(out.join)
                          else
-                           YAML.load(out.join) # rubocop:disable Security/YAMLLoad
+                           YAML.load(out.join) # rubocop:disable Security/YAMLLoad -- the input is written by this spec
                          end
 
         expected_cop_names.each do |cop_name|
@@ -1771,7 +1771,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
         end
       end
 
-      # rubocop:disable-next Layout/LineContinuationLeadingSpace
+      # rubocop:disable-next Layout/LineContinuationLeadingSpace -- the source under test is what it is
       context 'when clang format is specified' do
         it 'outputs with clang format' do
           create_file('example1.rb', ['x= 0 ', '#' * 130, 'y ', 'puts x'])

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::CommentConfig do
 
   describe '#cop_enabled_at_line?' do
     let(:source) do
-      # rubocop:disable-next Lint/EmptyExpression, Lint/EmptyInterpolation
+      # rubocop:disable-next Lint/EmptyExpression, Lint/EmptyInterpolation -- the source under test is what it is
       <<~RUBY
         # rubocop:disable Metrics/MethodLength with a comment why
         def some_method

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Commissioner do
       stub_const('Fake::FakeCop', Class.new(RuboCop::Cop::Base) do
                                     # The investigation callbacks are only dispatched
                                     # to cops that refine them.
-                                    # rubocop:disable Lint/UselessMethodDefinition
+                                    # rubocop:disable Lint/UselessMethodDefinition -- a stub that exists to be called
                                     def on_new_investigation
                                       super
                                     end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       describe 'for a builtin cop class' do
         let(:cop_class) { RuboCop::Cop::Layout::BlockEndNewline }
 
-        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength
+        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength -- the expected URL is verbatim
       end
 
       describe 'for a custom cop class without DocumentationBaseURL', :restore_registry do
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Cop, :config do
       describe 'for a builtin cop class' do
         let(:cop_class) { RuboCop::Cop::Layout::BlockEndNewline }
 
-        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength
+        it { is_expected.to eq 'https://docs.rubocop.org/rubocop/cops_layout.html#layoutblockendnewline' } # rubocop:disable Layout/LineLength -- the expected URL is verbatim
       end
 
       describe 'for a custom cop class without DocumentationBaseURL', :restore_registry do

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::Generator do
 
     before do
       # It is hacked to use `IO.write` to avoid mocking `File.write` for testing.
-      IO.write(path, <<~YAML) # rubocop:disable Security/IoMethods
+      IO.write(path, <<~YAML) # rubocop:disable Security/IoMethods -- the path is built by this spec
         Style/Alias:
           Enabled: true
 

--- a/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/heredoc_indentation_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe RuboCop::Cop::Layout::HeredocIndentation, :config do
       { empty: '', whitespace: '    ' }.each do |description, line|
         it "registers an offense for not indented enough with #{description} line" do
           # Using <<- in this section makes the code more readable.
-          # rubocop:disable Layout/HeredocIndentation
+          # rubocop:disable Layout/HeredocIndentation -- the heredoc under test is what it is
           expect_offense(<<-RUBY)
             def baz
               <<~#{quote}MSG#{quote}

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -808,7 +808,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       RUBY
     end
 
-    it 'does not autocorrect an offense within another offense' do # rubocop:disable InternalAffairs/ExampleDescription
+    it 'does not autocorrect an offense within another offense' do # rubocop:disable InternalAffairs/ExampleDescription -- the description names the offense twice on purpose
       expect_offense(<<~RUBY)
         require 'spec_helper'
         describe ArticlesController do

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable-next Style/NumericLiteralPrefix
+# rubocop:disable-next Style/NumericLiteralPrefix -- the source under test is what it is
 RSpec.describe RuboCop::Cop::Lint::ScriptPermission, :config do
   subject(:cop) { described_class.new(config, options) }
 

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::Offense do
     end
 
     # We want a nice table layout, so we allow space inside empty hashes.
-    # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/ExtraSpacing
+    # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/ExtraSpacing -- the spacing under test is what it is
     [
       [{                           }, {                           }, 0],
 

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -94,6 +94,16 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
     end
   end
 
+  it 'does not register an offense for a directive quoted inside another comment' do
+    expect_no_offenses(<<~RUBY)
+      # Example in documentation:
+      #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
+      #
+      # Prose about `# rubocop:disable Layout/SpaceAroundOperators`.
+      x = 0
+    RUBY
+  end
+
   context 'with AllowedDirectives and no other configuration' do
     let(:cop_config) { { 'AllowedDirectives' => ['todo'] } }
 

--- a/spec/rubocop/ext/regexp_node_spec.rb
+++ b/spec/rubocop/ext/regexp_node_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Ext::RegexpNode do
         nodes = node.parsed_tree.each_expression.map { |exp, _index| exp }
 
         # `Parser::Source::Map` does not have `source_range` method.
-        # rubocop:disable-next InternalAffairs/LocationExpression
+        # rubocop:disable-next InternalAffairs/LocationExpression -- exercises the very API the cop flags
         sources = nodes.map { |n| n.loc.expression.source }
 
         expect(sources).to eq %w{([a-z]+) [a-z]+ a-z a z \d* \s? (?:foo) foo}

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                 ],
                 correctable: true
               },
-              message: 'Layout/SpaceInsideArrayLiteralBrackets: Do not use space inside array brackets.', # rubocop:disable Layout/LineLength
+              message: 'Layout/SpaceInsideArrayLiteralBrackets: Do not use space inside array brackets.', # rubocop:disable Layout/LineLength -- the expected message is verbatim
               range: {
                 start: { character: 4, line: 2 },
                 end: { character: 6, line: 2 }
@@ -381,7 +381,7 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
                 ],
                 correctable: false
               },
-              message: "Lint/Syntax: unexpected token tIDENTIFIER\n\nThis offense is not autocorrectable.\n", # rubocop:disable Layout/LineLength
+              message: "Lint/Syntax: unexpected token tIDENTIFIER\n\nThis offense is not autocorrectable.\n", # rubocop:disable Layout/LineLength -- the expected message is verbatim
               range: {
                 start: { character: 8, line: 0 },
                 end: { character: 9, line: 0 }

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'shows help text' do
         begin
           options.parse(['--help'])
-        rescue SystemExit # rubocop:disable Lint/SuppressedException
+        rescue SystemExit # rubocop:disable Lint/SuppressedException -- the exit is the expected outcome
         end
 
-        # rubocop:todo-next Naming/InclusiveLanguage
+        # rubocop:todo-next Naming/InclusiveLanguage -- the deprecated flag spelling is the subject here
         expected_help = <<~OUTPUT
           Usage: rubocop [options] [file1, file2, ...]
 
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       it 'lists all builtin formatters' do
         begin
           options.parse(['--help'])
-        rescue SystemExit # rubocop:disable Lint/SuppressedException
+        rescue SystemExit # rubocop:disable Lint/SuppressedException -- the exit is the expected outcome
         end
 
         option_sections = $stdout.string.lines.slice_before(/^\s*-/)
@@ -675,7 +675,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
       end
     end
 
-    # rubocop:todo-next Naming/InclusiveLanguage
+    # rubocop:todo-next Naming/InclusiveLanguage -- the deprecated flag spelling is the subject here
     describe 'deprecated options' do
       describe '--auto-correct' do
         it 'emits a warning and sets the correct options instead' do

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::RakeTask do
   after { Rake::Task.clear }
 
   describe 'defining tasks' do
-    # rubocop:todo Naming/InclusiveLanguage
+    # rubocop:todo Naming/InclusiveLanguage -- `--auto-correct` is the deprecated flag name
     it 'creates a rubocop task and a rubocop auto_correct task' do
       described_class.new
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       end
 
       context 'when the extractor matches' do
-        # rubocop:disable-next Layout/LineLength
+        # rubocop:disable-next Layout/LineLength -- the source under test is what it is
         let(:custom_ruby_extractor) do
           lambda do |_processed_source|
             [

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -32,7 +32,7 @@ module FileHelper
     file_path
   end
 
-  # rubocop:disable-next InternalAffairs/CreateEmptyFile
+  # rubocop:disable-next InternalAffairs/CreateEmptyFile -- the helper is what `create_empty_file` is built on
   def create_empty_file(file_path)
     create_file(file_path, '')
   end


### PR DESCRIPTION
Turns `Style/DisableCopsWithinSourceCodeDirective` on for this repo with `AllowWithReason`, exempting `Metrics` and `RSpec`. For those the reason is already plain from the method the directive sits on, and requiring one would have meant writing two hundred variations of "this method is big". That leaves eighty directives where a reader genuinely cannot infer the answer, and each now says it.

The most repeated case is the cops that skip numbered and `it` blocks - the intent, that the check is about explicit block parameters which those blocks do not have, was recorded nowhere.

Writing the reasons out earned its keep beyond the comments themselves. `EnsureNode` turned out to have no accessor for the protected body, which is why that destructuring in `Layout/IndentationWidth` exists - I tried replacing it with the accessor and four specs failed. `match_with_lvasgn` has no named operands. And the JRuby workaround in `Style/ParallelAssignment` already had its reason in a comment above, just not anywhere the directive could carry it.

The first commit is a bug fix the adoption surfaced: the cop read directive text quoted inside *other* comments - the `@example` blocks in the cops that document directives - as real directives. Those suppress nothing, so it was asking for a justification on lines that justify nothing, and adding one would have corrupted the docs.