### PR TITLE
Fix an incorrect autocorrect for `Style/For` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_for_20260909171037.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_for_20260909171037.md
@@ -1,0 +1,1 @@
+* [#15678](https://github.com/rubocop/rubocop/pull/15678): Fix an incorrect autocorrect for `Style/For` when using `EnforcedStyle: for` and the block body has a `rescue` or `ensure` clause. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -69,6 +69,7 @@ module RuboCop
 
           if style == :for
             return unless node.receiver
+            return if rescue_or_ensure_body?(node)
 
             add_offense(node, message: PREFER_FOR) do |corrector|
               EachToForCorrector.new(node).call(corrector)
@@ -86,6 +87,10 @@ module RuboCop
 
         def suspect_enumerable?(node)
           node.multiline? && node.method?(:each) && !node.send_node.arguments?
+        end
+
+        def rescue_or_ensure_body?(node)
+          node.body&.type?(:rescue, :ensure)
         end
       end
     end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -407,6 +407,26 @@ RSpec.describe RuboCop::Cop::Style::For, :config do
   context 'when for is the enforced style' do
     let(:cop_config) { { 'EnforcedStyle' => 'for' } }
 
+    it 'does not register an offense for a block with a `rescue` body' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each do |n|
+          puts n
+        rescue StandardError
+          handle
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a block with an `ensure` body' do
+      expect_no_offenses(<<~RUBY)
+        [1, 2, 3].each do |n|
+          puts n
+        ensure
+          cleanup
+        end
+      RUBY
+    end
+
     it 'accepts for' do
       expect_no_offenses(<<~RUBY)
         def func


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --stdin example.rb --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/For:
  Enabled: true
  EnforcedStyle: for
YAML
) <<'RUBY'
xs.each do |x|
  foo(x)
rescue StandardError
  bar
end
RUBY
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/For: Prefer for over each.
xs.each do |x| ...
^^^^^^^^^^^^^^
example.rb:3:1: F: Lint/Syntax: unexpected token kRESCUE
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
rescue StandardError
^^^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
for x in xs do
  foo(x)
rescue StandardError
  bar
end
```

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
