### PR TITLE
Fix an incorrect autocorrect for `Style/EndlessMethod` cop when the method body has a `rescue` or `ensure` clause

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_endless_method_20260909171607.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_endless_method_20260909171607.md
@@ -1,0 +1,1 @@
+* [#15680](https://github.com/rubocop/rubocop/pull/15680): Fix an incorrect autocorrect for `Style/EndlessMethod` when using `EnforcedStyle: require_always` and the method body has a `rescue` or `ensure` clause. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -221,7 +221,7 @@ module RuboCop
         end
 
         def can_be_made_endless?(node)
-          node.body && !node.body.begin_type? && !node.body.kwbegin_type?
+          node.body && !node.body.type?(:begin, :kwbegin, :rescue, :ensure)
         end
 
         def single_line_when_made_endless?(node)

--- a/spec/rubocop/cop/style/endless_method_spec.rb
+++ b/spec/rubocop/cop/style/endless_method_spec.rb
@@ -523,6 +523,26 @@ RSpec.describe RuboCop::Cop::Style::EndlessMethod, :config do
     context 'EnforcedStyle: require_always' do
       let(:cop_config) { { 'EnforcedStyle' => 'require_always' } }
 
+      it 'does not register an offense for a method with a `rescue` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          rescue StandardError
+            y
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for a method with an `ensure` body' do
+        expect_no_offenses(<<~RUBY)
+          def my_method
+            x
+          ensure
+            y
+          end
+        RUBY
+      end
+
       it 'does not register an offense for an endless method' do
         expect_no_offenses(<<~RUBY)
           def my_method() = x


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --stdin example.rb --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_always
YAML
) <<'RUBY'
def read_file(path)
  File.read(path)
rescue Errno::ENOENT
  nil
end
RUBY
Inspecting 1 file
F

Offenses:

example.rb:1:1: C: [Corrected] Style/EndlessMethod: Use endless method definitions.
def read_file(path) ...
^^^^^^^^^^^^^^^^^^^
example.rb:2:1: F: Lint/Syntax: unexpected token rescue
(Using Ruby 3.4 parser; configure using TargetRubyVersion parameter, under AllCops)
rescue Errno::ENOENT
^^^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
====================
def read_file(path) = File.read(path)
rescue Errno::ENOENT
  nil
```

An endless definition has no body to attach `rescue` and `ensure` clauses to, so a method whose body is one cannot be made endless.

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
