### PR TITLE
[Fix #15672] Fix an error for `Lint/RedundantCopDisableDirective` with repeated `push`/`pop`

### DIFF
--- a/changelog/fix_an_error_for_lint_redundant_cop_disable_directive_with_repeated_push___pop_20260908173157.md
+++ b/changelog/fix_an_error_for_lint_redundant_cop_disable_directive_with_repeated_push___pop_20260908173157.md
@@ -1,0 +1,1 @@
+* [#15672](https://github.com/rubocop/rubocop/issues/15672): Fix an error for `Lint/RedundantCopDisableDirective` when a file contains more than one `rubocop:push`/`rubocop:pop` pair. ([@koic][])

--- a/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/redundant_cop_disable_directive.rb
@@ -170,6 +170,12 @@ module RuboCop
         end
 
         def skip_directive?(comment)
+          # A cop disabled in the configuration is represented by a synthetic directive that
+          # has no comment in the source, so there is nothing to report or to remove.
+          # Its range starts at `CONFIG_DISABLED_LINE_RANGE_MIN` and runs to the end of the file,
+          # but a `pop` splits it, and the pieces in between are bounded on both sides.
+          return true if comment.is_a?(CommentConfig::ConfigDisabledCopDirectiveComment)
+
           directive = DirectiveComment.new(comment)
           directive.push? || directive.pop? || directive.next?
         end

--- a/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_cop_disable_directive_spec.rb
@@ -70,6 +70,30 @@ RSpec.describe RuboCop::Cop::Lint::RedundantCopDisableDirective, :config do
             end
           end
 
+          context 'a cop that is disabled in the config, around `push`/`pop` blocks' do
+            let(:other_cops) { { 'Metrics/MethodLength' => { 'Enabled' => false } } }
+
+            it 'returns no offense for a single block' do
+              expect_no_offenses(<<~RUBY)
+                # rubocop:push -Style/For
+                foo
+                # rubocop:pop
+              RUBY
+            end
+
+            it 'returns no offense for repeated blocks' do
+              expect_no_offenses(<<~RUBY)
+                # rubocop:push -Style/For
+                foo
+                # rubocop:pop
+
+                # rubocop:push -Style/For
+                bar
+                # rubocop:pop
+              RUBY
+            end
+          end
+
           context 'a cop that is pending in the config' do
             let(:other_cops) { { 'Metrics/MethodLength' => { 'Enabled' => 'pending' } } }
 


### PR DESCRIPTION
A cop disabled in the configuration is injected into the analysis as a synthetic directive whose disabled range starts before the first line and runs to the end of the file. `pop` closes every open range at the line before the directive and reopens it there, so a second `push`/`pop` pair leaves such a cop with a range that is bounded on both sides:

```ruby
# rubocop:push -Lint/UnusedMethodArgument
def lorem
  nil
end
# rubocop:pop

# rubocop:push -Lint/UnusedMethodArgument
def ipsum
  nil
end
# rubocop:pop
```

Both guards that keep the synthetic directive out of the report look at the bounds of the range, so the piece in between passed them and the cop tried to build a source range for a comment that does not exist in the file:

```
undefined method 'begin_pos' for an instance of
RuboCop::CommentConfig::ConfigDisabledCopDirectiveComment::Expression
```

The synthetic directive is now recognized by its type, so no piece of its range is reported, however a `push`/`pop` splits it. A single `push`/`pop` pair was unaffected, because the two pieces it produces are the ones the bound checks already covered.

Fixes #15672.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
