### PR TITLE
Treat directives trailing comment text as real directives again

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,11 @@ Style/DisableCopsWithinSourceCodeDirective:
   AllowedCops:
     - Metrics
     - RSpec
+  Exclude:
+    # Its own `@example` blocks show unjustified directives, which is the whole
+    # point of them. The cop cannot be silenced by a directive once it is
+    # explicitly enabled, so the file has to be excluded here.
+    - 'lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb'
 
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays

--- a/changelog/fix_ignore_directives_quoted_inside_other_comments_20260902113245.md
+++ b/changelog/fix_ignore_directives_quoted_inside_other_comments_20260902113245.md
@@ -1,1 +1,0 @@
-* [#15653](https://github.com/rubocop/rubocop/pull/15653): Fix `Style/DisableCopsWithinSourceCodeDirective` reading directive text quoted inside other comments, such as documentation examples, as a real directive. ([@bbatsov][])

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -154,11 +154,7 @@ module RuboCop
           match_captures && match_captures[1] ? match_captures[1].split(',').map(&:strip) : []
         end
 
-        # A directive mentioned inside another comment - documentation, or prose
-        # about directives - suppresses nothing, so there is nothing to forbid
-        # or to ask a justification for.
         def ignored?(directive)
-          return true unless directive.start_with_marker?
           return true if exempt_mode?(directive)
 
           allow_with_reason? && (directive.reason || directive.enabled?)

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -94,16 +94,6 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
     end
   end
 
-  it 'does not register an offense for a directive quoted inside another comment' do
-    expect_no_offenses(<<~RUBY)
-      # Example in documentation:
-      #   x = 0 # rubocop:disable Layout/SpaceAroundOperators
-      #
-      # Prose about `# rubocop:disable Layout/SpaceAroundOperators`.
-      x = 0
-    RUBY
-  end
-
   context 'with AllowedDirectives and no other configuration' do
     let(:cop_config) { { 'AllowedDirectives' => ['todo'] } }
 


### PR DESCRIPTION
The guard added in #15653 assumed a `# rubocop:disable` appearing after other comment text was only being quoted and therefore suppressed nothing. It does suppress: `foo # some note # rubocop:disable Layout/LineLength` really disables the cop for that line, which is why `Lint/RedundantCopDisableDirective` has always reported that form. The guard made the cop blind to real unjustified disables written that way.

The cop's own `@example` blocks are the one place where the text genuinely is just prose, so the file gets an `Exclude` instead. It can't be silenced with a directive once explicitly enabled, so there is no lighter option.