### PR TITLE
Fix an incorrect autocorrect for `Style/EndlessMethod` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_endless_method_20260909222044.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_endless_method_20260909222044.md
@@ -1,0 +1,1 @@
+* [#15689](https://github.com/rubocop/rubocop/pull/15689): Fix an incorrect autocorrect for `Style/EndlessMethod` when a method is made endless while `Style/MethodCallWithArgsParentheses` omits parentheses in its body. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/endless_method.rb
+++ b/lib/rubocop/cop/style/endless_method.rb
@@ -143,6 +143,10 @@ module RuboCop
         MSG_REQUIRE_SINGLE = 'Use endless method definitions for single line methods.'
         MSG_REQUIRE_ALWAYS = 'Use endless method definitions.'
 
+        def self.autocorrect_incompatible_with
+          [Style::MethodCallWithArgsParentheses]
+        end
+
         def on_def(node)
           return if node.assignment_method? || use_heredoc?(node)
 

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -319,6 +319,33 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'keeps parentheses when `Style/EndlessMethod` makes a method endless in the same pass' do
+    create_file('.rubocop.yml', <<~YAML)
+      AllCops:
+        TargetRubyVersion: 3.4
+      Style/EndlessMethod:
+        EnforcedStyle: require_single_line
+      Style/MethodCallWithArgsParentheses:
+        EnforcedStyle: omit_parentheses
+      Layout/SpaceInsideArrayLiteralBrackets:
+        EnforcedStyle: space
+    YAML
+    source = <<~RUBY
+      def aa
+        @bb ||= [cc].dd("ee")
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run([
+                     '--autocorrect-all', '--only',
+                     'Style/EndlessMethod,Style/MethodCallWithArgsParentheses,' \
+                     'Layout/SpaceInsideArrayLiteralBrackets'
+                   ])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def aa = @bb ||= [ cc ].dd("ee")
+    RUBY
+  end
+
   it 'corrects `EnforcedStyle: require_parentheses` of `Style/MethodCallWithArgsParentheses` with `Style/NestedParenthesizedCalls`' do
     create_file('.rubocop.yml', <<~YAML)
       Style/MethodCallWithArgsParentheses:


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --stdin /dev/stdin -A --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 4.0
Style/EndlessMethod:
  Enabled: true
  EnforcedStyle: require_single_line
Style/MethodCallWithArgsParentheses:
  Enabled: true
  EnforcedStyle: omit_parentheses
Layout/SpaceInsideArrayLiteralBrackets:
  Enabled: true
  EnforcedStyle: space
YAML
) <<'RUBY'
def aa
  @bb ||= [cc].dd("ee")
end
RUBY
Inspecting 1 file
F

Offenses:

/dev/stdin:1:1: C: [Corrected] Style/EndlessMethod: Use endless method definitions for single line methods.
def aa ...
^^^^^^
/dev/stdin:1:28: F: Lint/Syntax: unexpected string literal, expecting end-of-input
(Using Ruby 4.0 parser; configure using TargetRubyVersion parameter, under AllCops)
def aa = @bb ||= [ cc ].dd "ee"
                           ^
/dev/stdin:2:11: C: [Corrected] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
  @bb ||= [cc].dd("ee")
          ^
/dev/stdin:2:18: C: [Corrected] Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
  @bb ||= [cc].dd("ee")
                 ^^^^^^

1 file inspected, 4 offenses detected, 3 offenses corrected
====================
def aa = @bb ||= [ cc ].dd "ee"
```

`Style/MethodCallWithArgsParentheses` already keeps parentheses inside endless definition, but the definition is only made endless by the correction merged along side it -- so the two must not correct in the same pass.

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
