### PR TITLE
Let cops carry their next-major defaults in a Preview section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,11 @@ not ready to be the default. Cops read it via `preview?`.
 
 Use it when:
 
+- **A cop's default should change in the next major release** (its `Enabled`
+  state, a `Max` threshold, an `EnforcedStyle`). Add a `Preview` section to the
+  cop's entry in `config/default.yml` with the new values. This needs no code:
+  the configuration loader applies the section under preview and drops it
+  otherwise. This is the most common case.
 - **An existing cop should start reporting a case it currently misses**, and the
   change is contested enough that turning it on for everyone would be rude.
   Without preview this waits for a major release.
@@ -136,7 +141,16 @@ Do **not** use it when:
 The rule of thumb: if you already know it should become the default, it is
 `pending`. If you are asking users to help you find out, it is `preview`.
 
+```yaml
+# config/default.yml: a default change, no code needed
+Style/Documentation:
+  Enabled: true
+  Preview:
+    Enabled: false
+```
+
 ```ruby
+# a behavior change inside a cop
 def on_send(node)
   return unless offense?(node)
   return if node.csend_type? && !preview?

--- a/changelog/change_disable_style_documentation_under_preview_20260903152115.md
+++ b/changelog/change_disable_style_documentation_under_preview_20260903152115.md
@@ -1,0 +1,1 @@
+* [#15363](https://github.com/rubocop/rubocop/issues/15363): Disable `Style/Documentation` under `Preview`, ahead of it being disabled by default in RuboCop 2.0. ([@bbatsov][])

--- a/changelog/new_let_cops_carry_their_next_major_defaults_in_a_preview_section_20260903152115.md
+++ b/changelog/new_let_cops_carry_their_next_major_defaults_in_a_preview_section_20260903152115.md
@@ -1,0 +1,1 @@
+* [#15363](https://github.com/rubocop/rubocop/issues/15363): Let a cop's entry in the default configuration carry a `Preview` section with the defaults it is expected to adopt in the next major release, applied under `Preview`. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4064,6 +4064,10 @@ Style/DocumentDynamicEvalDefinition:
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: true
+  # Turned off by over half of the projects that configure RuboCop at all, so it
+  # is expected to be disabled by default in the next major release.
+  Preview:
+    Enabled: false
   VersionAdded: '0.9'
   VersionChanged: '1.89'
   AllowedConstants: []

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -621,6 +621,23 @@ plainly a bug fix should just ship, and a whole new cop belongs in `pending`
 instead. See xref:versioning.adoc#preview["Preview"] for the full rule and the
 lifecycle a preview change follows afterwards.
 
+A change to a cop's *defaults* does not need `preview?` at all. Give the cop's
+entry in `config/default.yml` a `Preview` section with the values it is expected
+to adopt in the next major release, and the configuration loader applies them
+under preview:
+
+[source,yaml]
+----
+Style/Documentation:
+  Enabled: true
+  Preview:
+    Enabled: false
+----
+
+The section is rendered in the cop's documentation as a "Preview defaults" table
+and never appears in the resolved configuration, so the cop itself reads its
+settings the same way whether preview is on or off.
+
 [[common-patterns]]
 == Common patterns
 

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -55,10 +55,12 @@ changes to existing features.
 
 Some changes cannot ship as a pending cop. A cop that starts reporting a case it
 used to miss, or corrects one differently, changes results for everybody who has
-that cop enabled - so historically such changes have had to wait for a major
-release, whatever their merit.
+that cop enabled. A default that turns out to be wrong - a cop most projects
+disable, a threshold most projects raise - cannot move at all without a major
+release. Either way the change waits, whatever its merit.
 
-`Preview` is the channel for those changes. It is off by default:
+`Preview` is the channel for those changes: it is where the next major release's
+defaults live until that release ships. It is off by default:
 
 [source,yaml]
 ----
@@ -69,8 +71,20 @@ AllCops:
 or `--preview` on the command line, which overrides the configuration either way
 (`--no-preview` turns it back off).
 
-It gates two things:
+It gates three things:
 
+* **Changes to a cop's defaults.** A cop's entry in the default configuration
+  can carry a `Preview` section holding the defaults it is expected to adopt in
+  the next major release. Under preview those replace the current ones; an
+  explicit setting in your own configuration still wins over both.
++
+[source,yaml]
+----
+Style/Documentation:
+  Enabled: true
+  Preview:
+    Enabled: false
+----
 * **Behavior changes to existing cops.** A cop can put an unstable change behind
   `preview?` and ship it in a minor release. Nothing changes for anyone who has
   not opted in.
@@ -125,6 +139,11 @@ A cop marked `Enabled: preview` behaves like any other cop that is off:
   `Enabled: preview` you wrote in your own config is an explicit choice and wins
   over them, exactly as an explicit `Enabled: false` does.
 
+Preview defaults are defaults, so everything that rewrites defaults applies to
+them too: `--enable-all-cops`, `EnabledByDefault` and `DisabledByDefault` all
+win, and a re-enabled department under `DisabledByDefault` comes back with its
+preview defaults rather than its regular ones.
+
 Behavior gated behind `preview?` answers to the `Preview` setting and nothing
 else. Neither `--only` nor `--enable-all-cops` reaches inside a cop to switch it
 on, so a cop running under `--only` still reports its stable behavior unless
@@ -138,9 +157,11 @@ a change before it becomes the default:
 $ rubocop --preview
 ----
 
-NOTE: Preview behavior is unstable by definition. It can change or be withdrawn
-in any release, which is exactly what the flag buys us: a way to get a change in
-front of users early without committing to it.
+NOTE: Preview is provisional by definition. What it contains is our current
+intent for the next major release, not a promise: an entry can change or be
+withdrawn in any minor release if it does not work out, and a withdrawal is
+recorded in the changelog like any other change. That is exactly what the flag
+buys us: a way to get a change in front of users early without committing to it.
 
 == Pending Cops
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -197,12 +197,18 @@ module RuboCop
       # `AllCops/DisabledByDefault` to the given configuration. Used when the
       # configuration would otherwise be returned without going through
       # `merge_with_default` (e.g. there is no user-supplied `.rubocop.yml`).
+      # Used when there is no configuration file, so the defaults are the whole
+      # configuration and still need the same treatment `merge_with_default`
+      # would have given them.
       def apply_default_overrides(config)
-        return config if @enabled_by_default.nil? && @disabled_by_default.nil?
+        hash = resolver.apply_preview_defaults(config, preview == true)
 
-        hash = config.transform_values do |params|
-          params.is_a?(Hash) ? params.merge('Enabled' => !@disabled_by_default) : params
+        unless @enabled_by_default.nil? && @disabled_by_default.nil?
+          hash = hash.transform_values do |params|
+            params.is_a?(Hash) ? params.merge('Enabled' => !@disabled_by_default) : params
+          end
         end
+
         Config.new(hash, config.loaded_path)
       end
 

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -95,16 +95,19 @@ module RuboCop
     # When the `--disable-all-cops` or `--enable-all-cops` CLI option is given,
     # it takes precedence over the configuration values.
     def merge_with_default(config, config_file, unset_nil:)
-      default_configuration = ConfigLoader.default_configuration
+      base_defaults = apply_preview_defaults(ConfigLoader.default_configuration, preview?(config))
+      default_configuration = base_defaults
       disabled_by_default, enabled_by_default = resolve_default_overrides(config)
 
       if disabled_by_default || enabled_by_default
-        default_configuration = transform(default_configuration) do |params|
+        default_configuration = transform(base_defaults) do |params|
           params.merge('Enabled' => !disabled_by_default)
         end
       end
 
-      config = handle_disabled_by_default(config, default_configuration) if disabled_by_default
+      if disabled_by_default
+        config = handle_disabled_by_default(config, default_configuration, base_defaults)
+      end
       override_enabled_for_disabled_departments(default_configuration, config)
 
       opts = { inherit_mode: inherit_mode_for_default(config), unset_nil: unset_nil }
@@ -163,6 +166,21 @@ module RuboCop
         next unless base_hash.dig(cop_name, 'Enabled') == true
 
         derived_hash.replace(merge({ cop_name => { 'Enabled' => false } }, derived_hash))
+      end
+    end
+
+    # A cop's entry in the default configuration may carry a `Preview` section
+    # with the defaults it is expected to adopt in the next major release. Under
+    # `Preview` those replace the current defaults. The section is dropped either
+    # way, so the resolved configuration only ever shows what is in effect.
+    def apply_preview_defaults(default_configuration, preview)
+      transform(default_configuration) do |params|
+        # `AllCops: Preview` is the switch itself, not a section of defaults.
+        next params unless params['Preview'].is_a?(Hash)
+
+        params = params.dup
+        preview_params = params.delete('Preview')
+        preview ? params.merge(preview_params) : params
       end
     end
 
@@ -301,7 +319,7 @@ module RuboCop
       file.is_a?(RemoteConfig)
     end
 
-    def handle_disabled_by_default(config, new_default_configuration)
+    def handle_disabled_by_default(config, new_default_configuration, base_defaults)
       department_config = config.to_hash.reject { |cop| cop.include?('/') }
       department_config.each do |dept, dept_params|
         next unless dept_params['Enabled']
@@ -310,7 +328,7 @@ module RuboCop
           next unless cop.start_with?("#{dept}/")
 
           # Retain original default configuration for cops in the department.
-          params['Enabled'] = ConfigLoader.default_configuration[cop]['Enabled']
+          params['Enabled'] = base_defaults[cop]['Enabled']
         end
       end
 

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -11,7 +11,7 @@ module RuboCop
     COMMON_PARAMS = %w[Exclude Include Severity inherit_mode AutoCorrect StyleGuide Details
                        Enabled Reference References Safe SafeAutoCorrect].freeze
     # @api private
-    INTERNAL_PARAMS = %w[Description StyleGuide
+    INTERNAL_PARAMS = %w[Description StyleGuide Preview
                          VersionAdded VersionChanged VersionRemoved
                          Reference References Safe SafeAutoCorrect].freeze
     # @api private

--- a/lib/rubocop/cops_documentation_generator.rb
+++ b/lib/rubocop/cops_documentation_generator.rb
@@ -20,6 +20,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     safety:                ->(data) { safety_object(data.safety_objects, data.cop) },
     examples:              ->(data) { examples(data.example_objects, data.cop) },
     configuration:         ->(data) { configurations(data.cop.department, data.cop, data.config) },
+    preview:               ->(data) { preview_defaults(data.cop) },
     references:            ->(data) { references(data.cop, data.see_objects) }
   }.freeze
 
@@ -194,7 +195,7 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
   def configurations(department, cop, cop_config)
     header = ['Name', 'Default value', 'Configurable values']
     configs = cop_config.each_key.reject do |key|
-      key == 'AllowMultipleStyles' ||
+      key == 'AllowMultipleStyles' || key == 'Preview' ||
         (key != 'SupportedTypes' && key.start_with?('Supported'))
     end
     return '' if configs.empty?
@@ -207,6 +208,22 @@ class CopsDocumentationGenerator # rubocop:disable Metrics/ClassLength
     end
 
     cop_subsection('Configurable attributes', cop) + to_table(header, content)
+  end
+
+  def preview_defaults(cop)
+    cop_config = config.for_cop(cop)
+    preview = cop_config['Preview']
+    return '' unless preview.is_a?(Hash)
+
+    header = ['Name', 'Current default', 'Preview default']
+    content = preview.map do |name, value|
+      [name, format_table_value(cop_config[name]), format_table_value(value)]
+    end
+
+    cop_subsection('Preview defaults', cop) +
+      'These defaults apply under xref:versioning.adoc#preview[Preview] and are ' \
+      "expected to become the regular defaults in the next major release.\n\n" +
+      to_table(header, content)
   end
 
   def configuration_name(department, name)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -23,6 +23,7 @@ module RuboCop
         Enabled
         Exclude
         Include
+        Preview
         Reference
         References
         Safe

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe 'RuboCop Project', type: :feature do
       raise errors.join("\n") unless errors.empty?
     end
 
+    it 'only overrides existing parameters in `Preview` sections' do
+      cop_names.each do |cop_name|
+        preview = config.dig(cop_name, 'Preview')
+        next if preview.nil?
+
+        expect(preview).to be_a(Hash), "`#{cop_name}: Preview` should be a section of defaults."
+        expect(preview).not_to be_empty, "`#{cop_name}: Preview` should not be empty."
+
+        unknown = preview.keys - config[cop_name].keys
+        expect(unknown).to be_empty,
+                           "`#{cop_name}: Preview` overrides #{unknown.join(', ')}, " \
+                           'which the cop does not have.'
+      end
+    end
+
     # rubocop:disable-next RSpec/NoExpectationExample
     it 'does not have any duplication' do
       fname = File.expand_path('../config/default.yml', __dir__)

--- a/spec/rubocop/cli/preview_spec.rb
+++ b/spec/rubocop/cli/preview_spec.rb
@@ -172,6 +172,87 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
     end
   end
 
+  context 'when a cop carries preview defaults' do
+    # `Style/Documentation` ships with `Preview: { Enabled: false }`.
+    before do
+      create_file('undocumented.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        class Undocumented
+          def call; end
+        end
+      RUBY
+    end
+
+    # No `--only` here: that would force the cop on regardless of its defaults.
+    def documentation_offenses(*args)
+      cli.run(args + ['--format', 'simple', '.'])
+      $stdout.string.scan('Style/Documentation:').size
+    end
+
+    it 'keeps the regular defaults without preview' do
+      expect(documentation_offenses).to eq(1)
+    end
+
+    it 'applies the preview defaults with --preview' do
+      expect(documentation_offenses('--preview')).to eq(0)
+    end
+
+    it 'applies the preview defaults when the config opts in' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+      YAML
+
+      expect(documentation_offenses).to eq(0)
+    end
+
+    it 'lets an explicit setting in user configuration win over the preview defaults' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+        Style/Documentation:
+          Enabled: true
+      YAML
+
+      expect(documentation_offenses).to eq(1)
+    end
+
+    it 'still runs the cop when it is requested by name with --only' do
+      cli.run(['--preview', '--only', 'Style/Documentation', '--format', 'simple', '.'])
+
+      expect($stdout.string).to include('Style/Documentation')
+    end
+
+    it 'lets `EnabledByDefault` win over the preview defaults' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+          EnabledByDefault: true
+      YAML
+
+      expect(documentation_offenses).to eq(1)
+    end
+
+    it 'respects the preview defaults when a department is re-enabled under `DisabledByDefault`' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+          DisabledByDefault: true
+        Style:
+          Enabled: true
+      YAML
+
+      expect(documentation_offenses).to eq(0)
+    end
+
+    it 'does not expose the `Preview` section in the resolved configuration' do
+      cli.run(['--preview', '--show-cops', 'Style/Documentation'])
+
+      expect($stdout.string).not_to include('Preview')
+    end
+  end
+
   it 'rejects an unknown `Enabled` value' do
     create_file('.rubocop.yml', <<~YAML)
       Style/For:

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -19,7 +19,14 @@ RSpec.describe RuboCop::ConfigLoader do
     RuboCop::ConfigFinder.project_root = nil
   end
 
-  let(:default_config) { described_class.default_configuration }
+  # The default configuration as it resolves: a cop's `Preview` section never
+  # survives into the loaded configuration. (`AllCops: Preview` is the switch
+  # itself and stays.)
+  let(:default_config) do
+    described_class.default_configuration.to_h.transform_values do |params|
+      params.reject { |key, value| key == 'Preview' && value.is_a?(Hash) }
+    end
+  end
 
   describe '.configuration_file_for', :isolated_environment do
     subject(:configuration_file_for) { described_class.configuration_file_for(dir_path) }

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RuboCop::ConfigStore do
     allow(RuboCop::ConfigLoader)
       .to receive(:merge_with_default) { |config| "merged #{config.to_h}" }
     allow(RuboCop::ConfigLoader).to receive(:default_configuration).and_return('default config')
+    allow(RuboCop::ConfigLoader).to receive(:apply_default_overrides) { |arg| arg }
   end
 
   describe '.for' do

--- a/spec/rubocop/cops_documentation_generator_spec.rb
+++ b/spec/rubocop/cops_documentation_generator_spec.rb
@@ -16,4 +16,34 @@ RSpec.describe CopsDocumentationGenerator do
       end.to output(%r{generated .*docs/modules/ROOT/pages/cops_style.adoc}).to_stdout
     end
   end
+
+  context 'when a cop has preview defaults' do
+    around do |example|
+      new_global = RuboCop::Cop::Registry.new([RuboCop::Cop::Style::Documentation])
+      RuboCop::Cop::Registry.with_temporary_global(new_global) { example.run }
+    end
+
+    it 'renders them in their own section rather than as a parameter' do
+      Dir.mktmpdir do |tmpdir|
+        generator = described_class.new(departments: %w[Style], base_dir: tmpdir)
+        expect { generator.call }.to output.to_stdout
+
+        page = File.read(File.join(tmpdir, 'docs/modules/ROOT/pages/cops_style.adoc'))
+        expect(page).to include(<<~ADOC)
+          === Preview defaults
+
+          These defaults apply under xref:versioning.adoc#preview[Preview] and are expected to become the regular defaults in the next major release.
+
+          |===
+          | Name | Current default | Preview default
+
+          | Enabled
+          | `true`
+          | `false`
+          |===
+        ADOC
+        expect(page).not_to include("| Preview\n")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The preview channel could gate a behavior branch inside a cop, but the RuboCop 2.0 backlog in #15363 is almost entirely defaults: a cop that should be off, a threshold that should be higher, an enforced style the community has voted against. None of that is code, and there was no way to offer any of it ahead of a major release.

A cop's entry in `config/default.yml` can now carry a `Preview` section with the values it is expected to adopt next:

```yaml
Style/Documentation:
  Enabled: true
  Preview:
    Enabled: false
```

Under `Preview` the loader merges that over the current defaults before the user's configuration is applied, so an explicit user setting still wins. The section is dropped either way: `--show-cops` and `--auto-gen-config` never see it, and the cop reads its settings the same way regardless. The generated docs render it as a "Preview defaults" table, and `spec/project_spec.rb` rejects a section naming a parameter the cop does not have.

`Style/Documentation` is the first entry, being the most-disabled cop by a wide margin (53% of the configs in the #15363 corpus). It is also the first preview change that makes RuboCop quieter rather than noisier, which nothing had exercised yet.

Two things came out of building this that are worth knowing. Defaults are read in more places than `merge_with_default`: a project with no `.rubocop.yml` and `--force-default-config` both go through `apply_default_overrides` instead, and `DisabledByDefault` restores a re-enabled department from the raw defaults, which brought the preview-disabled cop straight back. All three are covered now, and the audit of the remaining `ConfigLoader.default_configuration` readers found only `same_max_line_length?` in `auto_generate_config.rb` that would care, and only once `Layout/LineLength` itself gets a `Preview` section.

Extensions get this for free, since plugin defaults are merged into the default configuration before any of this runs.

This subsumes `Enabled: preview`, which is now equivalent to `Enabled: false` plus `Preview: { Enabled: true }`. The shorthand stays for readability and for the status column in the docs.