### PR TITLE
Fix a race condition in the `Runner` SIGINT spec

### DIFF
--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -75,12 +75,20 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
       it 'returns false' do
         skip '`Process` does not respond to `fork` method.' unless Process.respond_to?(:fork)
 
-        # Make sure the runner works slowly and thus is interruptible
-        allow(runner).to receive(:process_file) do
-          sleep 99
-        end
-
         rd, wr = IO.pipe
+
+        # Make sure the runner works slowly and thus is interruptible, and signal when
+        # the forked child is inside `Runner#run`, whose `rescue Interrupt` turns
+        # the interrupt into an abort. An interrupt delivered before that point kills
+        # the child before it can write anything.
+        allow(runner).to receive(:process_file) do
+          wr.puts 'PROCESSING'
+          # The duration only has to outlast `wait_for_input`'s timeout, so that an interrupt
+          # that never arrives is reported there instead of letting the run finish on its own
+          # and write `true`.
+          sleep 99
+          []
+        end
 
         pid = Process.fork do
           rd.close
@@ -98,6 +106,10 @@ RSpec.describe RuboCop::Runner, :isolated_environment do
         # Make sure the runner has started by waiting for a specific message
         line = wait_for_input(rd)
         expect(line.chomp).to eq('READY')
+
+        # Wait until the runner is inside its interrupt-protected region.
+        line = wait_for_input(rd)
+        expect(line.chomp).to eq('PROCESSING')
 
         # Interrupt the runner
         interrupt(pid)


### PR DESCRIPTION
The "with SIGINT" example forks a child that writes READY and then calls `Runner#run`, while the parent sends SIGINT as soon as it reads READY. The surrounding hook sets `Signal.trap('INT', 'DEFAULT')`, which restores Ruby's default handling: the signal raises `Interrupt` in the child's main thread (verified with a forked probe). `Runner#run` rescues `Interrupt` across its whole body, so an interrupt landing inside `run` aborts cleanly and the child writes "false". But an interrupt landing in the few instructions between the READY write and the entry into the protected region kills the child before it writes anything, and the parent reads EOF. The pipe write itself wakes the parent, so the child being preempted right after READY while the parent reads and kills within its slice is a realistic schedule on a loaded CI runner.

Before #15703, that EOF made `wait_for_input` spin forever in `until line; line = io.gets; sleep 0.1; end`, hanging the worker with no output: this race is the root cause of the intermittent silent CI hangs observed since 2026-05-24, which only ever hit the fork-based ubuntu jobs (JRuby and Windows skip this example). #15703 turned the hang into a fast, diagnosable failure, but also removed the 0.1s pause after READY, so the parent now interrupts sooner and the race fires more often: on the day it merged, the following runs failed on their first attempts with "the forked runner exited without writing a line" in three jobs.

- https://github.com/rubocop/rubocop/actions/runs/34687217742
- https://github.com/rubocop/rubocop/actions/runs/34687235500

Close the race structurally instead of narrowing it: the mocked `process_file` now writes PROCESSING to the pipe before sleeping, and the parent interrupts only after reading it. PROCESSING is written from inside the file iteration, i.e. inside the `rescue Interrupt` region, so an interrupt sent after it always takes the abort path. The READY handshake stays to distinguish fork boot problems, and the timeout, crash reporter, and ensure-kill backstops from #15703 are unchanged.

The example passed 40 consecutive runs after the change.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
