### PR TITLE
Fix a flaky teardown race with git background maintenance

### DIFF
--- a/spec/rubocop/changed_files_spec.rb
+++ b/spec/rubocop/changed_files_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::ChangedFiles do
     raise "git #{args.join(' ')} failed: #{stderr}" unless status.success?
   end
 
+  def git_init
+    git('init')
+    # `git commit` may spawn a detached background maintenance process whose own lock file removal
+    # races with the temporary directory cleanup and makes it raise `Errno::ENOENT`.
+    git('config', 'maintenance.auto', 'false')
+    git('config', 'gc.auto', '0')
+  end
+
   def commit_all(message)
     git('add', '-A')
     git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', message)
@@ -36,7 +44,7 @@ RSpec.describe RuboCop::ChangedFiles do
       # Symlinked temporary directories (`/tmp` on macOS) make git and
       # `File.expand_path` disagree about the repository root.
       Dir.chdir(File.realpath(tmpdir)) do
-        git('init')
+        git_init
         example.run
       end
     end
@@ -166,7 +174,7 @@ RSpec.describe RuboCop::ChangedFiles do
     around do |example|
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(File.realpath(tmpdir)) do
-          git('init')
+          git_init
           example.run
         end
       end

--- a/spec/rubocop/cli/changed_spec.rb
+++ b/spec/rubocop/cli/changed_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe 'RuboCop::CLI --changed', :isolated_environment do # rubocop:disa
     raise "git #{args.join(' ')} failed: #{stderr}" unless status.success?
   end
 
+  def git_init
+    git('init')
+    # `git commit` may spawn a detached background maintenance process whose own lock file removal
+    # races with the temporary directory cleanup and makes it raise `Errno::ENOENT`.
+    git('config', 'maintenance.auto', 'false')
+    git('config', 'gc.auto', '0')
+  end
+
   def commit_all(message)
     git('add', '-A')
     git('-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', message)
@@ -19,7 +27,7 @@ RSpec.describe 'RuboCop::CLI --changed', :isolated_environment do # rubocop:disa
   let(:offending_source) { "# frozen_string_literal: true\n\nputs \"offense\"\n" }
 
   before do
-    git('init')
+    git_init
     create_file('.rubocop.yml', <<~YAML)
       AllCops:
         NewCops: disable


### PR DESCRIPTION
The `--changed` specs run `git init` and `git commit` inside the isolated temporary directory. Git spawns a detached background maintenance process on every commit (verified with `GIT_TRACE=1` on git 2.55.0, the same major version as the CI runners: each commit runs `git maintenance run --auto --quiet --detach`), and that process creates and later removes `.git/objects/maintenance.lock`. When the example finishes first, the `Dir.mktmpdir` cleanup in the 'isolated environment' context walks the tree while the background process is still running, and removing an already-listed entry that the process has just deleted itself raises:

```
Errno::ENOENT: No such file or directory @ apply2files -
  .../work/.git/objects/maintenance.lock
````

Since the process detaches on every commit, whether the race fires is purely a matter of timing. It failed the "explains what to do when given a path instead of a revision" example, which runs no git command of its own; the commit in the `before` hook had spawned the maintenance process:

- https://github.com/rubocop/rubocop/actions/runs/34703532922

Disable background maintenance in the repositories the specs create: with `maintenance.auto false`, the same `GIT_TRACE` measurement shows no maintenance invocation at all, and `gc.auto 0` stops the legacy `gc --auto` path on older gits. Both keys are inert no-ops for gits that do not know the corresponding behavior. Production code is untouched, since this is purely a property of the throwaway spec repositories.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
