### PR TITLE
Fix an incorrect autocorrect for `Style/FloatDivision` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_float_division_20260907163615.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_float_division_20260907163615.md
@@ -1,0 +1,1 @@
+* [#15669](https://github.com/rubocop/rubocop/pull/15669): Fix an incorrect autocorrect for `Style/FloatDivision` when using `EnforcedStyle: fdiv` and the divisor is a method call with parenthesized arguments. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -149,9 +149,7 @@ module RuboCop
           receiver_source = extract_receiver_source(receiver)
           argument_source = extract_receiver_source(argument)
 
-          if argument.respond_to?(:parenthesized?) && !argument.parenthesized?
-            argument_source = "(#{argument_source})"
-          end
+          argument_source = "(#{argument_source})" unless argument.begin_type?
 
           corrector.replace(node, "#{receiver_source}.fdiv#{argument_source}")
         end

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -226,6 +226,17 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when the divisor is a method call with arguments' do
+      expect_offense(<<~RUBY)
+        a.to_f / foo(1)
+        ^^^^^^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.fdiv(foo(1))
+      RUBY
+    end
+
     it 'does not register offense on usage of fdiv' do
       expect_no_offenses('a.fdiv(b)')
     end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --stdin /dev/stdin --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/FloatDivision:
  Enabled: true
  EnforcedStyle: fdiv
YAML
) <<'RUBY'
a.to_f / foo(1)
RUBY
Inspecting 1 file
C

Offenses:

/dev/stdin:1:1: C: [Corrected] Style/FloatDivision: Prefer using fdiv for float divisions.
a.to_f / foo(1)
^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
====================
a.fdivfoo(1)
```

`parenthesized?` answers whether the method call has argument parentheses, not whether the expression is wrapped in parentheses, so a divisor such as `foo(1)` was left unwrapped. `begin_type?` asks the intended question.

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
