### PR TITLE
Add rubocop-exception_messages to third-party plugins

### DIFF
--- a/docs/modules/ROOT/pages/plugins.adoc
+++ b/docs/modules/ROOT/pages/plugins.adoc
@@ -182,5 +182,7 @@ GraphQL-specific analysis
 Reduced CI time by analyzing only changed files
 * https://github.com/SketchUp/rubocop-sketchup[rubocop-sketchup] -
 SketchUp Ruby API specific analysis
+* https://github.com/dblock/rubocop-exception_messages[rubocop-exception_messages] -
+Standardizes the style of raised exception messages (casing, punctuation, quoting of interpolated values)
 
 Any plugins missing? Send us a Pull Request!


### PR DESCRIPTION
Adds [rubocop-exception_messages](https://github.com/dblock/rubocop-exception_messages) to the list of third-party plugins. It standardizes the style of raised exception messages: casing (`ExceptionMessages/Casing`), trailing punctuation (`ExceptionMessages/Punctuation`), redundant repetition of the exception class name in the message (`ExceptionMessages/RedundantExceptionName`), and consistent quoting of interpolated values (`ExceptionMessages/QuoteStyle`).

More background in [Standardizing Exception Message Style in Ruby](https://code.dblock.org/2026/09/05/standardizing-exception-message-style-in-ruby.html).