### PR TITLE
Fix Layout/LineLength breaking lines after nested heredoc arguments

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_line_length_20260902.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_line_length_20260902.md
@@ -1,0 +1,1 @@
+* [#15656](https://github.com/rubocop/rubocop/pull/15656): Fix an incorrect autocorrect for `Layout/LineLength` when breaking a line after an argument with a nested heredoc. ([@Starlexxx][])

--- a/lib/rubocop/cop/mixin/check_line_breakable.rb
+++ b/lib/rubocop/cop/mixin/check_line_breakable.rb
@@ -94,22 +94,29 @@ module RuboCop
 
       # @api private
       def first_argument_is_heredoc?(node)
-        first_argument = node.first_argument
-
-        first_argument.respond_to?(:heredoc?) && first_argument.heredoc?
+        node.first_argument.respond_to?(:heredoc?) && node.first_argument.heredoc?
       end
 
       # @api private
       # If a `send` or `csend` node contains a heredoc argument, splitting cannot happen
       # after the heredoc or else it will cause a syntax error.
       def shift_elements_for_heredoc_arg(node, elements, index)
-        return index unless node.type?(:call, :array)
+        return index unless node.type?(:call, :array, :hash)
+        return index unless (heredoc_pos = heredoc_begin_position(node))
 
-        heredoc_index = elements.index { |arg| arg.respond_to?(:heredoc?) && arg.heredoc? }
-        return index unless heredoc_index
-        return nil if heredoc_index.zero?
+        last_safe = elements.rindex { |element| element.source_range.begin_pos <= heredoc_pos }
+        return nil if last_safe.nil? ||
+                      (last_safe.zero? && elements.first.source_range.end_pos > heredoc_pos)
 
-        heredoc_index >= index ? index : heredoc_index + 1
+        [index, last_safe + 1].min
+      end
+
+      # @api private
+      def heredoc_begin_position(node)
+        children = node.call_type? ? node.arguments : node.children
+        children.flat_map { |child| [child, *child.each_descendant(:any_str)] }
+                .find { |descendant| descendant.type?(:any_str) && descendant.heredoc? }
+                &.source_range&.begin_pos
       end
 
       # @api private
@@ -128,9 +135,7 @@ module RuboCop
         # or redundant edits, we only mark one offense at a time.
         return true if contained_by_breakable_collection_on_same_line?(node)
 
-        return true if contained_by_multiline_collection_that_could_be_broken_up?(node)
-
-        false
+        contained_by_multiline_collection_that_could_be_broken_up?(node)
       end
 
       # @api private
@@ -145,9 +150,7 @@ module RuboCop
         # break before the second argument and the rest of the
         # argument will get auto-formatted onto separate lines
         # by other cops.
-        has_second_element = elements.length >= 2
-
-        starts_with_bracket && has_second_element
+        starts_with_bracket && elements.length >= 2
       end
 
       # @api private

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1817,6 +1817,46 @@ RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
             RUBY
           end
         end
+
+        context 'and the heredoc is nested inside another argument' do
+          it 'does not break up the line after the argument containing the heredoc' do
+            expect_offense(<<~RUBY)
+              foo bar(<<~STRING, 4), baz: /a_long_pattern/
+                                                      ^^^^ Line is too long. [44/40]
+                text
+              STRING
+            RUBY
+
+            expect_no_corrections
+          end
+
+          it 'breaks up the line before the argument containing the heredoc' do
+            expect_offense(<<~RUBY)
+              foo(abc, bar(<<~STRING, 4), xxxxxxxxxxxxx)
+                                                      ^^ Line is too long. [42/40]
+                text
+              STRING
+            RUBY
+
+            expect_correction(<<~RUBY)
+              foo(abc,#{trailing_whitespace}
+              bar(<<~STRING, 4), xxxxxxxxxxxxx)
+                text
+              STRING
+            RUBY
+          end
+
+          it 'does not break up a hash literal after the value containing the heredoc' do
+            expect_offense(<<~RUBY)
+              h = { key: bar(<<~STRING, 4), zz: /abc/ }
+                                                      ^ Line is too long. [41/40]
+                text
+              STRING
+            RUBY
+
+            expect_no_corrections
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Autocorrecting this real-world code from railties produces unparseable Ruby:

```ruby
insert_into_file "#{dummy_path}/config/application.rb", indent(<<~RUBY, 4), after: /^\s*config\.load_defaults.*\n/
  ...
RUBY
```

`Layout/LineLength` breaks the line after `indent(<<~RUBY, 4),`, and the moved tail lands on the line right after the heredoc opener, so the heredoc body swallows it:

```
syntax error, unexpected `end'
```

The existing guard only recognized heredocs passed directly as arguments; a heredoc nested inside another argument slipped through. The cop now locates the heredoc opener anywhere in the arguments and only allows a break before it, keeping the previous behavior for direct heredoc arguments. Two neighboring methods in the mixin are condensed to stay within `Metrics/ModuleLength`.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.