### PR TITLE
Fix an error for `Style/EndlessMethod` cop

### DIFF
--- a/changelog/fix_an_error_for_style_endless_method_20260909145046.md
+++ b/changelog/fix_an_error_for_style_endless_method_20260909145046.md
@@ -1,0 +1,1 @@
+* [#15680](https://github.com/rubocop/rubocop/pull/15680): Fix an error for `Style/EndlessMethod` when a method definition is nested inside another method definition. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -166,6 +166,8 @@ module RuboCop
           return if node.single_line? || style == :allow_always
 
           add_offense(node, message: MSG_MULTI_LINE) do |corrector|
+            next if endless_parent?(node)
+
             correct_to_multiline(corrector, node)
           end
         end
@@ -179,7 +181,7 @@ module RuboCop
             return if too_long_when_made_endless?(node)
 
             add_offense(node, message: MSG_REQUIRE_SINGLE) do |corrector|
-              corrector.replace(node, endless_replacement(node))
+              correct_to_endless(corrector, node)
             end
           end
         end
@@ -189,14 +191,22 @@ module RuboCop
           return if too_long_when_made_endless?(node)
 
           add_offense(node, message: MSG_REQUIRE_ALWAYS) do |corrector|
-            corrector.replace(node, endless_replacement(node))
+            correct_to_endless(corrector, node)
           end
         end
 
         def handle_disallow_style(node)
           return unless node.endless?
 
-          add_offense(node) { |corrector| correct_to_multiline(corrector, node) }
+          add_offense(node) do |corrector|
+            next if endless_parent?(node)
+
+            correct_to_multiline(corrector, node)
+          end
+        end
+
+        def endless_parent?(node)
+          node.parent&.any_def_type? && node.parent.endless?
         end
 
         def use_heredoc?(node)
@@ -204,6 +214,17 @@ module RuboCop
           return true if body.any_str_type? && body.heredoc?
 
           body.each_descendant(:str).any?(&:heredoc?)
+        end
+
+        def correct_to_endless(corrector, node)
+          corrector.replace(signature_to_body_range(node), ' = ')
+          corrector.remove(node.body.source_range.end.join(node.loc.end.end))
+        end
+
+        def signature_to_body_range(node)
+          signature_end = node.arguments.any? ? node.arguments.source_range.end : node.loc.name.end
+
+          signature_end.join(node.body.source_range.begin)
         end
 
         def endless_replacement(node)

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
     context 'EnforcedStyle: disallow' do
       let(:cop_config) { { 'EnforcedStyle' => 'disallow' } }
 
+      it 'registers an offense and corrects nested endless method definitions' do
+        expect_offense(<<~RUBY)
+          def a = def b = 1
+          ^^^^^^^^^^^^^^^^^ Avoid endless method definitions.
+                  ^^^^^^^^^ Avoid endless method definitions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def a
+            def b
+              1
+            end
+          end
+        RUBY
+      end
+
       it 'registers an offense for an endless method' do
         expect_offense(<<~RUBY)
           def my_method() = x
@@ -540,6 +556,22 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
           ensure
             y
           end
+        RUBY
+      end
+
+      it 'registers an offense and corrects nested method definitions' do
+        expect_offense(<<~RUBY)
+          def a
+          ^^^^^ Use endless method definitions.
+            def b
+            ^^^^^ Use endless method definitions.
+              1
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def a = def b = 1
         RUBY
       end
 


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin example.rb --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_always
YAML
) <<'RUBY'
def a
  def b
    1
  end
end
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning example.rb
An error occurred while Style/EndlessMethod cop was inspecting example.rb:2:2.
parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
        from lib/rubocop/cop/base.rb:399:in 'RuboCop::Cop::Base#apply_correction'
        from lib/rubocop/cop/base.rb:213:in 'RuboCop::Cop::Base#add_offense'
        from lib/rubocop/cop/style/endless_method.rb:191:in 'RuboCop::Cop::Style::EndlessMethod#handle_require_always_style'
        from lib/rubocop/cop/style/endless_method.rb:157:in 'RuboCop::Cop::Style::EndlessMethod#on_def'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
