### PR TITLE
Prefer bracketed arrays under Preview

### DIFF
--- a/changelog/change_15363_prefer_bracketed_arrays_under_preview_20260910085251.md
+++ b/changelog/change_15363_prefer_bracketed_arrays_under_preview_20260910085251.md
@@ -1,0 +1,1 @@
+* [#15363](https://github.com/rubocop/rubocop/issues/15363): Set the `EnforcedStyle` of `Style/SymbolArray` and `Style/WordArray` to `brackets` under `Preview`, ahead of it becoming the default in RuboCop 2.0. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -6263,6 +6263,10 @@ Style/SymbolArray:
   VersionAdded: '0.9'
   VersionChanged: '0.49'
   EnforcedStyle: percent
+  # Expected to become the default in the next major release.
+  # Bracketed arrays are the pick of nearly every project that sets this; Standard turns the cop off instead.
+  Preview:
+    EnforcedStyle: brackets
   MinSize: 2
   SupportedStyles:
     - percent
@@ -6520,6 +6524,10 @@ Style/WordArray:
   VersionAdded: '0.9'
   VersionChanged: '1.19'
   EnforcedStyle: percent
+  # Expected to become the default in the next major release.
+  # Same preference as `SymbolArray`, and the two are configured together in practice.
+  Preview:
+    EnforcedStyle: brackets
   SupportedStyles:
     # percent style: %w(word1 word2)
     - percent


### PR DESCRIPTION
The two cops I set aside in #15681 because everyone agreed `percent` was the wrong default and nobody agreed on what replaces it: `Style/SymbolArray` and `Style/WordArray` now prefer `brackets` under `Preview`. Standard's answer is to switch the cops off; the projects that actually set them say `brackets`, 22 of 25 for `SymbolArray` and 9 of 12 for `WordArray` over the configs that inherit neither Standard nor omakase. I've gone with the setters. Keeping the cop and flipping its direction preserves the consistency check, which is the part people who keep it are paying for.

That closes the last of the style questions the corpus raised. Trailing commas and hash brace spacing stay as they are: both curated configs keep `no_comma`, and brace spacing is the one place Standard and omakase disagree, so neither has the consensus this channel is meant to carry.

Related to #15363.