### PR TITLE
Merge Exclude with the default configuration under Preview

### DIFF
--- a/changelog/fix_merge_exclude_with_the_default_configuration_under_preview_20260902173642.md
+++ b/changelog/fix_merge_exclude_with_the_default_configuration_under_preview_20260902173642.md
@@ -1,0 +1,1 @@
+* [#9325](https://github.com/rubocop/rubocop/issues/9325): Merge `Exclude` with the default configuration under `Preview`. ([@bbatsov][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -183,12 +183,18 @@ module RuboCop
 
     def set_options_to_config_loader
       ConfigLoader.debug = @options[:debug]
-      ConfigLoader.disable_pending_cops = @options[:disable_pending_cops]
-      ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
       ConfigLoader.ignore_unrecognized_cops = @options[:ignore_unrecognized_cops]
+      set_cop_selection_options_to_config_loader
+    end
+
+    # Options that decide which cops run, as opposed to how configuration is loaded.
+    def set_cop_selection_options_to_config_loader
+      ConfigLoader.disable_pending_cops = @options[:disable_pending_cops]
+      ConfigLoader.enable_pending_cops = @options[:enable_pending_cops]
       ConfigLoader.enabled_by_default = @options[:enable_all_cops]
       ConfigLoader.disabled_by_default = @options[:disable_all_cops]
+      ConfigLoader.preview = @options[:preview]
     end
 
     def set_options_to_pending_cops_reporter

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -24,7 +24,8 @@ module RuboCop
       include FileFinder
 
       attr_accessor :debug, :ignore_parent_exclusion, :disable_pending_cops, :enable_pending_cops,
-                    :enabled_by_default, :disabled_by_default, :ignore_unrecognized_cops
+                    :enabled_by_default, :disabled_by_default, :ignore_unrecognized_cops,
+                    :preview
       attr_writer :default_configuration, :cache_root
       attr_reader :loaded_plugins, :loaded_features
 
@@ -41,6 +42,7 @@ module RuboCop
         @loaded_features = Set.new
         @disable_pending_cops = nil
         @enable_pending_cops = nil
+        @preview = nil
         @enabled_by_default = nil
         @disabled_by_default = nil
         @ignore_parent_exclusion = nil

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -107,7 +107,7 @@ module RuboCop
       config = handle_disabled_by_default(config, default_configuration) if disabled_by_default
       override_enabled_for_disabled_departments(default_configuration, config)
 
-      opts = { inherit_mode: config['inherit_mode'] || {}, unset_nil: unset_nil }
+      opts = { inherit_mode: inherit_mode_for_default(config), unset_nil: unset_nil }
       Config.new(merge(default_configuration, config, **opts), config_file)
     end
 
@@ -167,6 +167,28 @@ module RuboCop
     end
 
     private
+
+    # Under `Preview`, `Exclude` is merged with the default configuration rather
+    # than replacing it, so that excluding one directory does not silently drop
+    # `vendor/**/*` and the other defaults. An explicit `inherit_mode` in user
+    # configuration still wins, in either direction.
+    def inherit_mode_for_default(config)
+      mode = config['inherit_mode'] || {}
+      return mode unless preview?(config)
+      return mode if Array(mode['override']).include?('Exclude')
+      return mode if Array(mode['merge']).include?('Exclude')
+
+      mode.merge('merge' => Array(mode['merge']) + ['Exclude'])
+    end
+
+    # `config` has already been through `handle_disabled_by_default` by this
+    # point, which returns a plain hash, so read `AllCops` directly rather than
+    # going through `Config#for_all_cops`.
+    def preview?(config)
+      return ConfigLoader.preview unless ConfigLoader.preview.nil?
+
+      (config['AllCops'] || {})['Preview'] == true
+    end
 
     def resolve_default_overrides(config)
       if ConfigLoader.disabled_by_default || ConfigLoader.enabled_by_default

--- a/spec/rubocop/cli/preview_spec.rb
+++ b/spec/rubocop/cli/preview_spec.rb
@@ -85,6 +85,71 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
     end
   end
 
+  context 'when user configuration sets `AllCops: Exclude`' do
+    before do
+      create_file('vendor/bundle/gem.rb', 'x   =  1')
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Exclude:
+            - 'nothing/**/*'
+      YAML
+    end
+
+    it 'replaces the default excludes without preview' do
+      expect(cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])).to eq(1)
+      expect($stdout.string).to include('vendor/bundle/gem.rb')
+    end
+
+    it 'merges with the default excludes with --preview' do
+      expect(
+        cli.run(['--preview', '--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])
+      ).to eq(0)
+      expect($stdout.string).not_to include('vendor/bundle/gem.rb')
+    end
+
+    it 'merges with the default excludes when the config opts in' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+          Exclude:
+            - 'nothing/**/*'
+      YAML
+
+      expect(cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])).to eq(0)
+      expect($stdout.string).not_to include('vendor/bundle/gem.rb')
+    end
+
+    it 'lets an explicit `inherit_mode` override win over preview' do
+      create_file('.rubocop.yml', <<~YAML)
+        inherit_mode:
+          override:
+            - Exclude
+
+        AllCops:
+          Preview: true
+          Exclude:
+            - 'nothing/**/*'
+      YAML
+
+      expect(cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])).to eq(1)
+      expect($stdout.string).to include('vendor/bundle/gem.rb')
+    end
+
+    it 'lets --no-preview override the config' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+          Exclude:
+            - 'nothing/**/*'
+      YAML
+
+      args = ['--no-preview', '--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.']
+
+      expect(cli.run(args)).to eq(1)
+      expect($stdout.string).to include('vendor/bundle/gem.rb')
+    end
+  end
+
   it 'rejects an unknown `Enabled` value' do
     create_file('.rubocop.yml', <<~YAML)
       Style/For:


### PR DESCRIPTION
Setting `AllCops: Exclude` replaces RuboCop's own excludes instead of adding to them, so excluding one directory silently starts scanning `vendor/**/*` and friends. #9325 has been open since 2021 and people still hit it, usually on CI where Bundler installs into `vendor/bundle`.

#9624 has an implementation of this from 2021 that never merged, and jonas054's own summary of it was "I'm not convinced that this is a good idea... we're opening up a can of worms." That reservation is fair and five years of discussion has not resolved it, which is exactly the situation the new `Preview` channel is for: ship it to the projects that opt in and find out.

The gate lives in `merge_with_default` rather than as an `inherit_mode` entry in `config/default.yml` as the old PR did. That keeps the blast radius to the default-merge step instead of also changing how user files inherit from each other. An explicit `inherit_mode` in user configuration still wins in either direction, so there is a way out without turning preview off wholesale.

Note the `preview?` helper reads `config['AllCops']` rather than `Config#for_all_cops`: by that point `handle_disabled_by_default` may have returned a plain hash.

Closes #9624.