### PR TITLE
Fix an error for `Style/HashSyntax` cop

### DIFF
--- a/changelog/fix_an_error_for_style_hash_syntax_no_mixed_keys_20260911172300.md
+++ b/changelog/fix_an_error_for_style_hash_syntax_no_mixed_keys_20260911172300.md
@@ -1,0 +1,1 @@
+* [#15694](https://github.com/rubocop/rubocop/pull/15694): Fix an error for `Style/HashSyntax` when a `no_mixed_keys` style forces hash rockets on a hash whose value repeats its key. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
+++ b/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb
@@ -97,7 +97,16 @@ module RuboCop
       end
 
       def hash_rockets_enforced?(hash_node)
-        style == :hash_rockets || force_hash_rockets?(hash_node.pairs)
+        style == :hash_rockets || force_hash_rockets?(hash_node.pairs) ||
+          no_mixed_keys_enforces_hash_rockets?(hash_node.pairs)
+      end
+
+      def no_mixed_keys_enforces_hash_rockets?(pairs)
+        case style
+        when :no_mixed_keys then !sym_indices?(pairs) || pairs.first.delimiter == '=>'
+        when :ruby19_no_mixed_keys then !sym_indices?(pairs)
+        else false
+        end
       end
 
       def enforced_shorthand_syntax

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -2031,6 +2031,86 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
       end
     end
 
+    context 'by EnforcedStyle `no_mixed_keys`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'no_mixed_keys', 'EnforcedShorthandSyntax' => 'always' }
+      end
+
+      it 'converts to hash rockets rather than to shorthand when another key is not a symbol' do
+        expect_offense(<<~RUBY)
+          f(k => 1, b: b)
+                    ^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(k => 1, :b => b)
+        RUBY
+      end
+
+      it 'converts to hash rockets rather than to shorthand when the first pair is a hash rocket' do
+        expect_offense(<<~RUBY)
+          f(:a => a, b: b)
+                     ^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(:a => a, :b => b)
+        RUBY
+      end
+
+      it 'converts to hash rockets rather than to shorthand when a later key is not a symbol' do
+        expect_offense(<<~RUBY)
+          f(a: a, k => 1)
+            ^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(:a => a, k => 1)
+        RUBY
+      end
+
+      it 'converts to shorthand when the first pair uses the Ruby 1.9 syntax' do
+        expect_offense(<<~RUBY)
+          f(a: a, :b => b)
+               ^ Omit the hash value.
+                  ^^^^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(a:, b:)
+        RUBY
+      end
+    end
+
+    context 'by EnforcedStyle `ruby19_no_mixed_keys`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'ruby19_no_mixed_keys', 'EnforcedShorthandSyntax' => 'always' }
+      end
+
+      it 'converts to hash rockets rather than to shorthand when another key is not a symbol' do
+        expect_offense(<<~RUBY)
+          f(k => 1, b: b)
+                    ^^ Don't mix styles in the same hash.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(k => 1, :b => b)
+        RUBY
+      end
+
+      it 'converts to shorthand when every key is a symbol' do
+        expect_offense(<<~RUBY)
+          f(:a => a, b: b)
+            ^^^^^ Use the new Ruby 1.9 hash syntax.
+                        ^ Omit the hash value.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          f(a:, b:)
+        RUBY
+      end
+    end
+
     context 'by UseHashRocketsWithSymbolValues' do
       let(:cop_config) do
         {


### PR DESCRIPTION
Follow-up to #15642, which stopped the hash value omission check from competing with the hash rocket correction, but only covered `EnforcedStyle: hash_rockets` and `UseHashRocketsWithSymbolValues`.

The `no_mixed_keys` styles force hash rockets too, whenever the hash cannot be written entirely in the Ruby 1.9 syntax.

An MRE:

```bash
$ bundle exec rubocop --debug --stdin f.rb --autocorrect-all --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
  TargetRubyVersion: 3.4
Style/HashSyntax:
  Enabled: true
  EnforcedStyle: no_mixed_keys
  EnforcedShorthandSyntax: always
YAML
) <<'RUBY'
f(k => 1, b: b)
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning f.rb
An error occurred while Style/HashSyntax cop was inspecting f.rb:1:10.
parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser/source/tree_rewriter.rb:143:in 'Parser::Source::TreeRewriter#merge!'
	from lib/rubocop/cop/base.rb:404:in 'RuboCop::Cop::Base#apply_correction'
	from lib/rubocop/cop/base.rb:218:in 'RuboCop::Cop::Base#add_offense'
	from lib/rubocop/cop/mixin/hash_shorthand_syntax.rb:68:in 'RuboCop::Cop::HashShorthandSyntax#register_offense'
	from lib/rubocop/cop/mixin/hash_shorthand_syntax.rb:62:in 'RuboCop::Cop::HashShorthandSyntax#on_pair'
	from lib/rubocop/cop/commissioner.rb:71:in 'RuboCop::Cop::Commissioner#on_pair'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
