### PR TITLE
Fix an incorrect autocorrect for `Style/MethodDefParentheses` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_method_def_parentheses_20260912025654.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_method_def_parentheses_20260912025654.md
@@ -1,0 +1,1 @@
+* [#15696](https://github.com/rubocop/rubocop/pull/15696): Fix an incorrect autocorrect for `Style/MethodDefParentheses` when using `EnforcedStyle: require_no_parentheses` and the parameters begin on a line below the method name. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -137,8 +137,9 @@ module RuboCop
           # 3. Argument lists containing an anonymous rest arguments forwarding (`*`)
           # 4. Argument lists containing an anonymous keyword rest arguments forwarding (`**`)
           # 5. Argument lists containing an anonymous block forwarding (`&`)
+          # 6. Argument lists that begin on a line below the method name
           # Removing the parens would be a syntax error here.
-          node.endless? || anonymous_arguments?(node)
+          node.endless? || anonymous_arguments?(node) || arguments_on_own_line?(node)
         end
 
         def require_parentheses?(args)
@@ -175,6 +176,13 @@ module RuboCop
           return false unless (last_argument = node.last_argument)
 
           last_argument.blockarg_type? && last_argument.name.nil?
+        end
+
+        def arguments_on_own_line?(node)
+          return false unless (first_argument = node.first_argument)
+          return false unless parentheses?(node.arguments)
+
+          node.arguments.loc.begin.line != first_argument.first_line
         end
       end
     end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -334,6 +334,40 @@ RSpec.describe RuboCop::Cop::Style::MethodDefParentheses, :config do
 
     it_behaves_like 'no parentheses'
     it_behaves_like 'endless methods'
+
+    it 'requires parens when the parameters begin on a line below the method name' do
+      expect_no_offenses(<<~RUBY)
+        def func(
+          a,
+          b
+        )
+        end
+      RUBY
+    end
+
+    it 'requires parens when a sole parameter begins on a line below the method name' do
+      expect_no_offenses(<<~RUBY)
+        def func(
+          a
+        )
+        end
+      RUBY
+    end
+
+    it 'reports an offense when the parameters begin on the method name line' do
+      expect_offense(<<~RUBY)
+        def func(a,
+                ^^^ Use def without parentheses.
+          b)
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def func a,
+          b
+        end
+      RUBY
+    end
   end
 
   context 'require_no_parentheses_except_multiline' do


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin f.rb -a --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/MethodDefParentheses:
  Enabled: true
  EnforcedStyle: require_no_parentheses
YAML
) <<'RUBY'
def foo(
  a,
  b
)
end
RUBY
configuration from /proc/self/fd/11
Inspecting 1 file
Scanning f.rb
F

Offenses:

f.rb:1:8: C: [Corrected] Style/MethodDefParentheses: Use def without parentheses.
def foo( ...
       ^
f.rb:3:4: F: Lint/Syntax: unexpected token tNL
  b ...

```

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
