### PR TITLE
[Fix #15663] Fix an incorrect autocorrect for `Style/RedundantFetchBlock`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_redundant_fetch_block_20260910142729.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_redundant_fetch_block_20260910142729.md
@@ -1,0 +1,1 @@
+* [#15663](https://github.com/rubocop/rubocop/issues/15663): Fix an incorrect autocorrect for `Style/RedundantFetchBlock` when the key is a splat or keyword arguments. ([@jadhavgaurav][])

--- a/lib/rubocop/cop/style/redundant_fetch_block.rb
+++ b/lib/rubocop/cop/style/redundant_fetch_block.rb
@@ -74,8 +74,16 @@ module RuboCop
         def should_not_check?(send, body)
           (body&.const_type? && !check_for_constant?) ||
             (body&.str_type? && !check_for_string?) ||
-            rails_cache?(send.receiver)
+            rails_cache?(send.receiver) ||
+            splat_or_keyword_key?(send.first_argument)
         end
+
+        # A splat can stand for any number of arguments, and keyword arguments cannot be
+        # followed by a positional one, so neither form can take an appended default value.
+        # @!method splat_or_keyword_key?(node)
+        def_node_matcher :splat_or_keyword_key?, <<~PATTERN
+          {splat_type? [hash_type? !braces?]}
+        PATTERN
 
         # @!method rails_cache?(node)
         def_node_matcher :rails_cache?, <<~PATTERN

--- a/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
+++ b/spec/rubocop/cop/style/redundant_fetch_block_spec.rb
@@ -132,6 +132,41 @@ RSpec.describe RuboCop::Cop::Style::RedundantFetchBlock, :config do
         Rails.cache.fetch(:key) { :value }
       RUBY
     end
+
+    it 'does not register an offense when using `#fetch` with a splatted key' do
+      expect_no_offenses(<<~RUBY)
+        hash.fetch(*args) { 5 }
+      RUBY
+    end
+
+    it 'does not register an offense when using `&.fetch` with a splatted key' do
+      expect_no_offenses(<<~RUBY)
+        hash&.fetch(*args) { 5 }
+      RUBY
+    end
+
+    it 'does not register an offense when using `#fetch` with a keyword-splatted key' do
+      expect_no_offenses(<<~RUBY)
+        hash.fetch(**opts) { 5 }
+      RUBY
+    end
+
+    it 'does not register an offense when using `#fetch` with keyword arguments' do
+      expect_no_offenses(<<~RUBY)
+        hash.fetch(key: :value) { 5 }
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `#fetch` with a braced Hash key' do
+      expect_offense(<<~RUBY)
+        hash.fetch({ key: :value }) { 5 }
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `fetch({ key: :value }, 5)` instead of `fetch({ key: :value }) { 5 }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        hash.fetch({ key: :value }, 5)
+      RUBY
+    end
   end
 
   context 'with SafeForConstants: false' do


### PR DESCRIPTION
`Style/RedundantFetchBlock` matched any single `fetch` argument as the key, so it
appended a default value to argument forms that cannot take one.

```ruby
args = [:missing, :default]
hash = {}
hash.fetch(*args) { 5 }   # => 5
```

`rubocop --only Style/RedundantFetchBlock -A` rewrites the last line to
`hash.fetch(*args, 5)`, which raises `ArgumentError: wrong number of arguments
(given 3, expected 1..2)`. The splat can stand for any number of arguments, so
there is no way to tell from the AST that room is left for a default value. The
same correction was offered for `hash&.fetch(*args) { 5 }`.

The same matcher also covered keyword arguments, where the correction is not
merely wrong at runtime but unparsable:

```ruby
hash.fetch(**opts) { 5 }     # corrected to hash.fetch(**opts, 5)
hash.fetch(key: :value) { 5 } # corrected to hash.fetch(key: :value, 5)
```

Both results are syntax errors, since a positional argument cannot follow
keyword arguments.

The cop now skips a `fetch` whose only argument is a splat or a braceless hash.
A braced hash key is still a plain positional argument, so `hash.fetch({ key:
:value }) { 5 }` keeps registering an offense, and a spec covers that so the
guard does not grow past the broken cases.

The four new no-offense specs fail on `master` and pass with this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

Fixes #15663
