### PR TITLE
[Fix #15570] Fix false unused todo reports for glob exclusions

### DIFF
--- a/changelog/fix_false_unused_todo_reports_for_glob_exclusions_20260912232959.md
+++ b/changelog/fix_false_unused_todo_reports_for_glob_exclusions_20260912232959.md
@@ -1,0 +1,1 @@
+* [#15570](https://github.com/rubocop/rubocop/issues/15570): Fix false unused todo reports for glob exclusions. ([@aprylewu][])

--- a/lib/rubocop/todo_audit.rb
+++ b/lib/rubocop/todo_audit.rb
@@ -21,8 +21,11 @@ module RuboCop
       entries = todo_exclude_entries
       return [] if entries.empty?
 
-      offending_cops = offending_cops_without_todo(entries)
-      entries.reject { |entry| offending_cops[absolute(entry.path)]&.include?(entry.cop_name) }
+      files_by_entry = entries.to_h { |entry| [entry, expand_path(entry.path)] }
+      offending_cops = offending_cops_without_todo(files_by_entry)
+      entries.reject do |entry|
+        files_by_entry[entry].any? { |file| offending_cops[file]&.include?(entry.cop_name) }
+      end
     end
 
     def todo_file
@@ -62,13 +65,30 @@ module RuboCop
     # Inspects every file the todo entries mention, with the todo exclusions
     # subtracted from the configuration, and returns the names of the cops
     # that still report offenses, keyed by absolute file path.
-    def offending_cops_without_todo(entries)
-      files = entries.map { |entry| absolute(entry.path) }.uniq.select { |file| File.file?(file) }
-
-      files.to_h do |file|
+    def offending_cops_without_todo(files_by_entry)
+      entries = files_by_entry.keys
+      files_by_entry.values.flatten.uniq.to_h do |file|
         offenses = inspect_file(file, entries)
         [file, offenses.to_set(&:cop_name)]
       end
+    end
+
+    def expand_path(path)
+      absolute_path = absolute(path)
+      files = File.file?(absolute_path) ? [absolute_path] : []
+      return files unless PathUtil.glob?(path)
+
+      files | target_files(absolute_path).select do |file|
+        PathUtil.match_path?(absolute_path, file)
+      end
+    end
+
+    def target_files(path)
+      directory = File.dirname(path)
+      directory = File.dirname(directory) while PathUtil.glob?(directory)
+      @target_files ||= {}
+      @target_files[directory] ||= TargetFinder.new(@config_store, @options)
+                                               .target_files_in_dir(directory)
     end
 
     def inspect_file(file, entries)

--- a/spec/rubocop/cli/report_unused_todo_entries_spec.rb
+++ b/spec/rubocop/cli/report_unused_todo_entries_spec.rb
@@ -62,6 +62,144 @@ RSpec.describe 'RuboCop::CLI --report-unused-todo-entries', :isolated_environmen
     end
   end
 
+  context 'when todo entries contain glob patterns' do
+    before do
+      create_file('spec/nested/offending_spec.rb', <<~RUBY)
+        # frozen_string_literal: true
+
+        @@bad = 1
+        puts @@bad
+      RUBY
+      create_file('.rubocop_todo.yml', <<~YAML)
+        Style/ClassVars:
+          Exclude:
+            - 'offending.rb'
+            - '#{pattern}'
+      YAML
+    end
+
+    [
+      '**/*_spec.rb',
+      'spec/**/*.rb',
+      'spec/nested/{clean,offending}_spec.rb',
+      'spec/nested/offending_spec.?b',
+      'spec/nested/[co]*_spec.rb'
+    ].each do |glob|
+      context "with #{glob.inspect}" do
+        let(:pattern) { glob }
+
+        it 'keeps an entry when a matching file still offends' do
+          expect(cli.run(['--report-unused-todo-entries', '.'])).to eq(0)
+
+          expect($stderr.string).not_to include('unused todo')
+        end
+      end
+    end
+  end
+
+  context 'when glob patterns are stale for only some cops' do
+    before do
+      create_file('.rubocop_todo.yml', <<~YAML)
+        Style/ClassVars:
+          Exclude:
+            - '*.rb'
+            - 'missing/**/*.rb'
+            - 'clean*.rb'
+        Lint/UselessAssignment:
+          Exclude:
+            - '*.rb'
+      YAML
+    end
+
+    it 'reports patterns only when no matching file needs that cop excluded' do
+      expect(cli.run(['--report-unused-todo-entries', '.'])).to eq(1)
+      expect($stderr.string).to include('3 unused todo entries found in `.rubocop_todo.yml`:')
+      expect($stderr.string).to include('Style/ClassVars: missing/**/*.rb')
+      expect($stderr.string).to include('Style/ClassVars: clean*.rb')
+      expect($stderr.string).to include('Lint/UselessAssignment: *.rb')
+      expect($stderr.string).not_to include('Style/ClassVars: *.rb')
+    end
+  end
+
+  context 'when a literal filename contains glob characters' do
+    before do
+      create_file('offending[1].rb', "# frozen_string_literal: true\n\n@@bad = 1\nputs @@bad\n")
+      create_file('.rubocop_todo.yml', <<~YAML)
+        Style/ClassVars:
+          Exclude:
+            - 'offending.rb'
+            - 'offending[1].rb'
+      YAML
+    end
+
+    it 'also audits files matched by the pattern when the literal file is clean' do
+      create_file('offending[1].rb', File.read('clean.rb'))
+      create_file('offending1.rb', File.read('offending.rb'))
+
+      expect(cli.run(['--report-unused-todo-entries', '--only', 'Style/ClassVars', '.'])).to eq(0)
+      expect($stderr.string).not_to include('unused todo')
+    end
+
+    it 'still audits the literal file' do
+      expect(cli.run(['--report-unused-todo-entries', '--only', 'Style/ClassVars', '.'])).to eq(0)
+
+      expect($stderr.string).not_to include('unused todo')
+    end
+  end
+
+  context 'when matching files are below a symlink directory' do
+    before do
+      create_file('external/offending.rb', File.read('offending.rb'))
+      create_link('spec/link', '../external')
+      create_file('.rubocop_todo.yml', <<~YAML)
+        Style/ClassVars:
+          Exclude:
+            - 'offending.rb'
+            - 'spec/**/*.rb'
+            - 'external/**/*.rb'
+      YAML
+    end
+
+    it 'keeps the pattern that excludes the symlinked source' do
+      expect(cli.run(['--report-unused-todo-entries', '--only', 'Style/ClassVars', '.'])).to eq(0)
+      expect($stderr.string).not_to include('unused todo')
+    end
+  end
+
+  context 'when patterns refer to files outside the todo directory' do
+    before do
+      create_file('project/.rubocop.yml', "inherit_from: .rubocop_todo.yml\n")
+      create_file('external/offending.rb', File.read('offending.rb'))
+      create_file('project/.rubocop_todo.yml', <<~YAML)
+        Style/ClassVars:
+          Exclude:
+            - '#{pattern}'
+      YAML
+    end
+
+    shared_examples 'an external pattern' do
+      it 'keeps the pattern when an external source still offends' do
+        Dir.chdir('project') do
+          expect(cli.run(['--report-unused-todo-entries', '--only', 'Style/ClassVars',
+                          '--config', '.rubocop.yml', '../external'])).to eq(0)
+          expect($stderr.string).not_to include('unused todo')
+        end
+      end
+    end
+
+    context 'with a relative path' do
+      let(:pattern) { '../external/**/*.rb' }
+
+      it_behaves_like 'an external pattern'
+    end
+
+    context 'with an absolute path' do
+      let(:pattern) { File.join(Dir.pwd, 'external/**/*.rb') }
+
+      it_behaves_like 'an external pattern'
+    end
+  end
+
   context 'when the todo file lists a cop that is not loaded' do
     before do
       create_file('.rubocop_todo.yml', <<~YAML)


### PR DESCRIPTION
Fixes #15570.

`--report-unused-todo-entries` treats a glob exclusion as a literal filename, so it reports the entry as unused even when matching Ruby files still trigger that cop. Expand each entry to matching source files and keep it when any of those files still reports an offense for the relevant cop.

Use `TargetFinder` from the pattern's fixed directory prefix and `PathUtil` for matching, preserving normal source discovery and symlink traversal. Cache source files by prefix, inspect shared matches once, and retain literal filenames and duplicate-entry reporting. Regression tests cover live/stale patterns, different cops, literal names containing glob characters, symlink directories, and relative/absolute external paths.

AI assistance: Codex was used to prepare and validate this change.

-----------------

* [x] The PR relates to only one subject.
* [x] Wrote a focused commit message beginning with `[Fix #15570]`.
* [x] Feature branch is based on `master`.
* [x] Squashed related changes into one signed-off commit.
* [x] Added tests.
* [x] Ran `bundle exec rake default`: 33,225 examples, 3 pending, 0 failures; 1,762 files self-linted without offenses.
* [x] Added a changelog entry using `bundle exec rake changelog:fix`.

The 10 new bug regressions fail against unchanged `master`. The full CLI regression file also passes with Prism (15 examples). The repository codespell task also passed in a separate run using an existing local codespell installation.
