### PR TITLE
fix `cut_release:update_readme` release step

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To prevent an unwanted RuboCop update you might want to use a conservative versi
 in your `Gemfile`:
 
 ```rb
-gem 'rubocop', '~> 1.82', require: false
+gem 'rubocop', '~> 1.91', require: false
 ```
 
 See [our versioning policy](https://docs.rubocop.org/rubocop/versioning.html) for further details.

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -19,10 +19,10 @@ namespace :cut_release do
     version.split('.').take(2).join('.')
   end
 
-  def update_readme(old_version, new_version)
+  def update_readme(new_version)
     update_file('README.md') do |readme|
       readme.sub(
-        "gem 'rubocop', '~> #{version_sans_patch(old_version)}', require: false",
+        /gem 'rubocop', '~> \d+\.\d+', require: false/,
         "gem 'rubocop', '~> #{version_sans_patch(new_version)}', require: false"
       )
     end
@@ -43,7 +43,7 @@ namespace :cut_release do
 
     update_file('docs/modules/ROOT/pages/installation.adoc') do |installation|
       installation.sub(
-        "gem 'rubocop', '~> #{version_sans_patch(old_version)}', require: false",
+        /gem 'rubocop', '~> \d+\.\d+', require: false/,
         "gem 'rubocop', '~> #{version_sans_patch(new_version)}', require: false"
       )
     end
@@ -102,7 +102,7 @@ namespace :cut_release do
 
     update_cop_versions(old_version, new_version)
     Rake::Task['update_cops_documentation'].invoke
-    update_readme(old_version, new_version)
+    update_readme(new_version)
     update_docs(old_version, new_version)
     update_issue_template(old_version, new_version)
     update_contributing_doc(old_version, new_version)


### PR DESCRIPTION
Since some RuboCop release was skipped (circa 1.83) new releases do not update `README.md`'s RuboCop version.

ref: https://github.com/rubocop/rubocop/commits/master/README.md

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
