### PR TITLE
Fix Style/EmptyMethod loop with Style/SingleLineMethods

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_style_empty_method_20260905.md
+++ b/changelog/fix_an_infinite_loop_error_for_style_empty_method_20260905.md
@@ -1,0 +1,1 @@
+* [#15665](https://github.com/rubocop/rubocop/pull/15665): Fix an infinite loop between `Style/EmptyMethod` and `Style/SingleLineMethods` with `AllowIfMethodIsEmpty: false`. ([@Starlexxx][])

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -53,11 +53,11 @@ module RuboCop
 
         def on_def(node)
           return if node.body || processed_source.contains_comment?(node.source_range)
-          return if correct_style?(node)
+          return if correct_style?(node) || compact_style_disallowed?
 
           add_offense(node) do |corrector|
             correction = corrected(node)
-            next if compact_style? && max_line_length && correction.size > max_line_length
+            next if correction_exceeds_line_length?(correction)
 
             corrector.replace(node, correction)
           end
@@ -74,6 +74,12 @@ module RuboCop
           (compact_style? && compact?(node)) || (expanded_style? && expanded?(node))
         end
 
+        def compact_style_disallowed?
+          return false unless compact_style?
+
+          config.for_enabled_cop('Style/SingleLineMethods')['AllowIfMethodIsEmpty'] == false
+        end
+
         def corrected(node)
           scope = node.receiver ? "#{node.receiver.source}." : ''
           arguments = if node.arguments?
@@ -84,6 +90,10 @@ module RuboCop
           signature = [scope, node.method_name, arguments].join
 
           ["def #{signature}", 'end'].join(joint(node))
+        end
+
+        def correction_exceeds_line_length?(correction)
+          compact_style? && max_line_length && correction.size > max_line_length
         end
 
         def joint(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -731,6 +731,27 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Style/EmptyMethod` with `AllowIfMethodIsEmpty: false` of `Style/SingleLineMethods`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/SingleLineMethods:
+        AllowIfMethodIsEmpty: false
+    YAML
+    source = <<~RUBY
+      def foo; end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect',
+                     '--only', 'Style/EmptyMethod,Style/SingleLineMethods,Style/Semicolon,' \
+                               'Layout/TrailingWhitespace'
+                   ])).to eq(0)
+    expect($stderr.string).to eq('')
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo
+      end
+    RUBY
+  end
+
   it 'corrects `Style/GuardClause` with `Style/MissingElse`' do
     create_file('.rubocop.yml', <<~YAML)
       Style/EmptyElse:

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -345,4 +345,41 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
       end
     end
   end
+
+  context 'when `Style/SingleLineMethods` disallows empty single line methods' do
+    let(:config) do
+      merged = RuboCop::ConfigLoader.default_configuration['Style/EmptyMethod'].merge(cop_config)
+      RuboCop::Config.new(
+        'Style/EmptyMethod' => merged,
+        'Style/SingleLineMethods' => { 'Enabled' => true, 'AllowIfMethodIsEmpty' => false }
+      )
+    end
+
+    context 'when configured with compact style' do
+      let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
+
+      it 'does not register an offense for an expanded empty method' do
+        expect_no_offenses(<<~RUBY)
+          def foo
+          end
+        RUBY
+      end
+    end
+
+    context 'when configured with expanded style' do
+      let(:cop_config) { { 'EnforcedStyle' => 'expanded' } }
+
+      it 'registers an offense and corrects a compact empty method' do
+        expect_offense(<<~RUBY)
+          def foo; end
+          ^^^^^^^^^^^^ Put the `end` of empty method definitions on the next line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
With `AllowIfMethodIsEmpty: false` on `Style/SingleLineMethods`, autocorrecting an empty single-line method never converges:

```ruby
def foo; end
```

```
Infinite loop detected ... caused by Style/SingleLineMethods -> Layout/TrailingWhitespace, Style/EmptyMethod, Style/Semicolon
```

`Style/SingleLineMethods` expands the method, then `Style/EmptyMethod` with the default `compact` style collapses it right back. The configs contradict each other, and the explicit `AllowIfMethodIsEmpty: false` should win over the default, so `Style/EmptyMethod` now skips the compact check when an enabled `Style/SingleLineMethods` disallows empty single-line methods.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.