### PR TITLE
Document that a changelog entry belongs in the commit it describes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,9 @@ Format (single line):
 - `spec/project_spec.rb` validates the format in CI.
 - Skip the changelog only for purely internal changes (refactors with no
   user-visible effect).
+- Generate the entry after committing the change, then amend it into that commit.
+  `rake changelog:*` names the file after the last commit subject, so committing first
+  gives the entry the right filename.
 
 ## PR and Commit Conventions
 
@@ -238,6 +241,9 @@ Format (single line):
   unrelated fixes (e.g. multiple cops, multiple false positives), give each one a
   separate commit with its own changelog entry rather than squashing them all
   into a single commit. Squash only commits that are part of the *same* fix.
+- A changelog entry belongs in the same commit as the change it describes.
+  Never add a changelog-only commit, including a follow-up that just fills in
+  the PR number. Amend the entry into the commit it belongs to instead.
 - Run `bundle exec rake` and ensure it passes before pushing.
 
 ## Common Mistakes


### PR DESCRIPTION
`AGENTS.md` already asks for one logical commit per distinct fix, but it says nothing about where the changelog entry goes. A separate commit that only adds or edits an entry (`Point changelog entry to pull request` and the like) stays in the history, because this repository merges pull requests rather than squashing them.

The `Changelog Entries` section gains the mechanics that make the rule easy to follow: `rake changelog:*` derives the filename from the last commit subject, so committing the change first and amending the entry in gives both the right filename and a single commit.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
