### PR TITLE
Fix test suite hanging

### DIFF
--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'io/wait'
+
 module RuboCop
   class Runner
     attr_writer :errors # Needed only for testing.
@@ -23,15 +25,12 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       Process.kill 'INT', pid
     end
 
-    def wait_for_input(io)
-      line = nil
-
-      until line
-        line = io.gets
-        sleep 0.1
+    def wait_for_input(io, timeout: 30)
+      unless io.wait_readable(timeout)
+        raise "the forked runner produced no output within #{timeout}s"
       end
 
-      line
+      io.gets or raise 'the forked runner exited without writing a line'
     end
 
     around do |example|
@@ -54,7 +53,11 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         pid = Process.fork do
           rd.close
           wr.puts 'READY'
-          wr.puts runner.run(['example.rb'])
+          begin
+            wr.puts runner.run(['example.rb'])
+          rescue Exception => e # rubocop:disable Lint/RescueException -- all the deaths are unexpected, so we want to report it
+            wr.puts "EXCEPTION #{e.class}: #{e.message} (cause: #{e.cause.class})"
+          end
           wr.close
         end
 
@@ -70,6 +73,15 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         # Make sure the runner returns false
         line = wait_for_input(rd)
         expect(line.chomp).to eq('false')
+      ensure
+        if pid
+          begin
+            Process.kill('KILL', pid)
+            Process.waitpid(pid)
+          rescue Errno::ESRCH, Errno::ECHILD
+            nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Previous implementation assumed that the forked process actually writes something, which is not the case if it raises. `sleep`-based polling led to hanging.

An example of what could raise inside `Process.fork`: https://github.com/rubocop/rubocop/pull/15702

Might fix the root cause of https://github.com/rubocop/rubocop/pull/15685


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
