### PR TITLE
Let AllCops carry preview defaults, starting with FailLevel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,8 @@ Use it when:
 
 - **A cop's default should change in the next major release** (its `Enabled`
   state, a `Max` threshold, an `EnforcedStyle`). Add a `Preview` section to the
-  cop's entry in `config/default.yml` with the new values. This needs no code:
+  cop's entry in `config/default.yml` with the new values. `AllCops` can carry
+  one too. This needs no code:
   the configuration loader applies the section under preview and drops it
   otherwise. This is the most common case.
 - **An existing cop should start reporting a case it currently misses**, and the

--- a/changelog/change_15363_let_all_cops_carry_preview_defaults_starting_with_fail_level_20260910112404.md
+++ b/changelog/change_15363_let_all_cops_carry_preview_defaults_starting_with_fail_level_20260910112404.md
@@ -1,0 +1,1 @@
+* [#15363](https://github.com/rubocop/rubocop/issues/15363): Set `AllCops: FailLevel` to `warning` under `Preview`, so that style offenses are reported without failing the build, ahead of it becoming the default in RuboCop 2.0. ([@bbatsov][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -119,10 +119,14 @@ AllCops:
   # of extra memory proportional to the bundle's size. Has no effect when
   # `UseProjectIndex` is `false` or when RuboCop does not run inside Bundler.
   ProjectIndexIncludesGems: false
-  # Opts in to unstable behavior: cops that are `Enabled: preview`, and changes
-  # to existing cops that are not ready to be the default yet. Can be overridden
-  # by the `--preview` and `--no-preview` command line options.
-  Preview: false
+  # Projects opt in to preview with `Preview: true` here, or with the `--preview`
+  # command line option. In this file the key instead holds the `AllCops`
+  # settings expected to change in the next major release: they apply under
+  # preview and are dropped otherwise, exactly like a cop's `Preview` section.
+  Preview:
+    # Style offenses are reported but stop failing the build; `Lint` and
+    # `Security` offenses still do.
+    FailLevel: warning
 
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -102,6 +102,8 @@ AllCops:
 
 With this, only `Lint` and `Security` offenses, and anything else configured to
 report at `warning` or above, fail the run; everything below is still printed.
+This is the default under xref:versioning.adoc#preview[Preview], and is expected
+to become the default in the next major release.
 The `--fail-level` command line option overrides the setting for a single run,
 and `--display-only-fail-level-offenses` hides everything below the line. See
 xref:configuration/cop_settings.adoc#severity[Severity] for what each level

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -624,7 +624,8 @@ lifecycle a preview change follows afterwards.
 A change to a cop's *defaults* does not need `preview?` at all. Give the cop's
 entry in `config/default.yml` a `Preview` section with the values it is expected
 to adopt in the next major release, and the configuration loader applies them
-under preview:
+under preview. `AllCops` can carry such a section too, for settings like
+`FailLevel`:
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/versioning.adoc
+++ b/docs/modules/ROOT/pages/versioning.adoc
@@ -76,7 +76,9 @@ It gates three things:
 * **Changes to a cop's defaults.** A cop's entry in the default configuration
   can carry a `Preview` section holding the defaults it is expected to adopt in
   the next major release. Under preview those replace the current ones; an
-  explicit setting in your own configuration still wins over both.
+  explicit setting in your own configuration still wins over both. `AllCops`
+  can carry one as well: under preview, `FailLevel` is `warning`, so style
+  offenses are reported without failing the build.
 +
 [source,yaml]
 ----

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -175,7 +175,6 @@ module RuboCop
     # way, so the resolved configuration only ever shows what is in effect.
     def apply_preview_defaults(default_configuration, preview)
       transform(default_configuration) do |params|
-        # `AllCops: Preview` is the switch itself, not a section of defaults.
         next params unless params['Preview'].is_a?(Hash)
 
         params = params.dup

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -122,17 +122,17 @@ RSpec.describe 'RuboCop Project', type: :feature do
     end
 
     it 'only overrides existing parameters in `Preview` sections' do
-      cop_names.each do |cop_name|
-        preview = config.dig(cop_name, 'Preview')
+      (cop_names + ['AllCops']).each do |name|
+        preview = config.dig(name, 'Preview')
         next if preview.nil?
 
-        expect(preview).to be_a(Hash), "`#{cop_name}: Preview` should be a section of defaults."
-        expect(preview).not_to be_empty, "`#{cop_name}: Preview` should not be empty."
+        expect(preview).to be_a(Hash), "`#{name}: Preview` should be a section of defaults."
+        expect(preview).not_to be_empty, "`#{name}: Preview` should not be empty."
 
-        unknown = preview.keys - config[cop_name].keys
+        unknown = preview.keys - config[name].keys
         expect(unknown).to be_empty,
-                           "`#{cop_name}: Preview` overrides #{unknown.join(', ')}, " \
-                           'which the cop does not have.'
+                           "`#{name}: Preview` overrides #{unknown.join(', ')}, " \
+                           "which `#{name}` does not have."
       end
     end
 

--- a/spec/rubocop/cli/preview_spec.rb
+++ b/spec/rubocop/cli/preview_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
     end
 
     it 'runs the cop with --preview' do
-      expect(cli.run(['--preview', '--format', 'simple', 'example.rb'])).to eq(1)
+      cli.run(['--preview', '--format', 'simple', 'example.rb'])
+
       expect($stdout.string).to include('Style/For')
     end
 
@@ -39,7 +40,8 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
           Enabled: preview
       YAML
 
-      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+      cli.run(['--format', 'simple', 'example.rb'])
+
       expect($stdout.string).to include('Style/For')
     end
 
@@ -153,7 +155,8 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
             - 'nothing/**/*'
       YAML
 
-      expect(cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])).to eq(1)
+      cli.run(['--only', 'Layout/SpaceAroundOperators', '--format', 'simple', '.'])
+
       expect($stdout.string).to include('vendor/bundle/gem.rb')
     end
 
@@ -250,6 +253,49 @@ RSpec.describe 'RuboCop::CLI --preview', :isolated_environment do # rubocop:disa
       cli.run(['--preview', '--show-cops', 'Style/Documentation'])
 
       expect($stdout.string).not_to include('Preview')
+    end
+  end
+
+  context 'when `AllCops` carries preview defaults' do
+    # `AllCops: Preview` ships `FailLevel: warning`.
+    before do
+      # A convention offense (trailing whitespace) and nothing else.
+      create_file('example.rb', "# frozen_string_literal: true\n\nputs 1 \n")
+    end
+
+    it 'keeps failing on a convention offense without preview' do
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
+    end
+
+    it 'reports a convention offense without failing under --preview' do
+      expect(cli.run(['--preview', '--format', 'simple', 'example.rb'])).to eq(0)
+      expect($stdout.string).to include('Layout/TrailingWhitespace')
+    end
+
+    it 'applies the preview defaults when the config opts in' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+      YAML
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
+    end
+
+    it 'still fails on a warning-level offense under --preview' do
+      create_file('example.rb', "# frozen_string_literal: true\n\ndef m\n  x = 1\nend\n")
+
+      expect(cli.run(['--preview', '--format', 'simple', 'example.rb'])).to eq(1)
+      expect($stdout.string).to include('Lint/UselessAssignment')
+    end
+
+    it 'lets an explicit `FailLevel` win over the preview default' do
+      create_file('.rubocop.yml', <<~YAML)
+        AllCops:
+          Preview: true
+          FailLevel: refactor
+      YAML
+
+      expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
     end
   end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe RuboCop::ConfigLoader do
   end
 
   # The default configuration as it resolves: a cop's `Preview` section never
-  # survives into the loaded configuration. (`AllCops: Preview` is the switch
-  # itself and stays.)
+  # survives into the loaded configuration, and that includes the one under
+  # `AllCops`. (A project's own `AllCops: Preview: true` is a boolean, so a
+  # boolean would survive.)
   let(:default_config) do
     described_class.default_configuration.to_h.transform_values do |params|
       params.reject { |key, value| key == 'Preview' && value.is_a?(Hash) }


### PR DESCRIPTION
The last piece the severity work needed. `AllCops: Preview` is the switch that turns preview on, so `AllCops` couldn't also carry a `Preview` section of next-major defaults the way every cop can since #15660. The switch's `Preview: false` line in `config/default.yml` only ever documented the default, since the readers treat a missing key as off, so it goes, and the key in RuboCop's own file now holds the section. The resolver already consumes and strips a `Preview` hash before a project's configuration is merged, so a project's `Preview: true` never meets it.

The trade is that one key has two shapes: a boolean when a project writes it, a section when RuboCop does. I went with that over renaming the switch because it keeps `AllCops: Preview: true` as the spelling, and the whole change is a few lines; the comment in `config/default.yml` explains the dual role for whoever meets it next.

The first entry is `FailLevel: warning`. With `Lint` and `Security` at `warning` and everything else below, this is what makes the department rule from #15686 mean something: under preview, style offenses are still reported but no longer fail the build. Three existing preview specs used exit code 1 as a proxy for "the cop ran"; they now check the output, since a convention offense exiting 0 under preview is the point.

Related to #15363.