### PR TITLE
Fix an incorrect autocorrect for `Layout/EmptyLinesAroundBlockBody` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_layout_empty_lines_around_block_body_20260912031334.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_layout_empty_lines_around_block_body_20260912031334.md
@@ -1,0 +1,1 @@
+* [#15697](https://github.com/rubocop/rubocop/pull/15697): Fix an incorrect autocorrect for `Layout/EmptyLinesAroundBlockBody` when using `EnforcedStyle: empty_lines` and the empty line would precede a leading dot method call. ([@viralpraxis][])

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Layout
       # Common functionality for checking if presence/absence of empty lines
       # around some kind of body matches the configuration.
-      module EmptyLinesAroundBody
+      module EmptyLinesAroundBody # rubocop:disable Metrics/ModuleLength
         extend NodePattern::Macros
         include ConfigurableEnforcedStyle
         include RangeHelp
@@ -13,6 +13,8 @@ module RuboCop
         MSG_EXTRA = 'Extra empty line detected at %<kind>s body %<location>s.'
         MSG_MISSING = 'Empty line missing at %<kind>s body %<location>s.'
         MSG_DEFERRED = 'Empty line missing before first %<type>s definition'
+
+        LEADING_DOT_TYPES = %i[tDOT tANDDOT].to_set.freeze
 
         private
 
@@ -99,10 +101,18 @@ module RuboCop
           return unless yield(processed_source.lines[line])
 
           offset = style == :empty_lines && msg.include?('end.') ? 2 : 1
+          return if style == :empty_lines && leading_dot_line?(line + offset)
+
           range = source_range(processed_source.buffer, line + offset, 0)
           add_offense(range, message: msg) do |corrector|
             EmptyLineCorrector.correct(corrector, [style, range])
           end
+        end
+
+        def leading_dot_line?(line)
+          first_token = processed_source.sorted_tokens.find { |token| token.line == line }
+
+          LEADING_DOT_TYPES.include?(first_token&.type)
         end
 
         def check_deferred_empty_line(body)

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -139,4 +139,31 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
     end
   end
+
+  context 'when `EnforcedStyle` is `empty_lines` and the body is a chained method call' do
+    let(:cop_config) { { 'EnforcedStyle' => 'empty_lines' } }
+
+    it 'accepts a leading dot at the beginning of the body' do
+      expect_no_offenses(<<~RUBY)
+        aa { bb { cc }
+        .dd }
+      RUBY
+    end
+
+    it 'accepts a leading safe navigation dot at the beginning of the body' do
+      expect_no_offenses(<<~RUBY)
+        aa { bb
+        &.cc }
+      RUBY
+    end
+
+    it 'accepts a leading dot at the end of the body' do
+      expect_no_offenses(<<~RUBY)
+        aa {
+
+          bb
+          .cc }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -A --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Layout/EmptyLinesAroundBlockBody:
  Enabled: true
  EnforcedStyle: empty_lines
Layout/SingleLineBlockChain:
  Enabled: true
YAML
) <<'RUBY'
aa { bb { cc }.dd }
RUBY
configuration from /proc/self/fd/11
Inspecting 1 file
Scanning /dev/stdin
F

Offenses:

/dev/stdin:1:15: C: [Corrected] Layout/SingleLineBlockChain: Put method call on a separate line if chained to a single line block.
aa { bb { cc }.dd }
              ^^^
/dev/stdin:2:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Empty line missing at block body beginning.
.dd }
^
/dev/stdin:3:1: F: Lint/Syntax: unexpected token tDOT
.dd }
^
```

A blank line may not precede a leading dot, so the empty line is no longer added when the line it would precede begins a chained method call. This applies to the closing side as well, and to `&.`.

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
