### PR TITLE
Fix Layout/RedundantLineBreak crash on nested multiline assignments

### DIFF
--- a/changelog/fix_layout_redundant_line_break_crash_on_nested_multiline_assignments_20260911150321.md
+++ b/changelog/fix_layout_redundant_line_break_crash_on_nested_multiline_assignments_20260911150321.md
@@ -1,0 +1,1 @@
+* [#15692](https://github.com/rubocop/rubocop/pull/15692): Fix `Parser::ClobberingError` for `Layout/RedundantLineBreak` when autocorrecting nested assignments with a multiline right-hand side. ([@Starlexxx][])

--- a/lib/rubocop/cop/layout/redundant_line_break.rb
+++ b/lib/rubocop/cop/layout/redundant_line_break.rb
@@ -77,7 +77,7 @@ module RuboCop
         end
 
         def check_assignment(node, _rhs)
-          return unless offense?(node)
+          return unless offense?(node) && !part_of_ignored_node?(node)
 
           register_offense(node)
         end

--- a/spec/rubocop/cop/layout/redundant_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/redundant_line_break_spec.rb
@@ -418,6 +418,19 @@ RSpec.describe RuboCop::Cop::Layout::RedundantLineBreak, :config do
         RUBY
       end
 
+      it 'registers an offense for a nested assignment with a multiline right hand side' do
+        expect_offense(<<~RUBY)
+          a = b ||= {
+          ^^^^^^^^^^^ Redundant line break detected.
+            x: 1
+          }
+        RUBY
+
+        expect_correction(<<~RUBY)
+          a = b ||= { x: 1 }
+        RUBY
+      end
+
       context 'method chains' do
         it 'properly corrects a method chain on multiple lines' do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
Running `Layout/RedundantLineBreak` autocorrection over sequel blew up with `Parser::ClobberingError` on this line in `lib/sequel/adapters/ado/access.rb`:

```ruby
index = memo[m.call(idx["INDEX_NAME"])] ||= {
  :columns=>[], :unique=>idx["UNIQUE"]
}
```

Boils down to any nested assignment with a multiline RHS, e.g.

```ruby
a = b ||= {
  x: 1
}
```

The cop registers an offense on the outer `a = ...` and then another one on the inner `b ||= ...`, and the two corrections rewrite overlapping ranges, so the rewriter bails. Interestingly the send path doesn't have this problem — `on_send` checks `part_of_ignored_node?` before registering — it's just `check_assignment` that never got the same guard. Added it there; since parents are visited before children, the outer assignment gets corrected and the inner one is skipped as part of it.

Caught by [rubocop-fuzz](https://github.com/Starlexxx/rubocop-fuzz), which fuzzes autocorrection against real-world gem code.

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/