### PR TITLE
Fix an error for `Layout/HashAlignment` cop

### DIFF
--- a/changelog/fix_an_error_for_layout_hash_alignment_when_the_first_pair_omits_its_value_20260827215346.md
+++ b/changelog/fix_an_error_for_layout_hash_alignment_when_the_first_pair_omits_its_value_20260827215346.md
@@ -1,1 +1,1 @@
-* [#15623](https://github.com/rubocop/rubocop/pull/15623): Fix an error for `Layout/HashAlignment` when the first pair of a hash omits its value. ([@viralpraxis][])
+* [#15623](https://github.com/rubocop/rubocop/pull/15623): Fix an error for `Layout/HashAlignment` when the first pair of a hash omits its value, and an incorrect autocorrection when a later pair does. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/hash_alignment.rb
+++ b/lib/rubocop/cop/layout/hash_alignment.rb
@@ -330,7 +330,11 @@ module RuboCop
         end
 
         def correct_no_value(corrector, key_delta, key)
-          adjust(corrector, key_delta, key)
+          adjust(corrector, clamped_key_delta(key_delta, key), key)
+        end
+
+        def clamped_key_delta(key_delta, key)
+          [key_delta, -key.column].max
         end
 
         def correct_key_value(corrector, delta, key, value, separator)
@@ -341,10 +345,7 @@ module RuboCop
           value_delta     = delta[:value]     || 0
           key_delta       = delta[:key]       || 0
 
-          key_column = key.column
-          key_delta = -key_column if key_delta < -key_column
-
-          adjust(corrector, key_delta, key)
+          adjust(corrector, clamped_key_delta(key_delta, key), key)
           adjust(corrector, separator_delta, separator)
           adjust(corrector, value_delta, value)
         end

--- a/spec/rubocop/cop/layout/hash_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/hash_alignment_spec.rb
@@ -886,6 +886,38 @@ RSpec.describe RuboCop::Cop::Layout::HashAlignment, :config do
           ^^^ Align the separators of a hash literal if they span more than one line.
         )
       RUBY
+
+      expect_correction(<<~RUBY)
+        f(
+          aaa: nil,
+           bb:
+        )
+      RUBY
+    end
+  end
+
+  context 'when a later pair omits its value', :ruby31 do
+    let(:cop_config) do
+      { 'EnforcedHashRocketStyle' => 'table', 'EnforcedColonStyle' => 'separator' }
+    end
+
+    it 'does not shift the key past the start of its line' do
+      expect_offense(<<~RUBY)
+        f(
+          a: "x",
+          bbbbb:,
+          ^^^^^^ Align the separators of a hash literal if they span more than one line.
+          c: 1
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        f(
+          a: "x",
+        bbbbb:,
+          c: 1
+        )
+      RUBY
     end
   end
 


### PR DESCRIPTION
Follow-up to #15623 (so no new changelog entries).

An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Layout/HashAlignment:
  Enabled: true
  EnforcedColonStyle: separator
YAML
) <<'RUBY'
f(
  a: "x",
  bbbbb:,
  c: 1
)
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
/dev/stdin:3:3: C: [Corrected] Layout/HashAlignment: Align the separators of a hash literal if they span more than one line.
  bbbbb:,
  ^^^^^^
/dev/stdin:2:9: F: Lint/Syntax: unexpected local variable or method; expected a ) to close the arguments
  a: "x"bbbbb:,
        ^^^^^
====================
f(
  a: "x"bbbbb:,
  c: 1
)
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
