### PR TITLE
Fix RedundantFetchBlock autocorrection with splatted arguments

### DIFF
--- a/changelog/fix_avoid_redundant_fetch_autocorrection_with_splatted_arguments_20260905173211.md
+++ b/changelog/fix_avoid_redundant_fetch_autocorrection_with_splatted_arguments_20260905173211.md
@@ -1,0 +1,1 @@
+* [#15663](https://github.com/rubocop/rubocop/issues/15663): Avoid redundant fetch autocorrection with splatted arguments. ([@mehuljariwala][])

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -47,7 +47,7 @@ module RuboCop
         # @!method redundant_fetch_block_candidate?(node)
         def_node_matcher :redundant_fetch_block_candidate?, <<~PATTERN
           (block
-            $(call _ :fetch _)
+            $(call _ :fetch !splat)
             (args)
             ${nil? basic_literal? const_type?})
         PATTERN

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock, :config do
+  it 'does not register an offense for splatted arguments' do
+    expect_no_offenses(<<~RUBY)
+      hash.fetch(*args) { 5 }
+    RUBY
+  end
+
+  it 'does not register an offense for splatted arguments with safe navigation' do
+    expect_no_offenses(<<~RUBY)
+      hash&.fetch(*args) { 5 }
+    RUBY
+  end
+
   context 'with SafeForConstants: true' do
     let(:config) do
       RuboCop::Config.new('Style/RedundantFetchBlock' => { 'SafeForConstants' => true })


### PR DESCRIPTION
Fixes #15663.

`Style/RedundantFetchBlock` treats a splat AST node as one argument and changes `hash.fetch(*args) { 5 }` into `hash.fetch(*args, 5)`. When `args` contains a key and a default, the original returns 5 but the correction raises `ArgumentError` for three arguments.

Exclude splatted arguments from the node matcher because their runtime arity is unknown. Add no-offense regressions for both ordinary calls and safe navigation. The focused specs fail twice before the fix and pass all 17 examples afterward, on both Parser and Prism.

`bundle exec rake` passed the documentation syntax check, all 33,914 examples (0 failures, 3 pending), and self-linting across 1,761 files. The optional codespell task was skipped because codespell is not installed. The changelog was generated using `rake changelog:fix`.

Prepared with OpenAI Codex assistance. The Ruby runtime reproduction and validation commands were executed locally.

-----------------

- [x] One focused fix with a clear title and description.
- [x] Commit message starts with `[Fix #15663]`.
- [x] Feature branch is based on current master.
- [x] Related changes are in one commit.
- [x] Added tests, including safe navigation.
- [x] Ran `bundle exec rake` successfully.
- [x] Added a generated changelog entry.
