### PR TITLE
Fix result cache consuming non-regular files

### DIFF
--- a/changelog/fix_result_cache_consuming_non_regular_files_20260902034600.md
+++ b/changelog/fix_result_cache_consuming_non_regular_files_20260902034600.md
@@ -1,0 +1,1 @@
+* [#15661](https://github.com/rubocop/rubocop/pull/15661): Fix the result cache reading and processing non-regular files. ([@viralpraxis][])

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -178,16 +178,22 @@ module RuboCop
     end
 
     def file_checksum(file, config_store)
+      stat = File.stat(file)
+      return unavailable_checksum unless stat.file?
+
       digester = Digest::SHA1.new
-      mode = File.stat(file).mode
-      digester.update("#{file}#{mode}#{config_store.for_file(file).signature}")
+      digester.update("#{file}#{stat.mode}#{config_store.for_file(file).signature}")
       digester.file(file)
       digester.hexdigest
     rescue Errno::ENOENT
       # Spurious files that come and go should not cause a crash, at least not here.
-      # Every file that fails to checksum shares this sentinel value, so the cache entry
-      # must be neither saved nor considered valid, or one file's cached results could be
-      # served as another's.
+      unavailable_checksum
+    end
+
+    # Every file that fails to checksum shares this sentinel value, so the cache entry
+    # must be neither saved nor considered valid, or one file's cached results could be
+    # served as another's.
+    def unavailable_checksum
       @checksum_unavailable = true
       '_'
     end

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -339,6 +339,22 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
     end
   end
 
+  describe 'when the file is not a regular file' do
+    let(:file) { File::NULL }
+
+    before do
+      skip 'Device files are not stat-able on Windows' if RuboCop::Platform.windows?
+
+      allow(config_store).to receive(:for_file).with(file).and_return(RuboCop::Config.new)
+    end
+
+    it 'is neither saved nor considered valid' do
+      cache.save(offenses)
+
+      expect(cache).not_to be_valid
+    end
+  end
+
   describe '#save' do
     context 'when the default internal encoding is UTF-8' do
       let(:offenses) do


### PR DESCRIPTION
Non-regular files like `/dev/stdin` should not be processed by result cache.

Before (running for the 2nd time, with cache populated):

```shell
$ echo '123' | bundle exec rubocop /dev/stdin
Inspecting 1 file
W

Offenses:

/dev/stdin:1:1: W: Lint/EmptyFile: Empty file detected.

1 file inspected, 1 offense detected
```

After:

```shell
$ echo '123' | bundle exec rubocop /dev/stdin
Inspecting 1 file
C

Offenses:

/dev/stdin:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
123
^

1 file inspected, 1 offense detected, 1 offense autocorrectable

```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
