### PR TITLE
Do not autocorrect `Style/DisableCopsWithinSourceCodeDirective` reason offenses

### DIFF
--- a/changelog/fix_autocorrect_for_style_disable_cops_within_source_code_directive.md
+++ b/changelog/fix_autocorrect_for_style_disable_cops_within_source_code_directive.md
@@ -1,0 +1,1 @@
+* [#15690](https://github.com/rubocop/rubocop/pull/15690): Fix `Style/DisableCopsWithinSourceCodeDirective` to no longer autocorrect by removing a directive that only lacks a `--` justification when `AllowWithReason` is enabled. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -4144,7 +4144,7 @@ Style/DisableCopsWithinSourceCodeDirective:
                  Forbids disabling/enabling cops within source code.
   Enabled: false
   VersionAdded: '0.82'
-  VersionChanged: '1.90'
+  VersionChanged: '<<next>>'
   # Cop or department names. A directive is exempt only when everything it
   # disables is listed here.
   AllowedCops: []

--- a/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
+++ b/lib/rubocop/cop/style/disable_cops_within_source_code_directive.rb
@@ -33,7 +33,8 @@ module RuboCop
       # a `--` trailing justification comment is allowed, so a team can require
       # every disable to be documented instead of banning them outright. Enable
       # directives are not checked in this mode, since they end a suppression
-      # rather than start one.
+      # rather than start one. Offenses in this mode are not autocorrected,
+      # since only a human can supply the missing justification.
       #
       # This cop cannot be disabled via directive comments when it is explicitly
       # enabled with `Enabled: true`. This prevents users from bypassing the cop
@@ -128,6 +129,11 @@ module RuboCop
 
         def register_offense(comment, directive_cops, disallowed_cops)
           add_offense(comment, message: offense_message(disallowed_cops)) do |corrector|
+            # The remedy in `AllowWithReason` mode is to write the missing `--` justification,
+            # which cannot be autocorrected. Removing the directive would also unsuppress
+            # the disabled cops and let their autocorrections rewrite the annotated code.
+            next if allow_with_reason?
+
             replacement = ''
 
             if directive_cops.length != disallowed_cops.length

--- a/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
+++ b/spec/rubocop/cop/style/disable_cops_within_source_code_directive_spec.rb
@@ -318,9 +318,7 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
       RUBY
 
-      expect_correction(<<~RUBY)
-        x = 0#{trailing_whitespace}
-      RUBY
+      expect_no_corrections
     end
 
     it 'does not register an offense for a disable directive with a justification' do
@@ -343,6 +341,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
         x = 0 # rubocop:todo Layout/SpaceAroundOperators
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
       RUBY
+
+      expect_no_corrections
     end
 
     context 'when AllowedDirectives exempts todo directives' do
@@ -368,6 +368,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
           x = 0 # rubocop:disable Layout/SpaceAroundOperators
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -388,6 +390,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
           x = 0 # rubocop:disable Layout/SpaceAroundOperators
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -402,6 +406,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
           end
           # rubocop:enable Metrics
         RUBY
+
+        expect_no_corrections
       end
     end
 
@@ -413,6 +419,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
           foo # rubocop:disable Lint/Void
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
         RUBY
+
+        expect_no_corrections
       end
 
       it 'does not register an offense for a cop outside it' do
@@ -442,6 +450,8 @@ RSpec.describe RuboCop::Cop::Style::DisableCopsWithinSourceCodeDirective, :confi
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuboCop disable directives without a `--` justification comment are not permitted.
           end
         RUBY
+
+        expect_no_corrections
       end
     end
   end


### PR DESCRIPTION
With `AllowWithReason: true`, the cop demands a `--` justification (`MSG_MISSING_REASON`), but its autocorrection removed the directive altogether. The two do not match: the remedy the message asks for can only be written by a human, while the correction silently made the opposite decision of deleting a directive that the configuration permits once documented.

Worse, removing the directive unsuppresses the disabled cops, so under `-a`/`-A` their autocorrections rewrite the annotated code in the same run. This happened in rubocop's own CI workflow for #15685: the justification-less `rubocop:disable Style/GlobalStdStream` guard was deleted and `STDOUT` was rewritten to `$stdout`, breaking the very design decision the surrounding comment documents (the trap handler must write to the real stream because specs replace `$stdout`).

Report the offense without a corrector in `AllowWithReason` mode, so `-a`/`-A` leave the code untouched and a human supplies the missing justification. The other modes are unchanged: there the directive itself is not permitted, so removing it is exactly what the message asks for. This split matches `offense_message`, which selects `MSG_MISSING_REASON` whenever `AllowWithReason` is set, including when combined with `AllowedCops`/`DisallowedCops` (a justified directive is accepted by `ignored?` even for a disallowed cop, so the remedy in this mode is always to write the reason).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
