### PR TITLE
Fix `Lint/NameTypo` false positives for methods Ruby itself provides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,12 @@ gem 'rake', '~> 13.0'
 # rbs 4.1.0.pre.2 ships a `java` platform gem that works on JRuby, so pin to it there
 # until a stable release that supports JRuby ships.
 # https://github.com/ruby/rdoc/issues/1746
-gem 'rbs', '4.1.0.pre.2' if RUBY_ENGINE == 'jruby'
+#
+# `Lint/NameTypo` also reads the RBS core signatures to recognize the methods the
+# interpreter itself provides, which are in no source index, so rbs is declared for
+# every engine rather than arriving only as an rdoc dependency.
+rbs_requirement = RUBY_ENGINE == 'jruby' ? ['4.1.0.pre.2'] : []
+gem 'rbs', *rbs_requirement, require: false
 gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.27.0', require: false
 gem 'rubocop-rake', '~> 0.7.0', require: false

--- a/changelog/fix_lint_name_typo_false_positives_for_methods_ruby_itself_provides_20260907123457.md
+++ b/changelog/fix_lint_name_typo_false_positives_for_methods_ruby_itself_provides_20260907123457.md
@@ -1,0 +1,1 @@
+* [#15643](https://github.com/rubocop/rubocop/issues/15643): Fix `Lint/NameTypo` false positives for methods Ruby itself provides, such as `Time.now`, `Regexp.new`, and methods every namespace inherits like `Bar.send`. ([@IslamElsayed][])

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -6,6 +6,15 @@ rescue LoadError
   nil
 end
 
+# Ruby's own core signatures, used to recognize the methods the interpreter
+# provides. Shipped with Ruby as a bundled gem; without it those names are
+# simply not recognized.
+begin
+  require 'rbs'
+rescue LoadError
+  nil
+end
+
 module RuboCop
   module Cop
     module Lint
@@ -16,6 +25,15 @@ module RuboCop
       # The check is powered by the project-wide index, so it only runs when
       # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed.
       # Without the index the cop does nothing.
+      #
+      # Methods the interpreter itself provides are in no source index, since
+      # they are implemented in C or compiled in: `Time.now` and `Regexp.new`,
+      # and everything a constant naming a class or module inherits from
+      # `Class`/`Module`, `Object` and `Kernel`. Those are recognized from the
+      # RBS core signatures, which describe the language rather than RuboCop's
+      # own process. That reads the `rbs` gem -- shipped with Ruby, but as a
+      # bundled gem rather than a default one, so it has to be in the bundle to
+      # be loadable. Without it such names can be reported as typos.
       #
       # Constants are checked only in qualified references (`Foo::Bar`) whose
       # namespace resolves in the index; bare names cannot be distinguished
@@ -74,11 +92,99 @@ module RuboCop
 
         METHOD_MEMBER_REGEXP = /#([a-zA-Z_]\w*[?!]?)\(\)\z/.freeze
         LITERAL_IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!]?/.freeze
-        # Bare class and module objects, used to ask what every namespace
-        # inherits from Ruby itself rather than hardcoding a list of names that
-        # would rot between Ruby versions.
-        CLASS_PROBE = Class.new
-        MODULE_PROBE = Module.new
+        # Ruby's own methods, read from the RBS core signatures that ship with
+        # the `rbs` gem. This is static, versioned data describing the Ruby
+        # being targeted, not a reflection of RuboCop's own process, so the
+        # answer does not change with what RuboCop happens to have loaded.
+        #
+        # Nothing is loaded until the first query, and only `core` is read --
+        # never a stdlib or gem signature -- so the vocabulary is exactly what
+        # the interpreter itself provides.
+        module CoreSignatures
+          class << self
+            # Whether Ruby's core gives the named class or module a singleton
+            # method by one of these names. Always false for a name core does
+            # not declare, which includes every class a project defines itself.
+            def singleton_method?(namespace, names)
+              type_name = core_type_names[qualified(namespace)]
+
+              type_name ? any_method?(type_name, :singleton, names) : false
+            end
+
+            # Whether a bare class or module object answers to one of these
+            # names, as every constant naming one does. Asked by kind, since
+            # `Module` has no `superclass` and `Formatting.superclass` is
+            # therefore a real offense.
+            def object_method?(kind, names)
+              type_name = core_type_names[kind == :class ? '::Class' : '::Module']
+
+              type_name ? any_method?(type_name, :instance, names) : false
+            end
+
+            private
+
+            def any_method?(type_name, kind, names)
+              methods = methods_for(type_name, kind)
+
+              methods ? names.any? { |name| methods.include?(name.to_sym) } : false
+            end
+
+            def methods_for(type_name, kind)
+              key = [type_name.to_s, kind]
+              method_cache.fetch(key) do
+                method_cache[key] = build_methods(type_name, kind)
+              end
+            end
+
+            def build_methods(type_name, kind)
+              definition = if kind == :singleton
+                             builder.build_singleton(type_name)
+                           else
+                             builder.build_instance(type_name)
+                           end
+              definition.methods.keys.to_set
+            rescue StandardError
+              nil
+            end
+
+            def method_cache
+              @method_cache ||= {}
+            end
+
+            # Core type names by their fully qualified string, which sidesteps
+            # constructing an `RBS::TypeName` and the API differences between
+            # `rbs` versions in doing so.
+            def core_type_names
+              @core_type_names ||= begin
+                env = environment
+                env ? env.class_decls.keys.to_h { |type_name| [type_name.to_s, type_name] } : {}
+              end
+            end
+
+            # Core declares every name at the root, so a namespace is looked up
+            # fully qualified. A project's own `Foo::Bar` simply misses.
+            def qualified(namespace)
+              name = namespace.to_s
+              name.start_with?('::') ? name : "::#{name}"
+            end
+
+            def builder
+              @builder ||= RBS::DefinitionBuilder.new(env: environment)
+            end
+
+            # The core signatures alone: `EnvironmentLoader` with no library
+            # asked for reads `core` and nothing else.
+            def environment
+              return @environment if defined?(@environment)
+
+              @environment = begin
+                RBS::Environment.from_loader(RBS::EnvironmentLoader.new).resolve_type_names
+              rescue StandardError, LoadError
+                nil
+              end
+            end
+          end
+        end
 
         def on_const(node)
           return unless check?('CheckConstants') && checkable_constant?(node)
@@ -212,14 +318,14 @@ module RuboCop
           return nil if responds_in_index?(declaration, node.method_name.to_s, base)
           return nil unless fully_resolved_index_ancestry?(declaration)
           return nil if gem_owned_namespace?(declaration)
-          return nil if responds_natively?(declaration, node.method_name.to_s, base)
+          return nil if core_provided_method?(declaration, node.method_name.to_s, base)
 
           declaration
         end
 
-        # Whether Ruby itself answers the call, in which case the name's
-        # absence from the index is no evidence of a typo. There are two ways
-        # that happens, and neither is visible to a source index because the
+        # Whether Ruby itself provides the method, in which case its absence
+        # from the index is no evidence of a typo. There are two ways that
+        # happens, and neither is visible to a source index because the
         # interpreter implements them in C or compiles them in.
         #
         # First, the namespace may be one Ruby provides. `Time` and `Regexp`
@@ -232,33 +338,26 @@ module RuboCop
         #
         # Second, the constant may be any class or module at all. It is itself
         # an object, so it answers everything `Class`/`Module`, `Object` and
-        # `Kernel` define -- `send`, `to_s`, `freeze` and the rest. That holds
-        # for a project's own classes, which the first case does not cover
-        # because they do not exist in this process: `Bar.send` was reported as
-        # a typo of `Bar.send_pm`.
+        # `Kernel` define -- `send`, `to_s`, `freeze` and the rest. That covers
+        # a project's own classes, which the first case does not, since core
+        # does not declare them: `Bar.send` was reported as a typo of
+        # `Bar.send_pm`.
         #
-        # Only names the running Ruby answers to are skipped, so a genuine typo
-        # is still reported. Methods from a stdlib file RuboCop has not itself
-        # required are not covered: they are equally invisible to the index,
-        # but there is nothing to ask.
-        def responds_natively?(declaration, name, base)
+        # Only names core actually declares are skipped, so a genuine typo is
+        # still reported. Methods a stdlib library adds (`Time.rfc2822`) are
+        # equally invisible to the index and stay uncovered: whether the
+        # analyzed project requires that library is not something the core
+        # signatures can say.
+        def core_provided_method?(declaration, name, base)
+          return false unless defined?(RBS)
+
           candidates = [name, base].uniq
+          kind = declaration.is_a?(Rubydex::Class) ? :class : :module
 
-          return true if core_object_responds?(declaration, candidates)
-
-          const = Object.const_get(declaration.name.to_s)
-          const.is_a?(Module) && candidates.any? { |candidate| const.respond_to?(candidate) }
+          CoreSignatures.object_method?(kind, candidates) ||
+            CoreSignatures.singleton_method?(declaration.name, candidates)
         rescue StandardError
           false
-        end
-
-        # Whether a bare object of the same kind already answers the name. A
-        # module is probed with a module: `Formatting.superclass` is a real
-        # offense, since modules have no `superclass`.
-        def core_object_responds?(declaration, candidates)
-          probe = declaration.is_a?(Rubydex::Class) ? CLASS_PROBE : MODULE_PROBE
-
-          candidates.any? { |candidate| probe.respond_to?(candidate) }
         end
 
         def setter_call?(node)

--- a/lib/rubocop/cop/lint/name_typo.rb
+++ b/lib/rubocop/cop/lint/name_typo.rb
@@ -74,6 +74,11 @@ module RuboCop
 
         METHOD_MEMBER_REGEXP = /#([a-zA-Z_]\w*[?!]?)\(\)\z/.freeze
         LITERAL_IDENTIFIER_PATTERN = /[a-zA-Z_]\w*[?!]?/.freeze
+        # Bare class and module objects, used to ask what every namespace
+        # inherits from Ruby itself rather than hardcoding a list of names that
+        # would rot between Ruby versions.
+        CLASS_PROBE = Class.new
+        MODULE_PROBE = Module.new
 
         def on_const(node)
           return unless check?('CheckConstants') && checkable_constant?(node)
@@ -207,8 +212,53 @@ module RuboCop
           return nil if responds_in_index?(declaration, node.method_name.to_s, base)
           return nil unless fully_resolved_index_ancestry?(declaration)
           return nil if gem_owned_namespace?(declaration)
+          return nil if responds_natively?(declaration, node.method_name.to_s, base)
 
           declaration
+        end
+
+        # Whether Ruby itself answers the call, in which case the name's
+        # absence from the index is no evidence of a typo. There are two ways
+        # that happens, and neither is visible to a source index because the
+        # interpreter implements them in C or compiles them in.
+        #
+        # First, the namespace may be one Ruby provides. `Time` and `Regexp`
+        # resolve in the index only because something indexed reopens them --
+        # `ProjectIndexIncludesGems` makes that routine, since gems like
+        # ActiveSupport reopen both -- and their ancestry resolves too, so
+        # every other completeness guard passes and the handful of members the
+        # reopening added become the whole dictionary. `Time.now` then looks
+        # like a typo of `Time.noon`.
+        #
+        # Second, the constant may be any class or module at all. It is itself
+        # an object, so it answers everything `Class`/`Module`, `Object` and
+        # `Kernel` define -- `send`, `to_s`, `freeze` and the rest. That holds
+        # for a project's own classes, which the first case does not cover
+        # because they do not exist in this process: `Bar.send` was reported as
+        # a typo of `Bar.send_pm`.
+        #
+        # Only names the running Ruby answers to are skipped, so a genuine typo
+        # is still reported. Methods from a stdlib file RuboCop has not itself
+        # required are not covered: they are equally invisible to the index,
+        # but there is nothing to ask.
+        def responds_natively?(declaration, name, base)
+          candidates = [name, base].uniq
+
+          return true if core_object_responds?(declaration, candidates)
+
+          const = Object.const_get(declaration.name.to_s)
+          const.is_a?(Module) && candidates.any? { |candidate| const.respond_to?(candidate) }
+        rescue StandardError
+          false
+        end
+
+        # Whether a bare object of the same kind already answers the name. A
+        # module is probed with a module: `Formatting.superclass` is a real
+        # offense, since modules have no `superclass`.
+        def core_object_responds?(declaration, candidates)
+          probe = declaration.is_a?(Rubydex::Class) ? CLASS_PROBE : MODULE_PROBE
+
+          candidates.any? { |candidate| probe.respond_to?(candidate) }
         end
 
         def setter_call?(node)

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -378,6 +378,7 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
 
               module Formatting
                 def self.names; end
+                def self.superclasses; end
               end
             RUBY
           )
@@ -399,6 +400,16 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
           expect_offense(<<~RUBY)
             Bar.send_pmm
                 ^^^^^^^^ Possible typo: `Bar` does not respond to `send_pmm`. Did you mean `send_pm`?
+          RUBY
+        end
+
+        # Core is consulted by kind. `superclass` is a method of `Class` and
+        # not of `Module`, so a module is not credited with it and the typo of
+        # the module's own `superclasses` is still caught.
+        it 'still registers an offense for a class-only method called on a module' do
+          expect_offense(<<~RUBY)
+            Formatting.superclass
+                       ^^^^^^^^^^ Possible typo: `Formatting` does not respond to `superclass`. Did you mean `superclasses`?
           RUBY
         end
       end

--- a/spec/rubocop/cop/lint/name_typo_spec.rb
+++ b/spec/rubocop/cop/lint/name_typo_spec.rb
@@ -320,6 +320,89 @@ RSpec.describe RuboCop::Cop::Lint::NameTypo, :config do
         end
       end
 
+      context 'when the receiver is a namespace Ruby itself provides' do
+        # `ProjectIndexIncludesGems` makes this the common case rather than an
+        # exotic one: gems such as ActiveSupport reopen `Time` and `Regexp`, so
+        # the namespace resolves in the index and its ancestry resolves too,
+        # leaving the few members the reopening added as the whole dictionary.
+        # `Time.now` is compiled into the interpreter and `Regexp.new` is
+        # implemented in C, so neither is in the index, and each has a
+        # close-named sibling among the added members to be blamed on.
+        before do
+          cop.project_index = build_index(
+            'file:///core_ext.rb' => <<~RUBY
+              class Time
+                def self.noon; end
+                def self.current; end
+              end
+
+              class Regexp
+                def self.next; end
+              end
+            RUBY
+          )
+        end
+
+        it 'does not register an offense for a method compiled into the interpreter' do
+          expect_no_offenses(<<~RUBY)
+            Time.now
+          RUBY
+        end
+
+        it 'does not register an offense for a method implemented in C' do
+          expect_no_offenses(<<~RUBY)
+            Regexp.new('foo')
+          RUBY
+        end
+
+        it 'still registers an offense for a typo of an indexed member' do
+          expect_offense(<<~RUBY)
+            Time.currrent
+                 ^^^^^^^^ Possible typo: `Time` does not respond to `currrent`. Did you mean `current`?
+          RUBY
+        end
+      end
+
+      context 'when the call is a method every namespace inherits from Ruby' do
+        # A constant naming a class or module is itself an object, so it answers
+        # everything Class/Module, Object and Kernel define. The interpreter
+        # implements those in C, so they are missing from the index for a
+        # project's own classes too, not just for the ones Ruby provides -- and
+        # a nearby member name is then blamed for them.
+        before do
+          cop.project_index = build_index(
+            'file:///models.rb' => <<~RUBY
+              class Bar
+                def send_pm; end
+              end
+
+              module Formatting
+                def self.names; end
+              end
+            RUBY
+          )
+        end
+
+        it 'does not register an offense for a method inherited from Object' do
+          expect_no_offenses(<<~RUBY)
+            Bar.send(:send_pm)
+          RUBY
+        end
+
+        it 'does not register an offense for a method inherited from Module' do
+          expect_no_offenses(<<~RUBY)
+            Formatting.name
+          RUBY
+        end
+
+        it 'still registers an offense for a typo of a method the class defines' do
+          expect_offense(<<~RUBY)
+            Bar.send_pmm
+                ^^^^^^^^ Possible typo: `Bar` does not respond to `send_pmm`. Did you mean `send_pm`?
+          RUBY
+        end
+      end
+
       context 'when CheckMethods is false' do
         let(:cop_config) { { 'CheckMethods' => false } }
 


### PR DESCRIPTION
Fixes #15643.

### Problem

`Lint/NameTypo` reports `Time.now` and `Regexp.new` as typos when
`AllCops/ProjectIndexIncludesGems` is enabled:

```
time.rb:1:11: W: Lint/NameTypo: Possible typo: Time does not respond to now. Did you mean noon?
time.rb:2:13: W: Lint/NameTypo: Possible typo: Regexp does not respond to new. Did you mean next?
```

A namespace the interpreter provides keeps its own members out of any source
index: they are implemented in C (`Regexp.new`) or compiled into the
interpreter (`Time.now`, whose source location is `<internal:timev>`). Nothing
the index reads ever declares them.

Such a namespace still *resolves* in the index as soon as anything indexed
reopens it, and `ProjectIndexIncludesGems` makes that routine rather than
exotic — ActiveSupport reopens both `Time` and `Regexp`. Every existing
completeness guard then passes: the ancestry resolves, and
`gem_owned_namespace?` is disabled by that same option. So the handful of
members the reopening added become the whole dictionary, and a core method
missing from it looks like a typo of the nearest one.

Indexing the bundle's sources was the escape hatch #15568 added for gem
namespaces, and it works for them because gems are Ruby source. It cannot
close this hole, because there is no Ruby source to index.

There is a second way the same root cause bites, reported by @Aqualon on this
PR and now fixed here too. Any constant naming a class or module is an object
in its own right, so it answers everything `Class`/`Module`, `Object` and
`Kernel` define — `send`, `to_s`, `freeze`. Those are equally invisible to the
index, and this applies to a project's *own* classes, which resolve in the
index and are therefore trusted completely. `Bar.send` was reported as a typo
of `Bar.send_pm`.

### Fix

Recognize the names from the **RBS core signatures**. They ship with Ruby, are
versioned with it, and describe the language itself, so consulting them tells
the cop what the interpreter provides without asking RuboCop's own process
anything.

Two questions are put to core, and both are needed:

- the singleton methods of the namespace itself, when core declares it — this
  is `Time.now` and `Regexp.new`;
- the instance methods of `Class` or `Module`, which every constant naming one
  answers to — this is `Bar.send`, including for a project's own classes,
  which core does not declare at all.

The second is asked **by kind**, which is where the precision lives: core gives
`superclass` to `Class` and not to `Module`, so `Formatting.superclass` is
still a real offense. Only names core actually declares are skipped, so genuine
typos are still reported — `Time.currrent` suggests `current`, `Bar.send_pmm`
suggests `send_pm`.

Only `core` is read, never a stdlib or gem signature, so the vocabulary is
exactly what the interpreter itself provides. Nothing is loaded until the first
query, which in practice means only when a call has already passed every other
guard.

### Why this replaced the first approach

The first version of this PR asked the running Ruby instead — `Object.const_get`
on the analyzed project's constant name, plus `respond_to?` on a bare class or
module object. @viralpraxis pointed out that RuboCop's runtime is by design
separate from the code being analyzed, so that makes the cop's answer depend on
what RuboCop happens to have loaded (#14724).

That is not only theoretical. With an unrelated `::Bar` in RuboCop's own
process, the old approach silenced a **real** typo:

```ruby
# patchbar.rb — unrelated code that merely happens to be loaded
class Bar
  def self.send_pmm; end
end
```

```ruby
# typo.rb
class Bar; def send_pm; end; end

Bar.send_pmm
```

| | clean runtime | `RUBYOPT=-r./patchbar` |
| --- | --- | --- |
| runtime probe (old) | offense reported | **no offense — real typo silenced** |
| RBS signatures (new) | offense reported | offense reported |

Reading static signatures removes the whole class of inconsistency: the answer
no longer moves with RuboCop's load path.

### One open question — the `rbs` dependency

`rbs` is a **bundled** gem, not a default one, so it has to be in the bundle to
be loadable. This PR declares it in the `Gemfile` for every engine (keeping the
existing JRuby pin) rather than letting it arrive as an rdoc dependency, and
the cop degrades to leaving these names unrecognized when it cannot be loaded.

That degradation is silent, which I am not entirely happy with: a user who has
`rubydex` but not `rbs` gets today's false positives back with no hint why. The
alternative is a real `add_dependency` in the gemspec, which I did not want to
assume for a gem as widely installed as this one. Happy to switch it if you
would prefer that.

The cop is already gated on installing `rubydex`, so requiring `rbs` alongside
it is at least consistent — but the call is yours.

### Verification

Reproduced against a real bundle (`activesupport` + `rubydex`,
`ProjectIndexIncludesGems: true`) before and after. All three of the reporter's
examples are resolved, the deliberate typo still reports, and the output is now
byte-identical with and without a mutated `RUBYOPT`.

Four specs cover the suppressions and two cover the other direction. Each is
load-bearing: disabling the check fails exactly the four suppression specs, and
removing the kind-awareness fails exactly the `Formatting.superclass` one.

`bundle exec rake default` is green — 34,021 examples, 0 failures, and internal
RuboCop clean across 1,761 files.

### Known limit

Methods a stdlib library adds (`Time.rfc2822`) are equally invisible to the
index and stay uncovered: whether the analyzed project requires that library is
not something the core signatures can say. This is unchanged from before, and
strictly better than the old behavior, which answered it from whether *RuboCop*
had required it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
