### PR TITLE
Derive severity from the department and add AllCops: FailLevel

### DIFF
--- a/changelog/change_derive_default_severity_from_the_department_20260910104728.md
+++ b/changelog/change_derive_default_severity_from_the_department_20260910104728.md
@@ -1,0 +1,1 @@
+* [#15686](https://github.com/rubocop/rubocop/pull/15686): Derive a cop's default severity from its department: `Security` cops now report as `warning` and `Metrics` cops as `refactor`. ([@bbatsov][])

--- a/changelog/new_add_all_cops_fail_level_20260910104728.md
+++ b/changelog/new_add_all_cops_fail_level_20260910104728.md
@@ -1,0 +1,1 @@
+* [#15686](https://github.com/rubocop/rubocop/pull/15686): Add `AllCops: FailLevel`, the configuration equivalent of `--fail-level`. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -487,6 +487,7 @@ Layout/BeginEndAlignment:
   SupportedStylesAlignWith:
     - start_of_line
     - begin
+  # A misaligned `end` usually means a structural mistake, so this reports as a lint would.
   Severity: warning
 
 Layout/BlockAlignment:
@@ -598,6 +599,7 @@ Layout/DefEndAlignment:
   SupportedStylesAlignWith:
     - start_of_line
     - def
+  # A misaligned `end` usually means a structural mistake, so this reports as a lint would.
   Severity: warning
 
 Layout/DotPosition:
@@ -789,6 +791,7 @@ Layout/EndAlignment:
     - keyword
     - variable
     - start_of_line
+  # A misaligned `end` usually means a structural mistake, so this reports as a lint would.
   Severity: warning
 
 Layout/EndOfLine:

--- a/config/default.yml
+++ b/config/default.yml
@@ -60,6 +60,9 @@ AllCops:
     - '.git/**/*'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
+  # The lowest severity that makes a run fail. Offenses below it are still
+  # reported. Can be overridden by the `--fail-level` command line option.
+  FailLevel: refactor
   # Cop names are displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the `--no-display-cop-names`
   # option.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -86,6 +86,27 @@ default settings that all configurations inherit from. Project and personal
 default ones. If there is no `.rubocop.yml` file in the project, home or XDG
 directories, `config/default.yml` will be used.
 
+[#fail-level]
+== Choosing what fails a run
+
+By default any offense at `refactor` severity or above makes `rubocop` exit with
+a non-zero status, which is every enabled cop except those at `info`. To draw
+the line higher, so that style offenses are reported without failing the build,
+set `FailLevel`:
+
+[source,yaml]
+----
+AllCops:
+  FailLevel: warning
+----
+
+With this, only `Lint` and `Security` offenses, and anything else configured to
+report at `warning` or above, fail the run; everything below is still printed.
+The `--fail-level` command line option overrides the setting for a single run,
+and `--display-only-fail-level-offenses` hides everything below the line. See
+xref:configuration/cop_settings.adoc#severity[Severity] for what each level
+means.
+
 == Setting the target Ruby version
 
 Some checks are dependent on the version of the Ruby interpreter which the

--- a/docs/modules/ROOT/pages/configuration/cop_settings.adoc
+++ b/docs/modules/ROOT/pages/configuration/cop_settings.adoc
@@ -88,19 +88,39 @@ Style/Alias:
 
 == Severity
 
-Each cop has a default severity level based on which department it belongs
-to. The level is normally `warning` for `Lint` and `convention` for all the
-others, but this can be changed in user configuration. Cops can customize their
-severity level. Allowed values are `info`, `refactor`, `convention`, `warning`, `error`
-and `fatal`.
+Every offense carries a severity, which is what `--fail-level` and
+`AllCops: FailLevel` filter on and what the leading letter in the default output
+shows. The allowed values, from lowest to highest, are `info`, `refactor`,
+`convention`, `warning`, `error` and `fatal`.
 
-Cops with severity `info` will be reported but will not cause `rubocop` to return
-a non-zero value.
+A cop's default severity comes from its department:
 
-There is one exception from the general rule above and that is `Lint/Syntax`, a
-special cop that checks for syntax errors before the other cops are invoked. It
-cannot be disabled and its severity (`fatal`) cannot be changed in
-configuration.
+|===
+| Department | Default | What it says
+
+| `Lint`, `Security`
+| `warning`
+| The code is probably wrong: a likely bug, a security problem, or something
+  that misbehaves at runtime. Worth failing a build over.
+
+| `Metrics`
+| `refactor`
+| A maintainability smell such as size or complexity. Something to fix
+  deliberately, not something to be blocked by.
+
+| everything else
+| `convention`
+| A matter of style and consistency. The code works; it does not read the way
+  the project wants it to.
+|===
+
+`info` sits below all of these: offenses at that level are reported but never
+cause a non-zero exit, whatever the fail level.
+
+A few cops ship with a severity other than their department's, where a
+department mixes lint-like and style cops: `Bundler/InsecureProtocolSource`
+reports as a `warning` while `Bundler/OrderedGems` does not. Any cop's severity
+can be changed in configuration, and so can a whole department's:
 
 [source,yaml]
 ----
@@ -110,6 +130,14 @@ Lint:
 Metrics/CyclomaticComplexity:
   Severity: warning
 ----
+
+A cop configured this way keeps reporting exactly what it reported before; only
+the level changes. Which level makes the run fail is a separate setting, see
+xref:configuration.adoc#fail-level[Choosing what fails a run].
+
+`Lint/Syntax` is the one exception to all of this: it checks for syntax errors
+before any other cop runs, and neither its `Enabled` nor its `Severity`
+(`fatal`) can be changed in configuration.
 
 == Details
 

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -103,7 +103,7 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | Inspect files in order of modification time and stop after the first file with offenses.
 
 | `--fail-level`
-| Minimum xref:configuration/cop_settings.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like any autocorrectable offense to trigger failure, regardless of severity.
+| Minimum xref:configuration/cop_settings.adoc#severity[severity] for exit with error code. Full severity name or upper case initial can be given. Normally, autocorrected offenses are ignored. Use `A` or `autocorrect` if you'd like any autocorrectable offense to trigger failure, regardless of severity. Overrides `AllCops: FailLevel` in the configuration.
 
 | `--force-exclusion`
 | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.

--- a/lib/rubocop/config_validator.rb
+++ b/lib/rubocop/config_validator.rb
@@ -48,7 +48,7 @@ module RuboCop
 
       check_obsoletions
       alert_about_unrecognized_cops(invalid_cop_names)
-      validate_new_cops_parameter
+      validate_all_cops_parameters
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
       validate_syntax_cop
@@ -168,6 +168,21 @@ module RuboCop
     def validate_new_cops_parameter
       validate_all_cops_new_cops_parameter
       validate_department_new_cops_parameters
+    end
+
+    def validate_all_cops_parameters
+      validate_new_cops_parameter
+      validate_fail_level_parameter
+    end
+
+    def validate_fail_level_parameter
+      fail_level = @config.for_all_cops['FailLevel']
+      return if fail_level.nil? || Cop::Severity::NAMES.include?(fail_level.to_sym)
+
+      message = "invalid #{fail_level} for `FailLevel` found in #{smart_loaded_path}\n" \
+                "Valid choices are: #{Cop::Severity::NAMES.join(', ')}"
+
+      raise ValidationError, message
     end
 
     def validate_all_cops_new_cops_parameter

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -51,6 +51,11 @@ module RuboCop
       # List of methods names to restrict calls for `on_send` / `on_csend`
       RESTRICT_ON_SEND = Set[].freeze # rubocop:disable InternalAffairs/UselessRestrictOnSend -- the base class default, which cops override
 
+      # Departments whose cops report above `convention` unless a cop says
+      # otherwise. The exceptions live in `config/default.yml` as an explicit
+      # `Severity`, such as the lint-like cops in `Bundler` and `Gemspec`.
+      DEPARTMENT_SEVERITIES = { Lint: :warning, Security: :warning, Metrics: :refactor }.freeze
+
       # List of cops that should not try to autocorrect at the same
       # time as this cop
       #
@@ -568,7 +573,7 @@ module RuboCop
       end
 
       def default_severity
-        self.class.lint? ? :warning : :convention
+        DEPARTMENT_SEVERITIES.fetch(self.class.department, :convention)
       end
 
       def custom_severity

--- a/lib/rubocop/cop/severity.rb
+++ b/lib/rubocop/cop/severity.rb
@@ -21,6 +21,18 @@ module RuboCop
       #   any of `:info`, `:refactor`, `:convention`, `:warning`, `:error` or `:fatal`.
       attr_reader :name
 
+      # The lowest severity that makes a run fail: `--fail-level` when given,
+      # otherwise `AllCops: FailLevel`. `autocorrect` is a pseudo level on the
+      # command line that gates on corrections instead, so it leaves the
+      # threshold at the configured one.
+      def self.minimum_to_fail(options, config)
+        name = options[:fail_level]
+        if name.nil? || name == :autocorrect
+          name = (config&.for_all_cops&.[]('FailLevel') || :refactor).to_sym
+        end
+        new(name)
+      end
+
       def self.name_from_code(code)
         name = code.to_sym
         CODE_TABLE[name] || name

--- a/lib/rubocop/formatter/github_actions_formatter.rb
+++ b/lib/rubocop/formatter/github_actions_formatter.rb
@@ -15,6 +15,10 @@ module RuboCop
         @offenses_for_files[file] = offenses unless offenses.empty?
       end
 
+      def file_started(_file, options)
+        @config_store = options[:config_store]
+      end
+
       def finished(_inspected_files)
         @offenses_for_files.each do |file, offenses|
           offenses.each do |offense|
@@ -31,11 +35,8 @@ module RuboCop
       end
 
       def minimum_severity_to_fail
-        @minimum_severity_to_fail ||= begin
-          # Unless given explicitly as `fail_level`, `:info` severity offenses do not fail
-          name = options.fetch(:fail_level, :refactor)
-          RuboCop::Cop::Severity.new(name)
-        end
+        @minimum_severity_to_fail ||=
+          RuboCop::Cop::Severity.minimum_to_fail(options, @config_store&.for_pwd)
       end
 
       def github_severity(offense)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -651,6 +651,7 @@ module RuboCop
                                          'specified --format, or the default format',
                                          'if no format is specified.'],
       fail_level:                       ['Minimum severity for exit with error code.',
+                                         'Overrides `AllCops: FailLevel` in the configuration.',
                                          '  [A] autocorrect',
                                          '  [I] info',
                                          '  [R] refactor',

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -650,13 +650,8 @@ module RuboCop
     end
 
     def minimum_severity_to_fail
-      @minimum_severity_to_fail ||= begin
-        # Unless given explicitly as `fail_level`, `:info` severity offenses do not fail
-        name = @options[:fail_level] || :refactor
-
-        # autocorrect is a fake level - use the default
-        RuboCop::Cop::Severity.new(name == :autocorrect ? :refactor : name)
-      end
+      @minimum_severity_to_fail ||=
+        RuboCop::Cop::Severity.minimum_to_fail(@options, @config_store.for_pwd)
     end
 
     # rubocop:disable-next Metrics/MethodLength

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe 'RuboCop Project', type: :feature do
       raise errors.join("\n") unless errors.empty?
     end
 
+    it 'does not restate the severity its department already implies' do
+      cop_names.each do |cop_name|
+        severity = config.dig(cop_name, 'Severity')
+        next if severity.nil?
+
+        department = cop_name.split('/').first.to_sym
+        implied = RuboCop::Cop::Base::DEPARTMENT_SEVERITIES.fetch(department, :convention)
+        expect(severity.to_sym).not_to eq(implied),
+                                       "`#{cop_name}` sets `Severity: #{severity}`, " \
+                                       'which is already the default for its department.'
+      end
+    end
+
     it 'only overrides existing parameters in `Preview` sections' do
       cop_names.each do |cop_name|
         preview = config.dig(cop_name, 'Preview')

--- a/spec/rubocop/cli/disable_uncorrectable_spec.rb
+++ b/spec/rubocop/cli/disable_uncorrectable_spec.rb
@@ -244,11 +244,11 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
             == example.rb ==
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
-            C:  3:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
-            C:  3:  3: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
-            C:  3:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
-            C:  4:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
-            C:  4:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
+            R:  3:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
+            R:  3:  3: [Todo] Metrics/CyclomaticComplexity: Cyclomatic complexity for choose_move is too high. [7/6]
+            R:  3:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
+            R:  4:  3: [Todo] Metrics/AbcSize: Assignment Branch Condition size for choose_move is too high. [<8, 12, 6> 15.62/15]
+            R:  4:  3: [Todo] Metrics/MethodLength: Method has too many lines. [11/10]
             W:  4: 32: [Corrected] Lint/CopDirectiveSyntax: Malformed directive comment detected. Only the first directive on a line takes effect. List the cop names in a single directive instead.
 
             1 file inspected, 8 offenses detected, 8 offenses corrected
@@ -454,7 +454,7 @@ RSpec.describe 'RuboCop::CLI --disable-uncorrectable', :isolated_environment do 
           expect($stderr.string).to eq('')
           expect($stdout.string).to eq(<<~OUTPUT)
             == example.rb ==
-            C:  1:  1: [Todo] Metrics/MethodLength: Method has too many lines. [3/2]
+            R:  1:  1: [Todo] Metrics/MethodLength: Method has too many lines. [3/2]
             C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
             C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Expected at least 1 empty line after magic comments; found 0.
 

--- a/spec/rubocop/cli/fail_level_spec.rb
+++ b/spec/rubocop/cli/fail_level_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --fail-level and AllCops: FailLevel', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'cli spec behavior'
+
+  before do
+    # A convention offense (trailing whitespace) and nothing else.
+    create_file('example.rb', "# frozen_string_literal: true\n\nputs 1 \n")
+  end
+
+  it 'fails on a convention offense by default' do
+    expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+  end
+
+  context 'when the configuration raises the fail level' do
+    before do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          FailLevel: warning
+      YAML
+    end
+
+    it 'still reports the offense but exits with 0' do
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+      expect($stdout.string).to include('Layout/TrailingWhitespace')
+    end
+
+    it 'fails once a warning-level offense is present' do
+      create_file('example.rb', "# frozen_string_literal: true\n\ndef m\n  x = 1\nend\n")
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Lint/UselessAssignment')
+    end
+
+    it 'lets --fail-level override the configuration' do
+      expect(cli.run(['--fail-level', 'C', '--format', 'simple', 'example.rb'])).to eq(1)
+    end
+
+    it 'is honored by --display-only-fail-level-offenses' do
+      cli.run(['--display-only-fail-level-offenses', '--format', 'simple', 'example.rb'])
+
+      expect($stdout.string).not_to include('Layout/TrailingWhitespace')
+    end
+
+    it 'is used by the GitHub Actions formatter to pick the annotation level' do
+      cli.run(['--format', 'github', 'example.rb'])
+
+      expect($stdout.string).to include('::warning file=')
+      expect($stdout.string).not_to include('::error file=')
+    end
+  end
+
+  it 'rejects an unknown fail level' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        FailLevel: severe
+    YAML
+
+    expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(2)
+    expect($stderr.string).to include('invalid severe for `FailLevel`')
+  end
+end

--- a/spec/rubocop/cli/options_spec.rb
+++ b/spec/rubocop/cli/options_spec.rb
@@ -1376,7 +1376,7 @@ RSpec.describe 'RuboCop::CLI options', :isolated_environment do # rubocop:disabl
 
       expect(cli.run(['--format', 'emacs', '--display-style-guide', 'example1.rb'])).to eq(1)
 
-      output = "#{file}:1:6: C: [Correctable] Security/JSONLoad: " \
+      output = "#{file}:1:6: W: [Correctable] Security/JSONLoad: " \
                "Prefer `JSON.parse` over `JSON.load`. (#{urls})"
       expect($stdout.string.lines.to_a[-1]).to eq([output, ''].join("\n"))
     end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -213,6 +213,21 @@ RSpec.describe RuboCop::Cop::Cop, :config do
     expect(cop.offenses.first.severity).to eq(:convention)
   end
 
+  { 'Lint' => :warning, 'Security' => :warning, 'Metrics' => :refactor,
+    'Style' => :convention }.each do |department, severity|
+    context "for a #{department} cop", :restore_registry do
+      # Inherits from `Base` rather than the deprecated class under test, whose
+      # inheritance warning would fail the run under strict warnings.
+      let(:cop_class) { stub_cop_class("RuboCop::Cop::#{department}::TestCop") }
+
+      it "defaults to #{severity} severity" do
+        cop.add_offense(location, message: 'message')
+
+        expect(cop.send(:complete_investigation).offenses.first.severity).to eq(severity)
+      end
+    end
+  end
+
   it 'sets custom severity if present' do
     cop.config[cop.name] = { 'Severity' => 'warning' }
     cop.add_offense(nil, location: location, message: 'message')

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                This is used to prevent cops from failing silently.
                                                Default is false.
                   --fail-level SEVERITY        Minimum severity for exit with error code.
+                                               Overrides `AllCops: FailLevel` in the configuration.
                                                  [A] autocorrect
                                                  [I] info
                                                  [R] refactor


### PR DESCRIPTION
Two changes that together give severity a model it never had written down. The default level now comes from a department table in code, with `Security` joining `Lint` at `warning` and `Metrics` dropping to `refactor`, and the manual finally says what the levels mean and where the blocking line sits. Then `AllCops: FailLevel` makes that line a project setting instead of a flag in every CI script, which was the entire motivation for `--fail-level` back in 2014.

This replaces #15632. That backfill put 41 per-cop severities into the default configuration; deriving them from the department gets the same Security and Metrics outcome with no per-cop lines at all, and a project spec now rejects any `Severity` that merely restates its department. The eleven existing lines stay because they're doing real work: `Bundler` and `Gemspec` mix lint-like cops with style cops, so `Bundler/InsecureProtocolSource` reports as a warning while `Bundler/OrderedGems` doesn't, and the three `Layout` alignment cops keep the lint severity they had before they changed departments.

Who notices: nobody on the default fail level. On `--fail-level W`, Security offenses now fail the build; on `--fail-level C`, Metrics offenses no longer do. The letter in front of a Metrics offense is now `R` and in front of a Security offense `W`, and editors get the corresponding LSP levels.

One thing this doesn't do yet is put `FailLevel: warning` behind `Preview` as the 2.0 default, which is the change that would make the department rule actually mean something. `AllCops` can't carry a `Preview` section because `AllCops: Preview` is the switch itself, so that needs a small change to the preview mechanism first.