### PR TITLE
Fix an incorrect autocorrect for `Style/HashLookupMethod` cop

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_style_hash_lookup_method_20260912035759.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_style_hash_lookup_method_20260912035759.md
@@ -1,0 +1,1 @@
+* [#15698](https://github.com/rubocop/rubocop/pull/15698): Fix an incorrect autocorrect for `Style/HashLookupMethod` when the lookup is the target of a compound assignment. ([@viralpraxis][])

--- a/lib/rubocop/cop/style/hash_lookup_method.rb
+++ b/lib/rubocop/cop/style/hash_lookup_method.rb
@@ -81,7 +81,12 @@ module RuboCop
         end
 
         def offense_for_fetch?(node)
-          style == :fetch && node.method?(:[]) && node.arguments.one?
+          style == :fetch && node.method?(:[]) && node.arguments.one? &&
+            !compound_assignment_target?(node)
+        end
+
+        def compound_assignment_target?(node)
+          node.parent&.type?(:op_asgn, :or_asgn, :and_asgn) && node.parent.children.first == node
         end
 
         def correct_fetch_to_brackets(corrector, node)

--- a/spec/rubocop/cop/style/hash_lookup_method_spec.rb
+++ b/spec/rubocop/cop/style/hash_lookup_method_spec.rb
@@ -173,6 +173,50 @@ RSpec.describe RuboCop::Cop::Style::HashLookupMethod, :config do
     end
   end
 
+  context 'with `EnforcedStyle: fetch` and a compound assignment' do
+    let(:cop_config) { { 'EnforcedStyle' => 'fetch' } }
+
+    it 'does not register an offense when the lookup is the target of `||=`' do
+      expect_no_offenses(<<~RUBY)
+        a[:x] ||= b
+      RUBY
+    end
+
+    it 'does not register an offense when the lookup is the target of `&&=`' do
+      expect_no_offenses(<<~RUBY)
+        a[:x] &&= b
+      RUBY
+    end
+
+    it 'does not register an offense when the lookup is the target of `+=`' do
+      expect_no_offenses(<<~RUBY)
+        a[:x] += b
+      RUBY
+    end
+
+    it 'registers an offense when the lookup is the value of `||=`' do
+      expect_offense(<<~RUBY)
+        a[:x] ||= b[:y]
+                  ^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        a[:x] ||= b.fetch(:y)
+      RUBY
+    end
+
+    it 'registers an offense when the lookup is the value of a plain assignment' do
+      expect_offense(<<~RUBY)
+        x = a[:y]
+            ^^^^^ Use `Hash#fetch` instead of `Hash#[]`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x = a.fetch(:y)
+      RUBY
+    end
+  end
+
   context "when `AllowedReceivers: ['Rails.cache']`" do
     let(:cop_config) { { 'AllowedReceivers' => ['Rails.cache'] } }
 


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -A --config <(cat <<'YAML'
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Style/HashLookupMethod:
  Enabled: true
  EnforcedStyle: fetch
YAML
) <<'RUBY'
ENV["AA"] ||= bb
RUBY
configuration from /proc/self/fd/11
Inspecting 1 file
Scanning /dev/stdin
F

Offenses:

/dev/stdin:1:1: C: [Corrected] Style/HashLookupMethod: Use Hash#fetch instead of Hash#[].
ENV["AA"] ||= bb
^^^^^^^^^
/dev/stdin:1:17: F: Lint/Syntax: unexpected token tOP_ASGN
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
ENV.fetch("AA") ||= bb
                ^^^
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
