### PR TITLE
Add --max-offenses-per-cop to cap a single cop's output

### DIFF
--- a/changelog/new_add_max_offenses_per_cop_to_cap_how_much_a_single_cop_can_report_20260912090312.md
+++ b/changelog/new_add_max_offenses_per_cop_to_cap_how_much_a_single_cop_can_report_20260912090312.md
@@ -1,0 +1,1 @@
+* [#15699](https://github.com/rubocop/rubocop/pull/15699): Add `--max-offenses-per-cop` to cap how many offenses a single cop reports. ([@bbatsov][])

--- a/docs/modules/ROOT/pages/usage/cli_reference.adoc
+++ b/docs/modules/ROOT/pages/usage/cli_reference.adoc
@@ -81,6 +81,9 @@ $ rubocop --only Rails/Blank,Layout/HeredocIndentation,Naming/FileName
 | `--display-suppressed`
 | Also output offenses suppressed by directive comments, tagged `[Suppressed]` (with their `--` justification in the JSON formatter). Suppressed offenses do not affect the exit code.
 
+| `--max-offenses-per-cop=COUNT`
+| Report at most `COUNT` offenses per cop across the whole run. Like the other display filters, offenses beyond the limit are not reported and do not count towards the totals; a note on stderr says how many were held back and which cops they came from.
+
 | `--enable-all-cops`
 | Run with all cops enabled, including those disabled by default. Overrides `AllCops/EnabledByDefault` and `AllCops/DisabledByDefault` in configuration files.
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -13,7 +13,8 @@ module RuboCop
     DEFAULT_PARALLEL_OPTIONS = %i[
       color config debug display_style_guide display_time display_only_fail_level_offenses
       display_only_failed editor_mode except extra_details fail_level fix_layout format formatters
-      ignore_disable_comments lint only only_guide_cops out preview require safe
+      ignore_disable_comments lint max_offenses_per_cop only only_guide_cops out preview require
+      safe
       autocorrect safe_autocorrect autocorrect_all
     ].freeze
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -148,6 +148,9 @@ module RuboCop
         option(opts, '--display-only-correctable')
         option(opts, '--display-only-safe-correctable')
         option(opts, '--display-suppressed')
+        option(opts, '--max-offenses-per-cop COUNT') do
+          @validator.validate_max_offenses_per_cop_option
+        end
       end
     end
 
@@ -556,6 +559,12 @@ module RuboCop
             'compare against HEAD.'
     end
 
+    def validate_max_offenses_per_cop_option
+      return if /^[1-9]\d*$/.match?(@options[:max_offenses_per_cop])
+
+      raise OptionParser::InvalidArgument, '--max-offenses-per-cop must be a positive integer'
+    end
+
     def validate_exclude_limit_option
       return if /^\d+$/.match?(@options[:exclude_limit])
 
@@ -611,6 +620,11 @@ module RuboCop
                                          'when running --auto-gen-config, except if the',
                                          'number of files with offenses is bigger than',
                                          'exclude-limit. Default is false.'],
+      max_offenses_per_cop:             ['Report at most COUNT offenses per cop across the',
+                                         'whole run, so a single noisy cop cannot bury the',
+                                         'rest. Offenses beyond the limit are not reported',
+                                         'and do not count towards the totals, the same way',
+                                         'the other display filters work.'],
       exclude_limit:                    ['Set the limit for how many files to explicitly exclude.',
                                          'If there are more files than the limit, the cop will',
                                          "be disabled instead. Default is #{MAX_EXCL}."],

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -173,6 +173,7 @@ module RuboCop
       end
       formatter_set.finished(@inspected_files.freeze)
       formatter_set.close_output_files
+      warn_about_elided_offenses
     end
 
     def file_iterator(files, &block)
@@ -630,7 +631,40 @@ module RuboCop
     end
 
     def offenses_to_report(offenses)
-      offenses.select { |o| offense_displayed?(o) }
+      offenses = offenses.select { |o| offense_displayed?(o) }
+      offenses = offenses.select { |o| within_offense_limit?(o) } if max_offenses_per_cop
+      offenses
+    end
+
+    def max_offenses_per_cop
+      return @max_offenses_per_cop if defined?(@max_offenses_per_cop)
+
+      @max_offenses_per_cop = @options[:max_offenses_per_cop]&.to_i
+    end
+
+    # Counted across the whole run rather than per file, since a cop that fires
+    # a handful of times in every file is exactly the one worth capping. Files
+    # are reported in order, so which offenses survive does not depend on how
+    # the run was parallelized.
+    def within_offense_limit?(offense)
+      reported = (@offenses_reported_per_cop ||= Hash.new(0))
+      count = reported[offense.cop_name] += 1
+
+      return true if count <= max_offenses_per_cop
+
+      (@offenses_elided_per_cop ||= Hash.new(0))[offense.cop_name] += 1
+      false
+    end
+
+    def warn_about_elided_offenses
+      return if @offenses_elided_per_cop.nil? || @offenses_elided_per_cop.empty?
+
+      total = @offenses_elided_per_cop.values.sum
+      cops = @offenses_elided_per_cop.keys.sort.join(', ')
+      warn Rainbow(
+        "#{total} more offenses were not reported because of " \
+        "--max-offenses-per-cop=#{max_offenses_per_cop} (#{cops})."
+      ).yellow
     end
 
     def supports_safe_autocorrect?(offense)

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -185,6 +185,11 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                when combined with --display-only-correctable.
                   --display-suppressed         Also output offenses suppressed by directive
                                                comments. They do not affect the exit code.
+                  --max-offenses-per-cop COUNT Report at most COUNT offenses per cop across the
+                                               whole run, so a single noisy cop cannot bury the
+                                               rest. Offenses beyond the limit are not reported
+                                               and do not count towards the totals, the same way
+                                               the other display filters work.
 
           Autocorrection:
               -a, --autocorrect                Autocorrect offenses (only when it's safe).
@@ -414,6 +419,26 @@ RSpec.describe RuboCop::Options, :isolated_environment do
           expect { options.parse ['--display-only-fail-level-offenses', o] }
             .not_to raise_error(RuboCop::OptionArgumentError)
         end
+      end
+    end
+
+    describe '--max-offenses-per-cop' do
+      it 'accepts a positive integer' do
+        options.parse %w[--max-offenses-per-cop 3]
+
+        expect(options.instance_variable_get(:@options)[:max_offenses_per_cop]).to eq('3')
+      end
+
+      %w[0 -1 abc 1.5].each do |value|
+        it "rejects #{value.inspect}" do
+          expect { options.parse ['--max-offenses-per-cop', value] }
+            .to raise_error(OptionParser::InvalidArgument)
+        end
+      end
+
+      it 'requires an argument' do
+        expect { options.parse %w[--max-offenses-per-cop] }
+          .to raise_error(OptionParser::MissingArgument)
       end
     end
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -615,6 +615,57 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
 
         before { create_file('example.rb', source) }
 
+        context '--max-offenses-per-cop' do
+          let(:options) do
+            {
+              formatters: [['progress', formatter_output_path]],
+              max_offenses_per_cop: '1'
+            }
+          end
+          let(:source) { <<~RUBY }
+            # frozen_string_literal: true
+
+            x = "a"
+            y = "b"
+            z = "c"
+            puts x, y, z
+          RUBY
+
+          it 'reports only the first offense of a cop that fires repeatedly' do
+            runner.run([])
+
+            expect(formatter_output.scan('Style/StringLiterals').size).to eq(1)
+          end
+
+          it 'counts only the offenses it reported' do
+            runner.run([])
+
+            expect(formatter_output).to include('1 file inspected, 1 offense detected')
+          end
+
+          it 'still fails the run' do
+            expect(runner.run([])).to be false
+          end
+
+          it 'names the cops it held back on stderr' do
+            expect { runner.run([]) }.to output(
+              %r{2 more offenses were not reported .*max-offenses-per-cop=1.*Style/StringLiterals}m
+            ).to_stderr
+          end
+
+          context 'when no cop exceeds the limit' do
+            let(:source) { <<~RUBY }
+              # frozen_string_literal: true
+
+              puts "a"
+            RUBY
+
+            it 'says nothing on stderr' do
+              expect { runner.run([]) }.not_to output.to_stderr
+            end
+          end
+        end
+
         context '--display-only-safe-correctable' do
           let(:options) do
             {


### PR DESCRIPTION
A run with thousands of offenses is dominated by whichever cop fires most, which buries everything else. Capping per cop makes a first run on a legacy codebase skimmable, and keeps the output inside a size budget when something else is consuming it.

The count is per cop across the whole run, not per file, since a cop firing a few times in every file is the one worth capping. It filters where the other display options filter, so the totals reflect what was reported, the same way `--display-only-correctable` already behaves. Dropping offenses silently would be worse than useless, so a note on stderr says how many were held back and which cops they came from, out of the way of the JSON.