### PR TITLE
Fix an infinite loop for `Layout/IndentationStyle` cop

### DIFF
--- a/changelog/fix_an_infinite_loop_for_layout_indentation_style_20260911024936.md
+++ b/changelog/fix_an_infinite_loop_for_layout_indentation_style_20260911024936.md
@@ -1,0 +1,1 @@
+* [#15693](https://github.com/rubocop/rubocop/pull/15693): Fix an infinite loop for `Layout/IndentationStyle` when using `EnforcedStyle: tabs` and a line is aligned with spaces following the indenting tab. ([@viralpraxis][])

--- a/lib/rubocop/cop/layout/indentation_style.rb
+++ b/lib/rubocop/cop/layout/indentation_style.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Checks that the indentation method is consistent.
       # Either tabs only or spaces only are used for indentation.
       #
+      # With `EnforcedStyle: tabs`, spaces that follow the indenting tabs are
+      # taken to be alignment rather than indentation, and are left alone.
+      #
       # @example EnforcedStyle: spaces (default)
       #   # bad
       #   # This example uses a tab to indent bar.
@@ -67,7 +70,7 @@ module RuboCop
           match = if style == :spaces
                     line.match(/\A\s*\t+/)
                   else
-                    line.match(/\A\s* +/)
+                    line.match(/\A +/)
                   end
           return unless match
 

--- a/spec/rubocop/cop/layout/indentation_style_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_style_spec.rb
@@ -162,6 +162,15 @@ RSpec.describe RuboCop::Cop::Layout::IndentationStyle, :config do
       RUBY
     end
 
+    it 'accepts spaces that align a line after the indenting tab' do
+      expect_no_offenses(<<~RUBY)
+        a = {
+        \tbb: 1,
+        \t c: 2
+        }
+      RUBY
+    end
+
     it 'accepts a line a tab other than indentation' do
       expect_no_offenses("\tfoo \t bar")
     end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/IndentationStyle:
  Enabled: true
  EnforcedStyle: tabs
Layout/HashAlignment:
  Enabled: true
  EnforcedHashRocketStyle: separator
  EnforcedColonStyle: separator
YAML
) <<'RUBY'
a = {
  bb: 1,
  c: 2
}
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
Infinite loop detected in /dev/stdin and caused by Layout/IndentationStyle -> Layout/HashAlignment, Layout/IndentationStyle -> Layout/HashAlignment
C

Offenses:

/dev/stdin:3:2: C: [Corrected] Layout/HashAlignment: Align the separators of a hash literal if they span more than one line.
	c: 2
	^^^^
/dev/stdin:3:3: C: [Corrected] Layout/IndentationStyle: Space detected in indentation.
	 c: 2
	^
```

`Layout/HashAlignment` inserts the space that aligns the separator, and `Layout/IndentationStyle` removes it again as indentation.

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
