### PR TITLE
Report autocorrection edits in the JSON formatter

### DIFF
--- a/changelog/new_report_autocorrection_edits_in_the_json_formatter_20260911124907.md
+++ b/changelog/new_report_autocorrection_edits_in_the_json_formatter_20260911124907.md
@@ -1,0 +1,1 @@
+* [#15695](https://github.com/rubocop/rubocop/pull/15695): Report autocorrection edits in the JSON formatter. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/formatters.adoc
+++ b/docs/modules/ROOT/pages/formatters.adoc
@@ -254,6 +254,19 @@ The JSON structure is like the following example:
             "length": 4,
             "line": 546,
             "column": 80
+          },
+          "correction": {
+            "safe": true,
+            "edits": [{
+                "start_line": 546,
+                "start_column": 80,
+                "last_line": 546,
+                "last_column": 84,
+                "begin_pos": 17046,
+                "end_pos": 17050,
+                "replacement": ""
+              }
+            ]
           }
         }, {
           "severity": "warning",
@@ -281,6 +294,32 @@ The JSON structure is like the following example:
   }
 }
 ----
+
+=== Corrections
+
+An offense that autocorrection knows how to fix carries a `correction` object
+describing the edits it would make, so a consumer can apply or review them
+without running autocorrection itself. The key is absent when there is nothing
+to apply.
+
+Each edit replaces the source between `begin_pos` and `end_pos` (byte offsets
+into the file) with `replacement`. An insertion has an empty range, a removal an
+empty replacement. The line and column fields describe the same range and follow
+the convention used by `location`.
+
+`safe` says whether a normal `rubocop -a` run would apply the correction. A cop
+marked `Safe: false` or `SafeAutoCorrect: false` still reports its edits, but
+only `-A` applies them, so a consumer applying edits itself has to make the same
+distinction.
+
+Two things to keep in mind when applying edits yourself:
+
+* The edits describe a *single* pass. Autocorrection runs repeatedly until the
+  file stops changing, so one correction can expose another. Re-run RuboCop
+  after applying a batch, the way `-a` does internally.
+* Edits from different offenses can overlap, and RuboCop resolves those
+  conflicts while correcting. Apply a batch from the end of the file backwards
+  and skip any edit that overlaps one already applied, then re-run.
 
 == JUnit Style Formatter
 

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -38,7 +38,21 @@ module RuboCop
       # Only offenses suppressed by a directive can carry one, so keep the key out of the
       # common case rather than writing a null for every cached offense.
       hash[:justification] = offense.justification if offense.justification
+      add_corrections(hash, offense)
       hash
+    end
+
+    # A corrector cannot be serialized, so the edits it would make are cached
+    # separately; without this a cache hit would report no corrections.
+    def add_corrections(hash, offense)
+      return if offense.corrections.empty?
+
+      hash[:corrections] = offense.corrections.map do |correction|
+        { begin_pos: correction.begin_pos,
+          end_pos: correction.end_pos,
+          replacement: correction.replacement }
+      end
+      hash[:correction_safe] = offense.correction_safe
     end
 
     def message(offense)
@@ -52,7 +66,19 @@ module RuboCop
       offenses.map! do |o|
         location = location_from_source_buffer(o)
         Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'], o['status'].to_sym,
-                         justification: o['justification'])
+                         justification: o['justification'],
+                         corrections: corrections_from_cache(o),
+                         correction_safe: o.fetch('correction_safe', true))
+      end
+    end
+
+    def corrections_from_cache(offense)
+      cached = offense['corrections']
+      return [] unless cached
+
+      cached.map do |correction|
+        Cop::Offense::Correction.new(correction['begin_pos'], correction['end_pos'],
+                                     correction['replacement']).freeze
       end
     end
 

--- a/lib/rubocop/cop/base.rb
+++ b/lib/rubocop/cop/base.rb
@@ -216,14 +216,8 @@ module RuboCop
         message = find_message(range_to_pass, message)
 
         status, corrector = enabled_lines?(range) ? correct(range, &block) : :disabled
-        justification = suppression_reason(range) if status == :disabled
 
-        # Since this range may be generated from Ruby code embedded in some
-        # template file, we convert it to location info in the original file.
-        range = range_for_original(range)
-
-        current_offenses << Offense.new(severity, range, message, name, status, corrector,
-                                        justification: justification)
+        current_offenses << new_offense(range, severity, message, status, corrector)
       end
 
       # This method should be overridden when a cop's behavior depends
@@ -392,6 +386,16 @@ module RuboCop
 
       private_class_method def self.restrict_on_send
         @restrict_on_send ||= self::RESTRICT_ON_SEND.to_a.freeze
+      end
+
+      # @return [Offense]
+      def new_offense(range, severity, message, status, corrector)
+        justification = suppression_reason(range) if status == :disabled
+
+        # Since this range may be generated from Ruby code embedded in some
+        # template file, we convert it to location info in the original file.
+        Offense.new(severity, range_for_original(range), message, name, status, corrector,
+                    justification: justification, correction_safe: safe_autocorrect?)
       end
 
       ### Reserved for Cop::Cop

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -86,6 +86,9 @@ module RuboCop
 
       NO_LOCATION = PseudoSourceRange.new(1, 0, '', 0, 0).freeze
 
+      EMPTY_CORRECTIONS = [].freeze
+      private_constant :EMPTY_CORRECTIONS
+
       # @api public
       #
       # @!attribute [r] justification
@@ -96,9 +99,43 @@ module RuboCop
       #   or the directive carries no reason
       attr_reader :justification
 
+      # @api public
+      #
+      # @!attribute [r] corrections
+      #
+      # @return [Array<Correction>]
+      #   the individual edits that autocorrecting this offense would make, in
+      #   source order. Empty when the offense has no correction. Unlike
+      #   {#corrector}, this survives serialization, so it is available on a
+      #   cache hit and in parallel runs.
+      attr_reader :corrections
+
+      # @api public
+      #
+      # @!attribute [r] correction_safe
+      #
+      # @return [Boolean]
+      #   whether autocorrection would apply {#corrections} in a normal `-a`
+      #   run. A cop marked `Safe: false` or `SafeAutoCorrect: false` still
+      #   builds its correction, but only `-A` applies it, so a consumer that
+      #   applies edits itself has to make the same distinction.
+      attr_reader :correction_safe
+
+      # A single edit of an autocorrection: the source range it replaces and
+      # the text it replaces it with. An insertion has an empty range, a
+      # removal an empty replacement.
+      #
+      # @api public
+      Correction = Struct.new(:begin_pos, :end_pos, :replacement) do
+        def length
+          end_pos - begin_pos
+        end
+      end
+
       # @api private
       def initialize(severity, location, message, cop_name, # rubocop:disable Metrics/ParameterLists
-                     status = :uncorrected, corrector = nil, justification: nil)
+                     status = :uncorrected, corrector = nil, justification: nil,
+                     corrections: nil, correction_safe: true)
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
 
@@ -112,15 +149,21 @@ module RuboCop
         @status = status
         @corrector = corrector
         @justification = justification.freeze
+        @corrections = (corrections || corrections_from(corrector)).freeze
+        @correction_safe = correction_safe
         freeze
       end
 
       def marshal_dump
-        [@severity, @location, @message, @cop_name, @status, @justification]
+        [@severity, @location, @message, @cop_name, @status, @justification, @corrections,
+         @correction_safe]
       end
 
       def marshal_load(array)
-        @severity, @location, @message, @cop_name, @status, @justification = array
+        @severity, @location, @message, @cop_name, @status, @justification, @corrections,
+          @correction_safe = array
+        @corrections ||= EMPTY_CORRECTIONS
+        @correction_safe = true if @correction_safe.nil?
         @line = @location.line
         @column = @location.column
       end
@@ -275,6 +318,19 @@ module RuboCop
           return result unless result.zero?
         end
         0
+      end
+
+      private
+
+      # Extracted eagerly rather than on demand because the offense is frozen,
+      # and because a corrector cannot be serialized - the cache and parallel
+      # workers would otherwise hand back offenses that have lost their edits.
+      def corrections_from(corrector)
+        return EMPTY_CORRECTIONS unless corrector
+
+        corrector.as_replacements.map do |range, replacement|
+          Correction.new(range.begin_pos, range.end_pos, replacement.freeze).freeze
+        end
       end
     end
   end

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -63,7 +63,41 @@ module RuboCop
           hash[:justification] = offense.justification
         end
 
+        # The edits autocorrection would make, so a consumer can apply or review
+        # them without running autocorrection itself. Additive, and absent when
+        # the offense has no correction.
+        hash[:correction] = correction_for(offense) unless offense.corrections.empty?
+
         hash
+      end
+
+      def correction_for(offense)
+        { safe: offense.correction_safe, edits: edits_for(offense) }
+      end
+
+      def edits_for(offense)
+        buffer = offense.location.source_buffer
+
+        offense.corrections.map do |correction|
+          # Built as a range so the columns follow the same 1-based convention
+          # as `hash_for_location`, end-exclusive column included.
+          range = ::Parser::Source::Range.new(buffer, correction.begin_pos, correction.end_pos)
+
+          hash_for_edit_range(range).merge!(
+            begin_pos: correction.begin_pos,
+            end_pos: correction.end_pos,
+            replacement: correction.replacement
+          )
+        end
+      end
+
+      def hash_for_edit_range(range)
+        {
+          start_line: range.line,
+          start_column: range.column + 1,
+          last_line: range.last_line,
+          last_column: range.last_column.zero? ? 1 : range.last_column
+        }
       end
 
       def hash_for_location(offense)

--- a/spec/rubocop/cached_data_spec.rb
+++ b/spec/rubocop/cached_data_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::CachedData, :isolated_environment do
+  include FileHelper
+
+  subject(:cached_data) { described_class.new(filename) }
+
+  let(:filename) { File.expand_path('example.rb') }
+  let(:source) { %(x = "hello"\n) }
+  let(:buffer) do
+    Parser::Source::Buffer.new(filename, source: source)
+  end
+  let(:location) { Parser::Source::Range.new(buffer, 4, 11) }
+
+  before { create_file(filename, source) }
+
+  def round_trip(offense)
+    cached_data.from_json(cached_data.to_json([offense])).first
+  end
+
+  it 'restores an offense that has no correction' do
+    offense = RuboCop::Cop::Offense.new(:convention, location, 'message', 'CopName')
+
+    restored = round_trip(offense)
+
+    expect(restored.corrections).to be_empty
+    expect(restored.correction_safe).to be(true)
+  end
+
+  # The corrector itself cannot be serialized, so without the edits being cached
+  # separately a cache hit would report a correctable offense with no edits.
+  it 'restores the edits of a correctable offense' do
+    corrector = RuboCop::Cop::Corrector.new(buffer).tap { |c| c.replace(location, "'hello'") }
+    offense = RuboCop::Cop::Offense.new(:convention, location, 'message', 'CopName',
+                                        :uncorrected, corrector)
+
+    restored = round_trip(offense)
+
+    expect(restored.corrections.map(&:to_a)).to eq([[4, 11, "'hello'"]])
+    expect(restored.correction_safe).to be(true)
+  end
+
+  it 'restores the unsafety of a correction' do
+    corrector = RuboCop::Cop::Corrector.new(buffer).tap { |c| c.replace(location, "'hello'") }
+    offense = RuboCop::Cop::Offense.new(:convention, location, 'message', 'CopName',
+                                        :uncorrected, corrector, correction_safe: false)
+
+    expect(round_trip(offense).correction_safe).to be(false)
+  end
+
+  it 'restores an offense cached before corrections were stored' do
+    legacy = JSON.dump(
+      [{ 'severity' => 'convention',
+         'location' => { 'begin_pos' => 4, 'end_pos' => 11 },
+         'message' => 'message',
+         'cop_name' => 'CopName',
+         'status' => 'uncorrected' }]
+    )
+
+    restored = cached_data.from_json(legacy).first
+
+    expect(restored.corrections).to be_empty
+    expect(restored.correction_safe).to be(true)
+  end
+end

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -21,6 +21,62 @@ RSpec.describe RuboCop::Cop::Offense do
     expect(offense.highlighted_area.source).to eq('a')
   end
 
+  describe 'corrections' do
+    let(:corrector) do
+      RuboCop::Cop::Corrector.new(location.source_buffer).tap { |c| c.replace(location, 'b') }
+    end
+
+    it 'has no corrections when the offense has no corrector' do
+      offense = described_class.new(:convention, location, 'message', 'CopName')
+
+      expect(offense.corrections).to be_empty
+      expect(offense.corrections).to be_frozen
+    end
+
+    it 'extracts the edits the corrector would make' do
+      offense = described_class.new(:convention, location, 'message', 'CopName',
+                                    :uncorrected, corrector)
+
+      expect(offense.corrections.map(&:to_a)).to eq([[0, 1, 'b']])
+    end
+
+    it 'reports a correction as safe unless told otherwise' do
+      offense = described_class.new(:convention, location, 'message', 'CopName',
+                                    :uncorrected, corrector)
+
+      expect(offense.correction_safe).to be(true)
+    end
+
+    it 'carries the unsafety of a cop that only `-A` would correct' do
+      offense = described_class.new(:convention, location, 'message', 'CopName',
+                                    :uncorrected, corrector, correction_safe: false)
+
+      expect(offense.correction_safe).to be(false)
+    end
+
+    # A corrector cannot be marshalled, so parallel workers would otherwise hand
+    # back offenses that have lost their edits.
+    it 'survives a marshal round trip' do
+      offense = described_class.new(:convention, location, 'message', 'CopName',
+                                    :uncorrected, corrector, correction_safe: false)
+
+      restored = Marshal.load(Marshal.dump(offense))
+
+      expect(restored.corrections.map(&:to_a)).to eq([[0, 1, 'b']])
+      expect(restored.correction_safe).to be(false)
+    end
+
+    it 'defaults to safe when loading an offense dumped without the flag' do
+      offense = described_class.new(:convention, location, 'message', 'CopName')
+      dumped = offense.marshal_dump[0..5]
+
+      restored = described_class.allocate.tap { |o| o.marshal_load(dumped) }
+
+      expect(restored.corrections).to be_empty
+      expect(restored.correction_safe).to be(true)
+    end
+  end
+
   it 'overrides #to_s' do
     expect(offense.to_s).to eq('C:  1:  1: message')
   end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -145,6 +145,44 @@ RSpec.describe RuboCop::Formatter::JSONFormatter do
       end
     end
 
+    it 'does not include a :correction key when the offense has no correction' do
+      expect(hash).not_to have_key(:correction)
+    end
+
+    context 'for an offense that has a correction' do
+      let(:corrector) do
+        RuboCop::Cop::Corrector.new(location.source_buffer).tap do |c|
+          c.replace(location, 'replacement')
+        end
+      end
+      let(:offense) do
+        RuboCop::Cop::Offense.new(:convention, location, 'This is message', 'CopName',
+                                  :uncorrected, corrector)
+      end
+
+      it 'includes the edits autocorrection would make' do
+        expect(hash[:correction][:edits]).to eq(
+          [{ start_line: 2, start_column: 1, last_line: 3, last_column: 6,
+             begin_pos: 2, end_pos: 10, replacement: 'replacement' }]
+        )
+      end
+
+      it 'reports the correction as safe by default' do
+        expect(hash[:correction][:safe]).to be(true)
+      end
+
+      context 'when the cop is not safe to autocorrect' do
+        let(:offense) do
+          RuboCop::Cop::Offense.new(:convention, location, 'This is message', 'CopName',
+                                    :uncorrected, corrector, correction_safe: false)
+        end
+
+        it 'reports the correction as unsafe' do
+          expect(hash[:correction][:safe]).to be(false)
+        end
+      end
+    end
+
     it 'sets value of #hash_for_location for :location key' do
       location_hash = {
         start_line: 2,


### PR DESCRIPTION
`correctable: true` never said what the fix actually was, so anything wanting to apply corrections had to run autocorrect and diff the working tree, or guess the edit from the offense message.

The edits get extracted eagerly rather than on demand, because a corrector can't be serialized and the result cache and parallel workers would otherwise hand back offenses that had quietly lost them. Cost is under 1% on a corpus of 88k offenses. Each correction also carries whether a plain `-a` would apply it, since a `SafeAutoCorrect: false` cop still builds a correction that only `-A` applies; Ruff draws the same line with `fix.applicability`.