### PR TITLE
Add a stall watchdog to the parallel spec runner

### DIFF
--- a/tasks/spec_runner.rake
+++ b/tasks/spec_runner.rake
@@ -68,12 +68,27 @@ module RuboCop
       SUMMARY_REGEXP = /(?<=# SUMMARY BEGIN\n).*(?=\n# SUMMARY END)/m.freeze
       FAILURE_OUTPUT_REGEXP = /(?<=# FAILURES BEGIN\n\n).*(?=# FAILURES END)/m.freeze
       RERUN_REGEXP = /(?<=# RERUN BEGIN\n).+(?=\n# RERUN END)/m.freeze
+      THREAD_DUMP_SIGNAL = 'USR2'
 
       def initialize(rspec_args)
         super(Framework.new(rspec_args))
 
         @exit_when_done = false
         @failure_count = 0
+        @stall_watchdog = nil
+      end
+
+      # The test-queue master produces no output between startup and the final summary,
+      # so a single stuck worker (or a stuck suite discovery process) hangs the whole run
+      # silently until an external timeout kills the job, leaving no clue about where it
+      # was stuck. The watchdog turns such a hang into a fast failure that reports what
+      # every process was doing.
+      def execute_internal
+        install_thread_dump_signal_handler
+        start_stall_watchdog
+        super
+      ensure
+        stop_stall_watchdog
       end
 
       def run_worker(iterator)
@@ -87,6 +102,10 @@ module RuboCop
         return if @aborting
 
         @completed << worker
+        # A worker without an exit status was killed by a signal (the stall watchdog,
+        # the kernel OOM killer, ...), so its failures never reach the summary regexps
+        # and its raw output is the only trace left.
+        puts worker.output if worker.status.exitstatus.nil?
       end
 
       def summarize_worker(worker)
@@ -108,6 +127,124 @@ module RuboCop
       end
 
       private
+
+      # Installed in the master before forking so that the suite discovery
+      # process and all workers inherit it. The handler writes to `STDOUT`
+      # rather than `$stdout` because specs may temporarily replace `$stdout`,
+      # while each worker's `STDOUT` is reopened to the output file that the
+      # master collects.
+      def install_thread_dump_signal_handler
+        Signal.trap(THREAD_DUMP_SIGNAL) do
+          # rubocop:disable Style/GlobalStdStream -- Specs may replace $stdout with a StringIO.
+          STDOUT.write(thread_dump)
+          STDOUT.flush
+          # rubocop:enable Style/GlobalStdStream
+        end
+      end
+
+      def thread_dump
+        lines = ["=== Thread dump for pid #{Process.pid} (#{$PROGRAM_NAME}) ==="]
+
+        Thread.list.each do |thread|
+          lines << "--- #{thread.inspect} ---"
+          lines.concat(thread.backtrace || ['(no backtrace)'])
+        end
+
+        "#{lines.join("\n")}\n"
+      end
+
+      def start_stall_watchdog
+        return unless (deadline_minutes = stall_deadline_minutes)
+
+        @stall_watchdog = Thread.new do
+          # Runs taking longer than the deadline are considered stalled.
+          sleep(deadline_minutes * 60)
+
+          handle_stall(deadline_minutes)
+        end
+      end
+
+      def stall_deadline_minutes
+        deadline = ENV.fetch('RUBOCOP_SPEC_RUNNER_DEADLINE', nil)
+        if deadline
+          minutes = deadline.to_f
+
+          return minutes.positive? ? minutes : nil
+        end
+
+        # A parallel spec run normally takes a few minutes, so a run exceeding this deadline on CI
+        # is considered stalled. Keep the deadline well below the job-level `timeout-minutes` in
+        # the CI workflow, so that the watchdog dumps its diagnostics before the job is killed.
+        # There is no default deadline elsewhere so that slow development machines are not killed.
+        return 15.0 if ENV['GITHUB_ACTIONS'] == 'true'
+
+        nil
+      end
+
+      def handle_stall(deadline_minutes)
+        puts "The spec run did not finish within #{deadline_minutes} minutes; assuming it stalled."
+        report_master_state
+        puts thread_dump
+        request_child_thread_dumps
+
+        # Give the signaled processes time to write their thread dumps before they are killed.
+        sleep(15)
+
+        kill_stalled_processes
+      end
+
+      def report_master_state
+        puts "Suites still queued: #{@queue.size}"
+
+        if @discovering_suites_pid
+          puts "Suite discovery process #{@discovering_suites_pid} is still running."
+        end
+
+        @workers.each do |pid, worker|
+          suite_name, path = last_assignment(pid)
+          assignment = suite_name ? "#{suite_name} (#{path})" : 'with no assigned suite'
+          puts "Worker [#{worker.num}] (pid #{pid}) is still running: #{assignment}"
+        end
+      end
+
+      def last_assignment(pid)
+        # `@assignments` maps a suite to the worker it was handed to. Hash insertion order makes
+        # the last matching entry the most recently assigned suite, i.e. the one the worker is
+        # likely stuck in.
+        assignment = @assignments.to_a.reverse_each.find do |_suite, (_host, assigned_pid)|
+          assigned_pid == pid
+        end
+        return if assignment.nil?
+
+        assignment.first
+      end
+
+      def request_child_thread_dumps
+        stalled_process_ids.each do |pid|
+          Process.kill(THREAD_DUMP_SIGNAL, pid)
+        rescue Errno::ESRCH
+          nil
+        end
+      end
+
+      # SIGKILL rather than SIGTERM: a process stuck in a tight loop or a deadlock cannot be trusted
+      # to honor a catchable signal. Killing the workers also unblocks the master's final blocking
+      # reap, and killed workers count as failures in the summary, so the run exits non-zero.
+      def kill_stalled_processes
+        stalled_process_ids.each do |pid|
+          Process.kill('KILL', pid)
+        rescue Errno::ESRCH
+          nil
+        end
+      end
+
+      def stalled_process_ids
+        ([@discovering_suites_pid] + @workers.keys).compact
+      end
+
+      def stop_stall_watchdog
+        @stall_watchdog&.kill
+      end
 
       def update_count(failures)
         # The ParallelFormatter formatter doesn't try to count failures, but


### PR DESCRIPTION
Follow-up to #15573.

The test-queue master prints nothing between "Starting test-queue master" and the final summary, so when a single worker (or the suite discovery process) gets stuck, the whole run hangs silently and the existing CI logs contain zero information about where it was stuck. This is why the intermittent CI hangs occurring since 2026-05-24 have remained undiagnosed: the only record each one leaves is a cancelled job with a single line of output.

Add a watchdog to `ParallelRunner` that turns the next hang into a fast, diagnosable failure:

- The master installs a `USR2` handler that dumps all thread backtraces before forking, so the suite discovery process and every worker inherit it. The handler writes to `STDOUT` because specs may temporarily replace `$stdout`, and each worker's `STDOUT` is reopened to the output file the master collects.
- A watchdog thread in the master fires when the run exceeds a deadline (`RUBOCOP_SPEC_RUNNER_DEADLINE` in minutes; defaults to 15 minutes on GitHub Actions and to disabled elsewhere, so slow development machines are not affected). It reports the master state including the most recently assigned suite per live worker, dumps the master's own threads, signals the children to dump theirs, and then SIGKILLs them. Killing the workers unblocks the master's final blocking reap, and killed workers count as failures, so the job exits non-zero right away instead of hitting the job timeout.
- `worker_completed` now prints the raw output of a worker that has no exit status (killed by a signal, e.g. the watchdog or the kernel OOM killer), because the failure-extraction regexps find nothing in such output and the thread dump would otherwise be discarded.

Verified by running a spec with an infinite loop under a shortened deadline: the watchdog names the stuck suite, the worker's dump points at the exact looping line, and the run exits non-zero. A full `rake spec` with the watchdog enabled passes unaffected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
