### PR TITLE
Fix an error for `Style/FloatDivision` cop

### DIFF
--- a/changelog/fix_an_error_for_style_float_division_20260908142956.md
+++ b/changelog/fix_an_error_for_style_float_division_20260908142956.md
@@ -1,0 +1,1 @@
+* [#15674](https://github.com/rubocop/rubocop/pull/15674): Fix an error for `Style/FloatDivision` when using `EnforcedStyle: fdiv` and one operand of a float division is itself a parenthesized float division. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/float_division.rb
+++ b/lib/rubocop/cop/style/float_division.rb
@@ -107,7 +107,7 @@ module RuboCop
               remove_to_f_method(corrector, node.receiver)
               add_to_f_method(corrector, node.first_argument)
             when :fdiv
-              correct_from_slash_to_fdiv(corrector, node, node.receiver, node.first_argument)
+              correct_from_slash_to_fdiv(corrector, node.receiver, node.first_argument)
             end
           end
         end
@@ -145,21 +145,17 @@ module RuboCop
           corrector.remove(send_node.loc.selector)
         end
 
-        def correct_from_slash_to_fdiv(corrector, node, receiver, argument)
-          receiver_source = extract_receiver_source(receiver)
-          argument_source = extract_receiver_source(argument)
+        def correct_from_slash_to_fdiv(corrector, receiver, argument)
+          remove_to_f_method(corrector, receiver) if to_f_method?(receiver)
 
-          argument_source = "(#{argument_source})" unless argument.begin_type?
+          argument_parenthesized = argument.begin_type?
+          corrector.replace(
+            receiver.source_range.end.join(argument.source_range.begin),
+            argument_parenthesized ? '.fdiv' : '.fdiv('
+          )
 
-          corrector.replace(node, "#{receiver_source}.fdiv#{argument_source}")
-        end
-
-        def extract_receiver_source(node)
-          if node.send_type? && node.method?(:to_f)
-            node.receiver.source
-          else
-            node.source
-          end
+          remove_to_f_method(corrector, argument) if to_f_method?(argument)
+          corrector.insert_after(argument, ')') unless argument_parenthesized
         end
       end
     end

--- a/spec/rubocop/cop/style/float_division_spec.rb
+++ b/spec/rubocop/cop/style/float_division_spec.rb
@@ -226,6 +226,30 @@ RSpec.describe RuboCop::Cop::Style::FloatDivision, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when the divisor is a parenthesized division' do
+      expect_offense(<<~RUBY)
+        a.to_f / (b.to_f / 2)
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+                  ^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a.fdiv(b.fdiv(2))
+      RUBY
+    end
+
+    it 'registers an offense and corrects when the dividend is a parenthesized division' do
+      expect_offense(<<~RUBY)
+        (a.to_f / b) / c.to_f
+        ^^^^^^^^^^^^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+         ^^^^^^^^^^ Prefer using `fdiv` for float divisions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        (a.fdiv(b)).fdiv(c)
+      RUBY
+    end
+
     it 'registers an offense and corrects when the divisor is a method call with arguments' do
       expect_offense(<<~RUBY)
         a.to_f / foo(1)


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/FloatDivision:
  Enabled: true
  EnforcedStyle: fdiv
YAML
) <<'RUBY'
a.to_f / (b.to_f / 2)
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
An error occurred while Style/FloatDivision cop was inspecting /dev/stdin:1:10.
parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser/source/tree_rewriter.rb:143:in 'Parser::Source::TreeRewriter#merge!'
	from lib/rubocop/cop/base.rb:399:in 'RuboCop::Cop::Base#apply_correction'
	from lib/rubocop/cop/base.rb:213:in 'RuboCop::Cop::Base#add_offense'
	from lib/rubocop/cop/style/float_division.rb:101:in 'RuboCop::Cop::Style::FloatDivision#on_send'
	from lib/rubocop/cop/commissioner.rb:145:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_restricted_cops'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
