### PR TITLE
Fix `Style/StructInheritance` false positive for constants

### DIFF
--- a/changelog/fix_style_struct_inheritance_to_not_register_an_offense_when_the_class_body_20260902102842.md
+++ b/changelog/fix_style_struct_inheritance_to_not_register_an_offense_when_the_class_body_20260902102842.md
@@ -1,0 +1,1 @@
+* [#15655](https://github.com/rubocop/rubocop/pull/15655): Fix `Style/StructInheritance` to not register an offense when the class body defines constants, nested classes, or nested modules. ([@MatheusRich][])

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -10,6 +10,10 @@ module RuboCop
       #   Autocorrection is unsafe because it will change the inheritance
       #   tree (e.g. return value of `Module#ancestors`) of the constant.
       #
+      #   It is also unsafe because constants that the class body resolves through its
+      #   ancestors (e.g. one provided by an included module) fall out of scope inside
+      #   the block.
+      #
       # @example
       #   # bad
       #   class Person < Struct.new(:first_name, :last_name)
@@ -39,6 +43,7 @@ module RuboCop
 
         def on_class(node)
           return unless struct_constructor?(node.parent_class)
+          return if defines_constants?(node.body)
 
           add_offense(node.parent_class) do |corrector|
             corrector.remove(
@@ -57,6 +62,15 @@ module RuboCop
         PATTERN
 
         private
+
+        # Constants, including nested classes and modules, are scoped to the class when they
+        # are defined in a class body, but leak into the enclosing namespace once moved into a
+        # `Struct.new` block, so such a class cannot be rewritten as an assignment.
+        def defines_constants?(class_body)
+          return false unless class_body
+
+          class_body.each_node(:casgn, :class, :module).any?
+        end
 
         def correct_parent(parent, corrector)
           if parent.block_type?

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -130,6 +130,40 @@ RSpec.describe RuboCop::Cop::Style::StructInheritance, :config do
     RUBY
   end
 
+  it 'accepts extending instance of Struct when the class body assigns a constant' do
+    expect_no_offenses(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+        MAX_AGE = 120
+      end
+    RUBY
+  end
+
+  it 'accepts extending instance of Struct when a constant is assigned in a nested scope' do
+    expect_no_offenses(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+        if something
+          MAX_AGE = 120
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts extending instance of Struct when the class body defines a nested class' do
+    expect_no_offenses(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+        class Error < StandardError; end
+      end
+    RUBY
+  end
+
+  it 'accepts extending instance of Struct when the class body defines a nested module' do
+    expect_no_offenses(<<~RUBY)
+      class Person < Struct.new(:first_name, :last_name)
+        module Helpers; end
+      end
+    RUBY
+  end
+
   it 'accepts plain class' do
     expect_no_offenses(<<~RUBY)
       class Person


### PR DESCRIPTION
The cop would rewrite `class Person < Struct.new(:x)` as `Person = Struct.new(:x) do ... end`. That didn't work for constants, as a constant defined inside the block lands in the enclosing namespace rather than on the class, so `Person::MAX_AGE` stops resolving. Nested classes and modules go the same way, since defining one is itself a constant assignment.

This is the same fix as #15649, applied to the other half of the pair, as requested in review there.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
