### PR TITLE
Fix an incorrect autocorrect for `Style/MethodCallWithArgsParentheses` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_method_call_with_args_parentheses_20260904203132.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_method_call_with_args_parentheses_20260904203132.md
@@ -1,0 +1,1 @@
+* [#15668](https://github.com/rubocop/rubocop/pull/15668): Fix an incorrect autocorrect for `Style/MethodCallWithArgsParentheses` when `EnforcedStyle: omit_parentheses` is used together with `Style/TrailingCommaInArguments`. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -242,7 +242,7 @@ module RuboCop
         extend AutoCorrector
 
         def self.autocorrect_incompatible_with
-          [Style::NestedParenthesizedCalls, Style::RescueModifier]
+          [Style::NestedParenthesizedCalls, Style::RescueModifier, Style::TrailingCommaInArguments]
         end
 
         def on_send(node)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -359,6 +359,59 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `EnforcedStyle: omit_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/TrailingCommaInArguments`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: omit_parentheses
+      Style/TrailingCommaInArguments:
+        EnforcedStyleForMultiline: consistent_comma
+    YAML
+    source = <<~RUBY
+      do_something(
+        foo: 1,
+        bar: 2
+      )
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect-all',
+                     '--only', 'Style/MethodCallWithArgsParentheses,Style/TrailingCommaInArguments'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      do_something \\
+        foo: 1,
+        bar: 2
+
+    RUBY
+  end
+
+  it 'corrects `Style/TrailingCommaInArguments` when `EnforcedStyle: omit_parentheses` of ' \
+     '`Style/MethodCallWithArgsParentheses` keeps the parentheses' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: omit_parentheses
+      Style/TrailingCommaInArguments:
+        EnforcedStyleForMultiline: consistent_comma
+    YAML
+    source = <<~RUBY
+      value = do_something(
+        foo: 1,
+        bar: 2
+      ).result
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect-all',
+                     '--only', 'Style/MethodCallWithArgsParentheses,Style/TrailingCommaInArguments'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      value = do_something(
+        foo: 1,
+        bar: 2,
+      ).result
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with ' \
      '`EnforcedStyle: conditionals` of `Style/AndOr`' do
     create_file('.rubocop.yml', <<~YAML)


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --stdin /dev/stdin -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/MethodCallWithArgsParentheses:
  Enabled: true
  EnforcedStyle: omit_parentheses
Style/TrailingCommaInArguments:
  Enabled: true
  EnforcedStyleForMultiline: consistent_comma
YAML
) <<'RUBY'
def m
  a(
    b: 1,
    c: 2
  )
end
RUBY
Inspecting 1 file
F

Offenses:

/dev/stdin:2:4: C: [Corrected] Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
  a( ...
   ^
/dev/stdin:4:5: C: [Corrected] Style/TrailingCommaInArguments: Put a comma after the last parameter of a multiline method call.
    c: 2
    ^^^^
/dev/stdin:4:9: F: Lint/Syntax: unexpected 'end'; expected an argument
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    c: 2,
        ^
/dev/stdin:6:1: F: Lint/Syntax: unexpected 'end'; expected an argument
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^

1 file inspected, 4 offenses detected, 2 offenses corrected
====================
def m
  a \
    b: 1,
    c: 2,

end
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
