### PR TITLE
Fix an infinite loop for `Layout/SpaceAroundBlockParameters` cop

### DIFF
--- a/changelog/fix_an_infinite_loop_for_layout_space_around_block_parameters_20260904162601.md
+++ b/changelog/fix_an_infinite_loop_for_layout_space_around_block_parameters_20260904162601.md
@@ -1,0 +1,1 @@
+* [#15662](https://github.com/rubocop/rubocop/pull/15662): Fix an infinite loop between `Layout/SpaceAroundBlockParameters` and `Layout/SpaceInsideParens` when the two cops enforce conflicting styles for a lambda's parameter parentheses. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Layout
       # Checks the spacing inside and after block parameters pipes. Line breaks
       # inside parameter pipes are checked by `Layout/MultilineBlockLayout` and
-      # not by this cop.
+      # not by this cop. Spaces inside a lambda's parameter parentheses are left
+      # to `Layout/SpaceInsideParens` when that cop enforces a conflicting style.
       #
       # @example EnforcedStyleInsidePipes: no_space (default)
       #   # bad
@@ -34,7 +35,7 @@ module RuboCop
 
           return unless node.arguments? && pipes?(arguments)
 
-          check_inside_pipes(arguments)
+          check_inside_pipes(arguments) unless conflicting_space_inside_parens_style?(arguments)
           check_after_closing_pipe(arguments) if node.body
           check_each_arg(arguments)
         end
@@ -51,6 +52,16 @@ module RuboCop
 
         def style_parameter_name
           'EnforcedStyleInsidePipes'
+        end
+
+        def conflicting_space_inside_parens_style?(arguments)
+          return false unless arguments.loc.begin.source == '('
+
+          case config.for_enabled_cop('Layout/SpaceInsideParens')['EnforcedStyle']
+          when 'no_space' then style == :space
+          when 'space', 'compact' then style == :no_space
+          else false
+          end
         end
 
         def check_inside_pipes(arguments)

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -407,4 +407,59 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       RUBY
     end
   end
+
+  context 'when `Layout/SpaceInsideParens` enforces a conflicting style' do
+    context 'when EnforcedStyleInsidePipes is space' do
+      let(:cop_config) { { 'EnforcedStyleInsidePipes' => 'space' } }
+      let(:other_cops) do
+        { 'Layout/SpaceInsideParens' => { 'Enabled' => true, 'EnforcedStyle' => 'no_space' } }
+      end
+
+      it 'accepts a lambda with no spaces inside its parentheses' do
+        expect_no_offenses('->(x, y) { puts x }')
+      end
+
+      it 'registers an offense for a block with no spaces inside its pipes' do
+        expect_offense(<<~RUBY)
+          {}.each { |x, y| puts x }
+                     ^ Space before first block parameter missing.
+                        ^ Space after last block parameter missing.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          {}.each { | x, y | puts x }
+        RUBY
+      end
+    end
+
+    context 'when EnforcedStyleInsidePipes is no_space' do
+      let(:cop_config) { { 'EnforcedStyleInsidePipes' => 'no_space' } }
+      let(:other_cops) do
+        { 'Layout/SpaceInsideParens' => { 'Enabled' => true, 'EnforcedStyle' => 'space' } }
+      end
+
+      it 'accepts a lambda with spaces inside its parentheses' do
+        expect_no_offenses('->( x, y ) { puts x }')
+      end
+    end
+  end
+
+  context 'when `Layout/SpaceInsideParens` is disabled' do
+    let(:cop_config) { { 'EnforcedStyleInsidePipes' => 'space' } }
+    let(:other_cops) do
+      { 'Layout/SpaceInsideParens' => { 'Enabled' => false, 'EnforcedStyle' => 'no_space' } }
+    end
+
+    it 'registers an offense for a lambda with no spaces inside its parentheses' do
+      expect_offense(<<~RUBY)
+        ->(x, y) { puts x }
+           ^ Space before first block parameter missing.
+              ^ Space after last block parameter missing.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ->( x, y ) { puts x }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/SpaceAroundBlockParameters:
  Enabled: true
  EnforcedStyleInsidePipes: space
Layout/SpaceInsideParens:
  Enabled: true
YAML
) <<'RUBY'
->(a) {}
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
Infinite loop detected in /dev/stdin and caused by Layout/SpaceAroundBlockParameters, Layout/SpaceInsideParens -> Layout/SpaceAroundBlockParameters, Layout/SpaceInsideParens
C

Offenses:

/dev/stdin:1:4: C: [Corrected] Layout/SpaceAroundBlockParameters: Space before first block parameter missing.
->(a) {}
   ^
/dev/stdin:1:4: C: [Corrected] Layout/SpaceInsideParens: Space inside parentheses detected.
->( a) {}
   ^
/dev/stdin:1:5: C: [Corrected] Layout/SpaceAroundBlockParameters: Space after last block parameter missing.
->( a) {}
    ^
/dev/stdin:1:5: C: [Corrected] Layout/SpaceInsideParens: Space inside parentheses detected.
->(a ) {}
    ^
```

The same loop occurs with the styles swapped, and with `Layout/SpaceInsideParens: EnforcedStyle: compact`.

Found by `rubocop-nightly`.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
