### PR TITLE
Complete Exclude merging under Preview and fix --auto-gen-config

### DIFF
--- a/changelog/fix_merge_exclude_with_the_default_configuration_under_preview_20260902173642.md
+++ b/changelog/fix_merge_exclude_with_the_default_configuration_under_preview_20260902173642.md
@@ -1,1 +1,1 @@
-* [#9325](https://github.com/rubocop/rubocop/issues/9325): Merge `Exclude` with the default configuration under `Preview`. ([@bbatsov][])
+* [#9325](https://github.com/rubocop/rubocop/issues/9325): Merge `Exclude` with the default configuration and with inherited files under `Preview`. ([@bbatsov][])

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -168,12 +168,15 @@ module RuboCop
 
     private
 
-    # Under `Preview`, `Exclude` is merged with the default configuration rather
-    # than replacing it, so that excluding one directory does not silently drop
-    # `vendor/**/*` and the other defaults. An explicit `inherit_mode` in user
-    # configuration still wins, in either direction.
     def inherit_mode_for_default(config)
-      mode = config['inherit_mode'] || {}
+      with_preview_exclude_merge(config['inherit_mode'] || {}, config)
+    end
+
+    # Under `Preview`, `Exclude` is merged rather than replaced, so that excluding
+    # one directory does not silently drop the excludes it would have inherited -
+    # from the default configuration or from a file named in `inherit_from`. An
+    # explicit `inherit_mode` still wins, in either direction.
+    def with_preview_exclude_merge(mode, config)
       return mode unless preview?(config)
       return mode if Array(mode['override']).include?('Exclude')
       return mode if Array(mode['merge']).include?('Exclude')
@@ -232,7 +235,7 @@ module RuboCop
     def determine_inherit_mode(hash, key)
       cop_cfg = hash[key]
       local_inherit = cop_cfg['inherit_mode'] if cop_cfg.is_a?(Hash)
-      local_inherit || hash['inherit_mode'] || {}
+      with_preview_exclude_merge(local_inherit || hash['inherit_mode'] || {}, hash)
     end
 
     def should_union?(derived_hash, base_hash, root_mode, key)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -93,6 +93,7 @@ module RuboCop
         command += ' --auto-gen-only-exclude' if @options[:auto_gen_only_exclude]
         command += ' --disable-pending-cops' if @options[:disable_pending_cops]
         command += ' --enable-pending-cops' if @options[:enable_pending_cops]
+        command += preview_option
         command += exclude_limit_option
         command += ' --no-offense-counts' unless show_offense_counts?
 
@@ -101,6 +102,14 @@ module RuboCop
         command += ' --no-auto-gen-enforced-style' unless auto_gen_enforced_style?
 
         command
+      end
+
+      def preview_option
+        case @options[:preview]
+        when true then ' --preview'
+        when false then ' --no-preview'
+        else ''
+        end
       end
 
       def exclude_limit_option
@@ -259,7 +268,7 @@ module RuboCop
         config = ConfigStore.new.for(parent)
         cfg = config[cop_name] || {}
 
-        if merge_mode_for_exclude?(config) || merge_mode_for_exclude?(cfg)
+        if exclude_merges?(config, cfg)
           offending_files
         else
           cop_exclude = cfg['Exclude']
@@ -270,6 +279,14 @@ module RuboCop
           end
           ((cop_exclude || []) + offending_files).uniq
         end
+      end
+
+      # `Preview` merges `Exclude` with the default configuration, so the excludes
+      # already in the configuration do not have to be copied into the todo file.
+      def exclude_merges?(config, cop_config)
+        merge_mode_for_exclude?(config) ||
+          merge_mode_for_exclude?(cop_config) ||
+          config.preview?(@options)
       end
 
       def merge_mode_for_exclude?(cfg)

--- a/spec/rubocop/cli/auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/auto_gen_config_spec.rb
@@ -1111,6 +1111,25 @@ RSpec.describe 'RuboCop::CLI --auto-gen-config', :isolated_environment do # rubo
           Exclude:
             - 'example1.rb'
       YAML
+      it_behaves_like 'leaves out Excludes', 'because `Preview` is on', <<~YAML
+        AllCops:
+          Preview: true
+
+        Layout/TrailingWhitespace:
+          Exclude:
+            - 'example1.rb'
+      YAML
+
+      it 'records --preview in the regeneration command' do
+        create_file('.rubocop.yml', <<~YAML)
+          Layout/TrailingWhitespace:
+            Exclude:
+              - 'example1.rb'
+        YAML
+        expect(cli.run(['--preview', '--auto-gen-config'])).to eq(0)
+
+        expect(File.read('.rubocop_todo.yml')).to include('`rubocop --auto-gen-config --preview`')
+      end
     end
 
     context 'when duplicated default configuration parameter' do

--- a/spec/rubocop/cli/preview_spec.rb
+++ b/spec/rubocop/cli/preview_spec.rb
@@ -119,6 +119,28 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
       expect($stdout.string).not_to include('vendor/bundle/gem.rb')
     end
 
+    it 'merges a cop `Exclude` inherited from another file' do
+      create_file('legacy.rb', 'z   =  3')
+      create_file('shared.yml', <<~YAML)
+        Layout/SpaceAroundOperators:
+          Exclude:
+            - 'legacy.rb'
+      YAML
+      create_file('.rubocop.yml', <<~YAML)
+        inherit_from: shared.yml
+
+        AllCops:
+          Preview: true
+
+        Layout/SpaceAroundOperators:
+          Exclude:
+            - 'nothing.rb'
+      YAML
+
+      expect(cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])).to eq(0)
+      expect($stdout.string).not_to include('legacy.rb')
+    end
+
     it 'lets an explicit `inherit_mode` override win over preview' do
       create_file('.rubocop.yml', <<~YAML)
         inherit_mode:


### PR DESCRIPTION
Follow-up to #15657, which shipped the `Exclude` merging with two holes in it.

The gate only covered the merge against the default configuration, so `.rubocop.yml` still overrode any `Exclude` it inherited through `inherit_from`. `inherit_mode: merge: Exclude` has always applied at both levels, and splitting them broke the `--auto-gen-config` workflow outright: the generated `.rubocop_todo.yml` stopped suppressing anything the parent file also mentioned.

`DisabledConfigFormatter` had a related problem. It looks for `inherit_mode` on the resolved configuration to decide whether existing excludes need copying into the todo file, and `Preview` merges without writing that key. So it copied excludes that were about to merge in anyway (RuboCop's own defaults among them, which is how `'**/*.arb'` turned up in a generated entry) and printed advice to set `inherit_mode: merge: - Exclude` when that was already the effective behavior. The regeneration command in the todo header now records `--preview` too.

Worth noting for anyone touching this area: the first version of the inheritance spec passed without the fix, because the file it used sat under `vendor/`, which `AllCops: Exclude` already covers. It needs a path the defaults do not mention to test anything.

Separately, `Enabled: preview` on a department is accepted and silently does nothing. That is not new here - `Enabled: pending` behaves the same way - but it means a department-wide preview experiment is not expressible today.