### PR TITLE
Fix an error when interrupting RuboCop with `Ctrl-C`

### DIFF
--- a/changelog/fix_an_error_when_interrupting_rubo_cop_with_ctrl_c_20260912105245.md
+++ b/changelog/fix_an_error_when_interrupting_rubo_cop_with_ctrl_c_20260912105245.md
@@ -1,0 +1,1 @@
+* [#15702](https://github.com/rubocop/rubocop/pull/15702): Fix an error when interrupting RuboCop with `Ctrl-C`. ([@viralpraxis][])

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -158,6 +158,7 @@ module RuboCop
 
     def inspect_files(files) # rubocop:disable Metrics/AbcSize
       formatter_set.started(files)
+      formatters_started = true
       file_iterator(files) do |file|
         offenses = process_file(file)
         succeeded = offenses.none? { |o| considered_failure?(o) && offense_displayed?(o) }
@@ -171,7 +172,7 @@ module RuboCop
       if files.size > 1 && cached_run?
         ResultCache.cleanup(@config_store, @options[:debug], @options[:cache_root])
       end
-      formatter_set.finished(@inspected_files.freeze)
+      formatter_set.finished(@inspected_files.freeze) if formatters_started
       formatter_set.close_output_files
     end
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -40,6 +40,38 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       Signal.trap('INT', old_handler)
     end
 
+    context 'when a formatter raises while starting' do
+      let(:interrupting_formatter) do
+        Class.new(RuboCop::Formatter::ProgressFormatter) do
+          def started(_target_files)
+            raise Interrupt
+          end
+        end
+      end
+
+      it 'aborts cleanly instead of raising from the formatter' do
+        runner = described_class.new({ formatters: [[interrupting_formatter]] },
+                                     RuboCop::ConfigStore.new)
+
+        expect(runner.run(['example.rb'])).to be(false)
+        expect(runner).to be_aborting
+      end
+
+      it 'does not replace an error raised by an earlier formatter' do
+        failing_formatter = Class.new(RuboCop::Formatter::ProgressFormatter) do
+          def started(_target_files)
+            raise 'formatter boom'
+          end
+        end
+        runner = described_class.new(
+          { formatters: [[failing_formatter], ['progress', formatter_output_path]] },
+          RuboCop::ConfigStore.new
+        )
+
+        expect { runner.run(['example.rb']) }.to raise_error(RuntimeError, 'formatter boom')
+      end
+    end
+
     context 'with SIGINT' do
       it 'returns false' do
         skip '`Process` does not respond to `fork` method.' unless Process.respond_to?(:fork)


### PR DESCRIPTION
An interruption could arrive after entering the `inspect_files` method, but before the formatter starts (`formatter_set.started(files)`).

The `ensure` block assumes the formatter started, which is not guaranteed.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
