### PR TITLE
Fix duplicate methods in anonymous classes

### DIFF
--- a/changelog/fix_fix_false_positives_in_lint_duplicate_methods_for_20260909095952.md
+++ b/changelog/fix_fix_false_positives_in_lint_duplicate_methods_for_20260909095952.md
@@ -1,0 +1,1 @@
+* [#15679](https://github.com/rubocop/rubocop/pull/15679): Fix false positives in `Lint/DuplicateMethods` for singleton methods in separate anonymous classes. ([@rafaelfranca][])

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -316,7 +316,7 @@ module RuboCop
 
         def anon_block_scope_id(anon_block)
           parent = anon_block.parent
-          return unless parent&.type?(:any_block, :begin, :call, :casgn, :any_def)
+          return unless parent&.type?(:any_block, :begin, :call, :casgn, :ivasgn, :any_def)
 
           if (receiver = named_receiver(parent))
             "#{receiver.source}.#{parent.method_name}"

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1358,6 +1358,28 @@ RSpec.describe RuboCop::Cop::Lint::DuplicateMethods, :config do
     RUBY
   end
 
+  it 'does not register an offense for singleton methods in separate Class.new blocks assigned to an instance variable' do
+    expect_no_offenses(<<~RUBY)
+      def setup
+        @first = Class.new do
+          class << self
+            def name
+              'FIRST'
+            end
+          end
+        end
+
+        Class.new do
+          class << self
+            def name
+              'SECOND'
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense for duplicate methods inside the same Class.new block inside a block' do
     expect_offense(<<~RUBY)
       let(:klass) do


### PR DESCRIPTION
Scope `Class.new` blocks assigned to instance variables separately so singleton methods in distinct anonymous classes do not collide.

`Lint/DuplicateMethods` reported the second `name` method as a duplicate in this example:

```ruby
def setup
  @first = Class.new do
    class << self
      def name
        "FIRST"
      end
    end
  end

  Class.new do
    class << self
      def name
        "SECOND"
      end
    end
  end
end
```

The two `Class.new` calls create different classes, so the second method should not produce an offense.

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces a user-visible change. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/
