### PR TITLE
Fix Layout/SpaceAroundOperators loop with aligned operator assignments

### DIFF
--- a/changelog/fix_an_infinite_loop_error_for_layout_space_around_operators_20260908.md
+++ b/changelog/fix_an_infinite_loop_error_for_layout_space_around_operators_20260908.md
@@ -1,0 +1,1 @@
+* [#15675](https://github.com/rubocop/rubocop/pull/15675): Fix an infinite loop between `Layout/SpaceAroundOperators` and `Layout/ExtraSpacing` with `ForceEqualSignAlignment: true` for aligned operator assignments. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -258,7 +258,7 @@ module RuboCop
           return false unless allow_for_alignment?
           return false unless with_space.source.start_with?(EXCESSIVE_SPACE)
 
-          return !aligned_with_operator?(operator) unless type == :assignment
+          return !aligned_with_operator?(operator) unless grouped_alignment_type?(type)
 
           token            = Token.new(operator, nil, operator.source)
           align_preceding  = aligned_with_preceding_equals_operator(token)
@@ -267,6 +267,10 @@ module RuboCop
                           aligned_with_subsequent_equals_operator(token) == :none
 
           aligned_with_subsequent_equals_operator(token) != :yes
+        end
+
+        def grouped_alignment_type?(type)
+          type == :assignment || (type == :special_asgn && force_equal_sign_alignment?)
         end
 
         def excess_trailing_space?(right_operand, with_space)

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -1310,5 +1310,13 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAroundOperators, :config do
         SECOND = true
       RUBY
     end
+
+    it 'allows operator assignments to be aligned with a preceding assignment' do
+      expect_no_offenses(<<~RUBY)
+        aaaa = 1
+        foo
+        b   += 2
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
With `ForceEqualSignAlignment: true` on `Layout/ExtraSpacing`, the two cops fight over operator assignments until RuboCop reports an infinite loop:

```ruby
aaaa = 1
foo
b += 2
```

`Layout/ExtraSpacing` shifts `+=` under the `=` column, then `Layout/SpaceAroundOperators` strips the padding back: its alignment-group check only handled the `:assignment` operator type, while `+=` and friends are classified as `:special_asgn` and fell into the nearest-line check, which fails across the intervening `foo` line.

`:special_asgn` operators now use the same alignment-group check, but only when `ForceEqualSignAlignment` is enabled, so the default behavior for indexed setters and operator assignments is unchanged.

This is a follow-up to #15617, which fixed the same loop when the intervening line contains another alignable operator. Reproduced on net-ssh.

Found by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz) while fuzzing gems with config permutations.